### PR TITLE
perf: increase sessions in the pool in batches

### DIFF
--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -111,7 +111,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
           <configuration>
-            <ignoredDependencies>io.grpc:grpc-protobuf-lite,org.hamcrest:hamcrest,org.hamcrest:hamcrest-core,com.google.errorprone:error_prone_annotations,com.google.api.grpc:grpc-google-cloud-spanner-v1,com.google.api.grpc:grpc-google-cloud-spanner-admin-instance-v1,com.google.api.grpc:grpc-google-cloud-spanner-admin-database-v1</ignoredDependencies>
+            <ignoredDependencies>io.grpc:grpc-protobuf-lite,org.hamcrest:hamcrest,org.hamcrest:hamcrest-core,com.google.errorprone:error_prone_annotations,org.openjdk.jmh:jmh-generator-annprocess,com.google.api.grpc:grpc-google-cloud-spanner-v1,com.google.api.grpc:grpc-google-cloud-spanner-admin-instance-v1,com.google.api.grpc:grpc-google-cloud-spanner-admin-database-v1</ignoredDependencies>
           </configuration>
         </plugin>
       </plugins>

--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -305,6 +305,20 @@
       <version>2.2</version>
       <scope>test</scope>
     </dependency>
+    
+    <!-- Benchmarking dependencies -->
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>1.23</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>1.23</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>
@@ -319,6 +333,36 @@
           <artifactId>javax.annotation-api</artifactId>
         </dependency>
       </dependencies>
+    </profile>
+    <profile>
+      <id>benchmark</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>run-benchmarks</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <classpathScope>test</classpathScope>
+                  <executable>java</executable>
+                  <arguments>
+                      <argument>-classpath</argument>
+                      <classpath />
+                      <argument>org.openjdk.jmh.Main</argument>
+                      <argument>.*</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -1795,7 +1795,7 @@ final class SessionPool {
     }
   }
 
