### PR TITLE
chore: remove deprecated registration of the span names for zpages

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -457,7 +457,7 @@ abstract class AbstractReadContext
 
   @Override
   public void close() {
-    span.end();
+    span.end(TraceUtil.END_SPAN_OPTIONS);
     synchronized (lock) {
       isClosed = true;
     }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
@@ -847,7 +847,7 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
     public void close(@Nullable String message) {
       if (stream != null) {
         stream.close(message);
-        span.end();
+        span.end(TraceUtil.END_SPAN_OPTIONS);
       }
     }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
@@ -37,10 +37,6 @@ class DatabaseClientImpl implements DatabaseClient {
     READ_WRITE
   }
 
-  static {
-    TraceUtil.exportSpans(READ_WRITE_TRANSACTION, READ_ONLY_TRANSACTION, PARTITION_DML_TRANSACTION);
-  }
-
   @VisibleForTesting final SessionPool pool;
 
   DatabaseClientImpl(SessionPool pool) {
@@ -73,7 +69,7 @@ class DatabaseClientImpl implements DatabaseClient {
       TraceUtil.endSpanWithFailure(span, e);
       throw e;
     } finally {
-      span.end();
+      span.end(TraceUtil.END_SPAN_OPTIONS);
     }
   }
 
@@ -93,7 +89,7 @@ class DatabaseClientImpl implements DatabaseClient {
       TraceUtil.endSpanWithFailure(span, e);
       throw e;
     } finally {
-      span.end();
+      span.end(TraceUtil.END_SPAN_OPTIONS);
     }
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionClient.java
@@ -126,8 +126,8 @@ class SessionClient implements AutoCloseable {
     public void run() {
       List<SessionImpl> sessions = null;
       int remainingSessionsToCreate = sessionCount;
-      try (Scope scope =
-          SpannerImpl.tracer.spanBuilder(SpannerImpl.BATCH_CREATE_SESSIONS).startScopedSpan()) {
+      Span span = SpannerImpl.tracer.spanBuilder(SpannerImpl.BATCH_CREATE_SESSIONS).startSpan();
+      try (Scope s = SpannerImpl.tracer.withSpan(span)) {
         SpannerImpl.tracer
             .getCurrentSpan()
             .addAnnotation(String.format("Creating %d sessions", sessionCount));
@@ -144,6 +144,8 @@ class SessionClient implements AutoCloseable {
           }
           remainingSessionsToCreate -= sessions.size();
         }
+      } finally {
+        span.end(TraceUtil.END_SPAN_OPTIONS);
       }
     }
   }
@@ -205,7 +207,7 @@ class SessionClient implements AutoCloseable {
           spanner
               .getRpc()
               .createSession(db.getName(), spanner.getOptions().getSessionLabels(), options);
-      span.end();
+      span.end(TraceUtil.END_SPAN_OPTIONS);
       return new SessionImpl(spanner, session.getName(), options);
     } catch (RuntimeException e) {
       TraceUtil.endSpanWithFailure(span, e);
@@ -284,7 +286,7 @@ class SessionClient implements AutoCloseable {
       span.addAnnotation(
           String.format(
               "Request for %d sessions returned %d sessions", sessionCount, sessions.size()));
-      span.end();
+      span.end(TraceUtil.END_SPAN_OPTIONS);
       List<SessionImpl> res = new ArrayList<>(sessionCount);
       for (com.google.spanner.v1.Session session : sessions) {
         res.add(new SessionImpl(spanner, session.getName(), options));

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -138,7 +138,7 @@ class SessionImpl implements Session {
     try (Scope s = tracer.withSpan(span)) {
       CommitResponse response = spanner.getRpc().commit(request, options);
       Timestamp t = Timestamp.fromProto(response.getCommitTimestamp());
-      span.end();
+      span.end(TraceUtil.END_SPAN_OPTIONS);
       return t;
     } catch (IllegalArgumentException e) {
       TraceUtil.endSpanWithFailure(span, e);
@@ -201,7 +201,7 @@ class SessionImpl implements Session {
     Span span = tracer.spanBuilder(SpannerImpl.DELETE_SESSION).startSpan();
     try (Scope s = tracer.withSpan(span)) {
       spanner.getRpc().deleteSession(name, options);
-      span.end();
+      span.end(TraceUtil.END_SPAN_OPTIONS);
     } catch (RuntimeException e) {
       TraceUtil.endSpanWithFailure(span, e);
       throw e;
@@ -222,7 +222,7 @@ class SessionImpl implements Session {
       if (txn.getId().isEmpty()) {
         throw newSpannerException(ErrorCode.INTERNAL, "Missing id in transaction\n" + getName());
       }
-      span.end();
+      span.end(TraceUtil.END_SPAN_OPTIONS);
       return txn.getId();
     } catch (RuntimeException e) {
       TraceUtil.endSpanWithFailure(span, e);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -851,7 +851,7 @@ final class SessionPool {
       long currentTimeout = options.getInitialWaitForSessionTimeoutMillis();
       while (true) {
         Span span = tracer.spanBuilder(WAIT_FOR_SESSION).startSpan();
-        try (Scope ss = tracer.withSpan(span)) {
+        try (Scope waitScope = tracer.withSpan(span)) {
           SessionOrError s = pollUninterruptiblyWithTimeout(currentTimeout);
           if (s == null) {
             // Set the status to DEADLINE_EXCEEDED and retry.

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
@@ -37,7 +37,6 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.grpc.Context;
 import io.opencensus.trace.AttributeValue;
-import io.opencensus.trace.EndSpanOptions;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
 import java.io.IOException;
@@ -71,8 +70,6 @@ class SpannerImpl extends BaseService<SpannerOptions> implements Spanner {
   static final String COMMIT = "CloudSpannerOperation.Commit";
   static final String QUERY = "CloudSpannerOperation.ExecuteStreamingQuery";
   static final String READ = "CloudSpannerOperation.ExecuteStreamingRead";
-  static final EndSpanOptions END_SPAN_OPTIONS =
-      EndSpanOptions.builder().setSampleToLocalSpanStore(true).build();
 
   private final SpannerRpc gapicRpc;
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
@@ -37,6 +37,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.grpc.Context;
 import io.opencensus.trace.AttributeValue;
+import io.opencensus.trace.EndSpanOptions;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
 import java.io.IOException;
@@ -70,18 +71,8 @@ class SpannerImpl extends BaseService<SpannerOptions> implements Spanner {
   static final String COMMIT = "CloudSpannerOperation.Commit";
   static final String QUERY = "CloudSpannerOperation.ExecuteStreamingQuery";
   static final String READ = "CloudSpannerOperation.ExecuteStreamingRead";
-
-  static {
-    TraceUtil.exportSpans(
-        BATCH_CREATE_SESSIONS,
-        BATCH_CREATE_SESSIONS_REQUEST,
-        CREATE_SESSION,
-        DELETE_SESSION,
-        BEGIN_TRANSACTION,
-        COMMIT,
-        QUERY,
-        READ);
-  }
+  static final EndSpanOptions END_SPAN_OPTIONS =
+      EndSpanOptions.builder().setSampleToLocalSpanStore(true).build();
 
   private final SpannerRpc gapicRpc;
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionManagerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionManagerImpl.java
@@ -115,7 +115,7 @@ final class TransactionManagerImpl implements TransactionManager, SessionTransac
         txnState = TransactionState.ROLLED_BACK;
       }
     } finally {
-      span.end();
+      span.end(TraceUtil.END_SPAN_OPTIONS);
     }
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -130,7 +130,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
               ErrorCode.INTERNAL, "Missing commitTimestamp:\n" + session.getName());
         }
         commitTimestamp = Timestamp.fromProto(commitResponse.getCommitTimestamp());
-        opSpan.end();
+        opSpan.end(TraceUtil.END_SPAN_OPTIONS);
       } catch (RuntimeException e) {
         span.addAnnotation("Commit Failed", TraceUtil.getExceptionAnnotations(e));
         TraceUtil.endSpanWithFailure(opSpan, e);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ResumableStreamIteratorTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ResumableStreamIteratorTest.java
@@ -31,6 +31,7 @@ import com.google.spanner.v1.PartialResultSet;
 import io.grpc.Metadata;
 import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.ProtoUtils;
+import io.opencensus.trace.EndSpanOptions;
 import io.opencensus.trace.Span;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -157,7 +158,7 @@ public class ResumableStreamIteratorTest {
     assertThat(consume(resumableStreamIterator)).containsExactly("a", "b").inOrder();
 
     resumableStreamIterator.close("closed");
-    verify(span).end();
+    verify(span).end(EndSpanOptions.builder().setSampleToLocalSpanStore(true).build());
   }
 
   @Test


### PR DESCRIPTION
Fixes #21

The `registerSpanNamesForCollection()` method is deprecated since OpenCensus-`0.18` release, the alternative is `EndSpanOptions#getSampleToLocalSpanStore()`

See: https://github.com/census-instrumentation/opencensus-java/blob/2a17c8482ffb04540ea4ac0a5f746ad8d536c996/api/src/main/java/io/opencensus/trace/export/SampledSpanStore.java#L102-L112