### PR TITLE
fix: only register metrics once

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MetricRegistryConstants.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MetricRegistryConstants.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.spanner;
 
+import com.google.api.gax.core.GaxProperties;
 import com.google.common.collect.ImmutableList;
 import io.opencensus.metrics.LabelKey;
 import io.opencensus.metrics.LabelValue;
@@ -23,20 +24,13 @@ import io.opencensus.metrics.LabelValue;
 class MetricRegistryConstants {
 
   // The label keys are used to uniquely identify timeseries.
-  private static final LabelKey DATABASE = LabelKey.create("database", "Target database");
-  private static final LabelKey INSTANCE_ID =
-      LabelKey.create("instance_id", "Name of the instance");
   private static final LabelKey LIBRARY_VERSION =
       LabelKey.create("library_version", "Library version");
 
-  /** The label value is used to represent missing value. */
-  private static final LabelValue UNSET_LABEL = LabelValue.create(null);
-
-  static final ImmutableList<LabelKey> SPANNER_LABEL_KEYS =
-      ImmutableList.of(DATABASE, INSTANCE_ID, LIBRARY_VERSION);
+  static final ImmutableList<LabelKey> SPANNER_LABEL_KEYS = ImmutableList.of(LIBRARY_VERSION);
 
   static final ImmutableList<LabelValue> SPANNER_DEFAULT_LABEL_VALUES =
-      ImmutableList.of(UNSET_LABEL, UNSET_LABEL, UNSET_LABEL);
+      ImmutableList.of(LabelValue.create(GaxProperties.getLibraryVersion(SpannerImpl.class)));
 
   /** Unit to represent counts. */
   static final String COUNT = "1";

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.spanner;
 
-import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.paging.Page;
 import com.google.cloud.BaseService;
 import com.google.cloud.PageImpl;
@@ -28,11 +27,9 @@ import com.google.cloud.spanner.spi.v1.SpannerRpc.Paginated;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.spanner.v1.ExecuteSqlRequest.QueryOptions;
-import io.opencensus.metrics.LabelValue;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
 import java.util.ArrayList;
@@ -153,14 +150,8 @@ class SpannerImpl extends BaseService<SpannerOptions> implements Spanner {
       if (dbClients.containsKey(db)) {
         return dbClients.get(db);
       } else {
-        List<LabelValue> labelValues =
-            ImmutableList.of(
-                LabelValue.create(db.getDatabase()),
-                LabelValue.create(db.getInstanceId().getName()),
-                LabelValue.create(GaxProperties.getLibraryVersion(getOptions().getClass())));
         SessionPool pool =
-            SessionPool.createPool(
-                getOptions(), SpannerImpl.this.getSessionClient(db), labelValues);
+            SessionPool.createPool(getOptions(), SpannerImpl.this.getSessionClient(db));
         DatabaseClientImpl dbClient = createDatabaseClient(pool);
         dbClients.put(db, dbClient);
         return dbClient;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -1577,11 +1577,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     FakeClock clock = new FakeClock();
     clock.currentTimeMillis = System.currentTimeMillis();
     FakeMetricRegistry metricRegistry = new FakeMetricRegistry();
-    List<LabelValue> labelValues =
-        Arrays.asList(
-            LabelValue.create("database1"),
-            LabelValue.create("instance1"),
-            LabelValue.create("1.0.0"));
+    List<LabelValue> labelValues = Arrays.asList(LabelValue.create("1.0.0"));
 
     setupMockSessionCreation();
     pool = createPool(clock, metricRegistry, labelValues);
@@ -1590,7 +1586,10 @@ public class SessionPoolTest extends BaseSessionPoolTest {
 
     MetricsRecord record = metricRegistry.pollRecord();
     assertThat(record.getMetrics().size()).isEqualTo(6);
-    assertThat(record.getMetrics()).containsEntry(MetricRegistryConstants.IN_USE_SESSIONS, 2L);
+    assertThat(record.getMetrics()).containsKey(MetricRegistryConstants.IN_USE_SESSIONS);
+    assertThat(record.getMetrics().get(MetricRegistryConstants.IN_USE_SESSIONS)).isEqualTo(2L);
+    //    assertThat(record.getMetrics()).containsEntry(MetricRegistryConstants.IN_USE_SESSIONS,
+    // 2L);
     assertThat(record.getMetrics()).containsEntry(MetricRegistryConstants.MAX_IN_USE_SESSIONS, 2L);
     assertThat(record.getMetrics()).containsEntry(MetricRegistryConstants.GET_SESSION_TIMEOUTS, 0L);
     assertThat(record.getMetrics())

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -1586,10 +1586,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
 
     MetricsRecord record = metricRegistry.pollRecord();
     assertThat(record.getMetrics().size()).isEqualTo(6);
-    assertThat(record.getMetrics()).containsKey(MetricRegistryConstants.IN_USE_SESSIONS);
-    assertThat(record.getMetrics().get(MetricRegistryConstants.IN_USE_SESSIONS)).isEqualTo(2L);
-    //    assertThat(record.getMetrics()).containsEntry(MetricRegistryConstants.IN_USE_SESSIONS,
-    // 2L);
+    assertThat(record.getMetrics()).containsEntry(MetricRegistryConstants.IN_USE_SESSIONS, 2L);
     assertThat(record.getMetrics()).containsEntry(MetricRegistryConstants.MAX_IN_USE_SESSIONS, 2L);
     assertThat(record.getMetrics()).containsEntry(MetricRegistryConstants.GET_SESSION_TIMEOUTS, 0L);
     assertThat(record.getMetrics())


### PR DESCRIPTION
The default MetricsRegistry used by OpenCensus is a singleton that does not allow the same metrics to be registered multiple times. The session pool metrics gathering did not take this into account, and when multiple session pools were created within the same class loader, it would throw
an InvalidArgumentException for the second session pool.

Fixes #106.