### PR TITLE
fix: sets the project for the integration tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,11 @@ integration tests.
 
 ```bash
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account.json
-mvn -Penable-integration-tests clean verify
+mvn \
+  -Penable-integration-tests \
+  -Dspanner.testenv.instance=projects/<your-project>/instances/<your-instance> \
+  -Dspanner.gce.config.project_id=<your-project> \
+  clean verify
 ```
 
 ## Code Samples

--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -69,6 +69,7 @@
           <systemPropertyVariables>
             <spanner.testenv.config.class>com.google.cloud.spanner.GceTestEnvConfig</spanner.testenv.config.class>
             <spanner.testenv.instance>projects/gcloud-devel/instances/spanner-testing</spanner.testenv.instance>
+            <spanner.gce.config.project_id>gcloud-devel</spanner.gce.config.project_id>
           </systemPropertyVariables>
           <forkedProcessTimeoutInSeconds>3000</forkedProcessTimeoutInSeconds>
         </configuration>

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestEnv.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestEnv.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.spanner;
 
-import static com.google.cloud.spanner.testing.EmulatorSpannerHelper.isUsingEmulator;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.api.gax.longrunning.OperationFuture;
@@ -80,7 +79,7 @@ public class IntegrationTestEnv extends ExternalResource {
     SpannerOptions options = config.spannerOptions();
     String instanceProperty = System.getProperty(TEST_INSTANCE_PROPERTY, "");
     InstanceId instanceId;
-    if (!instanceProperty.isEmpty() && !isUsingEmulator()) {
+    if (!instanceProperty.isEmpty()) {
       instanceId = InstanceId.of(instanceProperty);
       isOwnedInstance = false;
       logger.log(Level.INFO, "Using existing test instance: {0}", instanceId);


### PR DESCRIPTION
The emulator uses the project id in order to list the instance configurations. If the none is set, it uses the project set through the `gcloud` tool, which might mismatch the project being used to create the databases in the integration tests.
Here, I explicitly set the project id to be the same as the one being used to create the databases for the integration tests.