### PR TITLE
fix: stop sending RPCs on InstanceNotFound

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceNotFoundException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceNotFoundException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+import com.google.cloud.spanner.SpannerException.ResourceNotFoundException;
+import com.google.rpc.ResourceInfo;
+import javax.annotation.Nullable;
+
+/**
+ * Exception thrown by Cloud Spanner when an operation detects that the instance that is being used
+ * no longer exists. This type of error has its own subclass as it is a condition that should cause
+ * the client library to stop trying to send RPCs to the backend until the user has taken action.
+ */
+public class InstanceNotFoundException extends ResourceNotFoundException {
+  private static final long serialVersionUID = 45297002L;
+
+  /** Private constructor. Use {@link SpannerExceptionFactory} to create instances. */
+  InstanceNotFoundException(
+      DoNotConstructDirectly token,
+      @Nullable String message,
+      ResourceInfo resourceInfo,
+      @Nullable Throwable cause) {
+    super(token, message, resourceInfo, cause);
+  }
+}

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
@@ -42,6 +42,8 @@ public final class SpannerExceptionFactory {
   static final String SESSION_RESOURCE_TYPE = "type.googleapis.com/google.spanner.v1.Session";
   static final String DATABASE_RESOURCE_TYPE =
       "type.googleapis.com/google.spanner.admin.database.v1.Database";
+  static final String INSTANCE_RESOURCE_TYPE =
+      "type.googleapis.com/google.spanner.admin.instance.v1.Instance";
   private static final Metadata.Key<ResourceInfo> KEY_RESOURCE_INFO =
       ProtoUtils.keyForProto(ResourceInfo.getDefaultInstance());
 
@@ -199,6 +201,8 @@ public final class SpannerExceptionFactory {
             return new SessionNotFoundException(token, message, resourceInfo, cause);
           } else if (resourceInfo.getResourceType().equals(DATABASE_RESOURCE_TYPE)) {
             return new DatabaseNotFoundException(token, message, resourceInfo, cause);
+          } else if (resourceInfo.getResourceType().equals(INSTANCE_RESOURCE_TYPE)) {
+            return new InstanceNotFoundException(token, message, resourceInfo, cause);
           }
         }
         // Fall through to the default.

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerExceptionFactoryTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerExceptionFactoryTest.java
@@ -52,6 +52,12 @@ public class SpannerExceptionFactoryTest {
             "Database", SpannerExceptionFactory.DATABASE_RESOURCE_TYPE, name);
   }
 
+  static InstanceNotFoundException newInstanceNotFoundException(String name) {
+    return (InstanceNotFoundException)
+        newResourceNotFoundException(
+            "Instance", SpannerExceptionFactory.INSTANCE_RESOURCE_TYPE, name);
+  }
+
   static StatusRuntimeException newStatusResourceNotFoundException(
       String shortName, String resourceType, String resourceName) {
     ResourceInfo resourceInfo =
@@ -184,6 +190,12 @@ public class SpannerExceptionFactoryTest {
     DatabaseNotFoundException e =
         newDatabaseNotFoundException("projects/p/instances/i/databases/d");
     assertThat(e.getResourceName()).isEqualTo("projects/p/instances/i/databases/d");
+  }
+
+  @Test
+  public void instanceNotFound() {
+    InstanceNotFoundException e = newInstanceNotFoundException("projects/p/instances/i");
+    assertThat(e.getResourceName()).isEqualTo("projects/p/instances/i");
   }
 
   @Test


### PR DESCRIPTION
The session pool should handle InstanceNotFound in the same way as DatabaseNotFound errors, i.e. stop sending RPCs and also consider an instance that has been re-created with the same name
as a different instance, and hence require the user to re-create any database client before it can be used again.

Fixes #60
