### PR TITLE
fix: use millis to prevent rounding errors

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerRetryHelper.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerRetryHelper.java
@@ -63,7 +63,7 @@ class SpannerRetryHelper {
   static <T> T runTxWithRetriesOnAborted(Callable<T> callable, RetrySettings retrySettings) {
     try {
       return RetryHelper.runWithRetries(
-          callable, txRetrySettings, new TxRetryAlgorithm<>(), NanoClock.getDefaultClock());
+          callable, retrySettings, new TxRetryAlgorithm<>(), NanoClock.getDefaultClock());
     } catch (RetryHelperException e) {
       if (e.getCause() != null) {
         Throwables.throwIfUnchecked(e.getCause());


### PR DESCRIPTION
Use milliseconds instead of nanoseconds as unit to prevent rounding errors to cause test failures.

Fixes #257
