### PR TITLE
Revert "perf: close sessions async"

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Session.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Session.java
@@ -16,9 +16,6 @@
 
 package com.google.cloud.spanner;
 
-import com.google.api.core.ApiFuture;
-import com.google.protobuf.Empty;
-
 /**
  * A {@code Session} can be used to perform transactions that read and/or modify data in a Cloud
  * Spanner database.
@@ -57,10 +54,4 @@ public interface Session extends DatabaseClient, AutoCloseable {
 
   @Override
   void close();
-
-  /**
-   * Closes the session asynchronously and returns the {@link ApiFuture} that can be used to monitor
-   * the operation progress.
-   */
-  ApiFuture<Empty> asyncClose();
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -19,7 +19,6 @@ package com.google.cloud.spanner;
 import static com.google.cloud.spanner.SpannerExceptionFactory.newSpannerException;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.api.core.ApiFuture;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.AbstractReadContext.MultiUseReadOnlyTransaction;
 import com.google.cloud.spanner.AbstractReadContext.SingleReadContext;
@@ -28,7 +27,6 @@ import com.google.cloud.spanner.TransactionRunnerImpl.TransactionContextImpl;
 import com.google.cloud.spanner.spi.v1.SpannerRpc;
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
-import com.google.protobuf.Empty;
 import com.google.spanner.v1.BeginTransactionRequest;
 import com.google.spanner.v1.CommitRequest;
 import com.google.spanner.v1.CommitResponse;
