### PR TITLE
feat: Add experimental DirectPath support

### DIFF
--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -15,7 +15,9 @@
   </parent>
   <properties>
     <site.installationModule>google-cloud-spanner</site.installationModule>
+    <skipUTs>false</skipUTs>
   </properties>
+
 
   <build>
     <plugins>
@@ -49,6 +51,7 @@
             <id>default-test</id>
             <configuration>
               <excludedGroups>com.google.cloud.spanner.TracerTest,com.google.cloud.spanner.IntegrationTest</excludedGroups>
+              <skipTests>${skipUTs}</skipTests>
             </configuration>
           </execution>
           <execution>
@@ -359,6 +362,27 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>spanner-directpath-it</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <spanner.testenv.config.class>com.google.cloud.spanner.GceTestEnvConfig</spanner.testenv.config.class>
+                <spanner.testenv.instance>projects/directpath-prod-manual-testing/instances/spanner-testing</spanner.testenv.instance>
+                <spanner.gce.config.project_id>directpath-prod-manual-testing</spanner.gce.config.project_id>
+                <spanner.attempt_directpath>true</spanner.attempt_directpath>
+                <spanner.directpath_test_scenario>ipv4</spanner.directpath_test_scenario>
+              </systemPropertyVariables>
+              <forkedProcessTimeoutInSeconds>3000</forkedProcessTimeoutInSeconds>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -320,9 +320,9 @@ public class GapicSpannerRpc implements SpannerRpc {
             // SpannerInterceptorProvider if none is provided
             .setInterceptorProvider(
                 SpannerInterceptorProvider.create(
-                    MoreObjects.firstNonNull(
-                        options.getInterceptorProvider(),
-                        SpannerInterceptorProvider.createDefault()))
+                        MoreObjects.firstNonNull(
+                            options.getInterceptorProvider(),
+                            SpannerInterceptorProvider.createDefault()))
                     .withEncoding(compressorName))
             .setHeaderProvider(mergedHeaderProvider);
 
@@ -333,8 +333,7 @@ public class GapicSpannerRpc implements SpannerRpc {
 
     TransportChannelProvider channelProvider =
         MoreObjects.firstNonNull(
-            options.getChannelProvider(),
-            defaultChannelProviderBuilder.build());
+            options.getChannelProvider(), defaultChannelProviderBuilder.build());
 
     CredentialsProvider credentialsProvider =
         GrpcTransportOptions.setUpCredentialsProvider(options);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -223,6 +223,9 @@ public class GapicSpannerRpc implements SpannerRpc {
   private static final int DEFAULT_PERIOD_SECONDS = 10;
   private static final int GRPC_KEEPALIVE_SECONDS = 2 * 60;
 
+  // TODO(weiranf): Remove this temporary endpoint once DirectPath goes to public beta.
+  private static final String DIRECT_PATH_ENDPOINT = "aa423245250f2bbf.sandbox.googleapis.com:443";
+
   private final ManagedInstantiatingExecutorProvider executorProvider;
   private boolean rpcIsClosed;
   private final SpannerStub spannerStub;
@@ -300,31 +303,38 @@ public class GapicSpannerRpc implements SpannerRpc {
                 .build());
     // First check if SpannerOptions provides a TransportChannerProvider. Create one
     // with information gathered from SpannerOptions if none is provided
+    InstantiatingGrpcChannelProvider.Builder defaultChannelProviderBuilder =
+        InstantiatingGrpcChannelProvider.newBuilder()
+            .setChannelConfigurator(options.getChannelConfigurator())
+            .setEndpoint(options.getEndpoint())
+            .setMaxInboundMessageSize(MAX_MESSAGE_SIZE)
+            .setMaxInboundMetadataSize(MAX_METADATA_SIZE)
+            .setPoolSize(options.getNumChannels())
+            .setExecutor(executorProvider.getExecutor())
+
+            // Set a keepalive time of 120 seconds to help long running
+            // commit GRPC calls succeed
+            .setKeepAliveTime(Duration.ofSeconds(GRPC_KEEPALIVE_SECONDS))
+
+            // Then check if SpannerOptions provides an InterceptorProvider. Create a default
+            // SpannerInterceptorProvider if none is provided
+            .setInterceptorProvider(
+                SpannerInterceptorProvider.create(
+                    MoreObjects.firstNonNull(
+                        options.getInterceptorProvider(),
+                        SpannerInterceptorProvider.createDefault()))
+                    .withEncoding(compressorName))
+            .setHeaderProvider(mergedHeaderProvider);
+
+    // TODO(weiranf): Set to true by default once DirectPath goes to public beta.
+    if (shouldAttemptDirectPath()) {
+      defaultChannelProviderBuilder.setEndpoint(DIRECT_PATH_ENDPOINT).setAttemptDirectPath(true);
+    }
+
     TransportChannelProvider channelProvider =
         MoreObjects.firstNonNull(
             options.getChannelProvider(),
-            InstantiatingGrpcChannelProvider.newBuilder()
-                .setChannelConfigurator(options.getChannelConfigurator())
-                .setEndpoint(options.getEndpoint())
-                .setMaxInboundMessageSize(MAX_MESSAGE_SIZE)
-                .setMaxInboundMetadataSize(MAX_METADATA_SIZE)
-                .setPoolSize(options.getNumChannels())
-                .setExecutor(executorProvider.getExecutor())
-
-                // Set a keepalive time of 120 seconds to help long running
-                // commit GRPC calls succeed
-                .setKeepAliveTime(Duration.ofSeconds(GRPC_KEEPALIVE_SECONDS))
-
-                // Then check if SpannerOptions provides an InterceptorProvider. Create a default
-                // SpannerInterceptorProvider if none is provided
-                .setInterceptorProvider(
-                    SpannerInterceptorProvider.create(
-                            MoreObjects.firstNonNull(
-                                options.getInterceptorProvider(),
-                                SpannerInterceptorProvider.createDefault()))
-                        .withEncoding(compressorName))
-                .setHeaderProvider(mergedHeaderProvider)
-                .build());
+            defaultChannelProviderBuilder.build());
 
     CredentialsProvider credentialsProvider =
         GrpcTransportOptions.setUpCredentialsProvider(options);
