### PR TITLE
feat: add lazy initializer

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractLazyInitializer.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractLazyInitializer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+/**
+ * Generic {@link AbstractLazyInitializer} for any heavy-weight object that might throw an exception during
+ * initialization. The underlying object is initialized at most once.
+ */
+public abstract class AbstractLazyInitializer<T> {
+  private final Object lock = new Object();
+  private volatile boolean initialized;
+  private volatile T object;
+  private volatile Exception error;
+
+  /** Returns an initialized instance of T. */
+  T get() throws Exception {
+    // First check without a lock to improve performance.
+    if (!initialized) {
+      synchronized (lock) {
+        if (!initialized) {
+          try {
+            object = initialize();
+          } catch (Exception e) {
+            error = e;
+          }
+          initialized = true;
+        }
+      }
+    }
+    if (error != null) {
+      throw error;
+    }
+    return object;
+  }
+
+  /**
+   * Initializes the actual object that should be returned. Is called once the first time an
+   * instance of T is required.
+   */
+  public abstract T initialize() throws Exception;
+}

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractLazyInitializer.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractLazyInitializer.java
@@ -17,8 +17,8 @@
 package com.google.cloud.spanner;
 
 /**
- * Generic {@link AbstractLazyInitializer} for any heavy-weight object that might throw an exception during
- * initialization. The underlying object is initialized at most once.
+ * Generic {@link AbstractLazyInitializer} for any heavy-weight object that might throw an exception
+ * during initialization. The underlying object is initialized at most once.
  */
 public abstract class AbstractLazyInitializer<T> {
   private final Object lock = new Object();

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/LazySpannerInitializer.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/LazySpannerInitializer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+/** Default implementation of {@link AbstractLazyInitializer} for a {@link Spanner} instance. */
+public class LazySpannerInitializer extends AbstractLazyInitializer<Spanner> {
+  /**
+   * Initializes a default {@link Spanner} instance. Override this method to create an instance with
+   * custom configuration.
+   */
+  @Override
+  public Spanner initialize() throws Exception {
+    return SpannerOptions.newBuilder().build().getService();
+  }
+}

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/LazySpannerInitializerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/LazySpannerInitializerTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class LazySpannerInitializerTest {
+
+  @Test
+  public void testGet_shouldReturnSameInstance() throws Throwable {
+    final LazySpannerInitializer initializer =
+        new LazySpannerInitializer() {
+          @Override
+          public Spanner initialize() {
+            return mock(Spanner.class);
+          }
+        };
+    Spanner s1 = initializer.get();
+    Spanner s2 = initializer.get();
+    assertThat(s1).isSameInstanceAs(s2);
+  }
+
+  @Test
+  public void testGet_shouldThrowErrorFromInitializeMethod() {
+    final LazySpannerInitializer initializer =
+        new LazySpannerInitializer() {
+          @Override
+          public Spanner initialize() throws IOException {
+            throw new IOException("Could not find credentials file");
+          }
+        };
+    Throwable t1 = null;
+    try {
+      initializer.get();
+      fail("Missing expected exception");
+    } catch (Throwable t) {
+      t1 = t;
+    }
+    Throwable t2 = null;
+    try {
+      initializer.get();
+      fail("Missing expected exception");
+    } catch (Throwable t) {
+      t2 = t;
+    }
+    assertThat(t1).isSameInstanceAs(t2);
+  }
+
+  @Test
+  public void testGet_shouldInvokeInitializeOnlyOnce()
+      throws InterruptedException, ExecutionException {
+    final AtomicInteger count = new AtomicInteger();
+    final LazySpannerInitializer initializer =
+        new LazySpannerInitializer() {
+          @Override
+          public Spanner initialize() {
+            count.incrementAndGet();
+            return mock(Spanner.class);
+          }
+        };
+    final int threads = 16;
+    final CountDownLatch latch = new CountDownLatch(threads);
+    ListeningExecutorService executor =
+        MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(threads));
+    List<ListenableFuture<Spanner>> futures = new ArrayList<>(threads);
+    for (int i = 0; i < threads; i++) {
+      futures.add(
+          executor.submit(
+              new Callable<Spanner>() {
+                @Override
+                public Spanner call() throws Exception {
+                  latch.countDown();
+                  latch.await(10L, TimeUnit.SECONDS);
+                  return initializer.get();
+                }
+              }));
+    }
+    assertThat(Futures.allAsList(futures).get()).hasSize(threads);
+    for (int i = 0; i < threads - 1; i++) {
+      assertThat(futures.get(i).get()).isSameInstanceAs(futures.get(i + 1).get());
+    }
+    assertThat(count.get()).isEqualTo(1);
+    executor.shutdown();
+  }
+}


### PR DESCRIPTION
Adds a `LazyInitializer` for `Spanner` instances that can be used in environments where it is desirable to initialize one instance once, and reuse this for multiple purposes, such as for example Google Cloud Functions.

This change would allow us to simplify the [Google Cloud Functions Java sample](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/functions/spanner/src/main/java/functions/HelloSpanner.java).

Towards https://github.com/GoogleCloudPlatform/java-docs-samples/issues/2862.
