### PR TITLE
cleanup: removes unnecessary comments

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/IsRetryableInternalError.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/IsRetryableInternalError.java
@@ -33,10 +33,8 @@ public class IsRetryableInternalError implements Predicate<Throwable> {
   public boolean apply(Throwable cause) {
     if (isInternalError(cause)) {
       if (cause.getMessage().contains(HTTP2_ERROR_MESSAGE)) {
-        // See b/25451313.
         return true;
       } else if (cause.getMessage().contains(CONNECTION_CLOSED_ERROR_MESSAGE)) {
-        // See b/27794742.
         return true;
       } else if (cause.getMessage().contains(EOS_ERROR_MESSAGE)) {
         return true;


### PR DESCRIPTION
Removes buganizer comments from recently created predicate classes.
These URLs are not accessible externally.