### PR TITLE
tests: benchmark should start the transaction

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolBenchmark.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolBenchmark.java
@@ -379,7 +379,9 @@ public class SessionPoolBenchmark {
     // Checkout maxSessions sessions by starting maxSessions read-only transactions sequentially.
     List<ReadOnlyTransaction> transactions = new ArrayList<>(server.maxSessions);
     for (int i = 0; i < server.maxSessions; i++) {
-      transactions.add(client.readOnlyTransaction());
+      ReadOnlyTransaction tx = client.readOnlyTransaction();
+      tx.executeQuery(MockServer.SELECT1);
+      transactions.add(tx);
     }
     for (ReadOnlyTransaction tx : transactions) {
       tx.close();


### PR DESCRIPTION
The `steadyIncrease` benchmark only checked out a read-only session from the pool, but did not actually start the transaction. That is only done once a statement is issued for the transaction.

Note that issuing the statement does not actually execute the statement. That is deferred to the first call to `ResultSet#next()`.

This keeps the benchmark in sync with the version for the Go client and makes the results from the two comparable with each other.