### PR TITLE
info: add additional information to error message

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseAdminClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseAdminClientImpl.java
@@ -28,6 +28,7 @@ import com.google.cloud.spanner.Options.ListOption;
 import com.google.cloud.spanner.SpannerImpl.PageFetcher;
 import com.google.cloud.spanner.spi.v1.SpannerRpc;
 import com.google.cloud.spanner.spi.v1.SpannerRpc.Paginated;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.Empty;
 import com.google.spanner.admin.database.v1.CreateDatabaseMetadata;
@@ -155,7 +156,18 @@ class DatabaseAdminClientImpl implements DatabaseAdminClient {
           @Override
           public Paginated<com.google.spanner.admin.database.v1.Database> getNextPage(
               String nextPageToken) {
-            return rpc.listDatabases(instanceName, pageSize, nextPageToken);
+            try {
+              return rpc.listDatabases(instanceName, pageSize, nextPageToken);
+            } catch (SpannerException e) {
+              throw SpannerExceptionFactory.newSpannerException(
+                  e.getErrorCode(),
+                  String.format(
+                      "Failed to list the databases of %s with pageToken %s: %s",
+                      instanceName,
+                      MoreObjects.firstNonNull(nextPageToken, "<null>"),
+                      e.getMessage()),
+                  e);
+            }
           }
 
           @Override


### PR DESCRIPTION
Any error that might occur during the listing of databases of an instance will now also include the name of the instance and the page token that was used to try to get the databases. This makes
it easier to debug why a particular RPC might have failed.

The flaky fails mentioned in #17 have not occurred for a while, and it is very well possible that this problem was a temporary backend problem. This extra information will make it easier to debug the failures should they occur again.

Closes #17