-  private void createSessions(final int sessionCount, boolean initialization) {
+  private void createSessions(final int sessionCount, boolean distributeOverChannels) {
     logger.log(Level.FINE, String.format("Creating %d sessions", sessionCount));
     synchronized (lock) {
       numSessionsBeingCreated += sessionCount;
@@ -1804,7 +1804,8 @@ final class SessionPool {
         // calls and the session consumer consumes the returned sessions as they become available.
         // The batchCreateSessions method automatically spreads the sessions evenly over all
         // available channels.
-        sessionClient.asyncBatchCreateSessions(sessionCount, initialization, sessionConsumer);
+        sessionClient.asyncBatchCreateSessions(
+            sessionCount, distributeOverChannels, sessionConsumer);
       } catch (Throwable t) {
         // Expose this to customer via a metric.
         numSessionsBeingCreated -= sessionCount;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -1718,13 +1718,6 @@ final class SessionPool {
     }
   }
 
-  @VisibleForTesting
-  int numSessionsTotalAndCreating() {
-    synchronized (lock) {
-      return totalSessions() + numSessionsBeingCreated;
-    }
-  }
-
   private ApiFuture<Empty> closeSessionAsync(final PooledSession sess) {
     ApiFuture<Empty> res = sess.delegate.asyncClose();
     res.addListener(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -1077,7 +1077,7 @@ final class SessionPool {
         // If we have gone below min pool size, create that many sessions.
         int sessionCount = options.getMinSessions() - (totalSessions() + numSessionsBeingCreated);
         if (sessionCount > 0) {
-          createSessions(getAllowedCreateSessions(sessionCount));
+          createSessions(getAllowedCreateSessions(sessionCount), false);
         }
       }
     }
@@ -1269,7 +1269,7 @@ final class SessionPool {
     synchronized (lock) {
       poolMaintainer.init();
       if (options.getMinSessions() > 0) {
-        createSessions(options.getMinSessions());
+        createSessions(options.getMinSessions(), true);
       }
     }
   }
@@ -1308,7 +1308,7 @@ final class SessionPool {
       }
       allSessions.remove(session);
       // replenish the pool.
-      createSessions(getAllowedCreateSessions(1));
+      createSessions(getAllowedCreateSessions(1), false);
     }
   }
 
@@ -1507,7 +1507,7 @@ final class SessionPool {
       if (numWaiters() >= numSessionsBeingCreated) {
         if (canCreateSession()) {
           span.addAnnotation("Creating sessions");
-          createSessions(getAllowedCreateSessions(numWaiters() - numSessionsBeingCreated + 1));
+          createSessions(getAllowedCreateSessions(options.getIncStep()), false);
         } else if (options.isFailIfPoolExhausted()) {
           span.addAnnotation("Pool exhausted. Failing");
           // throw specific exception
@@ -1718,6 +1718,13 @@ final class SessionPool {
     }
   }
 
+  @VisibleForTesting
+  int numSessionsTotalAndCreating() {
+    synchronized (lock) {
+      return totalSessions() + numSessionsBeingCreated;
+    }
+  }
+
   private ApiFuture<Empty> closeSessionAsync(final PooledSession sess) {
     ApiFuture<Empty> res = sess.delegate.asyncClose();
     res.addListener(
@@ -1732,7 +1739,8 @@ final class SessionPool {
               }
               // Create a new session if needed to unblock some waiter.
               if (numWaiters() > numSessionsBeingCreated) {
-                createSessions(getAllowedCreateSessions(numWaiters() - numSessionsBeingCreated));
+                createSessions(
+                    getAllowedCreateSessions(numWaiters() - numSessionsBeingCreated), false);
               }
             }
           }
@@ -1794,7 +1802,7 @@ final class SessionPool {
     }
   }
 
-  private void createSessions(final int sessionCount) {
+  private void createSessions(final int sessionCount, boolean initialization) {
     logger.log(Level.FINE, String.format("Creating %d sessions", sessionCount));
     synchronized (lock) {
       numSessionsBeingCreated += sessionCount;
@@ -1803,8 +1811,7 @@ final class SessionPool {
         // calls and the session consumer consumes the returned sessions as they become available.
         // The batchCreateSessions method automatically spreads the sessions evenly over all
         // available channels.
-        sessionClient.asyncBatchCreateSessions(sessionCount, sessionConsumer);
-        logger.log(Level.FINE, "Sessions created");
+        sessionClient.asyncBatchCreateSessions(sessionCount, initialization, sessionConsumer);
       } catch (Throwable t) {
         // Expose this to customer via a metric.
         numSessionsBeingCreated -= sessionCount;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
@@ -24,9 +24,11 @@ public class SessionPoolOptions {
   // Default number of channels * 100.
   private static final int DEFAULT_MAX_SESSIONS = 400;
   private static final int DEFAULT_MIN_SESSIONS = 100;
+  private static final int DEFAULT_INC_STEP = 25;
   private static final ActionOnExhaustion DEFAULT_ACTION = ActionOnExhaustion.BLOCK;
   private final int minSessions;
   private final int maxSessions;
+  private final int incStep;
   private final int maxIdleSessions;
   private final float writeSessionsFraction;
   private final ActionOnExhaustion actionOnExhaustion;
@@ -40,6 +42,7 @@ public class SessionPoolOptions {
     // maxSessions value is less than the default for minSessions.
     this.minSessions = Math.min(builder.minSessions, builder.maxSessions);
     this.maxSessions = builder.maxSessions;
+    this.incStep = builder.incStep;
     this.maxIdleSessions = builder.maxIdleSessions;
     this.writeSessionsFraction = builder.writeSessionsFraction;
     this.actionOnExhaustion = builder.actionOnExhaustion;
@@ -54,6 +57,10 @@ public class SessionPoolOptions {
 
   public int getMaxSessions() {
     return maxSessions;
+  }
+
+  int getIncStep() {
+    return incStep;
   }
 
   public int getMaxIdleSessions() {
@@ -105,6 +112,7 @@ public class SessionPoolOptions {
     private boolean minSessionsSet = false;
     private int minSessions = DEFAULT_MIN_SESSIONS;
     private int maxSessions = DEFAULT_MAX_SESSIONS;
+    private int incStep = DEFAULT_INC_STEP;
     private int maxIdleSessions;
     private float writeSessionsFraction = 0.2f;
     private ActionOnExhaustion actionOnExhaustion = DEFAULT_ACTION;
@@ -132,6 +140,16 @@ public class SessionPoolOptions {
     public Builder setMaxSessions(int maxSessions) {
       Preconditions.checkArgument(maxSessions > 0, "maxSessions must be > 0");
       this.maxSessions = maxSessions;
+      return this;
+    }
+
+    /**
+     * Number of sessions to batch create when the pool needs at least one more session. Defaults to
+     * 25.
+     */
+    Builder setIncStep(int incStep) {
+      Preconditions.checkArgument(incStep > 0, "incStep must be > 0");
+      this.incStep = incStep;
       return this;
     }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BatchCreateSessionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BatchCreateSessionsTest.java
@@ -104,6 +104,7 @@ public class BatchCreateSessionsTest {
   @Before
   public void setUp() throws IOException {
     mockSpanner.reset();
+    mockSpanner.removeAllExecutionTimes();
   }
 
   private Spanner createSpanner(int minSessions, int maxSessions) {
@@ -245,7 +246,7 @@ public class BatchCreateSessionsTest {
     int maxSessions = 1000;
     DatabaseClientImpl client = null;
     mockSpanner.setBeginTransactionExecutionTime(
-        SimulatedExecutionTime.ofException(
+        SimulatedExecutionTime.ofStickyException(
             Status.ABORTED.withDescription("BeginTransaction failed").asRuntimeException()));
     try (Spanner spanner = createSpanner(minSessions, maxSessions)) {
       client =

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -23,7 +23,6 @@ import com.google.cloud.spanner.TransactionRunnerImpl.TransactionContextImpl;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.protobuf.AbstractMessage;
 import com.google.protobuf.ByteString;
@@ -1622,10 +1621,6 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
     } catch (Throwable t) {
       responseObserver.onError(Status.INTERNAL.asRuntimeException());
     }
-  }
-
-  public List<Session> dumpSessions() {
-    return ImmutableList.copyOf(this.sessions.values());
   }
 
   @Override

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -23,6 +23,7 @@ import com.google.cloud.spanner.TransactionRunnerImpl.TransactionContextImpl;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.protobuf.AbstractMessage;
 import com.google.protobuf.ByteString;
@@ -1621,6 +1622,10 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
     } catch (Throwable t) {
       responseObserver.onError(Status.INTERNAL.asRuntimeException());
     }
+  }
+
+  public List<Session> dumpSessions() {
+    return ImmutableList.copyOf(this.sessions.values());
   }
 
   @Override

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionClientTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionClientTest.java
@@ -182,7 +182,7 @@ public class SessionClientTest {
         };
     final int numSessions = 10;
     try (SessionClient client = new SessionClient(spanner, db, new TestExecutorFactory())) {
-      client.asyncBatchCreateSessions(numSessions, consumer);
+      client.asyncBatchCreateSessions(numSessions, true, consumer);
     }
     assertThat(returnedSessionCount.get()).isEqualTo(numSessions);
     assertThat(usedChannels.size()).isEqualTo(spannerOptions.getNumChannels());
@@ -275,7 +275,7 @@ public class SessionClientTest {
             };
         final int numSessions = 10;
         try (SessionClient client = new SessionClient(spanner, db, new TestExecutorFactory())) {
-          client.asyncBatchCreateSessions(numSessions, consumer);
+          client.asyncBatchCreateSessions(numSessions, true, consumer);
         }
         assertThat(errorCount.get()).isEqualTo(errorOnChannels.size());
         assertThat(returnedSessionCount.get())
@@ -330,7 +330,7 @@ public class SessionClientTest {
     // sessions.
     final int numSessions = 100;
     try (SessionClient client = new SessionClient(spanner, db, new TestExecutorFactory())) {
-      client.asyncBatchCreateSessions(numSessions, consumer);
+      client.asyncBatchCreateSessions(numSessions, true, consumer);
     }
     assertThat(returnedSessionCount.get()).isEqualTo(numSessions);
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolBenchmark.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolBenchmark.java
@@ -279,9 +279,6 @@ public class SessionPoolBenchmark {
     }
     Futures.allAsList(futures).get();
     service.shutdown();
-    //    assertThat(pool.totalSessions()).isEqualTo(server.maxSessions);
-    //    assertThat(server.countRequests(BatchCreateSessionsRequest.class))
-    //        .isEqualTo(server.expectedStepsToMax());
   }
 
   /** Measures the time needed to execute a burst of write requests. */
@@ -317,9 +314,6 @@ public class SessionPoolBenchmark {
     }
     Futures.allAsList(futures).get();
     service.shutdown();
-    //    assertThat(pool.totalSessions()).isEqualTo(server.maxSessions);
-    //    assertThat(server.countRequests(BatchCreateSessionsRequest.class))
-    //        .isEqualTo(server.expectedStepsToMax());
   }
 
   /** Measures the time needed to execute a burst of read and write requests. */
@@ -372,9 +366,6 @@ public class SessionPoolBenchmark {
     }
     Futures.allAsList(futures).get();
     service.shutdown();
-    //    assertThat(pool.totalSessions()).isEqualTo(server.maxSessions);
-    //    assertThat(server.countRequests(BatchCreateSessionsRequest.class))
-    //        .isEqualTo(server.expectedStepsToMax());
   }
 
   /** Measures the time needed to acquire MaxSessions session sequentially. */
@@ -393,9 +384,5 @@ public class SessionPoolBenchmark {
     for (ReadOnlyTransaction tx : transactions) {
       tx.close();
     }
-
-    //    assertThat(pool.totalSessions()).isEqualTo(server.maxSessions);
-    //    assertThat(server.countRequests(BatchCreateSessionsRequest.class))
-    //        .isEqualTo(server.expectedStepsToMax());
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolBenchmark.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolBenchmark.java
@@ -1,0 +1,387 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.gax.grpc.testing.LocalChannelProvider;
+import com.google.cloud.NoCredentials;
+import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
+import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.protobuf.AbstractMessage;
+import com.google.protobuf.ListValue;
+import com.google.spanner.v1.BatchCreateSessionsRequest;
+import com.google.spanner.v1.ResultSetMetadata;
+import com.google.spanner.v1.StructType;
+import com.google.spanner.v1.StructType.Field;
+import com.google.spanner.v1.TypeCode;
+import io.grpc.Server;
+import io.grpc.Status;
+import io.grpc.inprocess.InProcessServerBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+/**
+ * Benchmarks for common session pool scenarios. The simulated execution times are based on
+ * reasonable estimates and are primarily intended to keep the benchmarks comparable with each other
+ * before and after changes have been made to the pool. The benchmarks are bound to the build
+ * profile `benchmark` and can be executed like this: `mvn test -Pbenchmark`
+ */
+@BenchmarkMode(Mode.SingleShotTime)
+@Fork(value = 1, warmups = 0)
+@Measurement(batchSize = 1, iterations = 1, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class SessionPoolBenchmark {
+  private static final String TEST_PROJECT = "my-project";
+  private static final String TEST_INSTANCE = "my-instance";
+  private static final String TEST_DATABASE = "my-database";
+  private static final int HOLD_SESSION_TIME = 100;
+  private static final int RND_WAIT_TIME_BETWEEN_REQUESTS = 10;
+  private static final Random RND = new Random();
+
+  public static void main(String[] args) throws Exception {
+    org.openjdk.jmh.Main.main(args);
+  }
+
+  @State(Scope.Benchmark)
+  public static class MockServer {
+    private static final int NETWORK_LATENCY_TIME = 10;
+    private static final int BATCH_CREATE_SESSIONS_MIN_TIME = 10;
+    private static final int BATCH_CREATE_SESSIONS_RND_TIME = 10;
+    private static final int BEGIN_TRANSACTION_MIN_TIME = 1;
+    private static final int BEGIN_TRANSACTION_RND_TIME = 1;
+    private static final int COMMIT_TRANSACTION_MIN_TIME = 5;
+    private static final int COMMIT_TRANSACTION_RND_TIME = 5;
+    private static final int ROLLBACK_TRANSACTION_MIN_TIME = 1;
+    private static final int ROLLBACK_TRANSACTION_RND_TIME = 1;
+    private static final int EXECUTE_STREAMING_SQL_MIN_TIME = 10;
+    private static final int EXECUTE_STREAMING_SQL_RND_TIME = 10;
+    private static final int EXECUTE_SQL_MIN_TIME = 10;
+    private static final int EXECUTE_SQL_RND_TIME = 10;
+
+    private static final Statement UPDATE_STATEMENT =
+        Statement.of("UPDATE FOO SET BAR=1 WHERE BAZ=2");
+    private static final Statement INVALID_UPDATE_STATEMENT =
+        Statement.of("UPDATE NON_EXISTENT_TABLE SET BAR=1 WHERE BAZ=2");
+    private static final long UPDATE_COUNT = 1L;
+    private static final Statement SELECT1 = Statement.of("SELECT 1 AS COL1");
+    private static final ResultSetMetadata SELECT1_METADATA =
+        ResultSetMetadata.newBuilder()
+            .setRowType(
+                StructType.newBuilder()
+                    .addFields(
+                        Field.newBuilder()
+                            .setName("COL1")
+                            .setType(
+                                com.google.spanner.v1.Type.newBuilder()
+                                    .setCode(TypeCode.INT64)
+                                    .build())
+                            .build())
+                    .build())
+            .build();
+    private static final com.google.spanner.v1.ResultSet SELECT1_RESULTSET =
+        com.google.spanner.v1.ResultSet.newBuilder()
+            .addRows(
+                ListValue.newBuilder()
+                    .addValues(com.google.protobuf.Value.newBuilder().setStringValue("1").build())
+                    .build())
+            .setMetadata(SELECT1_METADATA)
+            .build();
+    private MockSpannerServiceImpl mockSpanner;
+    private Server server;
+    private LocalChannelProvider channelProvider;
+
+    private Spanner spanner;
+    private DatabaseClientImpl client;
+
+    @Param({"100"})
+    int minSessions;
+
+    @Param({"400"})
+    int maxSessions;
+
+    @Param({"1", "10", "20", "25", "30", "40", "50", "100"})
+    int incStep;
+
+    @Param({"4"})
+    int numChannels;
+
+    @Param({"0.2"})
+    float writeFraction;
+
+    @Setup(Level.Invocation)
+    public void setup() throws Exception {
+      mockSpanner = new MockSpannerServiceImpl();
+      mockSpanner.setAbortProbability(
+          0.0D); // We don't want any unpredictable aborted transactions.
+      mockSpanner.putStatementResult(StatementResult.update(UPDATE_STATEMENT, UPDATE_COUNT));
+      mockSpanner.putStatementResult(StatementResult.query(SELECT1, SELECT1_RESULTSET));
+      mockSpanner.putStatementResult(
+          StatementResult.exception(
+              INVALID_UPDATE_STATEMENT,
+              Status.INVALID_ARGUMENT.withDescription("invalid statement").asRuntimeException()));
+
+      mockSpanner.setBatchCreateSessionsExecutionTime(
+          SimulatedExecutionTime.ofMinimumAndRandomTime(
+              NETWORK_LATENCY_TIME + BATCH_CREATE_SESSIONS_MIN_TIME,
+              BATCH_CREATE_SESSIONS_RND_TIME));
+      mockSpanner.setBeginTransactionExecutionTime(
+          SimulatedExecutionTime.ofMinimumAndRandomTime(
+              NETWORK_LATENCY_TIME + BEGIN_TRANSACTION_MIN_TIME, BEGIN_TRANSACTION_RND_TIME));
+      mockSpanner.setCommitExecutionTime(
+          SimulatedExecutionTime.ofMinimumAndRandomTime(
+              NETWORK_LATENCY_TIME + COMMIT_TRANSACTION_MIN_TIME, COMMIT_TRANSACTION_RND_TIME));
+      mockSpanner.setRollbackExecutionTime(
+          SimulatedExecutionTime.ofMinimumAndRandomTime(
+              NETWORK_LATENCY_TIME + ROLLBACK_TRANSACTION_MIN_TIME, ROLLBACK_TRANSACTION_RND_TIME));
+      mockSpanner.setExecuteStreamingSqlExecutionTime(
+          SimulatedExecutionTime.ofMinimumAndRandomTime(
+              NETWORK_LATENCY_TIME + EXECUTE_STREAMING_SQL_MIN_TIME,
+              EXECUTE_STREAMING_SQL_RND_TIME));
+      mockSpanner.setExecuteSqlExecutionTime(
+          SimulatedExecutionTime.ofMinimumAndRandomTime(
+              NETWORK_LATENCY_TIME + EXECUTE_SQL_MIN_TIME, EXECUTE_SQL_RND_TIME));
+
+      String uniqueName = InProcessServerBuilder.generateName();
+      server = InProcessServerBuilder.forName(uniqueName).addService(mockSpanner).build().start();
+      channelProvider = LocalChannelProvider.create(uniqueName);
+
+      SpannerOptions options =
+          SpannerOptions.newBuilder()
+              .setProjectId(TEST_PROJECT)
+              .setChannelProvider(channelProvider)
+              .setNumChannels(numChannels)
+              .setCredentials(NoCredentials.getInstance())
+              .setSessionPoolOption(
+                  SessionPoolOptions.newBuilder()
+                      .setMinSessions(minSessions)
+                      .setMaxSessions(maxSessions)
+                      .setIncStep(incStep)
+                      .setWriteSessionsFraction(writeFraction)
+                      .build())
+              .build();
+
+      spanner = options.getService();
+      client =
+          (DatabaseClientImpl)
+              spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+      // Wait until the session pool has initialized.
+      while (client.pool.getNumberOfSessionsInPool()
+          < spanner.getOptions().getSessionPoolOptions().getMinSessions()) {
+        Thread.sleep(1L);
+      }
+    }
+
+    @TearDown(Level.Trial)
+    public void teardown() throws Exception {
+      spanner.close();
+      server.shutdown();
+      server.awaitTermination();
+    }
+
+    int expectedStepsToMax() {
+      int remainder = (maxSessions - minSessions) % incStep == 0 ? 0 : 1;
+      return numChannels + ((maxSessions - minSessions) / incStep) + remainder;
+    }
+
+    int countRequests(final Class<? extends AbstractMessage> type) {
+      return Collections2.filter(
+              mockSpanner.getRequests(),
+              new Predicate<AbstractMessage>() {
+                @Override
+                public boolean apply(AbstractMessage input) {
+                  return input.getClass().equals(type);
+                }
+              })
+          .size();
+    }
+  }
+
+  /** Measures the time needed to execute a burst of read requests. */
+  @Benchmark
+  public void burstRead(final MockServer server) throws Exception {
+    int totalQueries = server.maxSessions * 8;
+    int parallelThreads = server.maxSessions * 2;
+    final DatabaseClient client =
+        server.spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+    SessionPool pool = ((DatabaseClientImpl) client).pool;
+    assertThat(pool.totalSessions()).isEqualTo(server.minSessions);
+
+    ListeningScheduledExecutorService service =
+        MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(parallelThreads));
+    List<ListenableFuture<?>> futures = new ArrayList<>(totalQueries);
+    for (int i = 0; i < totalQueries; i++) {
+      futures.add(
+          service.submit(
+              new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                  Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
+                  try (ResultSet rs = client.singleUse().executeQuery(MockServer.SELECT1)) {
+                    while (rs.next()) {
+                      Thread.sleep(RND.nextInt(HOLD_SESSION_TIME));
+                    }
+                    return null;
+                  }
+                }
+              }));
+    }
+    Futures.allAsList(futures).get();
+    service.shutdown();
+    assertThat(pool.totalSessions()).isEqualTo(server.maxSessions);
+    assertThat(server.countRequests(BatchCreateSessionsRequest.class))
+        .isEqualTo(server.expectedStepsToMax());
+  }
+
+  /** Measures the time needed to execute a burst of write requests. */
+  @Benchmark
+  public void burstWrite(final MockServer server) throws Exception {
+    int totalWrites = server.maxSessions * 8;
+    int parallelThreads = server.maxSessions * 2;
+    final DatabaseClient client =
+        server.spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+    SessionPool pool = ((DatabaseClientImpl) client).pool;
+    assertThat(pool.totalSessions()).isEqualTo(server.minSessions);
+
+    ListeningScheduledExecutorService service =
+        MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(parallelThreads));
+    List<ListenableFuture<?>> futures = new ArrayList<>(totalWrites);
+    for (int i = 0; i < totalWrites; i++) {
+      futures.add(
+          service.submit(
+              new Callable<Long>() {
+                @Override
+                public Long call() throws Exception {
+                  Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
+                  TransactionRunner runner = client.readWriteTransaction();
+                  return runner.run(
+                      new TransactionCallable<Long>() {
+                        @Override
+                        public Long run(TransactionContext transaction) throws Exception {
+                          return transaction.executeUpdate(MockServer.UPDATE_STATEMENT);
+                        }
+                      });
+                }
+              }));
+    }
+    Futures.allAsList(futures).get();
+    service.shutdown();
+    assertThat(pool.totalSessions()).isEqualTo(server.maxSessions);
+    assertThat(server.countRequests(BatchCreateSessionsRequest.class))
+        .isEqualTo(server.expectedStepsToMax());
+  }
+
+  /** Measures the time needed to execute a burst of read and write requests. */
+  @Benchmark
+  public void burstReadAndWrite(final MockServer server) throws Exception {
+    int totalWrites = server.maxSessions * 4;
+    int totalReads = server.maxSessions * 4;
+    int parallelThreads = server.maxSessions * 2;
+    final DatabaseClient client =
+        server.spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+    SessionPool pool = ((DatabaseClientImpl) client).pool;
+    assertThat(pool.totalSessions()).isEqualTo(server.minSessions);
+
+    ListeningScheduledExecutorService service =
+        MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(parallelThreads));
+    List<ListenableFuture<?>> futures = new ArrayList<>(totalReads + totalWrites);
+    for (int i = 0; i < totalWrites; i++) {
+      futures.add(
+          service.submit(
+              new Callable<Long>() {
+                @Override
+                public Long call() throws Exception {
+                  Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
+                  TransactionRunner runner = client.readWriteTransaction();
+                  return runner.run(
+                      new TransactionCallable<Long>() {
+                        @Override
+                        public Long run(TransactionContext transaction) throws Exception {
+                          return transaction.executeUpdate(MockServer.UPDATE_STATEMENT);
+                        }
+                      });
+                }
+              }));
+    }
+    for (int i = 0; i < totalReads; i++) {
+      futures.add(
+          service.submit(
+              new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                  Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
+                  try (ResultSet rs = client.singleUse().executeQuery(MockServer.SELECT1)) {
+                    while (rs.next()) {
+                      Thread.sleep(RND.nextInt(HOLD_SESSION_TIME));
+                    }
+                    return null;
+                  }
+                }
+              }));
+    }
+    Futures.allAsList(futures).get();
+    service.shutdown();
+    assertThat(pool.totalSessions()).isEqualTo(server.maxSessions);
+    assertThat(server.countRequests(BatchCreateSessionsRequest.class))
+        .isEqualTo(server.expectedStepsToMax());
+  }
+
+  /** Measures the time needed to acquire MaxSessions session sequentially. */
+  @Benchmark
+  public void steadyIncrease(MockServer server) throws Exception {
+    final DatabaseClient client =
+        server.spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+    SessionPool pool = ((DatabaseClientImpl) client).pool;
+    assertThat(pool.totalSessions()).isEqualTo(server.minSessions);
+
+    // Checkout maxSessions sessions by starting maxSessions read-only transactions sequentially.
+    List<ReadOnlyTransaction> transactions = new ArrayList<>(server.maxSessions);
+    for (int i = 0; i < server.maxSessions; i++) {
+      transactions.add(client.readOnlyTransaction());
+    }
+    for (ReadOnlyTransaction tx : transactions) {
+      tx.close();
+    }
+
+    assertThat(pool.totalSessions()).isEqualTo(server.maxSessions);
+    assertThat(server.countRequests(BatchCreateSessionsRequest.class))
+        .isEqualTo(server.expectedStepsToMax());
+  }
+}

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolLeakTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolLeakTest.java
@@ -81,7 +81,7 @@ public class SessionPoolLeakTest {
             .setChannelProvider(channelProvider)
             .setCredentials(NoCredentials.getInstance());
     // Make sure the session pool is empty by default, does not contain any write-prepared sessions,
-    // contains at most 2 sessions and creates sessions in steps of 1.
+    // contains at most 2 sessions, and creates sessions in steps of 1.
     builder.setSessionPoolOption(
         SessionPoolOptions.newBuilder()
             .setMinSessions(0)

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolLeakTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolLeakTest.java
@@ -81,11 +81,12 @@ public class SessionPoolLeakTest {
             .setChannelProvider(channelProvider)
             .setCredentials(NoCredentials.getInstance());
     // Make sure the session pool is empty by default, does not contain any write-prepared sessions,
-    // and contains at most 2 sessions.
+    // contains at most 2 sessions and creates sessions in steps of 1.
     builder.setSessionPoolOption(
         SessionPoolOptions.newBuilder()
             .setMinSessions(0)
             .setMaxSessions(2)
+            .setIncStep(1)
             .setWriteSessionsFraction(0.0f)
             .build());
     spanner = builder.build().getService();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolStressTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolStressTest.java
@@ -128,7 +128,7 @@ public class SessionPoolStressTest extends BaseSessionPoolTest {
                       maxAliveSessions = sessions.size();
                     }
                     SessionConsumerImpl consumer =
-                        invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
                     consumer.onSessionReady(session);
                   }
                 }
@@ -136,7 +136,8 @@ public class SessionPoolStressTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.anyInt(), Mockito.any(SessionConsumer.class));
+        .asyncBatchCreateSessions(
+            Mockito.anyInt(), Mockito.anyBoolean(), Mockito.any(SessionConsumer.class));
   }
 
   private void setupSession(final Session session) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -136,6 +136,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
         SessionPoolOptions.newBuilder()
             .setMinSessions(minSessions)
             .setMaxSessions(2)
+            .setIncStep(1)
             .setBlockIfPoolExhausted()
             .build();
   }
@@ -151,7 +152,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       public void run() {
                         int sessionCount = invocation.getArgumentAt(0, Integer.class);
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         for (int i = 0; i < sessionCount; i++) {
                           consumer.onSessionReady(mockSession());
                         }
@@ -161,7 +162,8 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.anyInt(), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(
+            Mockito.anyInt(), Mockito.anyBoolean(), any(SessionConsumer.class));
   }
 
   @Test
@@ -220,7 +222,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(sessions.pop());
                       }
                     });
@@ -228,7 +230,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
     Session session1 = pool.getReadSession();
     // Leaked sessions
@@ -278,7 +280,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(session1);
                       }
                     });
