### PR TITLE
fix: clean up test instance if creation failed

### DIFF
--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -147,4 +147,16 @@
     <method>com.google.api.gax.paging.Page listDatabases()</method>
   </difference>
   
+  <!-- Adding operation RPCs to InstanceAdminClient. -->
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/InstanceAdminClient</className>
+    <method>void cancelOperation(java.lang.String)</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/InstanceAdminClient</className>
+    <method>com.google.longrunning.Operation getOperation(java.lang.String)</method>
+  </difference>
+  
 </differences>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceAdminClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceAdminClient.java
@@ -20,6 +20,7 @@ import com.google.api.gax.longrunning.OperationFuture;
 import com.google.api.gax.paging.Page;
 import com.google.cloud.Policy;
 import com.google.cloud.spanner.Options.ListOption;
+import com.google.longrunning.Operation;
 import com.google.spanner.admin.instance.v1.CreateInstanceMetadata;
 import com.google.spanner.admin.instance.v1.UpdateInstanceMetadata;
 
@@ -217,4 +218,10 @@ public interface InstanceAdminClient {
 
   /** Returns a builder for {@code Instance} object with the given id. */
   Instance.Builder newInstanceBuilder(InstanceId id);
+
+  /** Cancels the specified long-running operation. */
+  void cancelOperation(String name);
+
+  /** Gets the specified long-running operation. */
+  Operation getOperation(String name);
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceAdminClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceAdminClientImpl.java
@@ -30,6 +30,7 @@ import com.google.cloud.spanner.SpannerImpl.PageFetcher;
 import com.google.cloud.spanner.spi.v1.SpannerRpc;
 import com.google.cloud.spanner.spi.v1.SpannerRpc.Paginated;
 import com.google.common.base.Preconditions;
+import com.google.longrunning.Operation;
 import com.google.protobuf.FieldMask;
 import com.google.spanner.admin.instance.v1.CreateInstanceMetadata;
 import com.google.spanner.admin.instance.v1.UpdateInstanceMetadata;
@@ -219,5 +220,15 @@ class InstanceAdminClientImpl implements InstanceAdminClient {
   @Override
   public Instance.Builder newInstanceBuilder(InstanceId id) {
     return new Instance.Builder(this, dbClient, id);
+  }
+
+  @Override
+  public void cancelOperation(String name) {
+    rpc.cancelOperation(Preconditions.checkNotNull(name));
+  }
+
+  @Override
+  public Operation getOperation(String name) {
+    return rpc.getOperation(Preconditions.checkNotNull(name));
   }
 }


### PR DESCRIPTION
The integration test environment tries to cancel the `CreateInstance` RPC, and otherwise tries to delete the instance, if the creation fails. This also adds the methods `getOperation` and `cancelOperation` to `InstanceAdminClient`. These had already been added to `DatabaseAdminClient`, but not to `InstanceAdminClient`.

Fixes #144
