### PR TITLE
fix: remove the need for any env var in all tests

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerImplTest.java
@@ -103,7 +103,11 @@ public class SpannerImplTest {
 
     // Create a SpannerOptions with and without default query options.
     SpannerOptions optionsWithQueryOptions =
-        new SpannerOptions.Builder(SpannerOptions.getDefaultInstance()) {
+        new SpannerOptions.Builder(
+            SpannerOptions.newBuilder()
+                .setProjectId("some-project")
+                .setCredentials(NoCredentials.getInstance())
+                .build()) {
           @Override
           QueryOptions getEnvironmentQueryOptions() {
             // Override and return default instance to prevent environment variables from
@@ -112,7 +116,11 @@ public class SpannerImplTest {
           }
         }.setDefaultQueryOptions(db, queryOptions).build();
     SpannerOptions optionsWithoutQueryOptions =
-        new SpannerOptions.Builder(SpannerOptions.getDefaultInstance()) {
+        new SpannerOptions.Builder(
+            SpannerOptions.newBuilder()
+                .setProjectId("some-project")
+                .setCredentials(NoCredentials.getInstance())
+                .build()) {
           @Override
           QueryOptions getEnvironmentQueryOptions() {
             // Override and return default instance to prevent environment variables from

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
@@ -389,19 +389,36 @@ public class SpannerOptionsTest {
   public void testSetClientLibToken() {
     final String jdbcToken = "sp-jdbc";
     final String hibernateToken = "sp-hib";
-    SpannerOptions options = SpannerOptions.newBuilder().setClientLibToken(jdbcToken).build();
+    SpannerOptions options =
+        SpannerOptions.newBuilder()
+            .setProjectId("some-project")
+            .setCredentials(NoCredentials.getInstance())
+            .setClientLibToken(jdbcToken)
+            .build();
     assertThat(options.getClientLibToken()).isEqualTo(jdbcToken);
 
-    options = SpannerOptions.newBuilder().setClientLibToken(hibernateToken).build();
+    options =
+        SpannerOptions.newBuilder()
+            .setProjectId("some-project")
+            .setCredentials(NoCredentials.getInstance())
+            .setClientLibToken(hibernateToken)
+            .build();
     assertThat(options.getClientLibToken()).isEqualTo(hibernateToken);
 
-    options = SpannerOptions.newBuilder().build();
+    options =
+        SpannerOptions.newBuilder()
+            .setProjectId("some-project")
+            .setCredentials(NoCredentials.getInstance())
+            .build();
     assertThat(options.getClientLibToken()).isEqualTo(ServiceOptions.getGoogApiClientLibName());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testSetInvalidClientLibToken() {
-    SpannerOptions.newBuilder().setClientLibToken("foo");
+    SpannerOptions.newBuilder()
+        .setProjectId("some-project")
+        .setCredentials(NoCredentials.getInstance())
+        .setClientLibToken("foo");
   }
 
   @Test
@@ -443,6 +460,8 @@ public class SpannerOptionsTest {
             .setDefaultQueryOptions(
                 DatabaseId.of("p", "i", "d"),
                 QueryOptions.newBuilder().setOptimizerVersion("1").build())
+            .setProjectId("p")
+            .setCredentials(NoCredentials.getInstance())
             .build();
     assertThat(options.getDefaultQueryOptions(DatabaseId.of("p", "i", "d")))
         .isEqualTo(QueryOptions.newBuilder().setOptimizerVersion("1").build());
@@ -464,6 +483,8 @@ public class SpannerOptionsTest {
             .setDefaultQueryOptions(
                 DatabaseId.of("p", "i", "d"),
                 QueryOptions.newBuilder().setOptimizerVersion("1").build())
+            .setProjectId("p")
+            .setCredentials(NoCredentials.getInstance())
             .build();
     assertThat(options.getDefaultQueryOptions(DatabaseId.of("p", "i", "d")))
         .isEqualTo(QueryOptions.newBuilder().setOptimizerVersion("2").build());

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
@@ -281,6 +281,7 @@ public class GapicSpannerRpcTest {
   public void testCallCredentialsProviderPreferenceAboveCredentials() {
     SpannerOptions options =
         SpannerOptions.newBuilder()
+            .setProjectId("some-project")
             .setCredentials(STATIC_CREDENTIALS)
             .setCallCredentialsProvider(
                 new CallCredentialsProvider() {
@@ -302,6 +303,7 @@ public class GapicSpannerRpcTest {
   public void testCallCredentialsProviderReturnsNull() {
     SpannerOptions options =
         SpannerOptions.newBuilder()
+            .setProjectId("some-project")
             .setCredentials(STATIC_CREDENTIALS)
             .setCallCredentialsProvider(
                 new CallCredentialsProvider() {
@@ -319,7 +321,11 @@ public class GapicSpannerRpcTest {
 
   @Test
   public void testNoCallCredentials() {
-    SpannerOptions options = SpannerOptions.newBuilder().setCredentials(STATIC_CREDENTIALS).build();
+    SpannerOptions options =
+        SpannerOptions.newBuilder()
+            .setProjectId("some-project")
+            .setCredentials(STATIC_CREDENTIALS)
+            .build();
     GapicSpannerRpc rpc = new GapicSpannerRpc(options);
     assertThat(rpc.newCallContext(optionsMap, "/some/resource").getCallOptions().getCredentials())
         .isNull();


### PR DESCRIPTION
Some tests relied on an environment variable having been set for a default project id credentials file. This change removes this dependency by setting an explicit project id and credentials instance.

Fixes the build error in #218 

Towards #219