### PR TITLE
WIP: Attempt at reproducing "refCount dropped below zero"

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
@@ -997,11 +997,11 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
             continue;
           }
           span.addAnnotation("Stream broken. Not safe to retry");
-          TraceUtil.endSpanWithFailure(span, e);
+          //TraceUtil.endSpanWithFailure(span, e);
           throw e;
         } catch (RuntimeException e) {
           span.addAnnotation("Stream broken. Not safe to retry");
-          TraceUtil.endSpanWithFailure(span, e);
+          //TraceUtil.endSpanWithFailure(span, e);
           throw e;
         }
       }


### PR DESCRIPTION
Added `closedSpanOnNonRetryableError` test. The interesting thing is
that after commenting out all `TraceUtil.endSpanWithFailure()` calls,
something is still closing the span without calling `close()` because
the test passes. Not sure where this could be happening. Might explain
why the refcount drops below zero.

Towards #71.