### PR TITLE
chore: use java helper for templates

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -64,9 +64,7 @@ java.format_code('proto-google-cloud-spanner-admin-database-v1/src')
 java.format_code('grpc-google-cloud-spanner-admin-instance-v1/src')
 java.format_code('proto-google-cloud-spanner-admin-instance-v1/src')
 
-common_templates = gcp.CommonTemplates()
-templates = common_templates.java_library()
-s.copy(templates, excludes=[
+java.common_templates(excludes=[
     'README.md',
     '.kokoro/continuous/common.cfg',
     '.kokoro/nightly/common.cfg',


### PR DESCRIPTION
We are cleaning up usage of common templates in synthtool. This allows us the cleanup usage in a centralized place rather than in 60+ repos