@@ -413,6 +423,11 @@ public class GapicSpannerRpc implements SpannerRpc {
     } catch (Exception e) {
       throw newSpannerException(e);
     }
+  }
+
+  // TODO(weiranf): Remove this once DirectPath goes to public beta.
+  private static boolean shouldAttemptDirectPath() {
+    return Boolean.getBoolean("spanner.attempt_directpath");
   }
 
   private static void checkEmulatorConnection(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GceTestEnvConfig.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GceTestEnvConfig.java
@@ -79,10 +79,10 @@ public class GceTestEnvConfig implements TestEnvConfig {
       }
     }
     SpannerInterceptorProvider interceptorProvider =
-        SpannerInterceptorProvider.createDefault()
-            .with(new GrpcErrorInjector(errorProbability));
+        SpannerInterceptorProvider.createDefault().with(new GrpcErrorInjector(errorProbability));
     if (attemptDirectPath) {
-      interceptorProvider = interceptorProvider.with(new DirectPathAddressCheckInterceptor(directPathTestScenario));
+      interceptorProvider =
+          interceptorProvider.with(new DirectPathAddressCheckInterceptor(directPathTestScenario));
     }
     builder.setInterceptorProvider(interceptorProvider);
     options = builder.build();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GceTestEnvConfig.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GceTestEnvConfig.java
@@ -26,11 +26,15 @@ import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
 import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
 import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