@@ -296,7 +298,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                         insideCreation.countDown();
                         releaseCreation.await();
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(session2);
                         return null;
                       }
@@ -305,7 +307,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
 
     pool = createPool();
     PooledSession leakedSession = pool.getReadSession();
@@ -336,7 +338,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(session1);
                       }
                     });
@@ -354,7 +356,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                         insideCreation.countDown();
                         releaseCreation.await();
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(session2);
                         return null;
                       }
@@ -363,7 +365,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
 
     pool = createPool();
     PooledSession leakedSession = pool.getReadSession();
@@ -394,7 +396,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                         insideCreation.countDown();
                         releaseCreation.await();
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionCreateFailure(
                             SpannerExceptionFactory.newSpannerException(new RuntimeException()), 1);
                         return null;
@@ -404,7 +406,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
     AtomicBoolean failed = new AtomicBoolean(false);
     CountDownLatch latch = new CountDownLatch(1);
@@ -428,7 +430,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(session);
                       }
                     });
@@ -436,7 +438,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     final CountDownLatch insidePrepare = new CountDownLatch(1);
     final CountDownLatch releasePrepare = new CountDownLatch(1);
     doAnswer(
@@ -473,7 +475,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(session);
                       }
                     });
@@ -481,7 +483,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
     PooledSession leakedSession = pool.getReadSession();
     // Suppress expected leakedSession warning.