@@ -196,11 +194,6 @@ class SessionImpl implements Session {
   public void prepareReadWriteTransaction() {
     setActive(null);
     readyTransactionId = beginTransaction();
-  }
-
-  @Override
-  public ApiFuture<Empty> asyncClose() {
-    return spanner.getRpc().asyncDeleteSession(name, options);
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -18,8 +18,6 @@ package com.google.cloud.spanner;
 
 import static com.google.cloud.spanner.SpannerExceptionFactory.newSpannerException;
 
-import com.google.api.core.ApiFuture;
-import com.google.api.core.ApiFutures;
 import com.google.cloud.Timestamp;
 import com.google.cloud.grpc.GrpcTransportOptions;
 import com.google.cloud.grpc.GrpcTransportOptions.ExecutorFactory;
@@ -37,7 +35,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.common.util.concurrent.Uninterruptibles;
-import com.google.protobuf.Empty;
 import io.opencensus.common.Scope;
 import io.opencensus.trace.Annotation;
 import io.opencensus.trace.AttributeValue;
@@ -771,12 +768,6 @@ final class SessionPool {
     }
 
     @Override
-    public ApiFuture<Empty> asyncClose() {
-      close();
-      return ApiFutures.immediateFuture(Empty.getDefaultInstance());
-    }
-
-    @Override
     public void close() {
       synchronized (lock) {
         numSessionsInUse--;
@@ -1008,7 +999,7 @@ final class SessionPool {
       }
       for (PooledSession sess : sessionsToClose) {
         logger.log(Level.FINE, "Closing session {0}", sess.getName());
-        closeSessionAsync(sess);
+        closeSession(sess);
       }
     }
 
@@ -1621,27 +1612,37 @@ final class SessionPool {
     }
   }
 
-  private ApiFuture<Empty> closeSessionAsync(final PooledSession sess) {
-    ApiFuture<Empty> res = sess.delegate.asyncClose();
-    res.addListener(
+  private void closeSessionAsync(final PooledSession sess) {
+    executor.submit(
         new Runnable() {
           @Override
           public void run() {
-            synchronized (lock) {
-              allSessions.remove(sess);
-              if (isClosed()) {
-                decrementPendingClosures(1);
-                return;
-              }
-              // Create a new session if needed to unblock some waiter.
-              if (numWaiters() > numSessionsBeingCreated) {
-                createSessions(getAllowedCreateSessions(numWaiters() - numSessionsBeingCreated));
-              }
-            }
+            closeSession(sess);
           }
-        },
-        executor);
-    return res;
+        });
+  }
+
+  private void closeSession(PooledSession sess) {
+    try {
+      sess.delegate.close();
+    } catch (SpannerException e) {
+      // Backend will delete these sessions after a while even if we fail to close them.
+      if (logger.isLoggable(Level.FINE)) {
+        logger.log(Level.FINE, "Failed to close session: " + sess.getName(), e);
+      }
+    } finally {
+      synchronized (lock) {
+        allSessions.remove(sess);
+        if (isClosed()) {
+          decrementPendingClosures(1);
+          return;
+        }
+        // Create a new session if needed to unblock some waiter.
+        if (numWaiters() > numSessionsBeingCreated) {
+          createSessions(getAllowedCreateSessions(numWaiters() - numSessionsBeingCreated));
+        }
+      }
+    }
   }
 
   private void prepareSession(final PooledSession sess) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -18,7 +18,6 @@ package com.google.cloud.spanner.spi.v1;
 
 import static com.google.cloud.spanner.SpannerExceptionFactory.newSpannerException;
 
-import com.google.api.core.ApiFuture;
 import com.google.api.core.NanoClock;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.ExecutorProvider;
@@ -524,14 +523,9 @@ public class GapicSpannerRpc implements SpannerRpc {
   @Override
   public void deleteSession(String sessionName, @Nullable Map<Option, ?> options)
       throws SpannerException {
-    get(asyncDeleteSession(sessionName, options));
-  }
-
-  @Override
-  public ApiFuture<Empty> asyncDeleteSession(String sessionName, @Nullable Map<Option, ?> options) {
     DeleteSessionRequest request = DeleteSessionRequest.newBuilder().setName(sessionName).build();
     GrpcCallContext context = newCallContext(options, sessionName);
-    return spannerStub.deleteSessionCallable().futureCall(request, context);
+    get(spannerStub.deleteSessionCallable().futureCall(request, context));
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerRpc.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.spanner.spi.v1;
 
-import com.google.api.core.ApiFuture;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.cloud.ServiceRpc;
 import com.google.cloud.spanner.SpannerException;
@@ -219,9 +218,6 @@ public interface SpannerRpc extends ServiceRpc {
       throws SpannerException;
 
   void deleteSession(String sessionName, @Nullable Map<Option, ?> options) throws SpannerException;
-
-  ApiFuture<Empty> asyncDeleteSession(String sessionName, @Nullable Map<Option, ?> options)
-      throws SpannerException;
 
   StreamingCall read(
       ReadRequest request, ResultStreamConsumer consumer, @Nullable Map<Option, ?> options);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BaseSessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BaseSessionPoolTest.java
@@ -23,10 +23,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import com.google.api.core.ApiFutures;
 import com.google.cloud.grpc.GrpcTransportOptions.ExecutorFactory;
 import com.google.cloud.spanner.SessionPool.Clock;
-import com.google.protobuf.Empty;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -63,7 +61,6 @@ abstract class BaseSessionPoolTest {
     when(session.getName())
         .thenReturn(
             "projects/dummy/instances/dummy/database/dummy/sessions/session" + sessionIndex);
-    when(session.asyncClose()).thenReturn(ApiFutures.immediateFuture(Empty.getDefaultInstance()));
     sessionIndex++;
     return session;
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminGaxTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminGaxTest.java
@@ -216,9 +216,8 @@ public class DatabaseAdminGaxTest {
   }
 
   @AfterClass
-  public static void stopServer() throws InterruptedException {
+  public static void stopServer() {
     server.shutdown();
-    server.awaitTermination();
   }
 
   @Before

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceAdminGaxTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceAdminGaxTest.java
@@ -219,9 +219,8 @@ public class InstanceAdminGaxTest {
   }
 
   @AfterClass
-  public static void stopServer() throws InterruptedException {
+  public static void stopServer() {
     server.shutdown();
-    server.awaitTermination();
   }
 
   @Before

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RetryOnInvalidatedSessionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RetryOnInvalidatedSessionTest.java
@@ -172,10 +172,9 @@ public class RetryOnInvalidatedSessionTest {
   }
 
   @AfterClass
-  public static void stopServer() throws InterruptedException {
+  public static void stopServer() {
     spannerClient.close();
     server.shutdown();
-    server.awaitTermination();
   }
 
   @Before

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolLeakTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolLeakTest.java
@@ -29,7 +29,6 @@ import io.grpc.Server;
 import io.grpc.StatusRuntimeException;
 import io.grpc.inprocess.InProcessServerBuilder;
 import java.io.IOException;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -56,19 +55,13 @@ public class SessionPoolLeakTest {
     mockSpanner = new MockSpannerServiceImpl();
     mockSpanner.setAbortProbability(0.0D); // We don't want any unpredictable aborted transactions.
     String uniqueName = InProcessServerBuilder.generateName();
-    server =
-        InProcessServerBuilder.forName(uniqueName)
-            .scheduledExecutorService(new ScheduledThreadPoolExecutor(1))
-            .addService(mockSpanner)
-            .build()
-            .start();
+    server = InProcessServerBuilder.forName(uniqueName).addService(mockSpanner).build().start();
     channelProvider = LocalChannelProvider.create(uniqueName);
   }
 
   @AfterClass
-  public static void stopServer() throws InterruptedException {
+  public static void stopServer() {
     server.shutdown();
-    server.awaitTermination();
   }
 
   @Before

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerGaxRetryTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerGaxRetryTest.java
@@ -122,9 +122,8 @@ public class SpannerGaxRetryTest {
   }
 
   @AfterClass
-  public static void stopServer() throws InterruptedException {
+  public static void stopServer() {
     server.shutdown();
-    server.awaitTermination();
   }
 
   @Before

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerAbortedTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerAbortedTest.java
@@ -160,10 +160,9 @@ public class TransactionManagerAbortedTest {
   }
 
   @AfterClass
-  public static void stopServer() throws InterruptedException {
+  public static void stopServer() {
     spannerClient.close();
     server.shutdown();
-    server.awaitTermination();
   }
 
   @Before

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
@@ -25,14 +25,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import com.google.api.core.ApiFutures;
 import com.google.cloud.Timestamp;
 import com.google.cloud.grpc.GrpcTransportOptions;
 import com.google.cloud.grpc.GrpcTransportOptions.ExecutorFactory;
 import com.google.cloud.spanner.TransactionManager.TransactionState;
 import com.google.cloud.spanner.spi.v1.SpannerRpc;
 import com.google.protobuf.ByteString;
-import com.google.protobuf.Empty;
 import com.google.spanner.v1.BeginTransactionRequest;
 import com.google.spanner.v1.CommitRequest;
 import com.google.spanner.v1.CommitResponse;
@@ -200,8 +198,6 @@ public class TransactionManagerImplTest {
     when(options.getSessionPoolOptions()).thenReturn(sessionPoolOptions);
     when(options.getSessionLabels()).thenReturn(Collections.<String, String>emptyMap());
     SpannerRpc rpc = mock(SpannerRpc.class);
-    when(rpc.asyncDeleteSession(Mockito.anyString(), Mockito.anyMap()))
-        .thenReturn(ApiFutures.immediateFuture(Empty.getDefaultInstance()));
     when(rpc.batchCreateSessions(
             Mockito.anyString(), Mockito.eq(1), Mockito.anyMap(), Mockito.anyMap()))
         .thenAnswer(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.api.core.ApiFutures;
 import com.google.cloud.grpc.GrpcTransportOptions;
 import com.google.cloud.grpc.GrpcTransportOptions.ExecutorFactory;
 import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
@@ -33,7 +32,6 @@ import com.google.cloud.spanner.spi.v1.SpannerRpc;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Duration;
-import com.google.protobuf.Empty;
 import com.google.protobuf.Timestamp;
 import com.google.rpc.Code;
 import com.google.rpc.RetryInfo;
@@ -109,8 +107,6 @@ public class TransactionRunnerImplTest {
     when(options.getSessionPoolOptions()).thenReturn(sessionPoolOptions);
     when(options.getSessionLabels()).thenReturn(Collections.<String, String>emptyMap());
     SpannerRpc rpc = mock(SpannerRpc.class);
-    when(rpc.asyncDeleteSession(Mockito.anyString(), Mockito.anyMap()))
-        .thenReturn(ApiFutures.immediateFuture(Empty.getDefaultInstance()));
     when(rpc.batchCreateSessions(
             Mockito.anyString(), Mockito.eq(1), Mockito.anyMap(), Mockito.anyMap()))
         .thenAnswer(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
@@ -163,9 +163,8 @@ public class GapicSpannerRpcTest {
   }
 
   @After
-  public void stopServer() throws InterruptedException {
+  public void stopServer() {
     server.shutdown();
-    server.awaitTermination();
   }
 
   private static final int NUMBER_OF_TEST_RUNS = 2;


### PR DESCRIPTION
Reverts googleapis/java-spanner#24

The change continues to cause compatibility test failures.