### PR TITLE
feat: mark when a Spanner client is closed

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner;
 
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.SessionPool.PooledSession;
+import com.google.cloud.spanner.SpannerImpl.ClosedException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -225,7 +226,7 @@ class DatabaseClientImpl implements DatabaseClient {
     }
   }
 
-  ListenableFuture<Void> closeAsync() {
-    return pool.closeAsync();
+  ListenableFuture<Void> closeAsync(ClosedException closedException) {
+    return pool.closeAsync(closedException);
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolIntegrationTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolIntegrationTest.java
@@ -159,18 +159,18 @@ public class SessionPoolIntegrationTest {
 
   @Test
   public void closeQuicklyDoesNotBlockIndefinitely() throws Exception {
-    pool.closeAsync().get();
+    pool.closeAsync(new SpannerImpl.ClosedException()).get();
   }
 
   @Test
   public void closeAfterInitialCreateDoesNotBlockIndefinitely() throws Exception {
     pool.getReadSession().close();
-    pool.closeAsync().get();
+    pool.closeAsync(new SpannerImpl.ClosedException()).get();
   }
 
   @Test
   public void closeWhenSessionsActiveFinishes() throws Exception {
     Session session = pool.getReadSession();
-    pool.closeAsync().get();
+    pool.closeAsync(new SpannerImpl.ClosedException()).get();
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolStressTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolStressTest.java
@@ -322,7 +322,7 @@ public class SessionPoolStressTest extends BaseSessionPoolTest {
       assertThat(maxAliveSessions).isAtMost(maxSessions);
     }
     stopMaintenance.set(true);
-    pool.closeAsync().get();
+    pool.closeAsync(new SpannerImpl.ClosedException()).get();
     Exception e = getFailedError();
     if (e != null) {
       throw e;


### PR DESCRIPTION
Closing a Spanner client means that all resources that have been returned by the client are no longer valid, including all DatabaseClients and corresponding session pools. This will cause errors for any other process that might still want to use these resources. This change marks when and by which call stack a Spanner client is closed, and includes that in any subsequent IllegalStateException that is returned to any process that tries to use the resources that have been returned by the Spanner client. This makes it easier to track down where and when a Spanner client is closed by accident.
