### PR TITLE
fix: iterate over async result set in sync

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
@@ -559,7 +559,7 @@ class AsyncResultSetImpl extends ForwardingStructReader implements ListenableAsy
       this.state = State.SYNC;
     }
     boolean res = delegateResultSet.next();
-    currentRow = delegateResultSet.getCurrentRowAsStruct();
+    currentRow = res ? delegateResultSet.getCurrentRowAsStruct() : null;
     return res;
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -226,6 +226,19 @@ public class DatabaseClientImplTest {
   }
 
   @Test
+  public void singleUseAsyncWithoutCallback() throws Exception {
+    DatabaseClient client =
+        spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+    int rowCount = 0;
+    try (AsyncResultSet rs = client.singleUse().executeQueryAsync(SELECT1)) {
+      while (rs.next()) {
+        rowCount++;
+      }
+    }
+    assertThat(rowCount).isEqualTo(1);
+  }
+
+  @Test
   public void singleUseBound() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));


### PR DESCRIPTION
Iterating over an AsyncResultSet using a standard `while (rs.next())` loop would fail after the last row was consumed.
