### PR TITLE
fix: include an explicit version for javax-annotations-api

### DIFF
--- a/google-cloud-spanner-bom/pom.xml
+++ b/google-cloud-spanner-bom/pom.xml
@@ -90,7 +90,7 @@
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-spanner</artifactId>
         <type>test-jar</type>
-        <version>1.55.1</version><!-- {x-version-update:google-cloud-spanner:current} -->
+        <version>1.55.2-SNAPSHOT</version><!-- {x-version-update:google-cloud-spanner:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>

--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -336,6 +336,7 @@
         <dependency>
           <groupId>javax.annotation</groupId>
           <artifactId>javax.annotation-api</artifactId>
+          <version>1.3.2</version>
         </dependency>
       </dependencies>
     </profile>

--- a/grpc-google-cloud-spanner-v1/pom.xml
+++ b/grpc-google-cloud-spanner-v1/pom.xml
@@ -53,6 +53,7 @@
         <dependency>
           <groupId>javax.annotation</groupId>
           <artifactId>javax.annotation-api</artifactId>
+          <version>1.3.2</version>
         </dependency>
       </dependencies>
     </profile>


### PR DESCRIPTION
The Maven flatten plugin transforms the pom of the project from a set of imports and transitive dependencies into a pom that contains all dependencies and versions explicitly. This process did however miss the javax-annotations-api dependency that is only included for JDK9 and higher.

Fixes https://github.com/GoogleCloudPlatform/java-docs-samples/issues/3139
