### PR TITLE
fix: check for null input for Id classes

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BackupId.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BackupId.java
@@ -30,8 +30,8 @@ public final class BackupId {
   private final String backup;
 
   BackupId(InstanceId instanceId, String backup) {
-    this.instanceId = instanceId;
-    this.backup = backup;
+    this.instanceId = Preconditions.checkNotNull(instanceId);
+    this.backup = Preconditions.checkNotNull(backup);
   }
 
   /** Returns the instance id for this backup. */
@@ -81,6 +81,7 @@ public final class BackupId {
    * @throws IllegalArgumentException if {@code name} does not conform to the expected pattern
    */
   static BackupId of(String name) {
+    Preconditions.checkNotNull(name);
     Map<String, String> parts = NAME_TEMPLATE.match(name);
     Preconditions.checkArgument(
         parts != null, "Name should conform to pattern %s: %s", NAME_TEMPLATE, name);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseId.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseId.java
@@ -31,8 +31,8 @@ public final class DatabaseId {
   private final String database;
 
   DatabaseId(InstanceId instanceId, String database) {
-    this.instanceId = instanceId;
-    this.database = database;
+    this.instanceId = Preconditions.checkNotNull(instanceId);
+    this.database = Preconditions.checkNotNull(database);
   }
 
   /** Returns the instance id for this databse. */
@@ -82,6 +82,7 @@ public final class DatabaseId {
    * @throws IllegalArgumentException if {@code name} does not conform to the expected pattern
    */
   static DatabaseId of(String name) {
+    Preconditions.checkNotNull(name);
     Map<String, String> parts = NAME_TEMPLATE.match(name);
     Preconditions.checkArgument(
         parts != null, "Name should conform to pattern %s: %s", NAME_TEMPLATE, name);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceConfigId.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceConfigId.java
@@ -30,8 +30,8 @@ public final class InstanceConfigId {
   private final String instanceConfig;
 
   InstanceConfigId(String project, String instanceConfig) {
-    this.project = project;
-    this.instanceConfig = instanceConfig;
+    this.project = Preconditions.checkNotNull(project);
+    this.instanceConfig = Preconditions.checkNotNull(instanceConfig);
   }
 
   /** Returns project of this instane config. */
@@ -80,6 +80,7 @@ public final class InstanceConfigId {
    *     pattern.
    */
   static InstanceConfigId of(String name) {
+    Preconditions.checkNotNull(name);
     Map<String, String> parts = NAME_TEMPLATE.match(name);
     Preconditions.checkArgument(
         parts != null, "Name should confirm to pattern %s: %s", NAME_TEMPLATE, name);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceId.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceId.java
@@ -30,8 +30,8 @@ public final class InstanceId {
   private final String instance;
 
   InstanceId(String project, String instance) {
-    this.project = project;
-    this.instance = instance;
+    this.project = Preconditions.checkNotNull(project);
+    this.instance = Preconditions.checkNotNull(instance);
   }
 
   /** Returns the instance ID. */
@@ -79,6 +79,7 @@ public final class InstanceId {
    *     pattern.
    */
   static InstanceId of(String name) {
+    Preconditions.checkNotNull(name);
     Map<String, String> parts = NAME_TEMPLATE.match(name);
     Preconditions.checkArgument(
         parts != null, "Name should conform to pattern %s: %s", NAME_TEMPLATE, name);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionClient.java
@@ -44,11 +44,12 @@ class SessionClient implements AutoCloseable {
     private final String name;
 
     private SessionId(DatabaseId db, String name) {
-      this.db = db;
-      this.name = name;
+      this.db = Preconditions.checkNotNull(db);
+      this.name = Preconditions.checkNotNull(name);
     }
 
     static SessionId of(String name) {
+      Preconditions.checkNotNull(name);
       Map<String, String> parts = NAME_TEMPLATE.match(name);
       Preconditions.checkArgument(
           parts != null, "Name should conform to pattern %s: %s", NAME_TEMPLATE, name);


### PR DESCRIPTION
Check and report null input for the static create methods of the InstanceId, InstanceConfigId, DatabaseId, SessionId and BackupId classes.

Fixes #145