### PR TITLE
chore: ignore common kokoro config for setting test project

### DIFF
--- a/synth.metadata
+++ b/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2020-01-02T18:28:01.170427Z",
+  "updateTime": "2020-01-06T17:54:08.850187Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.42.3",
-        "dockerImage": "googleapis/artman@sha256:feed210b5723c6f524b52ef6d7740a030f2d1a8f7c29a71c5e5b4481ceaad7f5"
+        "version": "0.43.0",
+        "dockerImage": "googleapis/artman@sha256:264654a37596a44b0668b8ce6ac41082d713f6ee150b3fc6425fa78cc64e4f20"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "ec285d3d230810147ebbf8d5b691ee90320c6d2d",
-        "internalRef": "287608953"
+        "sha": "91ef2d9dd69807b0b79555f22566fb2d81e49ff9",
+        "internalRef": "287999179"
       }
     },
     {
@@ -661,9 +661,6 @@
       "path": ".kokoro/presubmit/java8-osx.cfg"
     },
     {
-      "path": ".kokoro/presubmit/common.cfg"
-    },
-    {
       "path": ".kokoro/continuous/propose_release.sh"
     },
     {
@@ -694,9 +691,6 @@
       "path": ".kokoro/continuous/java8-osx.cfg"
     },
     {
-      "path": ".kokoro/continuous/common.cfg"
-    },
-    {
       "path": ".kokoro/nightly/dependencies.cfg"
     },
     {
@@ -719,9 +713,6 @@
     },
     {
       "path": ".kokoro/nightly/java8-osx.cfg"
-    },
-    {
-      "path": ".kokoro/nightly/common.cfg"
     },
     {
       "path": ".kokoro/release/bump_snapshot.cfg"

--- a/synth.py
+++ b/synth.py
@@ -68,5 +68,7 @@ common_templates = gcp.CommonTemplates()
 templates = common_templates.java_library()
 s.copy(templates, excludes=[
     'README.md',
-    '.kokoro/common.cfg'
+    '.kokoro/continuous/common.cfg',
+    '.kokoro/nightly/common.cfg',
+    '.kokoro/presubmit/common.cfg',
 ])


### PR DESCRIPTION
Autosynth is changing config files that we needed to change for integration tests