### PR TITLE
fix: fixed visibility of LazyInit methods

### DIFF
--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -319,4 +319,10 @@
     <className>com/google/cloud/spanner/Value</className>
     <method>java.util.List getNumericArray()</method>
   </difference>
+  
+  <difference>
+    <differenceType>7009</differenceType>
+    <className>com/google/cloud/spanner/AbstractLazyInitializer</className>
+    <method>* initialize()</method>
+  </difference>
 </differences>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractLazyInitializer.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractLazyInitializer.java
@@ -27,7 +27,7 @@ public abstract class AbstractLazyInitializer<T> {
   private volatile Exception error;
 
   /** Returns an initialized instance of T. */
-  T get() throws Exception {
+  public T get() throws Exception {
     // First check without a lock to improve performance.
     if (!initialized) {
       synchronized (lock) {
@@ -51,5 +51,5 @@ public abstract class AbstractLazyInitializer<T> {
    * Initializes the actual object that should be returned. Is called once the first time an
    * instance of T is required.
    */
-  public abstract T initialize() throws Exception;
+  protected abstract T initialize() throws Exception;
 }


### PR DESCRIPTION
The visibility of the two methods in `AbstractLazyInitializer` were simply wrong:
* `initialize()`: Should be `protected` as it is only intended for sub classes to override if needed.
* `get()`: Should be `public` as it is intended for consumers to use to get an instance of the heavy-weight object.
