### PR TITLE
fix: retry non-idempotent long-running RPCs

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseAdminClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseAdminClientImpl.java
@@ -120,9 +120,9 @@ class DatabaseAdminClientImpl implements DatabaseAdminClient {
             .setExpireTime(expireTime.toProto())
             .build();
     String instanceName = getInstanceName(instanceId);
-
     OperationFuture<com.google.spanner.admin.database.v1.Backup, CreateBackupMetadata>
         rawOperationFuture = rpc.createBackup(instanceName, backupId, backup);
+
     return new OperationFutureImpl<Backup, CreateBackupMetadata>(
         rawOperationFuture.getPollingFuture(),
         rawOperationFuture.getInitialFuture(),

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseAdminClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseAdminClientImpl.java
@@ -120,9 +120,9 @@ class DatabaseAdminClientImpl implements DatabaseAdminClient {
             .setExpireTime(expireTime.toProto())
             .build();
     String instanceName = getInstanceName(instanceId);
+
     OperationFuture<com.google.spanner.admin.database.v1.Backup, CreateBackupMetadata>
         rawOperationFuture = rpc.createBackup(instanceName, backupId, backup);
-
     return new OperationFutureImpl<Backup, CreateBackupMetadata>(
         rawOperationFuture.getPollingFuture(),
         rawOperationFuture.getInitialFuture(),

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -21,6 +21,7 @@ import com.google.api.gax.grpc.GrpcInterceptorProvider;
 import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.longrunning.OperationTimedPollAlgorithm;
 import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.StatusCode;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.cloud.NoCredentials;
@@ -291,7 +292,8 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
           .setRetrySettings(longRunningRetrySettings);
       databaseAdminStubSettingsBuilder
           .updateBackupSettings()
-          .setRetrySettings(longRunningRetrySettings);
+          .setRetrySettings(longRunningRetrySettings)
+          .setRetryableCodes(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE);
     }
 
     Builder(SpannerOptions options) {
@@ -581,6 +583,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
       return this;
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
     public SpannerOptions build() {
       // Set the host of emulator has been set.

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -27,30 +27,38 @@ import com.google.api.gax.grpc.GaxGrpcProperties;
 import com.google.api.gax.grpc.GrpcCallContext;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.api.gax.retrying.ResultRetryAlgorithm;
+import com.google.api.gax.retrying.TimedAttemptSettings;
 import com.google.api.gax.rpc.AlreadyExistsException;
 import com.google.api.gax.rpc.ApiClientHeaderProvider;
+import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.HeaderProvider;
 import com.google.api.gax.rpc.InstantiatingWatchdogProvider;
 import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.ResponseObserver;
+import com.google.api.gax.rpc.StatusCode;
 import com.google.api.gax.rpc.StreamController;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.WatchdogProvider;
 import com.google.api.pathtemplate.PathTemplate;
+import com.google.cloud.RetryHelper;
 import com.google.cloud.grpc.GrpcTransportOptions;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.SpannerOptions.CallCredentialsProvider;
 import com.google.cloud.spanner.admin.database.v1.stub.DatabaseAdminStub;
+import com.google.cloud.spanner.admin.database.v1.stub.DatabaseAdminStubSettings;
 import com.google.cloud.spanner.admin.database.v1.stub.GrpcDatabaseAdminStub;
 import com.google.cloud.spanner.admin.instance.v1.stub.GrpcInstanceAdminStub;
 import com.google.cloud.spanner.admin.instance.v1.stub.InstanceAdminStub;
 import com.google.cloud.spanner.v1.stub.GrpcSpannerStub;
 import com.google.cloud.spanner.v1.stub.SpannerStub;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.iam.v1.GetIamPolicyRequest;
@@ -63,6 +71,9 @@ import com.google.longrunning.GetOperationRequest;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Empty;
 import com.google.protobuf.FieldMask;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+import com.google.protobuf.Timestamp;
 import com.google.spanner.admin.database.v1.Backup;
 import com.google.spanner.admin.database.v1.CreateBackupMetadata;
 import com.google.spanner.admin.database.v1.CreateBackupRequest;
@@ -123,9 +134,12 @@ import io.grpc.Context;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
@@ -193,6 +207,7 @@ public class GapicSpannerRpc implements SpannerRpc {
   private boolean rpcIsClosed;
   private final SpannerStub spannerStub;
   private final InstanceAdminStub instanceAdminStub;
+  private final DatabaseAdminStubSettings databaseAdminStubSettings;
   private final DatabaseAdminStub databaseAdminStub;
   private final String projectId;
   private final String projectName;
@@ -321,17 +336,162 @@ public class GapicSpannerRpc implements SpannerRpc {
                   .setStreamWatchdogProvider(watchdogProvider)
                   .build());
 
-      this.databaseAdminStub =
-          GrpcDatabaseAdminStub.create(
-              options
-                  .getDatabaseAdminStubSettings()
-                  .toBuilder()
-                  .setTransportChannelProvider(channelProvider)
-                  .setCredentialsProvider(credentialsProvider)
-                  .setStreamWatchdogProvider(watchdogProvider)
-                  .build());
+      this.databaseAdminStubSettings =
+          options
+              .getDatabaseAdminStubSettings()
+              .toBuilder()
+              .setTransportChannelProvider(channelProvider)
+              .setCredentialsProvider(credentialsProvider)
+              .setStreamWatchdogProvider(watchdogProvider)
+              .build();
+      this.databaseAdminStub = GrpcDatabaseAdminStub.create(this.databaseAdminStubSettings);
     } catch (Exception e) {
       throw newSpannerException(e);
+    }
+  }
+
+  private static final class OperationFutureRetryAlgorithm<ResultT, MetadataT>
+      implements ResultRetryAlgorithm<OperationFuture<ResultT, MetadataT>> {
+    private static final ImmutableList<StatusCode.Code> RETRYABLE_CODES =
+        ImmutableList.of(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE);
+
+    @Override
+    public TimedAttemptSettings createNextAttempt(
+        Throwable prevThrowable,
+        OperationFuture<ResultT, MetadataT> prevResponse,
+        TimedAttemptSettings prevSettings) {
+      // Use default retry settings.
+      return null;
+    }
+
+    @Override
+    public boolean shouldRetry(
+        Throwable prevThrowable, OperationFuture<ResultT, MetadataT> prevResponse)
+        throws CancellationException {
+      if (prevThrowable instanceof ApiException) {
+        ApiException e = (ApiException) prevThrowable;
+        return RETRYABLE_CODES.contains(e.getStatusCode().getCode());
+      }
+      if (prevResponse != null) {
+        try {
+          prevResponse.getInitialFuture().get();
+        } catch (ExecutionException ee) {
+          Throwable cause = ee.getCause();
+          if (cause instanceof ApiException) {
+            ApiException e = (ApiException) cause;
+            return RETRYABLE_CODES.contains(e.getStatusCode().getCode());
+          }
+        } catch (InterruptedException e) {
+          return false;
+        }
+      }
+      return false;
+    }
+  }
+
+  private final class OperationFutureCallable<RequestT, ResponseT, MetadataT extends Message>
+      implements Callable<OperationFuture<ResponseT, MetadataT>> {
+    final Class<MetadataT> metadataClass;
+    final OperationCallable<RequestT, ResponseT, MetadataT> operationCallable;
+    final RequestT initialRequest;
+    final String instanceName;
+    final OperationsLister lister;
+    final Function<MetadataT, Timestamp> getStartTimeFunction;
+    boolean isRetry = false;
+
+    OperationFutureCallable(
+        Class<MetadataT> metadataClass,
+        OperationCallable<RequestT, ResponseT, MetadataT> operationCallable,
+        RequestT initialRequest,
+        String instanceName,
+        OperationsLister lister,
+        Function<MetadataT, Timestamp> getStartTimeFunction) {
+      this.metadataClass = metadataClass;
+      this.operationCallable = operationCallable;
+      this.initialRequest = initialRequest;
+      this.instanceName = instanceName;
+      this.lister = lister;
+      this.getStartTimeFunction = getStartTimeFunction;
+    }
+
+    @Override
+    public OperationFuture<ResponseT, MetadataT> call() throws Exception {
+      acquireAdministrativeRequestsRateLimiter();
+
+      String operationName = null;
+      if (isRetry) {
+        // Query the backend to see if the operation was actually created, and that the
+        // problem was caused by a network problem or other transient problem client side.
+        Operation operation = mostRecentOperation(metadataClass, lister, getStartTimeFunction);
+        if (operation != null) {
+          // Operation found, resume tracking that operation.
+          operationName = operation.getName();
+        }
+      }
+      isRetry = true;
+
+      if (operationName == null) {
+        GrpcCallContext context = newCallContext(null, instanceName);
+        return operationCallable.futureCall(initialRequest, context);
+      } else {
+        return operationCallable.resumeFutureCall(operationName);
+      }
+    }
+  }
+
+  private interface OperationsLister {
+    Paginated<Operation> listOperations(String nextPageToken);
+  }
+
+  private <T extends Message> Operation mostRecentOperation(
+      Class<T> metadataClass, OperationsLister lister, Function<T, Timestamp> getStartTimeFunction)
+      throws InvalidProtocolBufferException {
+    Operation res = null;
+    Timestamp currMaxStartTime = null;
+    String nextPageToken = null;
+    Paginated<Operation> operations;
+    do {
+      operations = lister.listOperations(nextPageToken);
+      for (Operation op : operations.getResults()) {
+        T metadata = op.getMetadata().unpack(metadataClass);
+        Timestamp startTime = getStartTimeFunction.apply(metadata);
+        if (res == null || TimestampComparator.INSTANCE.compare(startTime, currMaxStartTime) > 0) {
+          currMaxStartTime = startTime;
+          res = op;
+        }
+        // If the operation does not report any start time, then the operation that is not yet done
+        // is the one that is the most recent.
+        if (startTime == null && currMaxStartTime == null && !op.getDone()) {
+          res = op;
+        }
+      }
+    } while (operations.getNextPageToken() != null);
+    return res;
+  }
+
+  private static final class TimestampComparator implements Comparator<Timestamp> {
+    private static final TimestampComparator INSTANCE = new TimestampComparator();
+
+    @Override
+    public int compare(Timestamp t1, Timestamp t2) {
+      if (t1 == null && t2 == null) {
+        return 0;
+      }
+      if (t1 != null && t2 == null) {
+        return 1;
+      }
+      if (t1 == null && t2 != null) {
+        return -1;
+      }
+      if (t1.getSeconds() > t2.getSeconds()
+          || (t1.getSeconds() == t2.getSeconds() && t1.getNanos() > t2.getNanos())) {
+        return 1;
+      }
+      if (t1.getSeconds() < t2.getSeconds()
+          || (t1.getSeconds() == t2.getSeconds() && t1.getNanos() < t2.getNanos())) {
+        return -1;
+      }
+      return 0;
     }
   }
 
@@ -508,17 +668,53 @@ public class GapicSpannerRpc implements SpannerRpc {
 
   @Override
   public OperationFuture<Database, CreateDatabaseMetadata> createDatabase(
-      String instanceName, String createDatabaseStatement, Iterable<String> additionalStatements)
+      final String instanceName,
+      String createDatabaseStatement,
+      Iterable<String> additionalStatements)
       throws SpannerException {
-    acquireAdministrativeRequestsRateLimiter();
+    final String databaseId =
+        createDatabaseStatement.substring(
+            "CREATE DATABASE `".length(), createDatabaseStatement.length() - 1);
     CreateDatabaseRequest request =
         CreateDatabaseRequest.newBuilder()
             .setParent(instanceName)
             .setCreateStatement(createDatabaseStatement)
             .addAllExtraStatements(additionalStatements)
             .build();
-    GrpcCallContext context = newCallContext(null, instanceName);
-    return databaseAdminStub.createDatabaseOperationCallable().futureCall(request, context);
+
+    OperationFutureCallable<CreateDatabaseRequest, Database, CreateDatabaseMetadata> callable =
+        new OperationFutureCallable<CreateDatabaseRequest, Database, CreateDatabaseMetadata>(
+            CreateDatabaseMetadata.class,
+            databaseAdminStub.createDatabaseOperationCallable(),
+            request,
+            instanceName,
+            new OperationsLister() {
+              @Override
+              public Paginated<Operation> listOperations(String nextPageToken) {
+                return listDatabaseOperations(
+                    instanceName,
+                    0,
+                    String.format(
+                        "(name:%s/operations/) AND (metadata.@type:type.googleapis.com/%s)",
+                        String.format("%s/databases/%s", instanceName, databaseId),
+                        CreateDatabaseMetadata.getDescriptor().getFullName()),
+                    nextPageToken);
+              }
+            },
+            new Function<CreateDatabaseMetadata, Timestamp>() {
+              @Override
+              public Timestamp apply(CreateDatabaseMetadata input) {
+                return null;
+              }
+            });
+    return RetryHelper.runWithRetries(
+        callable,
+        databaseAdminStubSettings
+            .createDatabaseOperationSettings()
+            .getInitialCallSettings()
+            .getRetrySettings(),
+        new OperationFutureRetryAlgorithm<>(),
+        NanoClock.getDefaultClock());
   }
 
   @Override
@@ -584,30 +780,92 @@ public class GapicSpannerRpc implements SpannerRpc {
 
   @Override
   public OperationFuture<Backup, CreateBackupMetadata> createBackup(
-      String instanceName, String backupId, Backup backup) throws SpannerException {
-    acquireAdministrativeRequestsRateLimiter();
+      final String instanceName, final String backupId, final Backup backup)
+      throws SpannerException {
     CreateBackupRequest request =
         CreateBackupRequest.newBuilder()
             .setParent(instanceName)
             .setBackupId(backupId)
             .setBackup(backup)
             .build();
-    GrpcCallContext context = newCallContext(null, instanceName);
-    return databaseAdminStub.createBackupOperationCallable().futureCall(request, context);
+    OperationFutureCallable<CreateBackupRequest, Backup, CreateBackupMetadata> callable =
+        new OperationFutureCallable<CreateBackupRequest, Backup, CreateBackupMetadata>(
+            CreateBackupMetadata.class,
+            databaseAdminStub.createBackupOperationCallable(),
+            request,
+            instanceName,
+            new OperationsLister() {
+              @Override
+              public Paginated<Operation> listOperations(String nextPageToken) {
+                return listBackupOperations(
+                    instanceName,
+                    0,
+                    String.format(
+                        "(metadata.name:%s) AND (metadata.@type:type.googleapis.com/%s)",
+                        String.format("%s/backups/%s", instanceName, backupId),
+                        CreateBackupMetadata.getDescriptor().getFullName()),
+                    nextPageToken);
+              }
+            },
+            new Function<CreateBackupMetadata, Timestamp>() {
+              @Override
+              public Timestamp apply(CreateBackupMetadata input) {
+                return input.getProgress().getStartTime();
+              }
+            });
+    return RetryHelper.runWithRetries(
+        callable,
+        databaseAdminStubSettings
+            .createBackupOperationSettings()
+            .getInitialCallSettings()
+            .getRetrySettings(),
+        new OperationFutureRetryAlgorithm<>(),
+        NanoClock.getDefaultClock());
   }
 
   @Override
   public final OperationFuture<Database, RestoreDatabaseMetadata> restoreDatabase(
-      String databaseInstanceName, String databaseId, String backupName) {
-    acquireAdministrativeRequestsRateLimiter();
+      final String databaseInstanceName, final String databaseId, String backupName) {
     RestoreDatabaseRequest request =
         RestoreDatabaseRequest.newBuilder()
             .setParent(databaseInstanceName)
             .setDatabaseId(databaseId)
             .setBackup(backupName)
             .build();
-    GrpcCallContext context = newCallContext(null, databaseInstanceName);
-    return databaseAdminStub.restoreDatabaseOperationCallable().futureCall(request, context);
+
+    OperationFutureCallable<RestoreDatabaseRequest, Database, RestoreDatabaseMetadata> callable =
+        new OperationFutureCallable<RestoreDatabaseRequest, Database, RestoreDatabaseMetadata>(
+            RestoreDatabaseMetadata.class,
+            databaseAdminStub.restoreDatabaseOperationCallable(),
+            request,
+            databaseInstanceName,
+            new OperationsLister() {
+              @Override
+              public Paginated<Operation> listOperations(String nextPageToken) {
+                return listDatabaseOperations(
+                    databaseInstanceName,
+                    0,
+                    String.format(
+                        "(metadata.name:%s) AND (metadata.@type:type.googleapis.com/%s)",
+                        String.format("%s/databases/%s", databaseInstanceName, databaseId),
+                        RestoreDatabaseMetadata.getDescriptor().getFullName()),
+                    nextPageToken);
+              }
+            },
+            new Function<RestoreDatabaseMetadata, Timestamp>() {
+              @Override
+              public Timestamp apply(RestoreDatabaseMetadata input) {
+                return input.getProgress().getStartTime();
+              }
+            });
+    return RetryHelper.runWithRetries(
+        callable,
+        databaseAdminStubSettings
+            .restoreDatabaseOperationSettings()
+            .getInitialCallSettings()
+            .getRetrySettings(),
+        new OperationFutureRetryAlgorithm<>(),
+        NanoClock.getDefaultClock());
   }
 
   @Override

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminGaxTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminGaxTest.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.spanner;
 
-import static org.junit.Assert.fail;
-
 import com.google.api.core.ApiFunction;
 import com.google.api.gax.grpc.testing.LocalChannelProvider;
 import com.google.api.gax.longrunning.OperationFuture;
@@ -32,7 +30,6 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.AbstractMessage;
 import com.google.protobuf.Any;
 import com.google.protobuf.Empty;
-import com.google.spanner.admin.database.v1.CreateDatabaseMetadata;
 import com.google.spanner.admin.database.v1.DatabaseName;
 import com.google.spanner.admin.database.v1.ListDatabasesRequest;
 import com.google.spanner.admin.database.v1.ListDatabasesResponse;
@@ -238,10 +235,10 @@ public class DatabaseAdminGaxTest {
         RetrySettings.newBuilder()
             .setInitialRetryDelay(Duration.ofMillis(1L))
             .setMaxRetryDelay(Duration.ofMillis(1L))
-            .setInitialRpcTimeout(Duration.ofMillis(2000L))
-            .setMaxRpcTimeout(Duration.ofMillis(5000L))
+            .setInitialRpcTimeout(Duration.ofMillis(1000L))
+            .setMaxRpcTimeout(Duration.ofMillis(2000L))
             .setMaxAttempts(3)
-            .setTotalTimeout(Duration.ofMillis(15000L))
+            .setTotalTimeout(Duration.ofMillis(5000L))
             .build();
     final RetrySettings retrySettingsToUse =
         exceptionType == ExceptionType.DELAYED
@@ -379,59 +376,6 @@ public class DatabaseAdminGaxTest {
 
     List<AbstractMessage> actualRequests = mockDatabaseAdmin.getRequests();
     Assert.assertEquals(2, actualRequests.size());
-  }
-
-  @Test
-  public void createDatabaseTest() throws Exception {
-    Exception exception = setupException();
-    DatabaseName name = DatabaseName.of(PROJECT, INSTANCE, "DATABASE");
-    com.google.spanner.admin.database.v1.Database expectedResponse =
-        com.google.spanner.admin.database.v1.Database.newBuilder().setName(name.toString()).build();
-    com.google.longrunning.Operation resultOperation =
-        com.google.longrunning.Operation.newBuilder()
-            .setName("createDatabaseTest")
-            .setDone(true)
-            .setResponse(Any.pack(expectedResponse))
-            .build();
-    if (exceptionAtCall == 0) {
-      mockDatabaseAdmin.addException(exception);
-    }
-    mockDatabaseAdmin.addResponse(resultOperation);
-    if (exceptionAtCall == 1) {
-      mockDatabaseAdmin.addException(exception);
-    }
-    mockDatabaseAdmin.addResponse(resultOperation);
-
-    boolean methodIsIdempotent =
-        !spanner
-            .getOptions()
-            .getDatabaseAdminStubSettings()
-            .createDatabaseOperationSettings()
-            .getInitialCallSettings()
-            .getRetryableCodes()
-            .isEmpty();
-    for (int i = 0; i < 2; i++) {
-      OperationFuture<Database, CreateDatabaseMetadata> actualResponse =
-          client.createDatabase(INSTANCE, "DATABASE", Arrays.<String>asList());
-      try {
-        Database returnedInstance = actualResponse.get();
-        if (!methodIsIdempotent && i == exceptionAtCall) {
-          fail("missing expected exception");
-        }
-        Assert.assertEquals(name.toString(), returnedInstance.getId().getName());
-      } catch (ExecutionException e) {
-        if (!exceptionType.isRetryable() || methodIsIdempotent || i != exceptionAtCall) {
-          Throwables.throwIfUnchecked(e.getCause());
-          throw e;
-        }
-      }
-    }
-    List<AbstractMessage> actualRequests = mockDatabaseAdmin.getRequests();
-    if (methodIsIdempotent) {
-      Assert.assertEquals(2, actualRequests.size());
-    } else {
-      Assert.assertEquals(1, actualRequests.size());
-    }
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminGaxTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminGaxTest.java
@@ -235,10 +235,10 @@ public class DatabaseAdminGaxTest {
         RetrySettings.newBuilder()
             .setInitialRetryDelay(Duration.ofMillis(1L))
             .setMaxRetryDelay(Duration.ofMillis(1L))
-            .setInitialRpcTimeout(Duration.ofMillis(1000L))
-            .setMaxRpcTimeout(Duration.ofMillis(2000L))
+            .setInitialRpcTimeout(Duration.ofMillis(2000L))
+            .setMaxRpcTimeout(Duration.ofMillis(5000L))
             .setMaxAttempts(3)
-            .setTotalTimeout(Duration.ofMillis(5000L))
+            .setTotalTimeout(Duration.ofMillis(15000L))
             .build();
     final RetrySettings retrySettingsToUse =
         exceptionType == ExceptionType.DELAYED

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockDatabaseAdminServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockDatabaseAdminServiceImpl.java
@@ -17,7 +17,10 @@
 package com.google.cloud.spanner;
 
 import com.google.api.gax.grpc.testing.MockGrpcService;
+import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
+import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
+import com.google.common.collect.Collections2;
 import com.google.iam.v1.GetIamPolicyRequest;
 import com.google.iam.v1.Policy;
 import com.google.iam.v1.SetIamPolicyRequest;
@@ -66,7 +69,6 @@ import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
@@ -77,6 +79,10 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implements MockGrpcService {
   private static final class MockDatabase {
@@ -253,9 +259,9 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
       Operation operation = operations.get(operationName);
       for (int progress = 1; progress <= 100; progress++) {
         operation = operations.get(operationName);
-        long sleep = createBackupExecutionTime / 100;
+        long sleep = createBackupOperationExecutionTime / 100;
         if (progress == 100) {
-          sleep += createBackupExecutionTime % 100;
+          sleep += createBackupOperationExecutionTime % 100;
         }
         Thread.sleep(sleep);
         if (operation != null) {
@@ -318,9 +324,9 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
       Database proto = db.toProto();
       Operation operation = operations.get(operationName);
       for (int progress = 1; progress <= 100; progress++) {
-        long sleep = restoreDatabaseExecutionTime / 100;
+        long sleep = restoreDatabaseOperationExecutionTime / 100;
         if (progress == 100) {
-          sleep += restoreDatabaseExecutionTime % 100;
+          sleep += restoreDatabaseOperationExecutionTime % 100;
         }
         Thread.sleep(sleep);
         if (operation != null) {
@@ -391,7 +397,7 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
           Thread.sleep(10L);
           restoreOperation = operations.get(restoreOperationName);
         }
-        Thread.sleep(optimizeDatabaseExecutionTime);
+        Thread.sleep(optimizeDatabaseOperationExecutionTime);
         db.state = State.READY;
         Database proto = db.toProto();
         if (operation != null) {
@@ -423,18 +429,30 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
     return com.google.rpc.Status.newBuilder().setCode(code).setMessage(e.getMessage()).build();
   }
 
+  private final Queue<AbstractMessage> requests = new ConcurrentLinkedQueue<>();
   private ConcurrentMap<String, Policy> policies = new ConcurrentHashMap<>();
   private static final String EXPIRE_TIME_MASK = "expire_time";
   private static final Random RND = new Random();
   private final Queue<Exception> exceptions = new ConcurrentLinkedQueue<>();
+  private final ReadWriteLock freezeLock = new ReentrantReadWriteLock();
   private final ConcurrentMap<String, MockDatabase> databases = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, MockBackup> backups = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, Set<String>> filterMatches = new ConcurrentHashMap<>();
   private final MockOperationsServiceImpl operations;
 
-  private long createBackupExecutionTime;
-  private long restoreDatabaseExecutionTime;
-  private long optimizeDatabaseExecutionTime;
+  private long createBackupOperationExecutionTime;
+  private long restoreDatabaseOperationExecutionTime;
+  private long optimizeDatabaseOperationExecutionTime;
+
+  private SimulatedExecutionTime createBackupStartupExecutionTime = SimulatedExecutionTime.none();
+  private SimulatedExecutionTime createBackupResponseExecutionTime = SimulatedExecutionTime.none();
+  private SimulatedExecutionTime createDatabaseStartupExecutionTime = SimulatedExecutionTime.none();
+  private SimulatedExecutionTime createDatabaseResponseExecutionTime =
+      SimulatedExecutionTime.none();
+  private SimulatedExecutionTime restoreDatabaseStartupExecutionTime =
+      SimulatedExecutionTime.none();
+  private SimulatedExecutionTime restoreDatabaseResponseExecutionTime =
+      SimulatedExecutionTime.none();
 
   public MockDatabaseAdminServiceImpl(MockOperationsServiceImpl operations) {
     this.operations = operations;
@@ -443,36 +461,44 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
   @Override
   public void createDatabase(
       CreateDatabaseRequest request, StreamObserver<Operation> responseObserver) {
-    String id = request.getCreateStatement().replace("CREATE DATABASE ", "");
-    if (id.startsWith("`") && id.endsWith("`")) {
-      id = id.substring(1, id.length() - 1);
-    }
-    String name = String.format("%s/databases/%s", request.getParent(), id);
-    MockDatabase db = new MockDatabase(name, request.getExtraStatementsList(), null);
-    if (databases.putIfAbsent(name, db) == null) {
-      CreateDatabaseMetadata metadata =
-          CreateDatabaseMetadata.newBuilder().setDatabase(name).build();
-      Database database = Database.newBuilder().setName(name).setState(db.state).build();
-      Operation operation =
-          Operation.newBuilder()
-              .setMetadata(Any.pack(metadata))
-              .setResponse(Any.pack(database))
-              .setDone(false)
-              .setName(operations.generateOperationName(name))
-              .build();
-      operations.addOperation(operation, new CreateDatabaseCallable(operation.getName(), name));
-      responseObserver.onNext(operation);
-      responseObserver.onCompleted();
-    } else {
-      responseObserver.onError(
-          Status.ALREADY_EXISTS
-              .withDescription(String.format("Database with name %s already exists", name))
-              .asRuntimeException());
+    requests.add(request);
+    try {
+      createDatabaseStartupExecutionTime.simulateExecutionTime(exceptions, false, freezeLock);
+      String id = request.getCreateStatement().replace("CREATE DATABASE ", "");
+      if (id.startsWith("`") && id.endsWith("`")) {
+        id = id.substring(1, id.length() - 1);
+      }
+      String name = String.format("%s/databases/%s", request.getParent(), id);
+      MockDatabase db = new MockDatabase(name, request.getExtraStatementsList(), null);
+      if (databases.putIfAbsent(name, db) == null) {
+        CreateDatabaseMetadata metadata =
+            CreateDatabaseMetadata.newBuilder().setDatabase(name).build();
+        Database database = Database.newBuilder().setName(name).setState(db.state).build();
+        Operation operation =
+            Operation.newBuilder()
+                .setMetadata(Any.pack(metadata))
+                .setResponse(Any.pack(database))
+                .setDone(false)
+                .setName(operations.generateOperationName(name))
+                .build();
+        operations.addOperation(operation, new CreateDatabaseCallable(operation.getName(), name));
+        createDatabaseResponseExecutionTime.simulateExecutionTime(exceptions, false, freezeLock);
+        responseObserver.onNext(operation);
+        responseObserver.onCompleted();
+      } else {
+        responseObserver.onError(
+            Status.ALREADY_EXISTS
+                .withDescription(String.format("Database with name %s already exists", name))
+                .asRuntimeException());
+      }
+    } catch (Throwable t) {
+      responseObserver.onError(t);
     }
   }
 
   @Override
   public void dropDatabase(DropDatabaseRequest request, StreamObserver<Empty> responseObserver) {
+    requests.add(request);
     MockDatabase db = databases.get(request.getDatabase());
     if (databases.remove(request.getDatabase(), db)) {
       responseObserver.onNext(Empty.getDefaultInstance());
@@ -484,6 +510,7 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
 
   @Override
   public void getDatabase(GetDatabaseRequest request, StreamObserver<Database> responseObserver) {
+    requests.add(request);
     MockDatabase db = databases.get(request.getName());
     if (db != null) {
       responseObserver.onNext(
@@ -501,6 +528,7 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
   @Override
   public void getDatabaseDdl(
       GetDatabaseDdlRequest request, StreamObserver<GetDatabaseDdlResponse> responseObserver) {
+    requests.add(request);
     MockDatabase db = databases.get(request.getDatabase());
     if (db != null) {
       responseObserver.onNext(GetDatabaseDdlResponse.newBuilder().addAllStatements(db.ddl).build());
@@ -513,6 +541,7 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
   @Override
   public void listDatabases(
       ListDatabasesRequest request, StreamObserver<ListDatabasesResponse> responseObserver) {
+    requests.add(request);
     List<Database> dbs = new ArrayList<>(databases.size());
     for (Entry<String, MockDatabase> entry : databases.entrySet()) {
       dbs.add(
@@ -530,6 +559,7 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
   public void listDatabaseOperations(
       ListDatabaseOperationsRequest request,
       StreamObserver<ListDatabaseOperationsResponse> responseObserver) {
+    requests.add(request);
     ListDatabaseOperationsResponse.Builder builder = ListDatabaseOperationsResponse.newBuilder();
     try {
       for (Operation op : operations.iterable()) {
@@ -554,6 +584,36 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
         String name = (String) obj.getClass().getMethod("getName").invoke(obj);
         return matches.contains(name);
       }
+      if (obj instanceof Operation) {
+        Operation operation = (Operation) obj;
+        Pattern pattern =
+            Pattern.compile(
+                "(?:\\(metadata.(?:name|database):(.*)\\)|\\(name:(.*)/operations/\\)) AND \\(metadata.@type:type.googleapis.com/(.*)\\)");
+        Matcher matcher = pattern.matcher(filter);
+        if (matcher.matches()) {
+          String objectName = matcher.group(1);
+          if (objectName == null) {
+            objectName = matcher.group(2);
+          }
+          String type = matcher.group(3);
+          Any anyMetadata = operation.getMetadata();
+          if (anyMetadata.getTypeUrl().endsWith(type)) {
+            if (type.equals(CreateBackupMetadata.getDescriptor().getFullName())) {
+              CreateBackupMetadata metadata =
+                  operation.getMetadata().unpack(CreateBackupMetadata.class);
+              return metadata.getName().equals(objectName);
+            } else if (type.equals(CreateDatabaseMetadata.getDescriptor().getFullName())) {
+              CreateDatabaseMetadata metadata =
+                  operation.getMetadata().unpack(CreateDatabaseMetadata.class);
+              return metadata.getDatabase().equals(objectName);
+            } else if (type.equals(RestoreDatabaseMetadata.getDescriptor().getFullName())) {
+              RestoreDatabaseMetadata metadata =
+                  operation.getMetadata().unpack(RestoreDatabaseMetadata.class);
+              return metadata.getName().equals(objectName);
+            }
+          }
+        }
+      }
       return false;
     }
     return true;
@@ -562,6 +622,7 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
   @Override
   public void updateDatabaseDdl(
       UpdateDatabaseDdlRequest request, StreamObserver<Operation> responseObserver) {
+    requests.add(request);
     MockDatabase db = databases.get(request.getDatabase());
     if (db != null) {
       db.ddl.addAll(request.getStatementsList());
@@ -588,50 +649,59 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
   @Override
   public void createBackup(
       CreateBackupRequest request, StreamObserver<Operation> responseObserver) {
-    String name = String.format("%s/backups/%s", request.getParent(), request.getBackupId());
-    MockDatabase db = databases.get(request.getBackup().getDatabase());
-    if (db == null) {
-      responseObserver.onError(
-          Status.NOT_FOUND
-              .withDescription(
-                  String.format(
-                      "Database with name %s not found", request.getBackup().getDatabase()))
-              .asRuntimeException());
-      return;
-    }
-    MockBackup bck = new MockBackup(name, request.getBackup(), db);
-    if (backups.putIfAbsent(name, bck) == null) {
-      CreateBackupMetadata metadata =
-          CreateBackupMetadata.newBuilder()
-              .setName(name)
-              .setDatabase(bck.database)
-              .setProgress(
-                  OperationProgress.newBuilder()
-                      .setStartTime(
-                          Timestamp.newBuilder()
-                              .setSeconds(System.currentTimeMillis() / 1000L)
-                              .build())
-                      .setProgressPercent(0))
-              .build();
-      Operation operation =
-          Operation.newBuilder()
-              .setMetadata(Any.pack(metadata))
-              .setResponse(Any.pack(bck.toProto()))
-              .setName(operations.generateOperationName(name))
-              .build();
-      operations.addOperation(operation, new CreateBackupCallable(operation.getName(), name));
-      responseObserver.onNext(operation);
-      responseObserver.onCompleted();
-    } else {
-      responseObserver.onError(
-          Status.ALREADY_EXISTS
-              .withDescription(String.format("Backup with name %s already exists", name))
-              .asRuntimeException());
+    requests.add(request);
+    try {
+      createBackupStartupExecutionTime.simulateExecutionTime(exceptions, false, freezeLock);
+      String name = String.format("%s/backups/%s", request.getParent(), request.getBackupId());
+      MockDatabase db = databases.get(request.getBackup().getDatabase());
+      if (db == null) {
+        responseObserver.onError(
+            Status.NOT_FOUND
+                .withDescription(
+                    String.format(
+                        "Database with name %s not found", request.getBackup().getDatabase()))
+                .asRuntimeException());
+        return;
+      }
+      MockBackup bck = new MockBackup(name, request.getBackup(), db);
+      if (backups.putIfAbsent(name, bck) == null) {
+        CreateBackupMetadata metadata =
+            CreateBackupMetadata.newBuilder()
+                .setName(name)
+                .setDatabase(bck.database)
+                .setProgress(
+                    OperationProgress.newBuilder()
+                        .setStartTime(
+                            Timestamp.newBuilder()
+                                .setSeconds(System.currentTimeMillis() / 1000L)
+                                .build())
+                        .setProgressPercent(0))
+                .build();
+        Operation operation =
+            Operation.newBuilder()
+                .setMetadata(Any.pack(metadata))
+                .setResponse(Any.pack(bck.toProto()))
+                .setName(operations.generateOperationName(name))
+                .build();
+        operations.addOperation(operation, new CreateBackupCallable(operation.getName(), name));
+
+        createBackupResponseExecutionTime.simulateExecutionTime(exceptions, false, freezeLock);
+        responseObserver.onNext(operation);
+        responseObserver.onCompleted();
+      } else {
+        responseObserver.onError(
+            Status.ALREADY_EXISTS
+                .withDescription(String.format("Backup with name %s already exists", name))
+                .asRuntimeException());
+      }
+    } catch (Throwable t) {
+      responseObserver.onError(t);
     }
   }
 
   @Override
   public void deleteBackup(DeleteBackupRequest request, StreamObserver<Empty> responseObserver) {
+    requests.add(request);
     MockBackup bck = backups.get(request.getName());
     if (backups.remove(request.getName(), bck)) {
       responseObserver.onNext(Empty.getDefaultInstance());
@@ -643,6 +713,7 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
 
   @Override
   public void getBackup(GetBackupRequest request, StreamObserver<Backup> responseObserver) {
+    requests.add(request);
     MockBackup bck = backups.get(request.getName());
     if (bck != null) {
       responseObserver.onNext(
@@ -663,6 +734,7 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
   @Override
   public void listBackups(
       ListBackupsRequest request, StreamObserver<ListBackupsResponse> responseObserver) {
+    requests.add(request);
     List<Backup> bcks = new ArrayList<>(backups.size());
     try {
       for (Entry<String, MockBackup> entry : backups.entrySet()) {
@@ -689,6 +761,7 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
   public void listBackupOperations(
       ListBackupOperationsRequest request,
       StreamObserver<ListBackupOperationsResponse> responseObserver) {
+    requests.add(request);
     ListBackupOperationsResponse.Builder builder = ListBackupOperationsResponse.newBuilder();
     try {
       for (Operation op : operations.iterable()) {
@@ -708,6 +781,7 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
 
   @Override
   public void updateBackup(UpdateBackupRequest request, StreamObserver<Backup> responseObserver) {
+    requests.add(request);
     MockBackup bck = backups.get(request.getBackup().getName());
     if (bck != null) {
       if (request.getUpdateMask().getPathsList().contains(EXPIRE_TIME_MASK)) {
@@ -731,70 +805,80 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
   @Override
   public void restoreDatabase(
       RestoreDatabaseRequest request, StreamObserver<Operation> responseObserver) {
-    MockBackup bck = backups.get(request.getBackup());
-    if (bck != null) {
-      String name = String.format("%s/databases/%s", request.getParent(), request.getDatabaseId());
-      MockDatabase db =
-          new MockDatabase(
-              name,
-              bck.ddl,
-              RestoreInfo.newBuilder()
+    requests.add(request);
+    try {
+      restoreDatabaseStartupExecutionTime.simulateExecutionTime(exceptions, false, freezeLock);
+      MockBackup bck = backups.get(request.getBackup());
+      if (bck != null) {
+        String name =
+            String.format("%s/databases/%s", request.getParent(), request.getDatabaseId());
+        MockDatabase db =
+            new MockDatabase(
+                name,
+                bck.ddl,
+                RestoreInfo.newBuilder()
+                    .setBackupInfo(bck.toBackupInfo())
+                    .setSourceType(RestoreSourceType.BACKUP)
+                    .build());
+        if (databases.putIfAbsent(name, db) == null) {
+          bck.referencingDatabases.add(db.name);
+          Operation optimizeOperation =
+              Operation.newBuilder()
+                  .setDone(false)
+                  .setName(operations.generateOperationName(name))
+                  .setMetadata(
+                      Any.pack(
+                          OptimizeRestoredDatabaseMetadata.newBuilder()
+                              .setName(name)
+                              .setProgress(
+                                  OperationProgress.newBuilder()
+                                      .setStartTime(currentTime())
+                                      .setProgressPercent(0)
+                                      .build())
+                              .build()))
+                  .setResponse(Any.pack(db.toProto()))
+                  .build();
+          RestoreDatabaseMetadata metadata =
+              RestoreDatabaseMetadata.newBuilder()
                   .setBackupInfo(bck.toBackupInfo())
+                  .setName(name)
+                  .setProgress(
+                      OperationProgress.newBuilder()
+                          .setStartTime(currentTime())
+                          .setProgressPercent(0)
+                          .build())
+                  .setOptimizeDatabaseOperationName(optimizeOperation.getName())
                   .setSourceType(RestoreSourceType.BACKUP)
-                  .build());
-      if (databases.putIfAbsent(name, db) == null) {
-        bck.referencingDatabases.add(db.name);
-        Operation optimizeOperation =
-            Operation.newBuilder()
-                .setDone(false)
-                .setName(operations.generateOperationName(name))
-                .setMetadata(
-                    Any.pack(
-                        OptimizeRestoredDatabaseMetadata.newBuilder()
-                            .setName(name)
-                            .setProgress(
-                                OperationProgress.newBuilder()
-                                    .setStartTime(currentTime())
-                                    .setProgressPercent(0)
-                                    .build())
-                            .build()))
-                .setResponse(Any.pack(db.toProto()))
-                .build();
-        RestoreDatabaseMetadata metadata =
-            RestoreDatabaseMetadata.newBuilder()
-                .setBackupInfo(bck.toBackupInfo())
-                .setName(name)
-                .setProgress(
-                    OperationProgress.newBuilder()
-                        .setStartTime(currentTime())
-                        .setProgressPercent(0)
-                        .build())
-                .setOptimizeDatabaseOperationName(optimizeOperation.getName())
-                .setSourceType(RestoreSourceType.BACKUP)
-                .build();
-        Operation operation =
-            Operation.newBuilder()
-                .setMetadata(Any.pack(metadata))
-                .setResponse(Any.pack(db.toProto()))
-                .setDone(false)
-                .setName(operations.generateOperationName(name))
-                .build();
-        operations.addOperation(operation, new RestoreDatabaseCallable(operation.getName(), name));
-        operations.addOperation(
-            optimizeOperation,
-            new OptimizeDatabaseCallable(optimizeOperation.getName(), operation.getName(), name));
-        responseObserver.onNext(operation);
-        responseObserver.onCompleted();
+                  .build();
+          Operation operation =
+              Operation.newBuilder()
+                  .setMetadata(Any.pack(metadata))
+                  .setResponse(Any.pack(db.toProto()))
+                  .setDone(false)
+                  .setName(operations.generateOperationName(name))
+                  .build();
+          operations.addOperation(
+              operation, new RestoreDatabaseCallable(operation.getName(), name));
+          operations.addOperation(
+              optimizeOperation,
+              new OptimizeDatabaseCallable(optimizeOperation.getName(), operation.getName(), name));
+          restoreDatabaseResponseExecutionTime.simulateExecutionTime(exceptions, false, freezeLock);
+          responseObserver.onNext(operation);
+          responseObserver.onCompleted();
+        } else {
+          responseObserver.onError(Status.ALREADY_EXISTS.asRuntimeException());
+        }
       } else {
-        responseObserver.onError(Status.ALREADY_EXISTS.asRuntimeException());
+        responseObserver.onError(Status.NOT_FOUND.asRuntimeException());
       }
-    } else {
-      responseObserver.onError(Status.NOT_FOUND.asRuntimeException());
+    } catch (Throwable t) {
+      responseObserver.onError(t);
     }
   }
 
   @Override
   public void getIamPolicy(GetIamPolicyRequest request, StreamObserver<Policy> responseObserver) {
+    requests.add(request);
     Policy policy = policies.get(request.getResource());
     if (policy != null) {
       responseObserver.onNext(policy);
@@ -806,6 +890,7 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
 
   @Override
   public void setIamPolicy(SetIamPolicyRequest request, StreamObserver<Policy> responseObserver) {
+    requests.add(request);
     policies.put(request.getResource(), request.getPolicy());
     responseObserver.onNext(request.getPolicy());
     responseObserver.onCompleted();
@@ -815,6 +900,7 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
   public void testIamPermissions(
       TestIamPermissionsRequest request,
       StreamObserver<TestIamPermissionsResponse> responseObserver) {
+    requests.add(request);
     // Just return the same permissions as in the request, as we don't have any credentials.
     responseObserver.onNext(
         TestIamPermissionsResponse.newBuilder()
@@ -825,7 +911,19 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
 
   @Override
   public List<AbstractMessage> getRequests() {
-    return Collections.emptyList();
+    return new ArrayList<>(requests);
+  }
+
+  public int countRequestsOfType(final Class<? extends AbstractMessage> type) {
+    return Collections2.filter(
+            getRequests(),
+            new Predicate<AbstractMessage>() {
+              @Override
+              public boolean apply(AbstractMessage input) {
+                return input.getClass().equals(type);
+              }
+            })
+        .size();
   }
 
   @Override
@@ -858,6 +956,7 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
 
   @Override
   public void reset() {
+    requests.clear();
     exceptions.clear();
     policies.clear();
     databases.clear();
@@ -865,7 +964,42 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
     filterMatches.clear();
   }
 
+  public void removeAllExecutionTimes() {
+    createBackupStartupExecutionTime = SimulatedExecutionTime.none();
+    createBackupResponseExecutionTime = SimulatedExecutionTime.none();
+    createBackupOperationExecutionTime = 0L;
+    createDatabaseStartupExecutionTime = SimulatedExecutionTime.none();
+    createDatabaseResponseExecutionTime = SimulatedExecutionTime.none();
+    restoreDatabaseStartupExecutionTime = SimulatedExecutionTime.none();
+    restoreDatabaseResponseExecutionTime = SimulatedExecutionTime.none();
+    restoreDatabaseOperationExecutionTime = 0L;
+  }
+
   private Timestamp currentTime() {
     return Timestamp.newBuilder().setSeconds(System.currentTimeMillis() * 1000L).build();
+  }
+
+  public void setCreateBackupStartupExecutionTime(SimulatedExecutionTime exec) {
+    this.createBackupStartupExecutionTime = exec;
+  }
+
+  public void setCreateBackupResponseExecutionTime(SimulatedExecutionTime exec) {
+    this.createBackupResponseExecutionTime = exec;
+  }
+
+  public void setCreateDatabaseStartupExecutionTime(SimulatedExecutionTime exec) {
+    this.createDatabaseStartupExecutionTime = exec;
+  }
+
+  public void setCreateDatabaseResponseExecutionTime(SimulatedExecutionTime exec) {
+    this.createDatabaseResponseExecutionTime = exec;
+  }
+
+  public void setRestoreDatabaseStartupExecutionTime(SimulatedExecutionTime exec) {
+    this.restoreDatabaseStartupExecutionTime = exec;
+  }
+
+  public void setRestoreDatabaseResponseExecutionTime(SimulatedExecutionTime exec) {
+    this.restoreDatabaseResponseExecutionTime = exec;
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -418,7 +418,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
       this.stickyException = stickyException;
     }
 
-    private void simulateExecutionTime(
+    void simulateExecutionTime(
         Queue<Exception> globalExceptions,
         boolean stickyGlobalExceptions,
         ReadWriteLock freezeLock) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDatabaseAdminTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDatabaseAdminTest.java
@@ -22,7 +22,6 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.api.gax.grpc.GrpcInterceptorProvider;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.api.gax.paging.Page;
-import com.google.api.gax.rpc.FailedPreconditionException;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Backup;
 import com.google.cloud.spanner.Database;
@@ -32,6 +31,7 @@ import com.google.cloud.spanner.IntegrationTestEnv;
 import com.google.cloud.spanner.Options;
 import com.google.cloud.spanner.ParallelIntegrationTest;
 import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.testing.RemoteSpannerHelper;
 import com.google.common.collect.ImmutableList;
@@ -341,13 +341,13 @@ public class ITDatabaseAdminTest {
                   restoredDbId);
           databases.add(op.get());
           // Assert that the RestoreDatabase RPC was called only once, and that the operation
-          // tracking
-          // was resumed through a GetOperation call.
+          // tracking was resumed through a GetOperation call.
           assertThat(createDbInterceptor.methodCount.get()).isEqualTo(1);
           assertThat(createDbInterceptor.getOperationCount.get()).isAtLeast(1);
           break;
         } catch (ExecutionException e) {
-          if (e.getCause() instanceof FailedPreconditionException
+          if (e.getCause() instanceof SpannerException
+              && ((SpannerException) e.getCause()).getErrorCode() == ErrorCode.FAILED_PRECONDITION
               && e.getCause()
                   .getMessage()
                   .contains("Please retry the operation once the pending restores complete")) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDatabaseAdminTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDatabaseAdminTest.java
@@ -19,22 +19,44 @@ package com.google.cloud.spanner.it;
 import static com.google.cloud.spanner.SpannerMatchers.isSpannerException;
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.api.gax.grpc.GrpcInterceptorProvider;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.api.gax.paging.Page;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Backup;
 import com.google.cloud.spanner.Database;
 import com.google.cloud.spanner.DatabaseAdminClient;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.IntegrationTestEnv;
 import com.google.cloud.spanner.Options;
 import com.google.cloud.spanner.ParallelIntegrationTest;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.testing.RemoteSpannerHelper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
+import com.google.spanner.admin.database.v1.CreateBackupMetadata;
 import com.google.spanner.admin.database.v1.CreateDatabaseMetadata;
+import com.google.spanner.admin.database.v1.RestoreDatabaseMetadata;
 import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientCall.Listener;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -172,5 +194,162 @@ public class ITDatabaseAdminTest {
       page = page.getNextPage();
     }
     assertThat(dbIdsGot).containsAtLeastElementsIn(dbIds);
+  }
+
+  private static final class InjectErrorInterceptorProvider implements GrpcInterceptorProvider {
+    final AtomicBoolean injectError = new AtomicBoolean(true);
+    final AtomicInteger getOperationCount = new AtomicInteger();
+    final AtomicInteger methodCount = new AtomicInteger();
+    final String methodName;
+
+    private InjectErrorInterceptorProvider(String methodName) {
+      this.methodName = methodName;
+    }
+
+    @Override
+    public List<ClientInterceptor> getInterceptors() {
+      ClientInterceptor interceptor =
+          new ClientInterceptor() {
+            @Override
+            public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+                MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+              if (method.getFullMethodName().contains("GetOperation")) {
+                getOperationCount.incrementAndGet();
+              }
+              if (!method.getFullMethodName().contains(methodName)) {
+                return next.newCall(method, callOptions);
+              }
+
+              methodCount.incrementAndGet();
+              final AtomicBoolean errorInjected = new AtomicBoolean();
+              final ClientCall<ReqT, RespT> clientCall = next.newCall(method, callOptions);
+
+              return new SimpleForwardingClientCall<ReqT, RespT>(clientCall) {
+                @Override
+                public void start(Listener<RespT> responseListener, Metadata headers) {
+                  super.start(
+                      new SimpleForwardingClientCallListener<RespT>(responseListener) {
+                        @Override
+                        public void onMessage(RespT message) {
+                          if (injectError.getAndSet(false)) {
+                            errorInjected.set(true);
+                            clientCall.cancel("Cancelling call for injected error", null);
+                          } else {
+                            super.onMessage(message);
+                          }
+                        }
+
+                        @Override
+                        public void onClose(Status status, Metadata metadata) {
+                          if (errorInjected.get()) {
+                            status = Status.UNAVAILABLE.augmentDescription("INJECTED BY TEST");
+                          }
+                          super.onClose(status, metadata);
+                        }
+                      },
+                      headers);
+                }
+              };
+            }
+          };
+      return Collections.singletonList(interceptor);
+    }
+  }
+
+  @Test
+  public void testRetryNonIdempotentRpcsReturningLongRunningOperations() throws Exception {
+    // RPCs that return a long-running operation such as CreateDatabase, CreateBackup and
+    // RestoreDatabase are non-idempotent and can normally not be automatically retried in case of a
+    // transient failure. The client library will however automatically query the backend to check
+    // whether the corresponding operation was started or not, and if it was, it will pick up the
+    // existing operation. If no operation is found, a new RPC call will be executed to start the
+    // operation.
+
+    List<Database> databases = new ArrayList<>();
+    List<Backup> backups = new ArrayList<>();
+
+    try {
+      // CreateDatabase
+      InjectErrorInterceptorProvider createDbInterceptor =
+          new InjectErrorInterceptorProvider("CreateDatabase");
+      SpannerOptions options =
+          testHelper.getOptions().toBuilder().setInterceptorProvider(createDbInterceptor).build();
+      try (Spanner spanner = options.getService()) {
+        String databaseId = testHelper.getUniqueDatabaseId();
+        DatabaseAdminClient client = spanner.getDatabaseAdminClient();
+        OperationFuture<Database, CreateDatabaseMetadata> op =
+            client.createDatabase(
+                testHelper.getInstanceId().getInstance(),
+                databaseId,
+                Collections.<String>emptyList());
+        databases.add(op.get());
+        // Assert that the CreateDatabase RPC was called only once, and that the operation tracking
+        // was resumed through a GetOperation call.
+        assertThat(createDbInterceptor.methodCount.get()).isEqualTo(1);
+        assertThat(createDbInterceptor.getOperationCount.get()).isAtLeast(1);
+      }
+
+      // CreateBackup
+      InjectErrorInterceptorProvider createBackupInterceptor =
+          new InjectErrorInterceptorProvider("CreateBackup");
+      options =
+          testHelper
+              .getOptions()
+              .toBuilder()
+              .setInterceptorProvider(createBackupInterceptor)
+              .build();
+      try (Spanner spanner = options.getService()) {
+        String databaseId = databases.get(0).getId().getDatabase();
+        String backupId = String.format("test-bck-%08d", new Random().nextInt(100000000));
+        DatabaseAdminClient client = spanner.getDatabaseAdminClient();
+        OperationFuture<Backup, CreateBackupMetadata> op =
+            client.createBackup(
+                testHelper.getInstanceId().getInstance(),
+                backupId,
+                databaseId,
+                Timestamp.ofTimeSecondsAndNanos(
+                    Timestamp.now().getSeconds() + TimeUnit.SECONDS.convert(7L, TimeUnit.DAYS), 0));
+        backups.add(op.get());
+        // Assert that the CreateBackup RPC was called only once, and that the operation tracking
+        // was resumed through a GetOperation call.
+        assertThat(createDbInterceptor.methodCount.get()).isEqualTo(1);
+        assertThat(createDbInterceptor.getOperationCount.get()).isAtLeast(1);
+      }
+
+      // RestoreBackup
+      InjectErrorInterceptorProvider restoreBackupInterceptor =
+          new InjectErrorInterceptorProvider("RestoreBackup");
+      options =
+          testHelper
+              .getOptions()
+              .toBuilder()
+              .setInterceptorProvider(restoreBackupInterceptor)
+              .build();
+      try (Spanner spanner = options.getService()) {
+        String backupId = backups.get(0).getId().getBackup();
+        String restoredDbId = testHelper.getUniqueDatabaseId();
+        DatabaseAdminClient client = spanner.getDatabaseAdminClient();
+        OperationFuture<Database, RestoreDatabaseMetadata> op =
+            client.restoreDatabase(
+                testHelper.getInstanceId().getInstance(),
+                backupId,
+                testHelper.getInstanceId().getInstance(),
+                restoredDbId);
+        databases.add(op.get());
+        // Assert that the RestoreDatabase RPC was called only once, and that the operation tracking
+        // was resumed through a GetOperation call.
+        assertThat(createDbInterceptor.methodCount.get()).isEqualTo(1);
+        assertThat(createDbInterceptor.getOperationCount.get()).isAtLeast(1);
+      }
+    } finally {
+      DatabaseAdminClient client = testHelper.getClient().getDatabaseAdminClient();
+      for (Database database : databases) {
+        client.dropDatabase(
+            database.getId().getInstanceId().getInstance(), database.getId().getDatabase());
+      }
+      for (Backup backup : backups) {
+        client.deleteBackup(backup.getInstanceId().getInstance(), backup.getId().getBackup());
+      }
+    }
   }
 }


### PR DESCRIPTION
RPCs returning a long-running operation, such as CreateDatabase, CreateBackup and RestoreDatabase, are non-idempotent and cannot be retried automatically by gax. This means that these RPCs sometimes fail with transient errors, such as `UNAVAILABLE` or `DEADLINE_EXCEEDED`. This change introduces automatic retries of these RPCs using the following logic:
1. Execute the RPC and wait for the operation to be returned.
2. If a transient error occurs while waiting for the operation, the client library queries the backend for the corresponding operation. If the operation is found, the resumes the tracking of the existing operation and returns that to the user.
3. If no corresponding operation is found in step 2, the client library retries the RPC from step 1.

Fixes https://github.com/GoogleCloudPlatform/java-docs-samples/issues/2571