### PR TITLE
feat: add num_sessions_in_pool metric

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MetricRegistryConstants.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MetricRegistryConstants.java
@@ -30,12 +30,21 @@ class MetricRegistryConstants {
       LabelKey.create("instance_id", "Name of the instance");
   private static final LabelKey LIBRARY_VERSION =
       LabelKey.create("library_version", "Library version");
+  private static final LabelKey SESSION_TYPE = LabelKey.create("Type", "Type of the Sessions");
 
   /** The label value is used to represent missing value. */
   private static final LabelValue UNSET_LABEL = LabelValue.create(null);
 
+  static final LabelValue NUM_IN_USE_SESSIONS = LabelValue.create("num_in_use_sessions");
+  static final LabelValue NUM_SESSIONS_BEING_PREPARED =
+      LabelValue.create("num_sessions_being_prepared");
+  static final LabelValue NUM_READ_SESSIONS = LabelValue.create("num_read_sessions");
+  static final LabelValue NUM_WRITE_SESSIONS = LabelValue.create("num_write_prepared_sessions");
+
   static final ImmutableList<LabelKey> SPANNER_LABEL_KEYS =
       ImmutableList.of(CLIENT_ID, DATABASE, INSTANCE_ID, LIBRARY_VERSION);
+  static final ImmutableList<LabelKey> SPANNER_LABEL_KEYS_WITH_TYPE =
+      ImmutableList.of(CLIENT_ID, DATABASE, INSTANCE_ID, LIBRARY_VERSION, SESSION_TYPE);
 
   static final ImmutableList<LabelValue> SPANNER_DEFAULT_LABEL_VALUES =
       ImmutableList.of(UNSET_LABEL, UNSET_LABEL, UNSET_LABEL, UNSET_LABEL);
@@ -46,20 +55,20 @@ class MetricRegistryConstants {
   // The Metric name and description
   static final String MAX_IN_USE_SESSIONS = "cloud.google.com/java/spanner/max_in_use_sessions";
   static final String MAX_ALLOWED_SESSIONS = "cloud.google.com/java/spanner/max_allowed_sessions";
-  static final String IN_USE_SESSIONS = "cloud.google.com/java/spanner/in_use_sessions";
   static final String GET_SESSION_TIMEOUTS = "cloud.google.com/java/spanner/get_session_timeouts";
   static final String NUM_ACQUIRED_SESSIONS = "cloud.google.com/java/spanner/num_acquired_sessions";
   static final String NUM_RELEASED_SESSIONS = "cloud.google.com/java/spanner/num_released_sessions";
+  static final String NUM_SESSIONS_IN_POOL = "cloud.google.com/java/spanner/num_sessions_in_pool";
 
   static final String MAX_IN_USE_SESSIONS_DESCRIPTION =
       "The maximum number of sessions in use during the last 10 minute interval.";
   static final String MAX_ALLOWED_SESSIONS_DESCRIPTION =
       "The maximum number of sessions allowed. Configurable by the user.";
-  static final String IN_USE_SESSIONS_DESCRIPTION = "The number of sessions currently in use.";
   static final String SESSIONS_TIMEOUTS_DESCRIPTION =
       "The number of get sessions timeouts due to pool exhaustion";
   static final String NUM_ACQUIRED_SESSIONS_DESCRIPTION =
       "The number of sessions acquired from the session pool.";
   static final String NUM_RELEASED_SESSIONS_DESCRIPTION =
       "The number of sessions released by the user and pool maintainer.";
+  static final String NUM_SESSIONS_IN_POOL_DESCRIPTION = "The number of sessions in the pool.";
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -1710,7 +1710,6 @@ public class SessionPoolTest extends BaseSessionPoolTest {
 
     MetricsRecord record = metricRegistry.pollRecord();
     assertThat(record.getMetrics().size()).isEqualTo(6);
-    assertThat(record.getMetrics()).containsEntry(MetricRegistryConstants.IN_USE_SESSIONS, 2L);
     assertThat(record.getMetrics()).containsEntry(MetricRegistryConstants.MAX_IN_USE_SESSIONS, 2L);
     assertThat(record.getMetrics()).containsEntry(MetricRegistryConstants.GET_SESSION_TIMEOUTS, 0L);
     assertThat(record.getMetrics())
@@ -1757,7 +1756,6 @@ public class SessionPoolTest extends BaseSessionPoolTest {
         .containsEntry(MetricRegistryConstants.NUM_ACQUIRED_SESSIONS, 3L);
     assertThat(record.getMetrics())
         .containsEntry(MetricRegistryConstants.NUM_RELEASED_SESSIONS, 3L);
-    assertThat(record.getMetrics()).containsEntry(MetricRegistryConstants.IN_USE_SESSIONS, 0L);
     assertThat(record.getMetrics()).containsEntry(MetricRegistryConstants.MAX_IN_USE_SESSIONS, 2L);
   }
 


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-spanner/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Updates #53, this is based on the last discussion in the thread: https://github.com/googleapis/java-spanner/issues/53#issuecomment-601455550

This is how it looks in Stackdriver UI:
<img width="1172" alt="Screen Shot 2020-03-25 at 1 42 39 PM" src="https://user-images.githubusercontent.com/6525361/77595504-94562c00-6eb6-11ea-9403-79fc090480b4.png">

**Breaking Note:**
The `cloud.google.com/java/spanner/in_use_sessions` metric has been deprecated since v1.55.2, use `cloud.google.com/java/spanner/num_sessions_in_pool` instead.
