### PR TITLE
refactor: normalises samples config names

### DIFF
--- a/.kokoro/continuous/java11-samples.cfg
+++ b/.kokoro/continuous/java11-samples.cfg
@@ -1,5 +1,11 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java11"
+}
+
 env_vars: {
   key: "JOB_TYPE"
   value: "samples"
@@ -23,3 +29,4 @@ before_action {
     }
   }
 }
+

--- a/.kokoro/continuous/java8-samples.cfg
+++ b/.kokoro/continuous/java8-samples.cfg
@@ -1,0 +1,32 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java8"
+}
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "samples"
+}
+
+env_vars: {
+    key: "GCLOUD_PROJECT"
+    value: "gcloud-devel"
+}
+
+env_vars: {
+    key: "GOOGLE_APPLICATION_CREDENTIALS"
+    value: "keystore/73713_java_it_service_account"
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "java_it_service_account"
+    }
+  }
+}
+

--- a/.kokoro/continuous/samples/samples-java11.cfg
+++ b/.kokoro/continuous/samples/samples-java11.cfg
@@ -1,7 +1,0 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-  key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/java11"
-}

--- a/.kokoro/continuous/samples/samples-java8.cfg
+++ b/.kokoro/continuous/samples/samples-java8.cfg
@@ -1,7 +1,0 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-  key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/java8"
-}

--- a/.kokoro/nightly/java11-samples.cfg
+++ b/.kokoro/nightly/java11-samples.cfg
@@ -1,0 +1,39 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java11"
+}
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "samples"
+}
+
+# TODO: remove this after we've migrated all tests and scripts
+env_vars: {
+  key: "GCLOUD_PROJECT"
+  value: "java-docs-samples-testing"
+}
+
+env_vars: {
+  key: "GOOGLE_CLOUD_PROJECT"
+  value: "java-docs-samples-testing"
+}
+
+env_vars: {
+  key: "GOOGLE_APPLICATION_CREDENTIALS"
+  value: "secret_manager/java-docs-samples-service-account"
+}
+
+env_vars: {
+  key: "SECRET_MANAGER_KEYS"
+  value: "java-docs-samples-service-account"
+}
+
+env_vars: {
+  key: "ENABLE_BUILD_COP"
+  value: "true"
+}
+

--- a/.kokoro/nightly/java8-samples.cfg
+++ b/.kokoro/nightly/java8-samples.cfg
@@ -1,5 +1,11 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java8"
+}
+
 env_vars: {
   key: "JOB_TYPE"
   value: "samples"
@@ -25,3 +31,9 @@ env_vars: {
   key: "SECRET_MANAGER_KEYS"
   value: "java-docs-samples-service-account"
 }
+
+env_vars: {
+  key: "ENABLE_BUILD_COP"
+  value: "true"
+}
+

--- a/.kokoro/nightly/samples/samples-java11.cfg
+++ b/.kokoro/nightly/samples/samples-java11.cfg
@@ -1,7 +1,0 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-  key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/java11"
-}

--- a/.kokoro/nightly/samples/samples-java8.cfg
+++ b/.kokoro/nightly/samples/samples-java8.cfg
@@ -1,7 +1,0 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-  key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/java8"
-}

--- a/.kokoro/presubmit/java11-samples.cfg
+++ b/.kokoro/presubmit/java11-samples.cfg
@@ -1,5 +1,11 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java11"
+}
+
 env_vars: {
   key: "JOB_TYPE"
   value: "samples"
@@ -26,7 +32,3 @@ env_vars: {
   value: "java-docs-samples-service-account"
 }
 
-env_vars: {
-  key: "ENABLE_BUILD_COP"
-  value: "true"
-}

--- a/.kokoro/presubmit/java8-samples.cfg
+++ b/.kokoro/presubmit/java8-samples.cfg
@@ -1,0 +1,34 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java8"
+}
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "samples"
+}
+
+# TODO: remove this after we've migrated all tests and scripts
+env_vars: {
+  key: "GCLOUD_PROJECT"
+  value: "java-docs-samples-testing"
+}
+
+env_vars: {
+  key: "GOOGLE_CLOUD_PROJECT"
+  value: "java-docs-samples-testing"
+}
+
+env_vars: {
+  key: "GOOGLE_APPLICATION_CREDENTIALS"
+  value: "secret_manager/java-docs-samples-service-account"
+}
+
+env_vars: {
+  key: "SECRET_MANAGER_KEYS"
+  value: "java-docs-samples-service-account"
+}
+

--- a/.kokoro/presubmit/samples/samples-java11.cfg
+++ b/.kokoro/presubmit/samples/samples-java11.cfg
@@ -1,7 +1,0 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-  key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/java11"
-}

--- a/.kokoro/presubmit/samples/samples-java8.cfg
+++ b/.kokoro/presubmit/samples/samples-java8.cfg
@@ -1,7 +1,0 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-  key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/java8"
-}


### PR DESCRIPTION
This PR renames the java specific sample config files for kokoro, so that they are the same as it is done in the BigQuery java client. The filename pattern is: java<version>-samples.cfg (see examples here https://github.com/googleapis/java-bigquery/tree/master/.kokoro/nightly).

Fixes #280 and #283 
