### PR TITLE
fix: remove potential infinite loop in administrative requests

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -575,6 +575,7 @@ public class GapicSpannerRpc implements SpannerRpc {
     Paginated<Operation> operations;
     do {
       operations = lister.listOperations(nextPageToken);
+      nextPageToken = operations.getNextPageToken();
       for (Operation op : operations.getResults()) {
         Timestamp startTime = getStartTimeFunction.apply(op);
         if (res == null
@@ -590,7 +591,7 @@ public class GapicSpannerRpc implements SpannerRpc {
           break;
         }
       }
-    } while (operations.getNextPageToken() != null);
+    } while (nextPageToken != null);
     return res;
   }
 


### PR DESCRIPTION
The automatic retryer for non-idempotent administrative requests did not keep track of the nextPageToken correctly when querying the backend for running operations. This could cause an infinite loop if a resource (database/backup) with the same name had been created repeatedly on the same instance.
