### PR TITLE
test: fix potential race condition in Async ResultSet

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
@@ -381,11 +381,11 @@ class AsyncResultSetImpl extends ForwardingStructReader implements ListenableAsy
         while (!stop) {
           waitIfPaused();
           startCallbackIfNecessary();
-          synchronized (monitor) {
-            stop = state.shouldStop || cursorReturnedDoneOrException;
-          }
           // Make sure we wait until the callback runner has actually finished.
           consumingLatch.await();
+          synchronized (monitor) {
+            stop = cursorReturnedDoneOrException;
+          }
         }
       } finally {
         if (executorProvider.shouldAutoClose()) {


### PR DESCRIPTION
If an AsyncResultSet was paused directly after receiving its last row and then cancelled while in paused mode, there was a small chance that the callback would not be called a last time to indicate to the user that the result set had been cancelled.

Updates #327
