### PR TITLE
fix: use streaming retry settings for ResumableStreamIterator

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -21,7 +21,6 @@ import static com.google.cloud.spanner.SpannerExceptionFactory.newSpannerExcepti
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
-import com.google.api.client.util.BackOff;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.SessionImpl.SessionTransaction;
 import com.google.cloud.spanner.spi.v1.SpannerRpc;
@@ -151,17 +150,6 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
       synchronized (lock) {
         return aborted;
       }
-    }
-
-    /** Return the delay in milliseconds between requests to Cloud Spanner. */
-    long getRetryDelayInMillis(BackOff backoff) {
-      long delay = SpannerImpl.nextBackOffMillis(backoff);
-      synchronized (lock) {
-        if (retryDelayInMillis >= 0) {
-          return retryDelayInMillis;
-        }
-      }
-      return delay;
     }
 
     void rollback() {


### PR DESCRIPTION
This PR moves the custom `Backoff` functionality and settings from the `SpannerImpl` class to `AbstractResultSet`, as that is the only place where it is still in use.

The `Backoff` configuration was previously a hard coded value. It now uses the gapic configuration for streaming RPCs as the backoff is only used for the `ResumableStreamIterator` which is used by the `executeStreamingSql` and `streamingRead` RPCs.

Updates #20