### PR TITLE
deps: stop auto updates of commons-lang3

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -74,6 +74,12 @@
         "^com.fasterxml.jackson.core"
       ],
       "groupName": "jackson dependencies"
+    },
+    {
+      "packageNames": [
+        "org.apache.commons:commons-lang3"
+      ],
+      "enabled": false
     }
   ],
   "semanticCommits": true,


### PR DESCRIPTION
The updated library only support Java 9+ but we still support Java 7 and
8. We want to stop renovate bot from asking us to update this
dependency.

Updates #258
