### PR TITLE
test: get write sessions in one call

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -1324,6 +1324,13 @@ final class SessionPool {
   }
 
   @VisibleForTesting
+  int getNumberOfWriteSessionsInPool() {
+    synchronized (lock) {
+      return writePreparedSessions.size() + numSessionsBeingPrepared;
+    }
+  }
+
+  @VisibleForTesting
   int getNumberOfSessionsBeingCreated() {
     synchronized (lock) {
       return numSessionsBeingCreated;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -1058,9 +1058,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     verify(session, times(options.getMinSessions())).singleUse(any(TimestampBound.class));
     // Verify that all sessions are still in the pool, and that the write fraction is maintained.
     assertThat(pool.getNumberOfSessionsInPool()).isEqualTo(options.getMinSessions());
-    assertThat(
-            pool.getNumberOfAvailableWritePreparedSessions()
-                + pool.getNumberOfSessionsBeingPrepared())
+    assertThat(pool.getNumberOfWriteSessionsInPool())
         .isEqualTo(
             (int) Math.ceil(pool.getNumberOfSessionsInPool() * options.getWriteSessionsFraction()));
 


### PR DESCRIPTION
The test case SessionPoolTest.testMaintainerKeepsWriteProportion could fail as it queried the session pool for the number of write sessions by doing two calls; one for available write sessions and one for sessions being prepared. If one of the sessions that was being prepared was returned to the pool between the two calls, the test case would fail because it calculated the wrong number.

Fixes #264
