### PR TITLE
test: rename integration test

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ITSessionPoolIntegrationTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ITSessionPoolIntegrationTest.java
@@ -102,11 +102,10 @@ public class ITSessionPoolIntegrationTest {
       assertThat(session.get()).isNotNull();
     }
 
-    try (PooledSessionFuture session = pool.getReadSession()) {
+    try (PooledSessionFuture session = pool.getReadSession();
+        PooledSessionFuture session2 = pool.getReadSession()) {
       assertThat(session.get()).isNotNull();
-      PooledSessionFuture session2 = pool.getReadSession();
       assertThat(session2.get()).isNotNull();
-      session2.close();
     }
   }
 


### PR DESCRIPTION
Rename the SessionPoolIntegrationTest to IT... so it is actually picked up by the configuration that executes the integration tests.
