### PR TITLE
fix: fix potential unnecessary transaction retry

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -654,7 +654,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
         new Callable<T>() {
           @Override
           public T call() {
-            if (txn.isAborted()) {
+            if (attempt.get() > 0) {
               txn = session.newTransaction();
             }
             checkState(


### PR DESCRIPTION
A transaction could in some circumstances be retried after an abort using the previous transaction id. This would cause the retry to abort directly as well, and then start a new transaction. This extra loop has now been removed.

Fixes #327
