### PR TITLE
fix: increase visibility of #get()

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractLazyInitializer.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractLazyInitializer.java
@@ -27,7 +27,7 @@ public abstract class AbstractLazyInitializer<T> {
   private volatile Exception error;
 
   /** Returns an initialized instance of T. */
-  T get() throws Exception {
+  public T get() throws Exception {
     // First check without a lock to improve performance.
     if (!initialized) {
       synchronized (lock) {


### PR DESCRIPTION
Increases the visibility of `AbstractLazyInitializer#get()` to make it usable outside the client library.

Replaces #461.