@@ -503,7 +505,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     }
     Uninterruptibles.awaitUninterruptibly(latch);
     verify(sessionClient, atMost(options.getMaxSessions()))
-        .asyncBatchCreateSessions(eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     assertThat(failed.get()).isFalse();
   }
 
@@ -518,7 +520,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public Void call() throws Exception {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionCreateFailure(
                             SpannerExceptionFactory.newSpannerException(ErrorCode.INTERNAL, ""), 1);
                         return null;
@@ -528,7 +530,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
     expectedException.expect(isSpannerException(ErrorCode.INTERNAL));
     pool.getReadSession();
@@ -545,7 +547,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public Void call() throws Exception {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionCreateFailure(
                             SpannerExceptionFactory.newSpannerException(ErrorCode.INTERNAL, ""), 1);
                         return null;
@@ -555,7 +557,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
     expectedException.expect(isSpannerException(ErrorCode.INTERNAL));
     pool.getReadWriteSession();
@@ -573,7 +575,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(session);
                       }
                     });
@@ -581,7 +583,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     doThrow(SpannerExceptionFactory.newSpannerException(ErrorCode.INTERNAL, ""))
         .when(session)
         .prepareReadWriteTransaction();
@@ -602,7 +604,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(mockSession);
                       }
                     });
