### PR TITLE
fix: do not close delegate rs in callback runnable

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
@@ -275,7 +275,7 @@ class AsyncResultSetImpl extends ForwardingStructReader implements ListenableAsy
               switch (response) {
                 case DONE:
                   state = State.DONE;
-                  closeDelegateResultSet();
+                  cursorReturnedDoneOrException = true;
                   return;
                 case PAUSE:
                   state = State.PAUSED;


### PR DESCRIPTION
`AsyncResultSetImpl` should not close its delegate `ResultSet` in the `CallbackRunnable`, but should leave that to the `ProduceRowsCallable` and instead only set the flag `cursorReturnedDoneOrException`. Otherwise, the main loop that fetches and produces rows could get stuck in an infinite loop.