### PR TITLE
test: fix flaky integration test

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestWithClosedSessionsEnv.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestWithClosedSessionsEnv.java
@@ -114,7 +114,8 @@ public class IntegrationTestWithClosedSessionsEnv extends IntegrationTestEnv {
           Thread.sleep(500L);
         } catch (SpannerException e) {
           if (e.getErrorCode() == ErrorCode.NOT_FOUND
-              && e.getMessage().contains("Session not found")) {
+              && (e.getMessage().contains("Session not found")
+                  || e.getMessage().contains("Session was concurrently deleted"))) {
             break;
           } else {
             throw e;


### PR DESCRIPTION
The ITClosedSessionTest could cause a flaky failure because it deletes sessions on the server and then repeatedly executes queries on the session until it returns a NOT_FOUND error. The actual deletion could however happen exactly at the moment that the test query was executed, which will cause Cloud Spanner to return a different error message than the standard 'Session not found' error message.

Fixes #41