@@ -610,7 +612,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
     try (Session session = pool.getReadWriteSession()) {
       assertThat(session).isNotNull();
@@ -633,7 +635,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(sessions.pop());
                       }
                     });
@@ -641,7 +643,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
     Session session1 = pool.getReadWriteSession();
     Session session2 = pool.getReadWriteSession();
@@ -664,7 +666,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(session);
                       }
                     });
@@ -672,7 +674,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
 
     pool = createPool();
     int numSessions = 5;
@@ -719,7 +721,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(mockSession1);
                         consumer.onSessionReady(mockSession2);
                       }
@@ -728,7 +730,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(2), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(2), Mockito.anyBoolean(), any(SessionConsumer.class));
 
     options =
         SessionPoolOptions.newBuilder()
@@ -770,7 +772,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(mockSession1);
                       }
                     });
@@ -778,7 +780,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     options =
         SessionPoolOptions.newBuilder()
             .setMinSessions(minSessions)
@@ -810,7 +812,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(mockSession());
                       }
                     });
@@ -818,7 +820,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
     Session session1 = pool.getReadSession();
     expectedException.expect(isSpannerException(ErrorCode.RESOURCE_EXHAUSTED));
@@ -847,7 +849,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(sessions.pop());
                       }
                     });
@@ -855,7 +857,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
     assertThat(pool.getReadWriteSession().delegate).isEqualTo(mockSession2);
   }
