### PR TITLE
fix: stop sending RPCs to deleted database

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseNotFoundException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseNotFoundException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseNotFoundException.java
@@ -20,7 +20,8 @@ import javax.annotation.Nullable;
 
 /**
  * Exception thrown by Cloud Spanner when an operation detects that the database that is being used
- * no longer exists. This type of error has its own subclass as it is a condition that should cause the client library to stop trying to send RPCs to the backend until the user has taken action.
+ * no longer exists. This type of error has its own subclass as it is a condition that should cause
+ * the client library to stop trying to send RPCs to the backend until the user has taken action.
  */
 public class DatabaseNotFoundException extends SpannerException {
   private static final long serialVersionUID = -6395746612598975751L;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseNotFoundException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseNotFoundException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+import javax.annotation.Nullable;
+
+/**
+ * Exception thrown by Cloud Spanner when an operation detects that the database that is being used
+ * no longer exists. This type of error has its own subclass as it is a condition that should cause the client library to stop trying to send RPCs to the backend until the user has taken action.
+ */
+public class DatabaseNotFoundException extends SpannerException {
+  private static final long serialVersionUID = -6395746612598975751L;
+
+  /** Private constructor. Use {@link SpannerExceptionFactory} to create instances. */
+  DatabaseNotFoundException(
+      DoNotConstructDirectly token, @Nullable String message, @Nullable Throwable cause) {
+    super(token, ErrorCode.NOT_FOUND, false, message, cause);
+  }
+}

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
@@ -176,6 +176,8 @@ public final class SpannerExceptionFactory {
       case NOT_FOUND:
         if (message != null && message.contains("Session not found")) {
           return new SessionNotFoundException(token, message, cause);
+        } else if (message != null && message.contains("Database not found")) {
+          return new DatabaseNotFoundException(token, message, cause);
         }
         // Fall through to the default.
       default:

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
@@ -38,7 +38,10 @@ import javax.net.ssl.SSLHandshakeException;
  */
 public final class SpannerExceptionFactory {
   static final String DATABASE_NOT_FOUND_MSG =
-      "Database not found: projects/.*/instances/.*/databases/.*\nresource_type: \"type.googleapis.com/google.spanner.admin.database.v1.Database\"\nresource_name: \"projects/.*/instances/.*/databases/.*\"\ndescription: \"Database does not exist.\"\n";
+      "Database not found: projects/.*/instances/.*/databases/.*\n"
+          + "resource_type: \"type.googleapis.com/google.spanner.admin.database.v1.Database\"\n"
+          + "resource_name: \"projects/.*/instances/.*/databases/.*\"\n"
+          + "description: \"Database does not exist.\"\n";
   private static final Pattern DATABASE_NOT_FOUND_MSG_PATTERN =
       Pattern.compile(".*" + DATABASE_NOT_FOUND_MSG + ".*");
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
@@ -219,7 +219,7 @@ class SpannerImpl extends BaseService<SpannerOptions> implements Spanner {
         invalidatedDbClients.add(dbClients.get(db));
         dbClients.remove(db);
       }
-      if (dbClients.containsKey(db) && dbClients.get(db).pool.isValid()) {
+      if (dbClients.containsKey(db)) {
         return dbClients.get(db);
       } else {
         SessionPool pool =

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -52,7 +52,10 @@ import org.threeten.bp.Duration;
 @RunWith(JUnit4.class)
 public class DatabaseClientImplTest {
   private static final String DATABASE_NOT_FOUND_FORMAT =
-      SpannerExceptionFactory.DATABASE_NOT_FOUND_MSG.replaceAll("\\.\\*", "%s");
+      "Database not found: projects/%s/instances/%s/databases/%s\n"
+          + "resource_type: \"type.googleapis.com/google.spanner.admin.database.v1.Database\"\n"
+          + "resource_name: \"projects/%s/instances/%s/databases/%s\"\n"
+          + "description: \"Database does not exist.\"\n";
   private static final String TEST_PROJECT = "my-project";
   private static final String TEST_INSTANCE = "my-instance";
   private static final String TEST_DATABASE = "my-database";

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDatabaseTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDatabaseTest.java
@@ -20,6 +20,7 @@ import static com.google.cloud.spanner.SpannerMatchers.isSpannerException;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
+import com.google.api.client.util.ExponentialBackOff;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.cloud.spanner.Database;
 import com.google.cloud.spanner.DatabaseClient;
@@ -31,7 +32,6 @@ import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Statement;
 import com.google.spanner.admin.database.v1.CreateDatabaseMetadata;
 import java.util.Collections;
-import java.util.concurrent.ExecutionException;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -56,7 +56,7 @@ public class ITDatabaseTest {
   }
 
   @Test
-  public void databaseDeletedTest() throws InterruptedException, ExecutionException {
+  public void databaseDeletedTest() throws Exception {
     // Create a test db, do a query, then delete it and verify that it returns
     // DatabaseNotFoundExceptions.
     Database db = env.getTestHelper().createTestDatabase();
@@ -70,14 +70,25 @@ public class ITDatabaseTest {
     // Delete the database.
     db.drop();
     // We need to wait a little before Spanner actually starts sending DatabaseNotFound errors.
-    Thread.sleep(5000L);
-    // Queries to this database should now return DatabaseNotFoundExceptions.
-    try (ResultSet rs = client.singleUse().executeQuery(Statement.of("SELECT 1"))) {
-      rs.next();
-      fail("Missing expected DatabaseNotFoundException");
-    } catch (DatabaseNotFoundException e) {
-      // This is what we expect.
+    ExponentialBackOff backoff =
+        new ExponentialBackOff.Builder()
+            .setInitialIntervalMillis(1000)
+            .setMaxElapsedTimeMillis(35000)
+            .setMaxIntervalMillis(5000)
+            .build();
+    DatabaseNotFoundException notFoundException = null;
+    long millis = 0L;
+    while ((millis = backoff.nextBackOffMillis()) != ExponentialBackOff.STOP) {
+      Thread.sleep(millis);
+      // Queries to this database should eventually return DatabaseNotFoundExceptions.
+      try (ResultSet rs = client.singleUse().executeQuery(Statement.of("SELECT 1"))) {
+        rs.next();
+      } catch (DatabaseNotFoundException e) {
+        // This is what we expect.
+        notFoundException = e;
+      }
     }
+    assertThat(notFoundException).isNotNull();
 
     // Now re-create a database with the same name.
     OperationFuture<Database, CreateDatabaseMetadata> op =

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDatabaseTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDatabaseTest.java
@@ -17,10 +17,21 @@
 package com.google.cloud.spanner.it;
 
 import static com.google.cloud.spanner.SpannerMatchers.isSpannerException;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
 
+import com.google.api.gax.longrunning.OperationFuture;
+import com.google.cloud.spanner.Database;
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.DatabaseNotFoundException;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.IntegrationTest;
 import com.google.cloud.spanner.IntegrationTestEnv;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
+import com.google.spanner.admin.database.v1.CreateDatabaseMetadata;
+import java.util.Collections;
+import java.util.concurrent.ExecutionException;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,5 +53,58 @@ public class ITDatabaseTest {
     expectedException.expectMessage("Syntax error on line 1");
 
     env.getTestHelper().createTestDatabase("CREATE TABLE T ( Illegal Way To Define A Table )");
+  }
+
+  @Test
+  public void databaseDeletedTest() throws InterruptedException, ExecutionException {
+    // Create a test db, do a query, then delete it and verify that it returns
+    // DatabaseNotFoundExceptions.
+    Database db = env.getTestHelper().createTestDatabase();
+    DatabaseClient client = env.getTestHelper().getClient().getDatabaseClient(db.getId());
+    try (ResultSet rs = client.singleUse().executeQuery(Statement.of("SELECT 1"))) {
+      assertThat(rs.next()).isTrue();
+      assertThat(rs.getLong(0)).isEqualTo(1L);
+      assertThat(rs.next()).isFalse();
+    }
+
+    // Delete the database.
+    db.drop();
+    // We need to wait a little before Spanner actually starts sending DatabaseNotFound errors.
+    Thread.sleep(5000L);
+    // Queries to this database should now return DatabaseNotFoundExceptions.
+    try (ResultSet rs = client.singleUse().executeQuery(Statement.of("SELECT 1"))) {
+      rs.next();
+      fail("Missing expected DatabaseNotFoundException");
+    } catch (DatabaseNotFoundException e) {
+      // This is what we expect.
+    }
+
+    // Now re-create a database with the same name.
+    OperationFuture<Database, CreateDatabaseMetadata> op =
+        env.getTestHelper()
+            .getClient()
+            .getDatabaseAdminClient()
+            .createDatabase(
+                db.getId().getInstanceId().getInstance(),
+                db.getId().getDatabase(),
+                Collections.<String>emptyList());
+    Database newDb = op.get();
+
+    // Queries using the same DatabaseClient should still return DatabaseNotFoundExceptions.
+    try (ResultSet rs = client.singleUse().executeQuery(Statement.of("SELECT 1"))) {
+      rs.next();
+      fail("Missing expected DatabaseNotFoundException");
+    } catch (DatabaseNotFoundException e) {
+      // This is what we expect.
+    }
+
+    // Now get a new DatabaseClient for the database. This should now result in a valid
+    // DatabaseClient.
+    DatabaseClient newClient = env.getTestHelper().getClient().getDatabaseClient(newDb.getId());
+    try (ResultSet rs = newClient.singleUse().executeQuery(Statement.of("SELECT 1"))) {
+      assertThat(rs.next()).isTrue();
+      assertThat(rs.getLong(0)).isEqualTo(1L);
+      assertThat(rs.next()).isFalse();
+    }
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDatabaseTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDatabaseTest.java
@@ -86,6 +86,7 @@ public class ITDatabaseTest {
       } catch (DatabaseNotFoundException e) {
         // This is what we expect.
         notFoundException = e;
+        break;
       }
     }
     assertThat(notFoundException).isNotNull();


### PR DESCRIPTION
DatabaseClients should not continue to try to send RPCs to a database that has been deleted. Instead, the session pool will keep track of whether a DatabaseNotFound error has been returned for a database, and if so, will invalidate itself. All subsequent calls for this database will return a DatabaseNotFoundException without calling a RPC.

If a database is re-created, the user must create a new DatabaseClient with a new session pool in order to resume usage of the database.

Fixes #16
