### PR TITLE
feat: add public method to get gRPC status code

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ErrorCode.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ErrorCode.java
@@ -69,6 +69,11 @@ public enum ErrorCode {
     return this.code.toStatus();
   }
 
+  /** @return the corresponding gRPC status code of this {@link ErrorCode}. */
+  public Status.Code getGrpcStatusCode() {
+    return this.code;
+  }
+
   /**
    * Returns the error code represents by {@code name}, or {@code defaultValue} if {@code name} does
    * not map to a known code.


### PR DESCRIPTION
Adds a public method to get the gRPC status code from a `SpannerException`.

Fixes #14.