@@ -866,6 +868,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
         SessionPoolOptions.newBuilder()
             .setMinSessions(1)
             .setMaxSessions(3)
+            .setIncStep(1)
             .setMaxIdleSessions(0)
             .build();
     SessionImpl session1 = mockSession();
@@ -883,7 +886,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(sessions.pop());
                       }
                     });
@@ -891,7 +894,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     for (Session session : new Session[] {session1, session2, session3}) {
       doAnswer(
               new Answer<ApiFuture<Empty>>() {
@@ -950,7 +953,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       public void run() {
                         int sessionCount = invocation.getArgumentAt(0, Integer.class);
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         for (int i = 0; i < sessionCount; i++) {
                           consumer.onSessionReady(session);
                         }
@@ -960,7 +963,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(anyInt(), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(anyInt(), Mockito.anyBoolean(), any(SessionConsumer.class));
     FakeClock clock = new FakeClock();
     clock.currentTimeMillis = System.currentTimeMillis();
     pool = createPool(clock);
@@ -1066,7 +1069,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(closedSession);
                       }
                     });
@@ -1082,7 +1085,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(openSession);
                       }
                     });
@@ -1090,7 +1093,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     FakeClock clock = new FakeClock();
     clock.currentTimeMillis = System.currentTimeMillis();
     pool = createPool(clock);
