### PR TITLE
feat: increase the max length of debug string

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Value.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Value.java
@@ -71,7 +71,7 @@ public abstract class Value implements Serializable {
    */
   public static final Timestamp COMMIT_TIMESTAMP = Timestamp.ofTimeMicroseconds(0L);
 
-  private static final int MAX_DEBUG_STRING_LENGTH = 32;
+  private static final int MAX_DEBUG_STRING_LENGTH = 36;
   private static final String ELLIPSIS = "...";
   private static final String NULL_STRING = "NULL";
   private static final char LIST_SEPERATOR = ',';

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueTest.java
@@ -212,11 +212,11 @@ public class ValueTest {
 
   @Test
   public void stringLong() {
-    String str = "aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd";
+    String str = "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeee";
     Value v = Value.string(str);
     assertThat(v.getString()).isEqualTo(str);
-    assertThat(v.toString()).hasLength(32);
-    assertThat(v.toString()).startsWith(str.substring(0, 32 - 3));
+    assertThat(v.toString()).hasLength(36);
+    assertThat(v.toString()).startsWith(str.substring(0, 36 - 3));
     assertThat(v.toString()).endsWith("...");
   }
 


### PR DESCRIPTION
Increase length of debug string to 36, due to UUID length. According to https://tools.ietf.org/html/rfc4122#section-3 a UUID should be represented as 36 characters (32 hex digits + 4 dashes) in string format. This makes it more convenient for debugging purposes.

Fixes #300 