### PR TITLE
deps: include test-jar in bom

### DIFF
--- a/google-cloud-spanner-bom/pom.xml
+++ b/google-cloud-spanner-bom/pom.xml
@@ -87,6 +87,12 @@
         <version>1.55.1</version><!-- {x-version-update:google-cloud-spanner:current} -->
       </dependency>
       <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-spanner</artifactId>
+        <type>test-jar</type>
+        <version>1.55.1</version><!-- {x-version-update:google-cloud-spanner:current} -->
+      </dependency>
+      <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-spanner-admin-instance-v1</artifactId>
         <version>1.55.1</version><!-- {x-version-update:grpc-google-cloud-spanner-admin-instance-v1:current} -->


### PR DESCRIPTION
Including the google-cloud-spanner test-jar in the bom will allow other libraries to use the test jar without having to specify a version. This again should prevent the kind of failures that we are currently seeing in https://github.com/googleapis/java-spanner-jdbc/pull/142

(The jdbc driver currently defines a specific version for the test-jar in the pom [here](https://github.com/googleapis/java-spanner-jdbc/blob/bc7d5bd6205b23c99d01d2895ffb5c48ba423ea3/pom.xml#L62).)