### PR TITLE
fix: use resource type to identify type of error

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseNotFoundException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseNotFoundException.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.spanner;
 
+import com.google.cloud.spanner.SpannerException.ResourceNotFoundException;
+import com.google.rpc.ResourceInfo;
 import javax.annotation.Nullable;
 
 /**
@@ -23,12 +25,15 @@ import javax.annotation.Nullable;
  * no longer exists. This type of error has its own subclass as it is a condition that should cause
  * the client library to stop trying to send RPCs to the backend until the user has taken action.
  */
-public class DatabaseNotFoundException extends SpannerException {
+public class DatabaseNotFoundException extends ResourceNotFoundException {
   private static final long serialVersionUID = -6395746612598975751L;
 
   /** Private constructor. Use {@link SpannerExceptionFactory} to create instances. */
   DatabaseNotFoundException(
-      DoNotConstructDirectly token, @Nullable String message, @Nullable Throwable cause) {
-    super(token, ErrorCode.NOT_FOUND, false, message, cause);
+      DoNotConstructDirectly token,
+      @Nullable String message,
+      ResourceInfo resourceInfo,
+      @Nullable Throwable cause) {
+    super(token, message, resourceInfo, cause);
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionNotFoundException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionNotFoundException.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.spanner;
 
+import com.google.cloud.spanner.SpannerException.ResourceNotFoundException;
+import com.google.rpc.ResourceInfo;
 import javax.annotation.Nullable;
 
 /**
@@ -23,12 +25,15 @@ import javax.annotation.Nullable;
  * is no longer valid. This type of error has its own subclass as it is a condition that should
  * normally be hidden from the user, and the client library should try to fix this internally.
  */
-public class SessionNotFoundException extends SpannerException {
+public class SessionNotFoundException extends ResourceNotFoundException {
   private static final long serialVersionUID = -6395746612598975751L;
 
   /** Private constructor. Use {@link SpannerExceptionFactory} to create instances. */
   SessionNotFoundException(
-      DoNotConstructDirectly token, @Nullable String message, @Nullable Throwable cause) {
-    super(token, ErrorCode.NOT_FOUND, false, message, cause);
+      DoNotConstructDirectly token,
+      @Nullable String message,
+      ResourceInfo resourceInfo,
+      @Nullable Throwable cause) {
+    super(token, message, resourceInfo, cause);
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerException.java
@@ -19,6 +19,7 @@ package com.google.cloud.spanner;
 import com.google.cloud.grpc.BaseGrpcServiceException;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.util.Durations;
+import com.google.rpc.ResourceInfo;
 import com.google.rpc.RetryInfo;
 import io.grpc.Metadata;
 import io.grpc.Status;
@@ -27,6 +28,24 @@ import javax.annotation.Nullable;
 
 /** Base exception type for all exceptions produced by the Cloud Spanner service. */
 public class SpannerException extends BaseGrpcServiceException {
+  /** Base exception type for NOT_FOUND exceptions for known resource types. */
+  public abstract static class ResourceNotFoundException extends SpannerException {
+    private final ResourceInfo resourceInfo;
+
+    ResourceNotFoundException(
+        DoNotConstructDirectly token,
+        @Nullable String message,
+        ResourceInfo resourceInfo,
+        @Nullable Throwable cause) {
+      super(token, ErrorCode.NOT_FOUND, /* retryable */ false, message, cause);
+      this.resourceInfo = resourceInfo;
+    }
+
+    public String getResourceName() {
+      return resourceInfo.getResourceName();
+    }
+  }
+
   private static final long serialVersionUID = 20150916L;
   private static final Metadata.Key<RetryInfo> KEY_RETRY_INFO =
       ProtoUtils.keyForProto(RetryInfo.getDefaultInstance());

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
@@ -21,12 +21,14 @@ import com.google.api.gax.rpc.ApiException;
 import com.google.cloud.spanner.SpannerException.DoNotConstructDirectly;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Predicate;
+import com.google.rpc.ResourceInfo;
 import io.grpc.Context;
+import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.ProtoUtils;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeoutException;
-import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLHandshakeException;
 
@@ -37,13 +39,11 @@ import javax.net.ssl.SSLHandshakeException;
  * ErrorCode#ABORTED} are always represented by {@link AbortedException}.
  */
 public final class SpannerExceptionFactory {
-  static final String DATABASE_NOT_FOUND_MSG =
-      "Database not found: projects/.*/instances/.*/databases/.*\n"
-          + "resource_type: \"type.googleapis.com/google.spanner.admin.database.v1.Database\"\n"
-          + "resource_name: \"projects/.*/instances/.*/databases/.*\"\n"
-          + "description: \"Database does not exist.\"\n";
-  private static final Pattern DATABASE_NOT_FOUND_MSG_PATTERN =
-      Pattern.compile(".*" + DATABASE_NOT_FOUND_MSG + ".*");
+  static final String SESSION_RESOURCE_TYPE = "type.googleapis.com/google.spanner.v1.Session";
+  static final String DATABASE_RESOURCE_TYPE =
+      "type.googleapis.com/google.spanner.admin.database.v1.Database";
+  private static final Metadata.Key<ResourceInfo> KEY_RESOURCE_INFO =
+      ProtoUtils.keyForProto(ResourceInfo.getDefaultInstance());
 
   public static SpannerException newSpannerException(ErrorCode code, @Nullable String message) {
     return newSpannerException(code, message, null);
@@ -175,6 +175,16 @@ public final class SpannerExceptionFactory {
     return message.startsWith(code.toString()) ? message : code + ": " + message;
   }
 
+  private static ResourceInfo extractResourceInfo(Throwable cause) {
+    if (cause != null) {
+      Metadata trailers = Status.trailersFromThrowable(cause);
+      if (trailers != null) {
+        return trailers.get(KEY_RESOURCE_INFO);
+      }
+    }
+    return null;
+  }
+
   private static SpannerException newSpannerExceptionPreformatted(
       ErrorCode code, @Nullable String message, @Nullable Throwable cause) {
     // This is the one place in the codebase that is allowed to call constructors directly.
@@ -183,10 +193,13 @@ public final class SpannerExceptionFactory {
       case ABORTED:
         return new AbortedException(token, message, cause);
       case NOT_FOUND:
-        if (message != null && message.contains("Session not found")) {
-          return new SessionNotFoundException(token, message, cause);
-        } else if (message != null && DATABASE_NOT_FOUND_MSG_PATTERN.matcher(message).matches()) {
-          return new DatabaseNotFoundException(token, message, cause);
+        ResourceInfo resourceInfo = extractResourceInfo(cause);
+        if (resourceInfo != null) {
+          if (resourceInfo.getResourceType().equals(SESSION_RESOURCE_TYPE)) {
+            return new SessionNotFoundException(token, message, resourceInfo, cause);
+          } else if (resourceInfo.getResourceType().equals(DATABASE_RESOURCE_TYPE)) {
+            return new DatabaseNotFoundException(token, message, resourceInfo, cause);
+          }
         }
         // Fall through to the default.
       default:

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolStressTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolStressTest.java
@@ -162,8 +162,7 @@ public class SessionPoolStressTest extends BaseSessionPoolTest {
                 synchronized (lock) {
                   if (expiredSessions.contains(session.getName())) {
                     return ApiFutures.immediateFailedFuture(
-                        SpannerExceptionFactory.newSpannerException(
-                            ErrorCode.NOT_FOUND, "Session not found"));
+                        SpannerExceptionFactoryTest.newSessionNotFoundException(session.getName()));
                   }
                   if (sessions.remove(session.getName()) == null) {
                     setFailed(closedSessions.get(session.getName()));
@@ -185,8 +184,7 @@ public class SessionPoolStressTest extends BaseSessionPoolTest {
               public Void answer(InvocationOnMock invocation) throws Throwable {
                 if (random.nextInt(100) < 10) {
                   expireSession(session);
-                  throw SpannerExceptionFactory.newSpannerException(
-                      ErrorCode.NOT_FOUND, "Session not found");
+                  throw SpannerExceptionFactoryTest.newSessionNotFoundException(session.getName());
                 }
                 synchronized (lock) {
                   if (sessions.put(session.getName(), true)) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerExceptionFactoryTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerExceptionFactoryTest.java
@@ -72,7 +72,7 @@ public class SpannerExceptionFactoryTest {
 
   private static ResourceNotFoundException newResourceNotFoundException(
       String shortName, String resourceType, String resourceName) {
-    return (SessionNotFoundException)
+    return (ResourceNotFoundException)
         SpannerExceptionFactory.newSpannerException(
             newStatusResourceNotFoundException(shortName, resourceType, resourceName));
   }
@@ -177,6 +177,13 @@ public class SpannerExceptionFactoryTest {
     SessionNotFoundException e =
         newSessionNotFoundException("projects/p/instances/i/databases/d/sessions/s");
     assertThat(e.getResourceName()).isEqualTo("projects/p/instances/i/databases/d/sessions/s");
+  }
+
+  @Test
+  public void databaseNotFound() {
+    DatabaseNotFoundException e =
+        newDatabaseNotFoundException("projects/p/instances/i/databases/d");
+    assertThat(e.getResourceName()).isEqualTo("projects/p/instances/i/databases/d");
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerExceptionFactoryTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerExceptionFactoryTest.java
@@ -20,7 +20,9 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.gax.grpc.GrpcStatusCode;
 import com.google.api.gax.rpc.ApiExceptionFactory;
+import com.google.cloud.spanner.SpannerException.ResourceNotFoundException;
 import com.google.protobuf.Duration;
+import com.google.rpc.ResourceInfo;
 import com.google.rpc.RetryInfo;
 import io.grpc.Context;
 import io.grpc.Metadata;
@@ -28,6 +30,7 @@ import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.ProtoUtils;
+import io.grpc.protobuf.lite.ProtoLiteUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -36,6 +39,44 @@ import org.mockito.Mockito;
 /** Unit tests for {@link SpannerExceptionFactory}. */
 @RunWith(JUnit4.class)
 public class SpannerExceptionFactoryTest {
+
+  static SessionNotFoundException newSessionNotFoundException(String name) {
+    return (SessionNotFoundException)
+        newResourceNotFoundException(
+            "Session", SpannerExceptionFactory.SESSION_RESOURCE_TYPE, name);
+  }
+
+  static DatabaseNotFoundException newDatabaseNotFoundException(String name) {
+    return (DatabaseNotFoundException)
+        newResourceNotFoundException(
+            "Database", SpannerExceptionFactory.DATABASE_RESOURCE_TYPE, name);
+  }
+
+  static StatusRuntimeException newStatusResourceNotFoundException(
+      String shortName, String resourceType, String resourceName) {
+    ResourceInfo resourceInfo =
+        ResourceInfo.newBuilder()
+            .setResourceType(resourceType)
+            .setResourceName(resourceName)
+            .build();
+    Metadata.Key<ResourceInfo> key =
+        Metadata.Key.of(
+            resourceInfo.getDescriptorForType().getFullName() + Metadata.BINARY_HEADER_SUFFIX,
+            ProtoLiteUtils.metadataMarshaller(resourceInfo));
+    Metadata trailers = new Metadata();
+    trailers.put(key, resourceInfo);
+    String message =
+        String.format("%s not found: %s with id %s not found", shortName, shortName, resourceName);
+    return Status.NOT_FOUND.withDescription(message).asRuntimeException(trailers);
+  }
+
+  private static ResourceNotFoundException newResourceNotFoundException(
+      String shortName, String resourceType, String resourceName) {
+    return (SessionNotFoundException)
+        SpannerExceptionFactory.newSpannerException(
+            newStatusResourceNotFoundException(shortName, resourceType, resourceName));
+  }
+
   @Test
   public void http2InternalErrorIsRetryable() {
     Status status =
@@ -132,13 +173,23 @@ public class SpannerExceptionFactoryTest {
   }
 
   @Test
+  public void sessionNotFound() {
+    SessionNotFoundException e =
+        newSessionNotFoundException("projects/p/instances/i/databases/d/sessions/s");
+    assertThat(e.getResourceName()).isEqualTo("projects/p/instances/i/databases/d/sessions/s");
+  }
+
+  @Test
   public void statusRuntimeExceptionSessionNotFound() {
     SpannerException spannerException =
         SpannerExceptionFactory.newSpannerException(
             Status.NOT_FOUND
                 .withDescription(
-                    "NOT_FOUND: Session not found: projects/<project>/instances/<instance>/databases/<database>/sessions/<session id>")
-                .asRuntimeException());
+                    "NOT_FOUND: Session not found: projects/p/instances/i/databases/d/sessions/s")
+                .asRuntimeException(
+                    createResourceTypeMetadata(
+                        SpannerExceptionFactory.SESSION_RESOURCE_TYPE,
+                        "projects/p/instances/i/databases/d/sessions/s")));
     assertThat(spannerException).isInstanceOf(SessionNotFoundException.class);
   }
 
@@ -147,10 +198,32 @@ public class SpannerExceptionFactoryTest {
     SpannerException spannerException =
         SpannerExceptionFactory.newSpannerException(
             ApiExceptionFactory.createException(
-                "NOT_FOUND: Session not found: projects/<project>/instances/<instance>/databases/<database>/sessions/<session id>",
-                null,
+                "NOT_FOUND: Session not found: projects/p/instances/i/databases/d/sessions/s",
+                Status.NOT_FOUND
+                    .withDescription(
+                        "NOT_FOUND: Session not found: projects/p/instances/i/databases/d/sessions/s")
+                    .asRuntimeException(
+                        createResourceTypeMetadata(
+                            SpannerExceptionFactory.SESSION_RESOURCE_TYPE,
+                            "projects/p/instances/i/databases/d/sessions/s")),
                 GrpcStatusCode.of(Code.NOT_FOUND),
                 false));
     assertThat(spannerException).isInstanceOf(SessionNotFoundException.class);
+  }
+
+  private Metadata createResourceTypeMetadata(String resourceType, String resourceName) {
+    ResourceInfo resourceInfo =
+        ResourceInfo.newBuilder()
+            .setResourceType(resourceType)
+            .setResourceName(resourceName)
+            .build();
+    Metadata.Key<ResourceInfo> key =
+        Metadata.Key.of(
+            resourceInfo.getDescriptorForType().getFullName() + Metadata.BINARY_HEADER_SUFFIX,
+            ProtoLiteUtils.metadataMarshaller(resourceInfo));
+    Metadata trailers = new Metadata();
+    trailers.put(key, resourceInfo);
+
+    return trailers;
   }
 }


### PR DESCRIPTION
Use the returned resource type instead of the error message to determine the type of error.