@@ -1122,7 +1125,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(closedSession);
                       }
                     });
@@ -1138,7 +1141,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(openSession);
                       }
                     });
@@ -1146,7 +1149,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     FakeClock clock = new FakeClock();
     clock.currentTimeMillis = System.currentTimeMillis();
     pool = createPool(clock);
@@ -1244,7 +1247,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                           @Override
                           public void run() {
                             SessionConsumerImpl consumer =
-                                invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                                invocation.getArgumentAt(2, SessionConsumerImpl.class);
                             consumer.onSessionReady(closedSession);
                           }
                         });
@@ -1260,7 +1263,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                           @Override
                           public void run() {
                             SessionConsumerImpl consumer =
-                                invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                                invocation.getArgumentAt(2, SessionConsumerImpl.class);
                             consumer.onSessionReady(openSession);
                           }
                         });
@@ -1268,11 +1271,13 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                   }
                 })
             .when(sessionClient)
-            .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+            .asyncBatchCreateSessions(
+                Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
         SessionPoolOptions options =
             SessionPoolOptions.newBuilder()
                 .setMinSessions(0) // The pool should not auto-create any sessions
                 .setMaxSessions(2)
+                .setIncStep(1)
                 .setBlockIfPoolExhausted()
                 .build();
         SpannerOptions spannerOptions = mock(SpannerOptions.class);
@@ -1378,7 +1383,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(closedSession);
                       }
                     });
@@ -1394,7 +1399,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(openSession);
                       }
                     });
@@ -1402,7 +1407,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     FakeClock clock = new FakeClock();
     clock.currentTimeMillis = System.currentTimeMillis();
     pool = createPool(clock);
@@ -1429,7 +1434,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(closedSession);
                       }
                     });
@@ -1445,7 +1450,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(openSession);
                       }
                     });
@@ -1453,7 +1458,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
 
     FakeClock clock = new FakeClock();
     clock.currentTimeMillis = System.currentTimeMillis();
@@ -1481,7 +1486,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(closedSession);
                       }
                     });
@@ -1497,7 +1502,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(openSession);
                       }
                     });
@@ -1505,7 +1510,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     FakeClock clock = new FakeClock();
     clock.currentTimeMillis = System.currentTimeMillis();
     pool = createPool(clock);
@@ -1532,7 +1537,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(closedSession);
                       }
                     });
@@ -1548,7 +1553,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                       @Override
                       public void run() {
                         SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(1, SessionConsumerImpl.class);
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
                         consumer.onSessionReady(openSession);
                       }
                     });
@@ -1556,7 +1561,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               }
             })
         .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), any(SessionConsumer.class));
+        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     FakeClock clock = new FakeClock();
     clock.currentTimeMillis = System.currentTimeMillis();
     pool = createPool(clock);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpanTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpanTest.java
