### PR TITLE
fix: ResultSet#close() should not throw exceptions from session creation

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ForwardingResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ForwardingResultSet.java
@@ -65,8 +65,8 @@ public class ForwardingResultSet extends ForwardingStructReader implements Resul
     try {
       rs = delegate.get();
     } catch (Exception e) {
-      // Ignore any exceptions when getting the underlying result set, as that would mean that there
-      // is nothing to close anyways.
+      // Ignore any exceptions when getting the underlying result set, as that means that there is
+      // nothing that needs to be closed.
       return;
     }
     rs.close();

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ForwardingResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ForwardingResultSet.java
@@ -61,7 +61,15 @@ public class ForwardingResultSet extends ForwardingStructReader implements Resul
 
   @Override
   public void close() {
-    delegate.get().close();
+    ResultSet rs;
+    try {
+      rs = delegate.get();
+    } catch (Exception e) {
+      // Ignore any exceptions when getting the underlying result set, as that would mean that there
+      // is nothing to close anyways.
+      return;
+    }
+    rs.close();
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -1255,7 +1255,10 @@ final class SessionPool {
         leakedException = null;
         checkedOutSessions.remove(this);
       }
-      get().close();
+      PooledSession delegate = getOrNull();
+      if (delegate != null) {
+        delegate.close();
+      }
     }
 
     @Override
@@ -1264,7 +1267,19 @@ final class SessionPool {
         leakedException = null;
         checkedOutSessions.remove(this);
       }
-      return get().asyncClose();
+      PooledSession delegate = getOrNull();
+      if (delegate != null) {
+        return delegate.asyncClose();
+      }
+      return ApiFutures.immediateFuture(Empty.getDefaultInstance());
+    }
+
+    private PooledSession getOrNull() {
+      try {
+        return get();
+      } catch (Throwable t) {
+        return null;
+      }
     }
 
     @Override


### PR DESCRIPTION
If a client application requested a session from the session pool, and that request required a new BatchCreateSessions request that would fail, then the error from the BatchCreateSessions RPC would be propagated to both the ReadContext#executeQuery(..) method as well as the ResultSet#close() method. The latter should not happen, as the close method should silently ignore any errors from the session creation.