### PR TITLE
fix: re-adds method used in internal testing

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -1408,6 +1408,14 @@ public class GapicSpannerRpc implements SpannerRpc {
     }
   }
 
+  // Before removing this method, please verify with a code owner that it is not used
+  // in any internal testing infrastructure.
+  @VisibleForTesting
+  @Deprecated
+  GrpcCallContext newCallContext(@Nullable Map<Option, ?> options, String resource) {
+    return newCallContext(options, resource, null, null);
+  }
+
   @VisibleForTesting
   <ReqT, RespT> GrpcCallContext newCallContext(
       @Nullable Map<Option, ?> options,

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
@@ -93,6 +93,7 @@ import org.threeten.bp.Duration;
 /** Tests that opening and closing multiple Spanner instances does not leak any threads. */
 @RunWith(JUnit4.class)
 public class GapicSpannerRpcTest {
+
   private static final Statement SELECT1AND2 =
       Statement.of("SELECT 1 AS COL1 UNION ALL SELECT 2 AS COL1");
   private static final ResultSetMetadata SELECT1AND2_METADATA =
@@ -380,6 +381,7 @@ public class GapicSpannerRpcTest {
   }
 
   private static final class TimeoutHolder {
+
     private Duration timeout;
   }
 
@@ -452,6 +454,14 @@ public class GapicSpannerRpcTest {
             }
           });
     }
+  }
+
+  @Test
+  public void testNewCallContextWithNullRequestAndNullMethod() {
+    SpannerOptions options = SpannerOptions.newBuilder().setProjectId("some-project").build();
+    GapicSpannerRpc rpc = new GapicSpannerRpc(options);
+    assertThat(rpc.newCallContext(optionsMap, "/some/resource", null, null)).isNotNull();
+    rpc.shutdown();
   }
 
   @SuppressWarnings("rawtypes")


### PR DESCRIPTION
We had removed a method from GapicSpannerRpc that was used in the internal testing infrastructure. We are adding this back for the time being.