### PR TITLE
fix: PDML retry settings were not applied for aborted tx

### DIFF
--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -170,5 +170,10 @@
     <className>com/google/cloud/spanner/spi/v1/GapicSpannerRpc</className>
     <method>com.google.spanner.v1.ResultSet executePartitionedDml(com.google.spanner.v1.ExecuteSqlRequest, java.util.Map, org.threeten.bp.Duration)</method>
   </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/spi/v1/SpannerRpc</className>
+    <method>com.google.api.gax.retrying.RetrySettings getPartitionedDmlRetrySettings()</method>
+  </difference>
   
 </differences>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/PartitionedDMLTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/PartitionedDMLTransaction.java
@@ -87,7 +87,8 @@ class PartitionedDMLTransaction implements SessionTransaction {
           }
         };
     com.google.spanner.v1.ResultSet resultSet =
-        SpannerRetryHelper.runTxWithRetriesOnAborted(callable);
+        SpannerRetryHelper.runTxWithRetriesOnAborted(
+            callable, rpc.getPartitionedDmlRetrySettings());
     if (!resultSet.hasStats()) {
       throw new IllegalArgumentException(
           "Partitioned DML response missing stats possibly due to non-DML statement as input");

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerRetryHelper.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerRetryHelper.java
@@ -53,6 +53,14 @@ class SpannerRetryHelper {
 
   /** Executes the {@link Callable} and retries if it fails with an {@link AbortedException}. */
   static <T> T runTxWithRetriesOnAborted(Callable<T> callable) {
+    return runTxWithRetriesOnAborted(callable, txRetrySettings);
+  }
+
+  /**
+   * Executes the {@link Callable} and retries if it fails with an {@link AbortedException} using
+   * the specific {@link RetrySettings}.
+   */
+  static <T> T runTxWithRetriesOnAborted(Callable<T> callable, RetrySettings retrySettings) {
     try {
       return RetryHelper.runWithRetries(
           callable, txRetrySettings, new TxRetryAlgorithm<>(), NanoClock.getDefaultClock());

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerRpc.java
@@ -19,6 +19,7 @@ package com.google.cloud.spanner.spi.v1;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.ServiceRpc;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.admin.database.v1.stub.DatabaseAdminStub;
@@ -282,6 +283,8 @@ public interface SpannerRpc extends ServiceRpc {
   ResultSet executeQuery(ExecuteSqlRequest request, @Nullable Map<Option, ?> options);
 
   ResultSet executePartitionedDml(ExecuteSqlRequest request, @Nullable Map<Option, ?> options);
+
+  RetrySettings getPartitionedDmlRetrySettings();
 
   StreamingCall executeQuery(
       ExecuteSqlRequest request, ResultStreamConsumer consumer, @Nullable Map<Option, ?> options);


### PR DESCRIPTION
The PartitionedDML retry settings were only applied for the RPC, and not for the generic retryer that would retry the PDML transaction if it was aborted by Spanner. This could cause long-running PDML transactions to fail with an Aborted exception.

Fixes #199
