### PR TITLE
fix: runs sample tests in java 8 and java 11

### DIFF
--- a/.kokoro/continuous/samples/common.cfg
+++ b/.kokoro/continuous/samples/common.cfg
@@ -1,0 +1,25 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "samples"
+}
+
+env_vars: {
+    key: "GCLOUD_PROJECT"
+    value: "gcloud-devel"
+}
+
+env_vars: {
+    key: "GOOGLE_APPLICATION_CREDENTIALS"
+    value: "keystore/73713_java_it_service_account"
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "java_it_service_account"
+    }
+  }
+}

--- a/.kokoro/continuous/samples/samples-java11.cfg
+++ b/.kokoro/continuous/samples/samples-java11.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java11"
+}

--- a/.kokoro/continuous/samples/samples-java8.cfg
+++ b/.kokoro/continuous/samples/samples-java8.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java8"
+}

--- a/.kokoro/nightly/samples/common.cfg
+++ b/.kokoro/nightly/samples/common.cfg
@@ -1,0 +1,32 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "samples"
+}
+
+# TODO: remove this after we've migrated all tests and scripts
+env_vars: {
+  key: "GCLOUD_PROJECT"
+  value: "java-docs-samples-testing"
+}
+
+env_vars: {
+  key: "GOOGLE_CLOUD_PROJECT"
+  value: "java-docs-samples-testing"
+}
+
+env_vars: {
+  key: "GOOGLE_APPLICATION_CREDENTIALS"
+  value: "secret_manager/java-docs-samples-service-account"
+}
+
+env_vars: {
+  key: "SECRET_MANAGER_KEYS"
+  value: "java-docs-samples-service-account"
+}
+
+env_vars: {
+  key: "ENABLE_BUILD_COP"
+  value: "true"
+}

--- a/.kokoro/nightly/samples/samples-java11.cfg
+++ b/.kokoro/nightly/samples/samples-java11.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java11"
+}

--- a/.kokoro/nightly/samples/samples-java8.cfg
+++ b/.kokoro/nightly/samples/samples-java8.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java8"
+}

--- a/.kokoro/presubmit/samples/common.cfg
+++ b/.kokoro/presubmit/samples/common.cfg
@@ -1,0 +1,27 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "samples"
+}
+
+# TODO: remove this after we've migrated all tests and scripts
+env_vars: {
+  key: "GCLOUD_PROJECT"
+  value: "java-docs-samples-testing"
+}
+
+env_vars: {
+  key: "GOOGLE_CLOUD_PROJECT"
+  value: "java-docs-samples-testing"
+}
+
+env_vars: {
+  key: "GOOGLE_APPLICATION_CREDENTIALS"
+  value: "secret_manager/java-docs-samples-service-account"
+}
+
+env_vars: {
+  key: "SECRET_MANAGER_KEYS"
+  value: "java-docs-samples-service-account"
+}

--- a/.kokoro/presubmit/samples/samples-java11.cfg
+++ b/.kokoro/presubmit/samples/samples-java11.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java11"
+}

--- a/.kokoro/presubmit/samples/samples-java8.cfg
+++ b/.kokoro/presubmit/samples/samples-java8.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java8"
+}


### PR DESCRIPTION
Adds configuration files in kokoro to run sample tests in java 8 and java 11. These were added in the continuous, nightly and presubmit builds.

This PR adds new `cfg` files for running the tests while not removing the existing sample tests (so that the build succeeds). 
When we switch over to the new `cfg` files for the sample tests, we can remove the old ones.

Fixes #280 and #283 