@@ -166,7 +166,11 @@ public class SpanTest {
             .setProjectId(TEST_PROJECT)
             .setChannelProvider(channelProvider)
             .setCredentials(NoCredentials.getInstance())
-            .setSessionPoolOption(SessionPoolOptions.newBuilder().setMinSessions(0).build());
+            .setSessionPoolOption(
+                SessionPoolOptions.newBuilder()
+                    .setMinSessions(0)
+                    .setWriteSessionsFraction(0.0f)
+                    .build());
 
     spanner = builder.build().getService();
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
@@ -196,7 +196,7 @@ public class TransactionManagerImplTest {
     when(transportOptions.getExecutorFactory()).thenReturn(new TestExecutorFactory());
     when(options.getTransportOptions()).thenReturn(transportOptions);
     SessionPoolOptions sessionPoolOptions =
-        SessionPoolOptions.newBuilder().setMinSessions(0).build();
+        SessionPoolOptions.newBuilder().setMinSessions(0).setIncStep(1).build();
     when(options.getSessionPoolOptions()).thenReturn(sessionPoolOptions);
     when(options.getSessionLabels()).thenReturn(Collections.<String, String>emptyMap());
     SpannerRpc rpc = mock(SpannerRpc.class);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
@@ -106,7 +106,7 @@ public class TransactionRunnerImplTest {
     when(transportOptions.getExecutorFactory()).thenReturn(new TestExecutorFactory());
     when(options.getTransportOptions()).thenReturn(transportOptions);
     SessionPoolOptions sessionPoolOptions =
-        SessionPoolOptions.newBuilder().setMinSessions(0).build();
+        SessionPoolOptions.newBuilder().setMinSessions(0).setIncStep(1).build();
     when(options.getSessionPoolOptions()).thenReturn(sessionPoolOptions);
     when(options.getSessionLabels()).thenReturn(Collections.<String, String>emptyMap());
     SpannerRpc rpc = mock(SpannerRpc.class);


### PR DESCRIPTION
When more sessions are requested by the user application than are available in the session pool,
the session pool will now create new sessions in batches instead of in steps of 1. This reduces
the number of RPCs needed to serve a burst of requests. The default step size is 25 sessions.

In a default setup with `MinSessions=100, MaxSessions=400, NumChannels=4` a session pool that receives a burst of read or write requests will now have to execute 16 `BatchCreateSessions` RPCs as opposed to 304 `BatchCreateSessions` RPCs when using steps of 1.

A benchmark for the session pool has also been added to be able to compare performance and the
number of RPCs needed before and after this change. This benchmark can also be used for future
changes to verify that the change does not deteriorate performance or increase the number of
RPCs needed. The full benchmark results for the session pool with varying values for the step size for `BatchCreateSessions` are:

### Execution time in milliseconds

Benchmark | (incStep) | Score
-- | -- | --
SessionPoolBenchmark.burstRead | 1 | 1218.416
SessionPoolBenchmark.burstRead | 10 | 827.376
SessionPoolBenchmark.burstRead | 20 | 843.336
SessionPoolBenchmark.burstRead | 25 | 828.906
SessionPoolBenchmark.burstRead | 30 | 1359.492
SessionPoolBenchmark.burstRead | 40 | 1021.871
SessionPoolBenchmark.burstRead | 50 | 1089.514
SessionPoolBenchmark.burstRead | 100 | 901.084
SessionPoolBenchmark.burstReadAndWrite | 1 | 2490.588
SessionPoolBenchmark.burstReadAndWrite | 10 | 2590.583
SessionPoolBenchmark.burstReadAndWrite | 20 | 2476.811
SessionPoolBenchmark.burstReadAndWrite | 25 | 2438.735
SessionPoolBenchmark.burstReadAndWrite | 30 | 2416.405
SessionPoolBenchmark.burstReadAndWrite | 40 | 2570.678
SessionPoolBenchmark.burstReadAndWrite | 50 | 2539.745
SessionPoolBenchmark.burstReadAndWrite | 100 | 2452.292
SessionPoolBenchmark.burstWrite | 1 | 4713.28
SessionPoolBenchmark.burstWrite | 10 | 4840.903
SessionPoolBenchmark.burstWrite | 20 | 4779.517
SessionPoolBenchmark.burstWrite | 25 | 4776.143
SessionPoolBenchmark.burstWrite | 30 | 4707.731
SessionPoolBenchmark.burstWrite | 40 | 4750.286
SessionPoolBenchmark.burstWrite | 50 | 4830.955
SessionPoolBenchmark.burstWrite | 100 | 4843.729
SessionPoolBenchmark.steadyIncrease | 1 | 8003.601
SessionPoolBenchmark.steadyIncrease | 10 | 819.771
SessionPoolBenchmark.steadyIncrease | 20 | 447.573
SessionPoolBenchmark.steadyIncrease | 25 | 425.566
SessionPoolBenchmark.steadyIncrease | 30 | 384.675
SessionPoolBenchmark.steadyIncrease | 40 | 324.946
SessionPoolBenchmark.steadyIncrease | 50 | 279.195
SessionPoolBenchmark.steadyIncrease | 100 | 205.646


### Number of BatchCreateSessions RPCs needed

Benchmark | (incStep) | Score
-- | -- | --
SessionPoolBenchmark.burstRead:numBatchCreateSessionsRpcs | 1 | 304
SessionPoolBenchmark.burstRead:numBatchCreateSessionsRpcs | 10 | 34
SessionPoolBenchmark.burstRead:numBatchCreateSessionsRpcs | 20 | 19
SessionPoolBenchmark.burstRead:numBatchCreateSessionsRpcs | 25 | 16
SessionPoolBenchmark.burstRead:numBatchCreateSessionsRpcs | 30 | 14
SessionPoolBenchmark.burstRead:numBatchCreateSessionsRpcs | 40 | 12
SessionPoolBenchmark.burstRead:numBatchCreateSessionsRpcs | 50 | 10
SessionPoolBenchmark.burstRead:numBatchCreateSessionsRpcs | 100 | 7
SessionPoolBenchmark.burstReadAndWrite:numBatchCreateSessionsRpcs | 1 | 304
SessionPoolBenchmark.burstReadAndWrite:numBatchCreateSessionsRpcs | 10 | 34
SessionPoolBenchmark.burstReadAndWrite:numBatchCreateSessionsRpcs | 20 | 19
SessionPoolBenchmark.burstReadAndWrite:numBatchCreateSessionsRpcs | 25 | 16
SessionPoolBenchmark.burstReadAndWrite:numBatchCreateSessionsRpcs | 30 | 14
SessionPoolBenchmark.burstReadAndWrite:numBatchCreateSessionsRpcs | 40 | 12
SessionPoolBenchmark.burstReadAndWrite:numBatchCreateSessionsRpcs | 50 | 10
SessionPoolBenchmark.burstReadAndWrite:numBatchCreateSessionsRpcs | 100 | 7
SessionPoolBenchmark.burstWrite:numBatchCreateSessionsRpcs | 1 | 304
SessionPoolBenchmark.burstWrite:numBatchCreateSessionsRpcs | 10 | 34
SessionPoolBenchmark.burstWrite:numBatchCreateSessionsRpcs | 20 | 19
SessionPoolBenchmark.burstWrite:numBatchCreateSessionsRpcs | 25 | 16
SessionPoolBenchmark.burstWrite:numBatchCreateSessionsRpcs | 30 | 14
SessionPoolBenchmark.burstWrite:numBatchCreateSessionsRpcs | 40 | 12
SessionPoolBenchmark.burstWrite:numBatchCreateSessionsRpcs | 50 | 10
SessionPoolBenchmark.burstWrite:numBatchCreateSessionsRpcs | 100 | 7
SessionPoolBenchmark.steadyIncrease:numBatchCreateSessionsRpcs | 1 | 304
SessionPoolBenchmark.steadyIncrease:numBatchCreateSessionsRpcs | 10 | 34
SessionPoolBenchmark.steadyIncrease:numBatchCreateSessionsRpcs | 20 | 19
SessionPoolBenchmark.steadyIncrease:numBatchCreateSessionsRpcs | 25 | 16
SessionPoolBenchmark.steadyIncrease:numBatchCreateSessionsRpcs | 30 | 14
SessionPoolBenchmark.steadyIncrease:numBatchCreateSessionsRpcs | 40 | 12
SessionPoolBenchmark.steadyIncrease:numBatchCreateSessionsRpcs | 50 | 10
SessionPoolBenchmark.steadyIncrease:numBatchCreateSessionsRpcs | 100 | 7
