### PR TITLE
tests: enable Connection API ITs

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ITAbstractSpannerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ITAbstractSpannerTest.java
@@ -49,7 +49,6 @@ import org.junit.experimental.categories.Category;
  * Base class for integration tests. This class is located in this package to be able to access
  * package-private methods of the Connection API
  */
-@Category(IntegrationTest.class)
 public abstract class ITAbstractSpannerTest {
   protected class ITConnectionProvider implements GenericConnectionProvider {
     public ITConnectionProvider() {}

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ITAbstractSpannerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ITAbstractSpannerTest.java
@@ -19,7 +19,6 @@ package com.google.cloud.spanner.connection;
 import com.google.cloud.spanner.Database;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.GceTestEnvConfig;
-import com.google.cloud.spanner.IntegrationTest;
 import com.google.cloud.spanner.IntegrationTestEnv;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerExceptionFactory;
@@ -43,7 +42,6 @@ import java.util.Random;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
 
 /**
  * Base class for integration tests. This class is located in this package to be able to access


### PR DESCRIPTION
The abstract base class for all Connection API integration tests were marked with category IntegrationTest, while all concrete subclasses were marked with ParallelIntegrationTest. This caused them to be excluded from the CI builds.