+import io.grpc.Grpc;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -41,6 +45,12 @@ public class GceTestEnvConfig implements TestEnvConfig {
   public static final String GCE_CREDENTIALS_FILE = "spanner.gce.config.credentials_file";
   public static final String GCE_STREAM_BROKEN_PROBABILITY =
       "spanner.gce.config.stream_broken_probability";
+  public static final String ATTEMPT_DIRECT_PATH = "spanner.attempt_directpath";
+  public static final String DIRECT_PATH_TEST_SCENARIO = "spanner.directpath_test_scenario";
+
+  // IP address prefixes allocated for DirectPath backends.
+  public static final String DP_IPV6_PREFIX = "2001:4860:8040";
+  public static final String DP_IPV4_PREFIX = "34.126";
 
   private final SpannerOptions options;
 
@@ -51,6 +61,8 @@ public class GceTestEnvConfig implements TestEnvConfig {
     double errorProbability =
         Double.parseDouble(System.getProperty(GCE_STREAM_BROKEN_PROBABILITY, "0.0"));
     checkState(errorProbability <= 1.0);
+    boolean attemptDirectPath = Boolean.getBoolean(ATTEMPT_DIRECT_PATH);
+    String directPathTestScenario = System.getProperty(DIRECT_PATH_TEST_SCENARIO, "");
     SpannerOptions.Builder builder =
         SpannerOptions.newBuilder().setAutoThrottleAdministrativeRequests();
     if (!projectId.isEmpty()) {
@@ -66,12 +78,14 @@ public class GceTestEnvConfig implements TestEnvConfig {
         throw new RuntimeException(e);
       }
     }
-    options =
-        builder
-            .setInterceptorProvider(
-                SpannerInterceptorProvider.createDefault()
-                    .with(new GrpcErrorInjector(errorProbability)))
-            .build();
+    SpannerInterceptorProvider interceptorProvider =
+        SpannerInterceptorProvider.createDefault()
+            .with(new GrpcErrorInjector(errorProbability));
+    if (attemptDirectPath) {
+      interceptorProvider = interceptorProvider.with(new DirectPathAddressCheckInterceptor(directPathTestScenario));
+    }
+    builder.setInterceptorProvider(interceptorProvider);
+    options = builder.build();
   }
 
   @Override
@@ -87,6 +101,7 @@ public class GceTestEnvConfig implements TestEnvConfig {
 
   /** Injects errors in streaming calls to simulate call restarts */
   private static class GrpcErrorInjector implements ClientInterceptor {
+
     private final double errorProbability;
     private final Random random = new Random();
 
@@ -138,6 +153,66 @@ public class GceTestEnvConfig implements TestEnvConfig {
 
     private boolean mayInjectError() {
       return random.nextDouble() < errorProbability;
+    }
+  }
+
+  /**
+   * Captures the request attributes "Grpc.TRANSPORT_ATTR_REMOTE_ADDR" when connection is
+   * established and verifies if the remote address is a DirectPath address. This is only used for
+   * DirectPath testing. {@link ClientCall#getAttributes()}
+   */
+  private static class DirectPathAddressCheckInterceptor implements ClientInterceptor {
+    private final String directPathTestScenario;
+
+    DirectPathAddressCheckInterceptor(String directPathTestScenario) {
+      this.directPathTestScenario = directPathTestScenario;
+    }
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+      final ClientCall<ReqT, RespT> clientCall = next.newCall(method, callOptions);
+      return new SimpleForwardingClientCall<ReqT, RespT>(clientCall) {
+        @Override
+        public void start(Listener<RespT> responseListener, Metadata headers) {
+          super.start(
+              new SimpleForwardingClientCallListener<RespT>(responseListener) {
+                @Override
+                public void onHeaders(Metadata headers) {
+                  // Check peer IP after connection is established.
+                  SocketAddress remoteAddr =
+                      clientCall.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
+                  if (!verifyRemoteAddress(remoteAddr)) {
+                    throw new RuntimeException(
+                        String.format(
+                            "Synthetically aborting the current request because it did not adhere"
+                                + " to the test environment's requirement for DirectPath."
+                                + " Expected test for DirectPath %s scenario,"
+                                + " but RPC was destined for %s",
+                            directPathTestScenario, remoteAddr.toString()));
+                  }
+                  super.onHeaders(headers);
+                }
+              },
+              headers);
+        }
+      };
+    }
+
+    private boolean verifyRemoteAddress(SocketAddress remoteAddr) {
+      if (remoteAddr instanceof InetSocketAddress) {
+        InetAddress inetAddress = ((InetSocketAddress) remoteAddr).getAddress();
+        String addr = inetAddress.getHostAddress();
+        if (directPathTestScenario.equals("ipv4")) {
+          // For ipv4-only VM, client should connect to ipv4 DirectPath addresses.
+          return addr.startsWith(DP_IPV4_PREFIX);
+        } else if (directPathTestScenario.equals("ipv6")) {
+          // For ipv6-enabled VM, client could connect to either ipv4 or ipv6 DirectPath addresses.
+          return addr.startsWith(DP_IPV6_PREFIX) || addr.startsWith(DP_IPV4_PREFIX);
+        }
+      }
+      // For all other scenarios(e.g. fallback), we should allow both DirectPath and CFE addresses.
+      return true;
     }
   }
 }


### PR DESCRIPTION
Previously DirectPath was enabled by an environment variable. Now since gax-java [v1.57.0](https://github.com/googleapis/gax-java/releases/tag/v1.57.0) DirectPath can be enabled by using `InstantiatingGrpcChannelProvider.Builder.setAttemptDirectPath(true)`.

Some changes are temporary and will be removed once DirectPath goes public using the default spanner endpoint. For now we want to be able to test the DirectPath-enabled endpoint with different client scenarios:
- Client is running on a ipv4-only VM
- Client is running on a ipv6-enabled VM
- Client fallbacks to use normal CFE path

For the purpose of our internal E2E tests, I added a test profile called `spanner-directpath-it` which introduces two new sys props:
- `spanner.attempt_directpath`: this defines whether the test client would call `setAttemptDirectPath(true)` and set the spanner endpoint to use the DirectPath-enabled target `aa423245250f2bbf.sandbox.googleapis.com:443`.
- `spanner.directpath_test_scenario`: this defines which of the three scenarios mentioned above to test. 

And for different scenarios we would have different assertions for the test:
- For ipv4-only VM, we introspect the peer IP addresses and expect they have `DP_IPV4_PREFIX`.
- For ipv6-enabled VM, we introspect the peer IP addresses and expect they have either `DP_IPV4_PREFIX` or `DP_IPV6_PREFIX`.
- For fallback cases, we should allow both DirectPath addresses and CFE addresses.

+cc @chingor13 , @vnorigoog 