### PR TITLE
fix: client library should use libraries-bom

### DIFF
--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-spanner</artifactId>
-  <version>1.52.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-spanner:current} -->
   <packaging>jar</packaging>
   <name>Google Cloud Spanner</name>
   <url>https://github.com/googleapis/java-spanner</url>
@@ -22,7 +20,6 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.5</version>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-spanner-parent</artifactId>
   <packaging>pom</packaging>
   <version>1.52.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-spanner:current} -->
@@ -63,17 +62,9 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <github.global.server>github</github.global.server>
     <site.installationModule>google-cloud-spanner-parent</site.installationModule>
-    <google.core.version>1.93.4</google.core.version>
-    <google.api-common.version>1.9.0</google.api-common.version>
-    <google.common-protos.version>1.17.0</google.common-protos.version>
-    <gax.version>1.56.0</gax.version>
-    <grpc.version>1.29.0</grpc.version>
-    <protobuf.version>3.11.4</protobuf.version>
+    <gax.testlib.version>1.56.0</gax.testlib.version>
     <junit.version>4.13</junit.version>
-    <guava.version>29.0-android</guava.version>
     <threeten.version>1.4.3</threeten.version>
-    <javax.annotations.version>1.3.2</javax.annotations.version>
-    <animal-sniffer.version>1.18</animal-sniffer.version>
     <opencensus.version>0.26.0</opencensus.version>
   </properties>
 
@@ -114,91 +105,18 @@
         <artifactId>google-cloud-spanner</artifactId>
         <version>1.52.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-spanner:current} -->
       </dependency>
-
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-bom</artifactId>
-        <version>${grpc.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api</groupId>
-        <artifactId>gax-bom</artifactId>
-        <version>${gax.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava-bom</artifactId>
-        <version>${guava.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-core-bom</artifactId>
-        <version>${google.core.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.auth</groupId>
-        <artifactId>google-auth-library-bom</artifactId>
-        <version>0.20.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.protobuf</groupId>
-        <artifactId>protobuf-bom</artifactId>
-        <version>${protobuf.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.http-client</groupId>
-        <artifactId>google-http-client-bom</artifactId>
-        <version>1.34.2</version>
+        <artifactId>libraries-bom</artifactId>
+        <version>5.1.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
 
-      <dependency>
-        <groupId>com.google.api</groupId>
-        <artifactId>api-common</artifactId>
-        <version>${google.api-common.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api.grpc</groupId>
-        <artifactId>proto-google-common-protos</artifactId>
-        <version>${google.common-protos.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api.grpc</groupId>
-        <artifactId>grpc-google-common-protos</artifactId>
-        <version>${google.common-protos.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api.grpc</groupId>
-        <artifactId>proto-google-iam-v1</artifactId>
-        <version>0.13.0</version>
-      </dependency>
       <dependency>
         <groupId>org.threeten</groupId>
         <artifactId>threetenbp</artifactId>
         <version>${threeten.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>javax.annotation</groupId>
-        <artifactId>javax.annotation-api</artifactId>
-        <version>${javax.annotations.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-annotations</artifactId>
-        <version>${animal-sniffer.version}</version>
       </dependency>
       <dependency>
         <groupId>io.opencensus</groupId>
@@ -220,7 +138,7 @@
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-grpc</artifactId>
-        <version>${gax.version}</version>
+        <version>${gax.testlib.version}</version>
         <classifier>testlib</classifier>
         <scope>test</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
     <gax.testlib.version>1.56.0</gax.testlib.version>
     <junit.version>4.13</junit.version>
     <threeten.version>1.4.3</threeten.version>
+    <javax.annotations.version>1.3.2</javax.annotations.version>
     <opencensus.version>0.26.0</opencensus.version>
   </properties>
 
@@ -117,6 +118,11 @@
         <groupId>org.threeten</groupId>
         <artifactId>threetenbp</artifactId>
         <version>${threeten.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>${javax.annotations.version}</version>
       </dependency>
       <dependency>
         <groupId>io.opencensus</groupId>


### PR DESCRIPTION
The client library should use the `com.google.cloud:libraries-bom` to prevent version conflicts.

Related to https://github.com/GoogleCloudPlatform/java-docs-samples/issues/2718
Fixes #168