### PR TITLE
tests: Attempt to fix random timeouts in ITBackup

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBackupTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBackupTest.java
@@ -246,11 +246,13 @@ public class ITBackupTest {
         Thread.sleep(10_000L);
       }
       if (!dbAdminClient.getOperation(op1.getName()).getDone()) {
+        logger.warning(String.format("Operation %s still not finished", op1.getName()));
         throw SpannerExceptionFactory.newSpannerException(
             ErrorCode.DEADLINE_EXCEEDED,
             "Backup1 still not finished. Test is giving up waiting for it.");
       }
       if (!dbAdminClient.getOperation(op2.getName()).getDone()) {
+        logger.warning(String.format("Operation %s still not finished", op2.getName()));
         throw SpannerExceptionFactory.newSpannerException(
             ErrorCode.DEADLINE_EXCEEDED,
             "Backup2 still not finished. Test is giving up waiting for it.");

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBackupTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBackupTest.java
@@ -240,7 +240,7 @@ public class ITBackupTest {
     } catch (TimeoutException e) {
       logger.warning(
           "Waiting for backup operations to finish timed out. Getting long-running operations.");
-      while (watch.elapsed(TimeUnit.MINUTES) < 5L
+      while (watch.elapsed(TimeUnit.MINUTES) < 12L
           && (!dbAdminClient.getOperation(op1.getName()).getDone()
               || !dbAdminClient.getOperation(op2.getName()).getDone())) {
         Thread.sleep(10_000L);


### PR DESCRIPTION
The `ITBackup` test fails randomly (and lately: consistently) on the CI environment with timeout errors. This seems to be caused by several backup operations that are still in progress and do not finish. Cancelling these before starting the actual backup tests seems to solve the problem (for now).