### PR TITLE
chore: bump Spanner version for samples without bom

### DIFF
--- a/samples/install-without-bom/pom.xml
+++ b/samples/install-without-bom/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
-      <version>1.53.0</version>
+      <version>1.54.0</version>
     </dependency>
     <!-- [END spanner_install_without_bom] -->
 


### PR DESCRIPTION
This should fix the broken samples builds.