### PR TITLE
fix: never use credentials in combination with plain text

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -20,6 +20,7 @@ import com.google.api.core.ApiFunction;
 import com.google.api.gax.grpc.GrpcInterceptorProvider;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.cloud.NoCredentials;
 import com.google.cloud.ServiceDefaults;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.ServiceRpc;
@@ -422,6 +423,8 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
                 return builder.usePlaintext();
               }
             });
+        // As we are using plain text, we should never send any credentials.
+        this.setCredentials(NoCredentials.getInstance());
       }
       return new SpannerOptions(this);
     }


### PR DESCRIPTION
Credentials should never be used in combination with plain text communication. Setting an emulator host should therefore also automatically override any credentials that may have been set.