### PR TITLE
feat: include SQL statement in error message

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -607,7 +607,7 @@ abstract class AbstractReadContext
   }
 
   ResultSet executeQueryInternalWithOptions(
-      Statement statement,
+      final Statement statement,
       com.google.spanner.v1.ExecuteSqlRequest.QueryMode queryMode,
       Options options,
       ByteString partitionToken) {
@@ -622,7 +622,7 @@ abstract class AbstractReadContext
         new ResumableStreamIterator(MAX_BUFFERED_CHUNKS, SpannerImpl.QUERY, span) {
           @Override
           CloseableIterator<PartialResultSet> startStream(@Nullable ByteString resumeToken) {
-            GrpcStreamIterator stream = new GrpcStreamIterator(prefetchChunks);
+            GrpcStreamIterator stream = new GrpcStreamIterator(statement, prefetchChunks);
             if (resumeToken != null) {
               request.setResumeToken(resumeToken);
             }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
@@ -188,7 +188,7 @@ public final class SpannerExceptionFactory {
     return null;
   }
 
-  private static SpannerException newSpannerExceptionPreformatted(
+  static SpannerException newSpannerExceptionPreformatted(
       ErrorCode code, @Nullable String message, @Nullable Throwable cause) {
     // This is the one place in the codebase that is allowed to call constructors directly.
     DoNotConstructDirectly token = DoNotConstructDirectly.ALLOWED;


### PR DESCRIPTION
Include the SQL statement in the error message when a query fails. By default it does not contain the parameter values of the SQL statement to prevent potentially sensitive information from being logged. The parameter values can be included in the error message by setting the log level for `GrpcStreamIterator` to at least `FINEST`.

Fixes #278
