### PR TITLE
feat!: remove session pool preparing

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
@@ -47,8 +47,8 @@ class DatabaseClientImpl implements DatabaseClient {
   }
 
   @VisibleForTesting
-  PooledSessionFuture getReadSession() {
-    return pool.get();
+  PooledSessionFuture getSession() {
+    return pool.getSession();
   }
 
   @Override
@@ -93,7 +93,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public ReadContext singleUse() {
     Span span = tracer.spanBuilder(READ_ONLY_TRANSACTION).startSpan();
     try (Scope s = tracer.withSpan(span)) {
-      return getReadSession().singleUse();
+      return getSession().singleUse();
     } catch (RuntimeException e) {
       TraceUtil.endSpanWithFailure(span, e);
       throw e;
@@ -104,7 +104,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public ReadContext singleUse(TimestampBound bound) {
     Span span = tracer.spanBuilder(READ_ONLY_TRANSACTION).startSpan();
     try (Scope s = tracer.withSpan(span)) {
-      return getReadSession().singleUse(bound);
+      return getSession().singleUse(bound);
     } catch (RuntimeException e) {
       TraceUtil.endSpanWithFailure(span, e);
       throw e;
@@ -115,7 +115,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public ReadOnlyTransaction singleUseReadOnlyTransaction() {
     Span span = tracer.spanBuilder(READ_ONLY_TRANSACTION).startSpan();
     try (Scope s = tracer.withSpan(span)) {
-      return getReadSession().singleUseReadOnlyTransaction();
+      return getSession().singleUseReadOnlyTransaction();
     } catch (RuntimeException e) {
       TraceUtil.endSpanWithFailure(span, e);
       throw e;
@@ -126,7 +126,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public ReadOnlyTransaction singleUseReadOnlyTransaction(TimestampBound bound) {
     Span span = tracer.spanBuilder(READ_ONLY_TRANSACTION).startSpan();
     try (Scope s = tracer.withSpan(span)) {
-      return getReadSession().singleUseReadOnlyTransaction(bound);
+      return getSession().singleUseReadOnlyTransaction(bound);
     } catch (RuntimeException e) {
       TraceUtil.endSpanWithFailure(span, e);
       throw e;
@@ -137,7 +137,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public ReadOnlyTransaction readOnlyTransaction() {
     Span span = tracer.spanBuilder(READ_ONLY_TRANSACTION).startSpan();
     try (Scope s = tracer.withSpan(span)) {
-      return getReadSession().readOnlyTransaction();
+      return getSession().readOnlyTransaction();
     } catch (RuntimeException e) {
       TraceUtil.endSpanWithFailure(span, e);
       throw e;
@@ -148,7 +148,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public ReadOnlyTransaction readOnlyTransaction(TimestampBound bound) {
     Span span = tracer.spanBuilder(READ_ONLY_TRANSACTION).startSpan();
     try (Scope s = tracer.withSpan(span)) {
-      return getReadSession().readOnlyTransaction(bound);
+      return getSession().readOnlyTransaction(bound);
     } catch (RuntimeException e) {
       TraceUtil.endSpanWithFailure(span, e);
       throw e;
@@ -159,7 +159,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public TransactionRunner readWriteTransaction() {
     Span span = tracer.spanBuilder(READ_WRITE_TRANSACTION).startSpan();
     try (Scope s = tracer.withSpan(span)) {
-      return getReadSession().readWriteTransaction();
+      return getSession().readWriteTransaction();
     } catch (RuntimeException e) {
       TraceUtil.endSpanWithFailure(span, e);
       throw e;
@@ -172,7 +172,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public TransactionManager transactionManager() {
     Span span = tracer.spanBuilder(READ_WRITE_TRANSACTION).startSpan();
     try (Scope s = tracer.withSpan(span)) {
-      return getReadSession().transactionManager();
+      return getSession().transactionManager();
     } catch (RuntimeException e) {
       TraceUtil.endSpanWithFailure(span, e);
       throw e;
@@ -183,7 +183,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public AsyncRunner runAsync() {
     Span span = tracer.spanBuilder(READ_WRITE_TRANSACTION).startSpan();
     try (Scope s = tracer.withSpan(span)) {
-      return getReadSession().runAsync();
+      return getSession().runAsync();
     } catch (RuntimeException e) {
       TraceUtil.endSpanWithFailure(span, e);
       throw e;
@@ -194,7 +194,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public AsyncTransactionManager transactionManagerAsync() {
     Span span = tracer.spanBuilder(READ_WRITE_TRANSACTION).startSpan();
     try (Scope s = tracer.withSpan(span)) {
-      return getReadSession().transactionManagerAsync();
+      return getSession().transactionManagerAsync();
     } catch (RuntimeException e) {
       TraceUtil.endSpanWithFailure(span, e);
       throw e;
@@ -219,7 +219,7 @@ class DatabaseClientImpl implements DatabaseClient {
   }
 
   private <T> T runWithSessionRetry(Function<Session, T> callable) {
-    PooledSessionFuture session = getReadSession();
+    PooledSessionFuture session = getSession();
     while (true) {
       try {
         return callable.apply(session);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MetricRegistryConstants.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MetricRegistryConstants.java
@@ -37,12 +37,20 @@ class MetricRegistryConstants {
 
   static final LabelValue NUM_IN_USE_SESSIONS = LabelValue.create("num_in_use_sessions");
 
+  /**
+   * The session pool no longer prepares a fraction of the sessions with a read/write transaction.
+   * This metric will therefore always be zero and may be removed in the future.
+   */
   @Deprecated
   static final LabelValue NUM_SESSIONS_BEING_PREPARED =
       LabelValue.create("num_sessions_being_prepared");
 
   static final LabelValue NUM_READ_SESSIONS = LabelValue.create("num_read_sessions");
 
+  /**
+   * The session pool no longer prepares a fraction of the sessions with a read/write transaction.
+   * This metric will therefore always be zero and may be removed in the future.
+   */
   @Deprecated
   static final LabelValue NUM_WRITE_SESSIONS = LabelValue.create("num_write_prepared_sessions");
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MetricRegistryConstants.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MetricRegistryConstants.java
@@ -36,9 +36,14 @@ class MetricRegistryConstants {
   private static final LabelValue UNSET_LABEL = LabelValue.create(null);
 
   static final LabelValue NUM_IN_USE_SESSIONS = LabelValue.create("num_in_use_sessions");
+
+  @Deprecated
   static final LabelValue NUM_SESSIONS_BEING_PREPARED =
       LabelValue.create("num_sessions_being_prepared");
+
   static final LabelValue NUM_READ_SESSIONS = LabelValue.create("num_read_sessions");
+
+  @Deprecated
   static final LabelValue NUM_WRITE_SESSIONS = LabelValue.create("num_write_prepared_sessions");
 
   static final ImmutableList<LabelKey> SPANNER_LABEL_KEYS =

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -228,34 +228,24 @@ class SessionImpl implements Session {
   @Override
   public TransactionRunner readWriteTransaction() {
     return setActive(
-        new TransactionRunnerImpl(
-            this,
-            spanner.getRpc(),
-            spanner.getDefaultPrefetchChunks(),
-            spanner.getOptions().isInlineBeginForReadWriteTransaction()));
+        new TransactionRunnerImpl(this, spanner.getRpc(), spanner.getDefaultPrefetchChunks()));
   }
 
   @Override
   public AsyncRunner runAsync() {
     return new AsyncRunnerImpl(
         setActive(
-            new TransactionRunnerImpl(
-                this,
-                spanner.getRpc(),
-                spanner.getDefaultPrefetchChunks(),
-                spanner.getOptions().isInlineBeginForReadWriteTransaction())));
+            new TransactionRunnerImpl(this, spanner.getRpc(), spanner.getDefaultPrefetchChunks())));
   }
 
   @Override
   public TransactionManager transactionManager() {
-    return new TransactionManagerImpl(
-        this, currentSpan, spanner.getOptions().isInlineBeginForReadWriteTransaction());
+    return new TransactionManagerImpl(this, currentSpan);
   }
 
   @Override
   public AsyncTransactionManagerImpl transactionManagerAsync() {
-    return new AsyncTransactionManagerImpl(
-        this, currentSpan, spanner.getOptions().isInlineBeginForReadWriteTransaction());
+    return new AsyncTransactionManagerImpl(this, currentSpan);
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -64,7 +64,6 @@ import com.google.common.util.concurrent.ForwardingListenableFuture.SimpleForwar
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.Empty;
 import io.opencensus.common.Scope;
 import io.opencensus.common.ToLongFunction;
@@ -81,7 +80,6 @@ import io.opencensus.trace.Status;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -92,10 +90,8 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -109,10 +105,8 @@ import org.threeten.bp.Duration;
 import org.threeten.bp.Instant;
 
 /**
- * Maintains a pool of sessions some of which might be prepared for write by invoking
- * BeginTransaction rpc. It maintains two queues of sessions(read and write prepared) and two queues
- * of waiters who are waiting for a session to become available. This class itself is thread safe
- * and is meant to be used concurrently across multiple threads.
+ * Maintains a pool of sessions. This class itself is thread safe and is meant to be used
+ * concurrently across multiple threads.
  */
 final class SessionPool {
 
@@ -319,7 +313,7 @@ final class SessionPool {
         if (isSingleUse || !sessionUsedForQuery) {
           // This class is only used by read-only transactions, so we know that we only need a
           // read-only session.
-          session = sessionPool.replaceReadSession(notFound, session);
+          session = sessionPool.replaceSession(notFound, session);
           readContextDelegate = readContextDelegateSupplier.apply(session);
         } else {
           throw notFound;
@@ -735,7 +729,7 @@ final class SessionPool {
         try {
           return internalBegin();
         } catch (SessionNotFoundException e) {
-          session = sessionPool.replaceReadWriteSession(e, session);
+          session = sessionPool.replaceSession(e, session);
           delegate = session.get().delegate.transactionManager();
         }
       }
@@ -748,7 +742,7 @@ final class SessionPool {
     }
 
     private SpannerException handleSessionNotFound(SessionNotFoundException notFound) {
-      session = sessionPool.replaceReadWriteSession(notFound, session);
+      session = sessionPool.replaceSession(notFound, session);
       delegate = session.get().delegate.transactionManager();
       restartedAfterSessionNotFound = true;
       return SpannerExceptionFactory.newSpannerException(
@@ -789,7 +783,7 @@ final class SessionPool {
             return new SessionPoolTransactionContext(delegate.resetForRetry());
           }
         } catch (SessionNotFoundException e) {
-          session = sessionPool.replaceReadWriteSession(e, session);
+          session = sessionPool.replaceSession(e, session);
           delegate = session.get().delegate.transactionManager();
           restartedAfterSessionNotFound = true;
         }
@@ -828,7 +822,7 @@ final class SessionPool {
 
   /**
    * {@link TransactionRunner} that automatically handles {@link SessionNotFoundException}s by
-   * replacing the underlying read/write session and then restarts the transaction.
+   * replacing the underlying session and then restarts the transaction.
    */
   private static final class SessionPoolTransactionRunner implements TransactionRunner {
     private final SessionPool sessionPool;
@@ -857,7 +851,7 @@ final class SessionPool {
             result = getRunner().run(callable);
             break;
           } catch (SessionNotFoundException e) {
-            session = sessionPool.replaceReadWriteSession(e, session);
+            session = sessionPool.replaceSession(e, session);
             runner = session.get().delegate.readWriteTransaction();
           }
         }
@@ -915,8 +909,7 @@ final class SessionPool {
                   se = SpannerExceptionFactory.newSpannerException(t);
                 } finally {
                   if (se != null && se instanceof SessionNotFoundException) {
-                    session =
-                        sessionPool.replaceReadWriteSession((SessionNotFoundException) se, session);
+                    session = sessionPool.replaceSession((SessionNotFoundException) se, session);
                   } else {
                     break;
                   }
@@ -963,109 +956,6 @@ final class SessionPool {
     AVAILABLE,
     BUSY,
     CLOSING,
-  }
-
-  /**
-   * Forwarding future that will return a {@link PooledSession}. If {@link #inProcessPrepare} has
-   * been set to true, the returned session will be prepared with a read/write session using the
-   * thread of the caller to {@link #get()}. This ensures that the executor that is responsible for
-   * background preparing of read/write transactions is not overwhelmed by requests in case of a
-   * large burst of write requests. Instead of filling up the queue of the background executor, the
-   * caller threads will be used for the BeginTransaction call.
-   */
-  private final class ForwardingListenablePooledSessionFuture
-      extends SimpleForwardingListenableFuture<SessionPool.PooledSession> {
-    private final boolean inProcessPrepare;
-    private final Span span;
-    private volatile boolean initialized = false;
-    private final Object prepareLock = new Object();
-    private volatile PooledSession result;
-    private volatile SpannerException error;
-
-    private ForwardingListenablePooledSessionFuture(
-        ListenableFuture<PooledSession> delegate, boolean inProcessPrepare, Span span) {
-      super(delegate);
-      this.inProcessPrepare = inProcessPrepare;
-      this.span = span;
-    }
-
-    @Override
-    public PooledSession get() throws InterruptedException, ExecutionException {
-      try {
-        return initialize(super.get());
-      } catch (ExecutionException e) {
-        throw SpannerExceptionFactory.newSpannerException(e.getCause());
-      } catch (InterruptedException e) {
-        throw SpannerExceptionFactory.propagateInterrupt(e);
-      }
-    }
-
-    @Override
-    public PooledSession get(long timeout, TimeUnit unit)
-        throws InterruptedException, ExecutionException, TimeoutException {
-      try {
-        return initialize(super.get(timeout, unit));
-      } catch (ExecutionException e) {
-        throw SpannerExceptionFactory.newSpannerException(e.getCause());
-      } catch (InterruptedException e) {
-        throw SpannerExceptionFactory.propagateInterrupt(e);
-      } catch (TimeoutException e) {
-        throw SpannerExceptionFactory.propagateTimeout(e);
-      }
-    }
-
-    private PooledSession initialize(PooledSession sess) {
-      if (!initialized) {
-        synchronized (prepareLock) {
-          if (!initialized) {
-            try {
-              result = prepare(sess);
-            } catch (Throwable t) {
-              error = SpannerExceptionFactory.newSpannerException(t);
-            } finally {
-              initialized = true;
-            }
-          }
-        }
-      }
-      if (error != null) {
-        throw error;
-      }
-      return result;
-    }
-
-    private PooledSession prepare(PooledSession sess) {
-      if (inProcessPrepare && !sess.delegate.hasReadyTransaction()) {
-        while (true) {
-          try {
-            sess.prepareReadWriteTransaction();
-            synchronized (lock) {
-              stopAutomaticPrepare = false;
-            }
-            break;
-          } catch (Throwable t) {
-            if (isClosed()) {
-              span.addAnnotation("Pool has been closed");
-              throw new IllegalStateException("Pool has been closed");
-            }
-            SpannerException e = newSpannerException(t);
-            WaiterFuture waiter = new WaiterFuture();
-            synchronized (lock) {
-              handlePrepareSessionFailure(e, sess, false);
-              if (!isSessionNotFound(e)) {
-                throw e;
-              }
-              readWaiters.add(waiter);
-            }
-            sess = waiter.get();
-            if (sess.delegate.hasReadyTransaction()) {
-              break;
-            }
-          }
-        }
-      }
-      return sess;
-    }
   }
 
   private PooledSessionFuture createPooledSessionFuture(
@@ -1634,18 +1524,15 @@ final class SessionPool {
       synchronized (lock) {
         // Determine the minimum last use time for a session to be deemed to still be alive. Remove
         // all sessions that have a lastUseTime before that time, unless it would cause us to go
-        // below MinSessions. Prefer to remove read sessions above write-prepared sessions.
+        // below MinSessions.
         Instant minLastUseTime = currTime.minus(options.getRemoveInactiveSessionAfter());
-        for (Iterator<PooledSession> iterator :
-            Arrays.asList(
-                readSessions.descendingIterator(), writePreparedSessions.descendingIterator())) {
-          while (iterator.hasNext()) {
-            PooledSession session = iterator.next();
-            if (session.lastUseTime.isBefore(minLastUseTime)) {
-              if (session.state != SessionState.CLOSING) {
-                removeFromPool(session);
-                iterator.remove();
-              }
+        Iterator<PooledSession> iterator = sessions.descendingIterator();
+        while (iterator.hasNext()) {
+          PooledSession session = iterator.next();
+          if (session.lastUseTime.isBefore(minLastUseTime)) {
+            if (session.state != SessionState.CLOSING) {
+              removeFromPool(session);
+              iterator.remove();
             }
           }
         }
@@ -1675,12 +1562,7 @@ final class SessionPool {
       while (numSessionsToKeepAlive > 0) {
         PooledSession sessionToKeepAlive = null;
         synchronized (lock) {
-          sessionToKeepAlive = findSessionToKeepAlive(readSessions, keepAliveThreshold, 0);
-          if (sessionToKeepAlive == null) {
-            sessionToKeepAlive =
-                findSessionToKeepAlive(
-                    writePreparedSessions, keepAliveThreshold, readSessions.size());
-          }
+          sessionToKeepAlive = findSessionToKeepAlive(sessions, keepAliveThreshold, 0);
         }
         if (sessionToKeepAlive == null) {
           break;
@@ -1716,9 +1598,7 @@ final class SessionPool {
   private final SessionClient sessionClient;
   private final ScheduledExecutorService executor;
   private final ExecutorFactory<ScheduledExecutorService> executorFactory;
-  private final ScheduledExecutorService prepareExecutor;
 
-  private final int prepareThreadPoolSize;
   final PoolMaintainer poolMaintainer;
   private final Clock clock;
   private final Object lock = new Object();
@@ -1740,19 +1620,10 @@ final class SessionPool {
   private boolean stopAutomaticPrepare;
 
   @GuardedBy("lock")
-  private final LinkedList<PooledSession> readSessions = new LinkedList<>();
+  private final LinkedList<PooledSession> sessions = new LinkedList<>();
 
   @GuardedBy("lock")
-  private final LinkedList<PooledSession> writePreparedSessions = new LinkedList<>();
-
-  @GuardedBy("lock")
-  private final Queue<WaiterFuture> readWaiters = new LinkedList<>();
-
-  @GuardedBy("lock")
-  private final Queue<WaiterFuture> readWriteWaiters = new LinkedList<>();
-
-  @GuardedBy("lock")
-  private int numSessionsBeingPrepared = 0;
+  private final Queue<WaiterFuture> waiters = new LinkedList<>();
 
   @GuardedBy("lock")
   private int numSessionsBeingCreated = 0;
@@ -1768,12 +1639,6 @@ final class SessionPool {
 
   @GuardedBy("lock")
   private long numSessionsReleased = 0;
-
-  @GuardedBy("lock")
-  private long numSessionsInProcessPrepared = 0;
-
-  @GuardedBy("lock")
-  private long numSessionsAsyncPrepared = 0;
 
   @GuardedBy("lock")
   private long numIdleSessionsRemoved = 0;
@@ -1859,18 +1724,6 @@ final class SessionPool {
     this.options = options;
     this.executorFactory = executorFactory;
     this.executor = executor;
-    if (executor instanceof ThreadPoolExecutor) {
-      prepareThreadPoolSize = Math.max(((ThreadPoolExecutor) executor).getCorePoolSize(), 1);
-    } else {
-      prepareThreadPoolSize = 8;
-    }
-    this.prepareExecutor =
-        Executors.newScheduledThreadPool(
-            prepareThreadPoolSize,
-            new ThreadFactoryBuilder()
-                .setDaemon(true)
-                .setNameFormat("session-pool-prepare-%d")
-                .build());
     this.sessionClient = sessionClient;
     this.clock = clock;
     this.poolMaintainer = new PoolMaintainer();
@@ -1881,19 +1734,6 @@ final class SessionPool {
   int getNumberOfSessionsInUse() {
     synchronized (lock) {
       return numSessionsInUse;
-    }
-  }
-
-  long getNumberOfSessionsInProcessPrepared() {
-    synchronized (lock) {
-      return numSessionsInProcessPrepared;
-    }
-  }
-
-  @VisibleForTesting
-  long getNumberOfSessionsAsyncPrepared() {
-    synchronized (lock) {
-      return numSessionsAsyncPrepared;
     }
   }
 
@@ -1919,23 +1759,9 @@ final class SessionPool {
   }
 
   @VisibleForTesting
-  int getNumberOfAvailableWritePreparedSessions() {
-    synchronized (lock) {
-      return writePreparedSessions.size();
-    }
-  }
-
-  @VisibleForTesting
   int getNumberOfSessionsInPool() {
     synchronized (lock) {
-      return readSessions.size() + writePreparedSessions.size() + numSessionsBeingPrepared;
-    }
-  }
-
-  @VisibleForTesting
-  int getNumberOfWriteSessionsInPool() {
-    synchronized (lock) {
-      return writePreparedSessions.size() + numSessionsBeingPrepared;
+      return sessions.size();
     }
   }
 
@@ -1943,13 +1769,6 @@ final class SessionPool {
   int getNumberOfSessionsBeingCreated() {
     synchronized (lock) {
       return numSessionsBeingCreated;
-    }
-  }
-
-  @VisibleForTesting
-  int getNumberOfSessionsBeingPrepared() {
-    synchronized (lock) {
-      return numSessionsBeingPrepared;
     }
   }
 
@@ -1989,11 +1808,6 @@ final class SessionPool {
     return e instanceof DatabaseNotFoundException || e instanceof InstanceNotFoundException;
   }
 
-  private boolean shouldStopPrepareSessions(SpannerException e) {
-    return isDatabaseOrInstanceNotFound(e)
-        || SHOULD_STOP_PREPARE_SESSIONS_ERROR_CODES.contains(e.getErrorCode());
-  }
-
   private void invalidateSession(PooledSession session) {
     synchronized (lock) {
       if (isClosed()) {
@@ -2031,7 +1845,7 @@ final class SessionPool {
   }
 
   /**
-   * Returns a session to be used for read requests to spanner. It will block if a session is not
+   * Returns a session to be used for requests to spanner. It will block if a session is not
    * currently available. In case the pool is exhausted and {@link
    * SessionPoolOptions#isFailIfPoolExhausted()} has been set, it will throw an exception. Returned
    * session must be closed by calling {@link Session#close()}.
@@ -2040,13 +1854,12 @@ final class SessionPool {
    *
    * <ol>
    *   <li>If a read session is available, return that.
-   *   <li>Otherwise if a writePreparedSession is available, return that.
    *   <li>Otherwise if a session can be created, fire a creation request.
    *   <li>Wait for a session to become available. Note that this can be unblocked either by a
    *       session being returned to the pool or a new session being created.
    * </ol>
    */
-  PooledSessionFuture getReadSession() throws SpannerException {
+  PooledSessionFuture get() throws SpannerException {
     Span span = Tracing.getTracer().getCurrentSpan();
     span.addAnnotation("Acquiring session");
     WaiterFuture waiter = null;
@@ -2065,151 +1878,39 @@ final class SessionPool {
                 resourceNotFoundException.getMessage()),
             resourceNotFoundException);
       }
-      sess = readSessions.poll();
+      sess = sessions.poll();
       if (sess == null) {
-        sess = writePreparedSessions.poll();
-        if (sess == null) {
-          span.addAnnotation("No session available");
-          maybeCreateSession();
-          waiter = new WaiterFuture();
-          readWaiters.add(waiter);
-        } else {
-          span.addAnnotation("Acquired read write session");
-        }
+        span.addAnnotation("No session available");
+        maybeCreateSession();
+        waiter = new WaiterFuture();
+        waiters.add(waiter);
       } else {
-        span.addAnnotation("Acquired read only session");
+        span.addAnnotation("Acquired rsession");
       }
-      return checkoutSession(span, sess, waiter, false, false);
-    }
-  }
-
-  /**
-   * Returns a session which has been prepared for writes by invoking BeginTransaction rpc. It will
-   * block if such a session is not currently available.In case the pool is exhausted and {@link
-   * SessionPoolOptions#isFailIfPoolExhausted()} has been set, it will throw an exception. Returned
-   * session must closed by invoking {@link Session#close()}.
-   *
-   * <p>Implementation strategy:
-   *
-   * <ol>
-   *   <li>If a writePreparedSession is available, return that.
-   *   <li>Otherwise if we have an extra session being prepared for write, wait for that.
-   *   <li>Otherwise, if there is a read session available, start preparing that for write and wait.
-   *   <li>Otherwise start creating a new session and wait.
-   *   <li>Wait for write prepared session to become available. This can be unblocked either by the
-   *       session create/prepare request we fired in above request or by a session being released
-   *       to the pool which is then write prepared.
-   * </ol>
-   */
-  PooledSessionFuture getReadWriteSession() {
-    Span span = Tracing.getTracer().getCurrentSpan();
-    span.addAnnotation("Acquiring read write session");
-    PooledSession sess = null;
-    WaiterFuture waiter = null;
-    boolean inProcessPrepare = stopAutomaticPrepare;
-    synchronized (lock) {
-      if (closureFuture != null) {
-        span.addAnnotation("Pool has been closed");
-        throw new IllegalStateException("Pool has been closed", closedException);
-      }
-      if (resourceNotFoundException != null) {
-        span.addAnnotation("Database has been deleted");
-        throw SpannerExceptionFactory.newSpannerException(
-            ErrorCode.NOT_FOUND,
-            String.format(
-                "The session pool has been invalidated because a previous RPC returned 'Database not found': %s",
-                resourceNotFoundException.getMessage()),
-            resourceNotFoundException);
-      }
-      sess = writePreparedSessions.poll();
-      if (sess == null) {
-        if (!inProcessPrepare && numSessionsBeingPrepared <= prepareThreadPoolSize) {
-          if (numSessionsBeingPrepared <= readWriteWaiters.size()) {
-            PooledSession readSession = readSessions.poll();
-            if (readSession != null) {
-              span.addAnnotation(
-                  "Acquired read only session. Preparing for read write transaction");
-              prepareSession(readSession);
-            } else {
-              span.addAnnotation("No session available");
-              maybeCreateSession();
-            }
-          }
-        } else {
-          inProcessPrepare = true;
-          numSessionsInProcessPrepared++;
-          PooledSession readSession = readSessions.poll();
-          if (readSession != null) {
-            // Create a read/write transaction in-process if there is already a queue for prepared
-            // sessions. This is more efficient than doing it asynchronously, as it scales with
-            // the number of user threads. The thread pool for asynchronously preparing sessions
-            // is fixed.
-            span.addAnnotation(
-                "Acquired read only session. Preparing in-process for read write transaction");
-            sess = readSession;
-          } else {
-            span.addAnnotation("No session available");
-            maybeCreateSession();
-          }
-        }
-        if (sess == null) {
-          waiter = new WaiterFuture();
-          if (inProcessPrepare) {
-            // inProcessPrepare=true means that we have already determined that the queue for
-            // preparing read/write sessions is larger than the number of threads in the prepare
-            // thread pool, and that it's more efficient to do the prepare in-process. We will
-            // therefore create a waiter for a read-only session, even though a read/write session
-            // has been requested.
-            readWaiters.add(waiter);
-          } else {
-            readWriteWaiters.add(waiter);
-          }
-        }
-      } else {
-        span.addAnnotation("Acquired read write session");
-      }
-      return checkoutSession(span, sess, waiter, true, inProcessPrepare);
+      return checkoutSession(span, sess, waiter);
     }
   }
 
   private PooledSessionFuture checkoutSession(
-      final Span span,
-      final PooledSession readySession,
-      WaiterFuture waiter,
-      boolean write,
-      final boolean inProcessPrepare) {
+      final Span span, final PooledSession readySession, WaiterFuture waiter) {
     ListenableFuture<PooledSession> sessionFuture;
     if (waiter != null) {
       logger.log(
           Level.FINE,
           "No session available in the pool. Blocking for one to become available/created");
-      span.addAnnotation(
-          String.format(
-              "Waiting for %s session to be available", write ? "read write" : "read only"));
+      span.addAnnotation(String.format("Waiting for a session to come available"));
       sessionFuture = waiter;
     } else {
       SettableFuture<PooledSession> fut = SettableFuture.create();
       fut.set(readySession);
       sessionFuture = fut;
     }
-    ForwardingListenablePooledSessionFuture forwardingFuture =
-        new ForwardingListenablePooledSessionFuture(sessionFuture, inProcessPrepare, span);
-    PooledSessionFuture res = createPooledSessionFuture(forwardingFuture, span);
+    PooledSessionFuture res = createPooledSessionFuture(sessionFuture, span);
     res.markCheckedOut();
     return res;
   }
 
-  PooledSessionFuture replaceReadSession(SessionNotFoundException e, PooledSessionFuture session) {
-    return replaceSession(e, session, false);
-  }
-
-  PooledSessionFuture replaceReadWriteSession(
-      SessionNotFoundException e, PooledSessionFuture session) {
-    return replaceSession(e, session, true);
-  }
-
-  private PooledSessionFuture replaceSession(
-      SessionNotFoundException e, PooledSessionFuture session, boolean write) {
+  PooledSessionFuture replaceSession(SessionNotFoundException e, PooledSessionFuture session) {
     if (!options.isFailIfSessionNotFound() && session.get().allowReplacing) {
       synchronized (lock) {
         numSessionsInUse--;
@@ -2218,7 +1919,7 @@ final class SessionPool {
       }
       session.leakedException = null;
       invalidateSession(session.get());
-      return write ? getReadWriteSession() : getReadSession();
+      return get();
     } else {
       throw e;
     }
@@ -2258,47 +1959,29 @@ final class SessionPool {
       }
     }
   }
-  /**
-   * Releases a session back to the pool. This might cause one of the waiters to be unblocked.
-   *
-   * <p>Implementation note:
-   *
-   * <ol>
-   *   <li>If there are no pending waiters, either add to the read sessions queue or start preparing
-   *       for write depending on what fraction of sessions are already prepared for writes.
-   *   <li>Otherwise either unblock a waiting reader or start preparing for a write. Exact strategy
-   *       on which option we chose, in case there are both waiting readers and writers, is
-   *       implemented in {@link #shouldUnblockReader}
-   * </ol>
-   */
+  /** Releases a session back to the pool. This might cause one of the waiters to be unblocked. */
   private void releaseSession(PooledSession session, Position position) {
     Preconditions.checkNotNull(session);
     synchronized (lock) {
       if (closureFuture != null) {
         return;
       }
-      if (readWaiters.size() == 0 && numSessionsBeingPrepared >= readWriteWaiters.size()) {
+      if (waiters.size() == 0) {
         // No pending waiters
-        if (shouldPrepareSession()) {
-          prepareSession(session);
-        } else {
-          switch (position) {
-            case RANDOM:
-              if (!readSessions.isEmpty()) {
-                int pos = random.nextInt(readSessions.size() + 1);
-                readSessions.add(pos, session);
-                break;
-              }
-              // fallthrough
-            case FIRST:
-            default:
-              readSessions.addFirst(session);
-          }
+        switch (position) {
+          case RANDOM:
+            if (!sessions.isEmpty()) {
+              int pos = random.nextInt(sessions.size() + 1);
+              sessions.add(pos, session);
+              break;
+            }
+            // fallthrough
+          case FIRST:
+          default:
+            sessions.addFirst(session);
         }
-      } else if (shouldUnblockReader()) {
-        readWaiters.poll().put(session);
       } else {
-        prepareSession(session);
+        waiters.poll().put(session);
       }
     }
   }
@@ -2306,52 +1989,14 @@ final class SessionPool {
   private void handleCreateSessionsFailure(SpannerException e, int count) {
     synchronized (lock) {
       for (int i = 0; i < count; i++) {
-        if (readWaiters.size() > 0) {
-          readWaiters.poll().put(e);
-        } else if (readWriteWaiters.size() > 0) {
-          readWriteWaiters.poll().put(e);
+        if (waiters.size() > 0) {
+          waiters.poll().put(e);
         } else {
           break;
         }
       }
       if (isDatabaseOrInstanceNotFound(e)) {
         setResourceNotFoundException((ResourceNotFoundException) e);
-      }
-    }
-  }
-
-  private void handlePrepareSessionFailure(
-      SpannerException e, PooledSession session, boolean informFirstWaiter) {
-    synchronized (lock) {
-      if (isSessionNotFound(e)) {
-        invalidateSession(session);
-      } else if (shouldStopPrepareSessions(e)) {
-        // Database has been deleted or the user has no permission to write to this database, or
-        // there is some other semi-permanent error. We should stop trying to prepare any
-        // transactions. Also propagate the error to all waiters if the database or instance has
-        // been deleted, as any further waiting is pointless.
-        stopAutomaticPrepare = true;
-        while (readWriteWaiters.size() > 0) {
-          readWriteWaiters.poll().put(e);
-        }
-        while (readWaiters.size() > 0) {
-          readWaiters.poll().put(e);
-        }
-        if (isDatabaseOrInstanceNotFound(e)) {
-          // Remove the session from the pool.
-          if (isClosed()) {
-            decrementPendingClosures(1);
-          }
-          allSessions.remove(session);
-          setResourceNotFoundException((ResourceNotFoundException) e);
-        } else {
-          releaseSession(session, Position.FIRST);
-        }
-      } else if (informFirstWaiter && readWriteWaiters.size() > 0) {
-        releaseSession(session, Position.FIRST);
-        readWriteWaiters.poll().put(e);
-      } else {
-        releaseSession(session, Position.FIRST);
       }
     }
   }
@@ -2368,9 +2013,9 @@ final class SessionPool {
   }
 
   /**
-   * Close all the sessions. Once this method is invoked {@link #getReadSession()} and {@link
-   * #getReadWriteSession()} will start throwing {@code IllegalStateException}. The returned future
-   * blocks till all the sessions created in this pool have been closed.
+   * Close all the sessions. Once this method is invoked {@link #get()} will start throwing {@code
+   * IllegalStateException}. The returned future blocks till all the sessions created in this pool
+   * have been closed.
    */
   ListenableFuture<Void> closeAsync(ClosedException closedException) {
     ListenableFuture<Void> retFuture = null;
@@ -2380,40 +2025,18 @@ final class SessionPool {
       }
       this.closedException = closedException;
       // Fail all pending waiters.
-      WaiterFuture waiter = readWaiters.poll();
+      WaiterFuture waiter = waiters.poll();
       while (waiter != null) {
         waiter.put(newSpannerException(ErrorCode.INTERNAL, "Client has been closed"));
-        waiter = readWaiters.poll();
-      }
-      waiter = readWriteWaiters.poll();
-      while (waiter != null) {
-        waiter.put(newSpannerException(ErrorCode.INTERNAL, "Client has been closed"));
-        waiter = readWriteWaiters.poll();
+        waiter = waiters.poll();
       }
       closureFuture = SettableFuture.create();
       retFuture = closureFuture;
       pendingClosure =
-          totalSessions()
-              + numSessionsBeingCreated
-              + 2 /* For pool maintenance thread + prepareExecutor */;
+          totalSessions() + numSessionsBeingCreated + 1 /* For pool maintenance thread */;
 
       poolMaintainer.close();
-      readSessions.clear();
-      writePreparedSessions.clear();
-      prepareExecutor.shutdown();
-      executor.submit(
-          new Runnable() {
-            @Override
-            public void run() {
-              try {
-                prepareExecutor.awaitTermination(5L, TimeUnit.SECONDS);
-              } catch (Throwable t) {
-              }
-              synchronized (lock) {
-                decrementPendingClosures(1);
-              }
-            }
-          });
+      sessions.clear();
       for (PooledSessionFuture session : checkedOutSessions) {
         if (session.leakedException != null) {
           if (options.isFailOnSessionLeak()) {
@@ -2440,29 +2063,9 @@ final class SessionPool {
     return retFuture;
   }
 
-  private boolean shouldUnblockReader() {
-    // This might not be the best strategy since a continuous burst of read requests can starve
-    // a write request. Maybe maintain a timestamp in the queue and unblock according to that
-    // or just flip a weighted coin.
-    synchronized (lock) {
-      int numWriteWaiters = readWriteWaiters.size() - numSessionsBeingPrepared;
-      return readWaiters.size() > numWriteWaiters;
-    }
-  }
-
-  private boolean shouldPrepareSession() {
-    synchronized (lock) {
-      if (stopAutomaticPrepare) {
-        return false;
-      }
-      int preparedSessions = writePreparedSessions.size() + numSessionsBeingPrepared;
-      return preparedSessions < Math.floor(options.getWriteSessionsFraction() * totalSessions());
-    }
-  }
-
   private int numWaiters() {
     synchronized (lock) {
-      return readWaiters.size() + readWriteWaiters.size();
+      return waiters.size();
     }
   }
 
@@ -2495,43 +2098,6 @@ final class SessionPool {
         },
         MoreExecutors.directExecutor());
     return res;
-  }
-
-  private void prepareSession(final PooledSession sess) {
-    synchronized (lock) {
-      numSessionsBeingPrepared++;
-    }
-    prepareExecutor.submit(
-        new Runnable() {
-          @Override
-          public void run() {
-            try {
-              logger.log(Level.FINE, "Preparing session");
-              sess.prepareReadWriteTransaction();
-              logger.log(Level.FINE, "Session prepared");
-              synchronized (lock) {
-                numSessionsAsyncPrepared++;
-                numSessionsBeingPrepared--;
-                if (!isClosed()) {
-                  if (readWriteWaiters.size() > 0) {
-                    readWriteWaiters.poll().put(sess);
-                  } else if (readWaiters.size() > 0) {
-                    readWaiters.poll().put(sess);
-                  } else {
-                    writePreparedSessions.add(sess);
-                  }
-                }
-              }
-            } catch (Throwable t) {
-              synchronized (lock) {
-                numSessionsBeingPrepared--;
-                if (!isClosed()) {
-                  handlePrepareSessionFailure(newSpannerException(t), sess, true);
-                }
-              }
-            }
-          }
-        });
   }
 
   /**
@@ -2742,7 +2308,8 @@ final class SessionPool {
         new ToLongFunction<SessionPool>() {
           @Override
           public long applyAsLong(SessionPool sessionPool) {
-            return sessionPool.numSessionsBeingPrepared;
+            // TODO: Remove metric.
+            return 0L;
           }
         });
 
@@ -2766,7 +2333,7 @@ final class SessionPool {
         new ToLongFunction<SessionPool>() {
           @Override
           public long applyAsLong(SessionPool sessionPool) {
-            return sessionPool.readSessions.size();
+            return sessionPool.sessions.size();
           }
         });
 
@@ -2778,7 +2345,8 @@ final class SessionPool {
         new ToLongFunction<SessionPool>() {
           @Override
           public long applyAsLong(SessionPool sessionPool) {
-            return sessionPool.writePreparedSessions.size();
+            // TODO: Remove metric.
+            return 0L;
           }
         });
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
@@ -31,7 +31,12 @@ public class SessionPoolOptions {
   private final int maxSessions;
   private final int incStep;
   private final int maxIdleSessions;
+  /**
+   * The session pool no longer prepares a fraction of the sessions with a read/write transaction.
+   * This setting therefore does not have any meaning anymore, and may be removed in the future.
+   */
   @Deprecated private final float writeSessionsFraction;
+
   private final ActionOnExhaustion actionOnExhaustion;
   private final long loopFrequency;
   private final int keepAliveIntervalMinutes;
@@ -77,7 +82,8 @@ public class SessionPoolOptions {
   /**
    * @deprecated This value is no longer used. The session pool does not prepare any sessions for
    *     read/write transactions. Instead, a transaction will be started by including a
-   *     BeginTransaction option with the first statement of a transaction.
+   *     BeginTransaction option with the first statement of a transaction. This method may be
+   *     removed in a future release.
    */
   @Deprecated
   public float getWriteSessionsFraction() {
@@ -145,7 +151,12 @@ public class SessionPoolOptions {
     private int maxSessions = DEFAULT_MAX_SESSIONS;
     private int incStep = DEFAULT_INC_STEP;
     private int maxIdleSessions;
+    /**
+     * The session pool no longer prepares a fraction of the sessions with a read/write transaction.
+     * This setting therefore does not have any meaning anymore, and may be removed in the future.
+     */
     @Deprecated private float writeSessionsFraction = 0.2f;
+
     private ActionOnExhaustion actionOnExhaustion = DEFAULT_ACTION;
     private long initialWaitForSessionTimeoutMillis = 30_000L;
     private ActionOnSessionNotFound actionOnSessionNotFound = ActionOnSessionNotFound.RETRY;
@@ -270,6 +281,7 @@ public class SessionPoolOptions {
      *     any sessions for read/write transactions. Instead, a transaction will automatically be
      *     started by the first statement that is executed by a transaction by including a
      *     BeginTransaction option with that statement.
+     *     <p>This method may be removed in a future release.
      */
     public Builder setWriteSessionsFraction(float writeSessionsFraction) {
       this.writeSessionsFraction = writeSessionsFraction;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
@@ -31,7 +31,7 @@ public class SessionPoolOptions {
   private final int maxSessions;
   private final int incStep;
   private final int maxIdleSessions;
-  private final float writeSessionsFraction;
+  @Deprecated private final float writeSessionsFraction;
   private final ActionOnExhaustion actionOnExhaustion;
   private final long loopFrequency;
   private final int keepAliveIntervalMinutes;
@@ -74,6 +74,12 @@ public class SessionPoolOptions {
     return maxIdleSessions;
   }
 
+  /**
+   * @deprecated This value is no longer used. The session pool does not prepare any sessions for
+   *     read/write transactions. Instead, a transaction will be started by including a
+   *     BeginTransaction option with the first statement of a transaction.
+   */
+  @Deprecated
   public float getWriteSessionsFraction() {
     return writeSessionsFraction;
   }
@@ -139,7 +145,7 @@ public class SessionPoolOptions {
     private int maxSessions = DEFAULT_MAX_SESSIONS;
     private int incStep = DEFAULT_INC_STEP;
     private int maxIdleSessions;
-    private float writeSessionsFraction = 0.2f;
+    @Deprecated private float writeSessionsFraction = 0.2f;
     private ActionOnExhaustion actionOnExhaustion = DEFAULT_ACTION;
     private long initialWaitForSessionTimeoutMillis = 30_000L;
     private ActionOnSessionNotFound actionOnSessionNotFound = ActionOnSessionNotFound.RETRY;
@@ -260,12 +266,10 @@ public class SessionPoolOptions {
     }
 
     /**
-     * Fraction of sessions to be kept prepared for write transactions. This is an optimisation to
-     * avoid the cost of sending a BeginTransaction() rpc. If all such sessions are in use and a
-     * write request comes, we will make the BeginTransaction() rpc inline. It must be between 0 and
-     * 1(inclusive).
-     *
-     * <p>Default value is 0.2.
+     * @deprecated This configuration value is no longer in use. The session pool does not prepare
+     *     any sessions for read/write transactions. Instead, a transaction will automatically be
+     *     started by the first statement that is executed by a transaction by including a
+     *     BeginTransaction option with that statement.
      */
     public Builder setWriteSessionsFraction(float writeSessionsFraction) {
       this.writeSessionsFraction = writeSessionsFraction;
@@ -288,9 +292,6 @@ public class SessionPoolOptions {
       }
       Preconditions.checkArgument(
           keepAliveIntervalMinutes < 60, "Keep alive interval should be less than" + "60 minutes");
-      Preconditions.checkArgument(
-          writeSessionsFraction >= 0 && writeSessionsFraction <= 1,
-          "Fraction of write sessions must be between 0 and 1 (inclusive)");
     }
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
@@ -233,8 +233,7 @@ class SpannerImpl extends BaseService<SpannerOptions> implements Spanner {
 
   @VisibleForTesting
   DatabaseClientImpl createDatabaseClient(String clientId, SessionPool pool) {
-    return new DatabaseClientImpl(
-        clientId, pool, getOptions().isInlineBeginForReadWriteTransaction());
+    return new DatabaseClientImpl(clientId, pool);
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -97,7 +97,6 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
   private final int prefetchChunks;
   private final int numChannels;
   private final ImmutableMap<String, String> sessionLabels;
-  private final boolean inlineBeginForReadWriteTransaction;
   private final SpannerStubSettings spannerStubSettings;
   private final InstanceAdminStubSettings instanceAdminStubSettings;
   private final DatabaseAdminStubSettings databaseAdminStubSettings;
@@ -547,7 +546,6 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
             : SessionPoolOptions.newBuilder().build();
     prefetchChunks = builder.prefetchChunks;
     sessionLabels = builder.sessionLabels;
-    inlineBeginForReadWriteTransaction = builder.inlineBeginForReadWriteTransaction;
     try {
       spannerStubSettings = builder.spannerStubSettingsBuilder.build();
       instanceAdminStubSettings = builder.instanceAdminStubSettingsBuilder.build();
@@ -626,7 +624,6 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     private int prefetchChunks = DEFAULT_PREFETCH_CHUNKS;
     private SessionPoolOptions sessionPoolOptions;
     private ImmutableMap<String, String> sessionLabels;
-    private boolean inlineBeginForReadWriteTransaction;
     private SpannerStubSettings.Builder spannerStubSettingsBuilder =
         SpannerStubSettings.newBuilder();
     private InstanceAdminStubSettings.Builder instanceAdminStubSettingsBuilder =
@@ -676,7 +673,6 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
       this.sessionPoolOptions = options.sessionPoolOptions;
       this.prefetchChunks = options.prefetchChunks;
       this.sessionLabels = options.sessionLabels;
-      this.inlineBeginForReadWriteTransaction = options.inlineBeginForReadWriteTransaction;
       this.spannerStubSettingsBuilder = options.spannerStubSettings.toBuilder();
       this.instanceAdminStubSettingsBuilder = options.instanceAdminStubSettings.toBuilder();
       this.databaseAdminStubSettingsBuilder = options.databaseAdminStubSettings.toBuilder();
@@ -766,34 +762,6 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
         Preconditions.checkNotNull(value, "Null values are not allowed in the labels map.");
       }
       this.sessionLabels = ImmutableMap.copyOf(sessionLabels);
-      return this;
-    }
-
-    /**
-     * Sets whether {@link DatabaseClient}s should inline the BeginTransaction option with the first
-     * query or update statement that is executed by a read/write transaction instead of using a
-     * write-prepared session from the session pool. Enabling this option can improve execution
-     * times for read/write transactions in the following scenarios:
-     *
-     * <p>
-     *
-     * <ul>
-     *   <li>Applications with a very high rate of read/write transactions where the session pool is
-     *       not able to prepare new read/write transactions at the same rate as the application is
-     *       requesting read/write transactions.
-     *   <li>Applications with a very low rate of read/write transactions where sessions with a
-     *       prepared read/write transaction are kept in the session pool for a long time without
-     *       being used.
-     * </ul>
-     *
-     * If you enable this option, you should also re-evaluate the value for {@link
-     * SessionPoolOptions.Builder#setWriteSessionsFraction(float)}. When this option is enabled,
-     * write-prepared sessions are only used for calls to {@link DatabaseClient#write(Iterable)}. If
-     * your application does not use this method, you should set the write fraction for the session
-     * pool to zero.
-     */
-    public Builder setInlineBeginForReadWriteTransaction(boolean inlineBegin) {
-      this.inlineBeginForReadWriteTransaction = inlineBegin;
       return this;
     }
 
@@ -1091,10 +1059,6 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
 
   public Map<String, String> getSessionLabels() {
     return sessionLabels;
-  }
-
-  public boolean isInlineBeginForReadWriteTransaction() {
-    return inlineBeginForReadWriteTransaction;
   }
 
   public SpannerStubSettings getSpannerStubSettings() {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -764,11 +764,9 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
           public T call() {
             boolean useInlinedBegin = true;
             if (attempt.get() > 0) {
-              if (useInlinedBegin) {
-                // Do not inline the BeginTransaction during a retry if the initial attempt did not
-                // actually start a transaction.
-                useInlinedBegin = txn.transactionId != null;
-              }
+              // Do not inline the BeginTransaction during a retry if the initial attempt did not
+              // actually start a transaction.
+              useInlinedBegin = txn.transactionId != null;
               txn = session.newTransaction();
             }
             checkState(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -718,7 +718,6 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
   private boolean blockNestedTxn = true;
   private final SessionImpl session;
   private Span span;
-  private final boolean inlineBegin;
   private TransactionContextImpl txn;
   private volatile boolean isValid = true;
 
@@ -728,10 +727,8 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
     return this;
   }
 
-  TransactionRunnerImpl(
-      SessionImpl session, SpannerRpc rpc, int defaultPrefetchChunks, boolean inlineBegin) {
+  TransactionRunnerImpl(SessionImpl session, SpannerRpc rpc, int defaultPrefetchChunks) {
     this.session = session;
-    this.inlineBegin = inlineBegin;
     this.txn = session.newTransaction();
   }
 
@@ -765,7 +762,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
         new Callable<T>() {
           @Override
           public T call() {
-            boolean useInlinedBegin = inlineBegin;
+            boolean useInlinedBegin = true;
             if (attempt.get() > 0) {
               if (useInlinedBegin) {
                 // Do not inline the BeginTransaction during a retry if the initial attempt did not

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ITSessionPoolIntegrationTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ITSessionPoolIntegrationTest.java
@@ -98,12 +98,12 @@ public class ITSessionPoolIntegrationTest {
 
   @Test
   public void sessionCreation() {
-    try (PooledSessionFuture session = pool.getReadSession()) {
+    try (PooledSessionFuture session = pool.get()) {
       assertThat(session.get()).isNotNull();
     }
 
-    try (PooledSessionFuture session = pool.getReadSession();
-        PooledSessionFuture session2 = pool.getReadSession()) {
+    try (PooledSessionFuture session = pool.get();
+        PooledSessionFuture session2 = pool.get()) {
       assertThat(session.get()).isNotNull();
       assertThat(session2.get()).isNotNull();
     }
@@ -111,14 +111,14 @@ public class ITSessionPoolIntegrationTest {
 
   @Test
   public void poolExhaustion() throws Exception {
-    Session session1 = pool.getReadSession().get();
-    Session session2 = pool.getReadSession().get();
+    Session session1 = pool.get().get();
+    Session session2 = pool.get().get();
     final CountDownLatch latch = new CountDownLatch(1);
     new Thread(
             new Runnable() {
               @Override
               public void run() {
-                try (Session session3 = pool.getReadSession().get()) {
+                try (Session session3 = pool.get().get()) {
                   latch.countDown();
                 }
               }
@@ -132,8 +132,8 @@ public class ITSessionPoolIntegrationTest {
 
   @Test
   public void multipleWaiters() throws Exception {
-    Session session1 = pool.getReadSession().get();
-    Session session2 = pool.getReadSession().get();
+    Session session1 = pool.get().get();
+    Session session2 = pool.get().get();
     int numSessions = 5;
     final CountDownLatch latch = new CountDownLatch(numSessions);
     for (int i = 0; i < numSessions; i++) {
@@ -141,7 +141,7 @@ public class ITSessionPoolIntegrationTest {
               new Runnable() {
                 @Override
                 public void run() {
-                  try (Session session = pool.getReadSession().get()) {
+                  try (Session session = pool.get().get()) {
                     latch.countDown();
                   }
                 }
@@ -161,13 +161,13 @@ public class ITSessionPoolIntegrationTest {
 
   @Test
   public void closeAfterInitialCreateDoesNotBlockIndefinitely() throws Exception {
-    pool.getReadSession().close();
+    pool.get().close();
     pool.closeAsync(new SpannerImpl.ClosedException()).get();
   }
 
   @Test
   public void closeWhenSessionsActiveFinishes() throws Exception {
-    pool.getReadSession().get();
+    pool.get().get();
     // This will log a warning that a session has been leaked, as the session that we retrieved in
     // the previous statement was never returned to the pool.
     pool.closeAsync(new SpannerImpl.ClosedException()).get();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ITSessionPoolIntegrationTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ITSessionPoolIntegrationTest.java
@@ -98,12 +98,12 @@ public class ITSessionPoolIntegrationTest {
 
   @Test
   public void sessionCreation() {
-    try (PooledSessionFuture session = pool.get()) {
+    try (PooledSessionFuture session = pool.getSession()) {
       assertThat(session.get()).isNotNull();
     }
 
-    try (PooledSessionFuture session = pool.get();
-        PooledSessionFuture session2 = pool.get()) {
+    try (PooledSessionFuture session = pool.getSession();
+        PooledSessionFuture session2 = pool.getSession()) {
       assertThat(session.get()).isNotNull();
       assertThat(session2.get()).isNotNull();
     }
@@ -111,14 +111,14 @@ public class ITSessionPoolIntegrationTest {
 
   @Test
   public void poolExhaustion() throws Exception {
-    Session session1 = pool.get().get();
-    Session session2 = pool.get().get();
+    Session session1 = pool.getSession().get();
+    Session session2 = pool.getSession().get();
     final CountDownLatch latch = new CountDownLatch(1);
     new Thread(
             new Runnable() {
               @Override
               public void run() {
-                try (Session session3 = pool.get().get()) {
+                try (Session session3 = pool.getSession().get()) {
                   latch.countDown();
                 }
               }
@@ -132,8 +132,8 @@ public class ITSessionPoolIntegrationTest {
 
   @Test
   public void multipleWaiters() throws Exception {
-    Session session1 = pool.get().get();
-    Session session2 = pool.get().get();
+    Session session1 = pool.getSession().get();
+    Session session2 = pool.getSession().get();
     int numSessions = 5;
     final CountDownLatch latch = new CountDownLatch(numSessions);
     for (int i = 0; i < numSessions; i++) {
@@ -141,7 +141,7 @@ public class ITSessionPoolIntegrationTest {
               new Runnable() {
                 @Override
                 public void run() {
-                  try (Session session = pool.get().get()) {
+                  try (Session session = pool.getSession().get()) {
                     latch.countDown();
                   }
                 }
@@ -161,13 +161,13 @@ public class ITSessionPoolIntegrationTest {
 
   @Test
   public void closeAfterInitialCreateDoesNotBlockIndefinitely() throws Exception {
-    pool.get().close();
+    pool.getSession().close();
     pool.closeAsync(new SpannerImpl.ClosedException()).get();
   }
 
   @Test
   public void closeWhenSessionsActiveFinishes() throws Exception {
-    pool.get().get();
+    pool.getSession().get();
     // This will log a warning that a session has been leaked, as the session that we retrieved in
     // the previous statement was never returned to the pool.
     pool.closeAsync(new SpannerImpl.ClosedException()).get();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginBenchmark.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginBenchmark.java
@@ -77,10 +77,10 @@ public class InlineBeginBenchmark {
     private Spanner spanner;
     private DatabaseClientImpl client;
 
-    @Param({"false", "true"})
+    @Param({"true"})
     boolean inlineBegin;
 
-    @Param({"0.0", "0.2"})
+    @Param({"0.2"})
     float writeFraction;
 
     @Setup(Level.Invocation)
@@ -122,7 +122,6 @@ public class InlineBeginBenchmark {
           .setCredentials(NoCredentials.getInstance())
           .setSessionPoolOption(
               SessionPoolOptions.newBuilder().setWriteSessionsFraction(writeFraction).build())
-          .setInlineBeginForReadWriteTransaction(inlineBegin)
           .build();
     }
 
@@ -130,7 +129,6 @@ public class InlineBeginBenchmark {
       return SpannerOptions.newBuilder()
           .setSessionPoolOption(
               SessionPoolOptions.newBuilder().setWriteSessionsFraction(writeFraction).build())
-          .setInlineBeginForReadWriteTransaction(inlineBegin)
           .build();
     }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
@@ -174,9 +174,6 @@ public class InlineBeginTransactionTest {
             .setProjectId("[PROJECT]")
             .setChannelProvider(channelProvider)
             .setCredentials(NoCredentials.getInstance())
-            .setInlineBeginForReadWriteTransaction(true)
-            .setSessionPoolOption(
-                SessionPoolOptions.newBuilder().setWriteSessionsFraction(0.0f).build())
             .build()
             .getService();
   }
@@ -1061,7 +1058,8 @@ public class InlineBeginTransactionTest {
         }
       }
     }
-    assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(0);
+    // The retry will use a BeginTransaction RPC.
+    assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(1);
     assertThat(countTransactionsStarted()).isEqualTo(2);
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestWithClosedSessionsEnv.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestWithClosedSessionsEnv.java
@@ -74,8 +74,8 @@ public class IntegrationTestWithClosedSessionsEnv extends IntegrationTestEnv {
     }
 
     @Override
-    PooledSessionFuture getReadSession() {
-      PooledSessionFuture session = super.getReadSession();
+    PooledSessionFuture getSession() {
+      PooledSessionFuture session = super.getSession();
       if (invalidateNextSession) {
         session.get().delegate.close();
         session.get().setAllowReplacing(false);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestWithClosedSessionsEnv.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestWithClosedSessionsEnv.java
@@ -47,8 +47,7 @@ public class IntegrationTestWithClosedSessionsEnv extends IntegrationTestEnv {
 
     @Override
     DatabaseClientImpl createDatabaseClient(String clientId, SessionPool pool) {
-      return new DatabaseClientWithClosedSessionImpl(
-          clientId, pool, getOptions().isInlineBeginForReadWriteTransaction());
+      return new DatabaseClientWithClosedSessionImpl(clientId, pool);
     }
   }
 
@@ -60,9 +59,8 @@ public class IntegrationTestWithClosedSessionsEnv extends IntegrationTestEnv {
     private boolean invalidateNextSession = false;
     private boolean allowReplacing = true;
 
-    DatabaseClientWithClosedSessionImpl(
-        String clientId, SessionPool pool, boolean inlineBeginReadWriteTransactions) {
-      super(clientId, pool, inlineBeginReadWriteTransactions);
+    DatabaseClientWithClosedSessionImpl(String clientId, SessionPool pool) {
+      super(clientId, pool);
     }
 
     /** Invalidate the next session that is checked out from the pool. */
@@ -78,20 +76,6 @@ public class IntegrationTestWithClosedSessionsEnv extends IntegrationTestEnv {
     @Override
     PooledSessionFuture getReadSession() {
       PooledSessionFuture session = super.getReadSession();
-      if (invalidateNextSession) {
-        session.get().delegate.close();
-        session.get().setAllowReplacing(false);
-        awaitDeleted(session.get().delegate);
-        session.get().setAllowReplacing(allowReplacing);
-        invalidateNextSession = false;
-      }
-      session.get().setAllowReplacing(allowReplacing);
-      return session;
-    }
-
-    @Override
-    PooledSessionFuture getReadWriteSession() {
-      PooledSessionFuture session = super.getReadWriteSession();
       if (invalidateNextSession) {
         session.get().delegate.close();
         session.get().setAllowReplacing(false);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadWriteTransactionWithInlineBeginTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadWriteTransactionWithInlineBeginTest.java
@@ -125,13 +125,9 @@ public class ReadWriteTransactionWithInlineBeginTest {
   public void setUp() throws IOException {
     mockSpanner.reset();
     mockSpanner.removeAllExecutionTimes();
-    // Create a Spanner instance with no read/write prepared sessions in the pool.
     spanner =
         SpannerOptions.newBuilder()
             .setProjectId("[PROJECT]")
-            .setInlineBeginForReadWriteTransaction(true)
-            .setSessionPoolOption(
-                SessionPoolOptions.newBuilder().setWriteSessionsFraction(0.0f).build())
             .setChannelProvider(channelProvider)
             .setCredentials(NoCredentials.getInstance())
             .build()

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerTest.java
@@ -150,8 +150,8 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
 
     // Checkout two sessions and do a maintenance loop. Still no sessions should be getting any
     // pings.
-    Session session1 = pool.getReadSession();
-    Session session2 = pool.getReadSession();
+    Session session1 = pool.get();
+    Session session2 = pool.get();
     runMaintainanceLoop(clock, pool, 1);
     assertThat(pingedSessions).isEmpty();
 
@@ -173,9 +173,9 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
 
     // Now check out three sessions so the pool will create an additional session. The pool will
     // only keep 2 sessions alive, as that is the setting for MinSessions.
-    Session session3 = pool.getReadSession();
-    Session session4 = pool.getReadSession();
-    Session session5 = pool.getReadSession();
+    Session session3 = pool.get();
+    Session session4 = pool.get();
+    Session session5 = pool.get();
     // Note that session2 was now the first session in the pool as it was the last to receive a
     // ping.
     assertThat(session3.getName()).isEqualTo(session2.getName());
@@ -192,7 +192,7 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
     // should cause only one session to get a ping.
     clock.currentTimeMillis += TimeUnit.MINUTES.toMillis(options.getKeepAliveIntervalMinutes()) + 1;
     // We are now checking out session2 because
-    Session session6 = pool.getReadSession();
+    Session session6 = pool.get();
     // The session that was first in the pool now is equal to the initial first session as each full
     // round of pings will swap the order of the first MinSessions sessions in the pool.
     assertThat(session6.getName()).isEqualTo(session1.getName());
@@ -208,9 +208,9 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
 
     // Now check out 3 sessions again and make sure the 'extra' session is checked in last. That
     // will make it eligible for pings.
-    Session session7 = pool.getReadSession();
-    Session session8 = pool.getReadSession();
-    Session session9 = pool.getReadSession();
+    Session session7 = pool.get();
+    Session session8 = pool.get();
+    Session session9 = pool.get();
 
     assertThat(session7.getName()).isEqualTo(session1.getName());
     assertThat(session8.getName()).isEqualTo(session2.getName());
@@ -244,8 +244,8 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
     assertThat(idledSessions).isEmpty();
 
     // Checkout two sessions and do a maintenance loop. Still no sessions should be removed.
-    Session session1 = pool.getReadSession();
-    Session session2 = pool.getReadSession();
+    Session session1 = pool.get();
+    Session session2 = pool.get();
     runMaintainanceLoop(clock, pool, 1);
     assertThat(idledSessions).isEmpty();
 
@@ -262,9 +262,9 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
 
     // Now check out three sessions so the pool will create an additional session. The pool will
     // only keep 2 sessions alive, as that is the setting for MinSessions.
-    Session session3 = pool.getReadSession().get();
-    Session session4 = pool.getReadSession().get();
-    Session session5 = pool.getReadSession().get();
+    Session session3 = pool.get().get();
+    Session session4 = pool.get().get();
+    Session session5 = pool.get().get();
     // Note that session2 was now the first session in the pool as it was the last to receive a
     // ping.
     assertThat(session3.getName()).isEqualTo(session2.getName());
@@ -279,9 +279,9 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
     assertThat(pool.totalSessions()).isEqualTo(2);
 
     // Check out three sessions again and keep one session checked out.
-    Session session6 = pool.getReadSession().get();
-    Session session7 = pool.getReadSession().get();
-    Session session8 = pool.getReadSession().get();
+    Session session6 = pool.get().get();
+    Session session7 = pool.get().get();
+    Session session8 = pool.get().get();
     session8.close();
     session7.close();
     // Now advance the clock to idle sessions. This should remove session8 from the pool.
@@ -293,9 +293,9 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
 
     // Check out three sessions and keep them all checked out. No sessions should be removed from
     // the pool.
-    Session session9 = pool.getReadSession().get();
-    Session session10 = pool.getReadSession().get();
-    Session session11 = pool.getReadSession().get();
+    Session session9 = pool.get().get();
+    Session session10 = pool.get().get();
+    Session session11 = pool.get().get();
     runMaintainanceLoop(clock, pool, loopsToIdleSessions);
     assertThat(idledSessions).containsExactly(session5, session8);
     assertThat(pool.totalSessions()).isEqualTo(3);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerTest.java
@@ -150,8 +150,8 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
 
     // Checkout two sessions and do a maintenance loop. Still no sessions should be getting any
     // pings.
-    Session session1 = pool.get();
-    Session session2 = pool.get();
+    Session session1 = pool.getSession();
+    Session session2 = pool.getSession();
     runMaintainanceLoop(clock, pool, 1);
     assertThat(pingedSessions).isEmpty();
 
@@ -173,9 +173,9 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
 
     // Now check out three sessions so the pool will create an additional session. The pool will
     // only keep 2 sessions alive, as that is the setting for MinSessions.
-    Session session3 = pool.get();
-    Session session4 = pool.get();
-    Session session5 = pool.get();
+    Session session3 = pool.getSession();
+    Session session4 = pool.getSession();
+    Session session5 = pool.getSession();
     // Note that session2 was now the first session in the pool as it was the last to receive a
     // ping.
     assertThat(session3.getName()).isEqualTo(session2.getName());
@@ -192,7 +192,7 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
     // should cause only one session to get a ping.
     clock.currentTimeMillis += TimeUnit.MINUTES.toMillis(options.getKeepAliveIntervalMinutes()) + 1;
     // We are now checking out session2 because
-    Session session6 = pool.get();
+    Session session6 = pool.getSession();
     // The session that was first in the pool now is equal to the initial first session as each full
     // round of pings will swap the order of the first MinSessions sessions in the pool.
     assertThat(session6.getName()).isEqualTo(session1.getName());
@@ -208,9 +208,9 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
 
     // Now check out 3 sessions again and make sure the 'extra' session is checked in last. That
     // will make it eligible for pings.
-    Session session7 = pool.get();
-    Session session8 = pool.get();
-    Session session9 = pool.get();
+    Session session7 = pool.getSession();
+    Session session8 = pool.getSession();
+    Session session9 = pool.getSession();
 
     assertThat(session7.getName()).isEqualTo(session1.getName());
     assertThat(session8.getName()).isEqualTo(session2.getName());
@@ -244,8 +244,8 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
     assertThat(idledSessions).isEmpty();
 
     // Checkout two sessions and do a maintenance loop. Still no sessions should be removed.
-    Session session1 = pool.get();
-    Session session2 = pool.get();
+    Session session1 = pool.getSession();
+    Session session2 = pool.getSession();
     runMaintainanceLoop(clock, pool, 1);
     assertThat(idledSessions).isEmpty();
 
@@ -262,9 +262,9 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
 
     // Now check out three sessions so the pool will create an additional session. The pool will
     // only keep 2 sessions alive, as that is the setting for MinSessions.
-    Session session3 = pool.get().get();
-    Session session4 = pool.get().get();
-    Session session5 = pool.get().get();
+    Session session3 = pool.getSession().get();
+    Session session4 = pool.getSession().get();
+    Session session5 = pool.getSession().get();
     // Note that session2 was now the first session in the pool as it was the last to receive a
     // ping.
     assertThat(session3.getName()).isEqualTo(session2.getName());
@@ -279,9 +279,9 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
     assertThat(pool.totalSessions()).isEqualTo(2);
 
     // Check out three sessions again and keep one session checked out.
-    Session session6 = pool.get().get();
-    Session session7 = pool.get().get();
-    Session session8 = pool.get().get();
+    Session session6 = pool.getSession().get();
+    Session session7 = pool.getSession().get();
+    Session session8 = pool.getSession().get();
     session8.close();
     session7.close();
     // Now advance the clock to idle sessions. This should remove session8 from the pool.
@@ -293,9 +293,9 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
 
     // Check out three sessions and keep them all checked out. No sessions should be removed from
     // the pool.
-    Session session9 = pool.get().get();
-    Session session10 = pool.get().get();
-    Session session11 = pool.get().get();
+    Session session9 = pool.getSession().get();
+    Session session10 = pool.getSession().get();
+    Session session11 = pool.getSession().get();
     runMaintainanceLoop(clock, pool, loopsToIdleSessions);
     assertThat(idledSessions).containsExactly(session5, session8);
     assertThat(pool.totalSessions()).isEqualTo(3);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolStressTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolStressTest.java
@@ -205,15 +205,6 @@ public class SessionPoolStressTest extends BaseSessionPoolTest {
     }
   }
 
-  private void assertWritePrepared(Session session) {
-    String name = session.getName();
-    synchronized (lock) {
-      if (!sessions.containsKey(name) || !sessions.get(name)) {
-        setFailed();
-      }
-    }
-  }
-
   private void resetTransaction(SessionImpl session) {
     String name = session.getName();
     synchronized (lock) {
@@ -242,7 +233,6 @@ public class SessionPoolStressTest extends BaseSessionPoolTest {
     final int numOperationsPerThread = 1000;
     final CountDownLatch releaseThreads = new CountDownLatch(1);
     final CountDownLatch threadsDone = new CountDownLatch(concurrentThreads);
-    final int writeOperationFraction = 5;
     setupSpanner(db);
     int minSessions = 2;
     int maxSessions = concurrentThreads / 2;
@@ -280,15 +270,8 @@ public class SessionPoolStressTest extends BaseSessionPoolTest {
                   Uninterruptibles.awaitUninterruptibly(releaseThreads);
                   for (int j = 0; j < numOperationsPerThread; j++) {
                     try {
-                      PooledSessionFuture session = null;
-                      if (random.nextInt(10) < writeOperationFraction) {
-                        session = pool.getReadWriteSession();
-                        PooledSession sess = session.get();
-                        assertWritePrepared(sess);
-                      } else {
-                        session = pool.getReadSession();
-                        session.get();
-                      }
+                      PooledSessionFuture session = pool.get();
+                      session.get();
                       Uninterruptibles.sleepUninterruptibly(
                           random.nextInt(5), TimeUnit.MILLISECONDS);
                       resetTransaction(session.get().delegate);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolStressTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolStressTest.java
@@ -270,7 +270,7 @@ public class SessionPoolStressTest extends BaseSessionPoolTest {
                   Uninterruptibles.awaitUninterruptibly(releaseThreads);
                   for (int j = 0; j < numOperationsPerThread; j++) {
                     try {
-                      PooledSessionFuture session = pool.get();
+                      PooledSessionFuture session = pool.getSession();
                       session.get();
                       Uninterruptibles.sleepUninterruptibly(
                           random.nextInt(5), TimeUnit.MILLISECONDS);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -54,7 +54,6 @@ import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import com.google.cloud.spanner.TransactionRunnerImpl.TransactionContextImpl;
 import com.google.cloud.spanner.spi.v1.SpannerRpc;
 import com.google.cloud.spanner.spi.v1.SpannerRpc.ResultStreamConsumer;
-import com.google.common.base.Stopwatch;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.protobuf.ByteString;
@@ -180,7 +179,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     assertThat(pool.isValid()).isTrue();
     closePoolWithStacktrace();
     try {
-      pool.getReadSession();
+      pool.get();
       fail("missing expected exception");
     } catch (IllegalStateException e) {
       assertThat(e.getCause()).isInstanceOf(ClosedException.class);
@@ -198,7 +197,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
   public void sessionCreation() {
     setupMockSessionCreation();
     pool = createPool();
-    try (Session session = pool.getReadSession()) {
+    try (Session session = pool.get()) {
       assertThat(session).isNotNull();
     }
   }
@@ -207,25 +206,18 @@ public class SessionPoolTest extends BaseSessionPoolTest {
   public void poolLifo() {
     setupMockSessionCreation();
     pool = createPool();
-    Session session1 = pool.getReadSession().get();
-    Session session2 = pool.getReadSession().get();
+    Session session1 = pool.get().get();
+    Session session2 = pool.get().get();
     assertThat(session1).isNotEqualTo(session2);
 
     session2.close();
     session1.close();
-    Session session3 = pool.getReadSession().get();
-    Session session4 = pool.getReadSession().get();
+    Session session3 = pool.get().get();
+    Session session4 = pool.get().get();
     assertThat(session3).isEqualTo(session1);
     assertThat(session4).isEqualTo(session2);
     session3.close();
     session4.close();
-
-    Session session5 = pool.getReadWriteSession().get();
-    Session session6 = pool.getReadWriteSession().get();
-    assertThat(session5).isEqualTo(session4);
-    assertThat(session6).isEqualTo(session3);
-    session6.close();
-    session5.close();
   }
 
   @Test
@@ -260,9 +252,9 @@ public class SessionPoolTest extends BaseSessionPoolTest {
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
-    Session session1 = pool.getReadSession();
+    Session session1 = pool.get();
     // Leaked sessions
-    PooledSessionFuture leakedSession = pool.getReadSession();
+    PooledSessionFuture leakedSession = pool.get();
     // Clear the leaked exception to suppress logging of expected exceptions.
     leakedSession.clearLeakedException();
     session1.close();
@@ -338,7 +330,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
 
     pool = createPool();
-    PooledSessionFuture leakedSession = pool.getReadSession();
+    PooledSessionFuture leakedSession = pool.get();
     // Suppress expected leakedSession warning.
     leakedSession.clearLeakedException();
     AtomicBoolean failed = new AtomicBoolean(false);
@@ -396,12 +388,12 @@ public class SessionPoolTest extends BaseSessionPoolTest {
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
 
     pool = createPool();
-    PooledSessionFuture leakedSession = pool.getReadSession();
+    PooledSessionFuture leakedSession = pool.get();
     // Suppress expected leakedSession warning.
     leakedSession.clearLeakedException();
     AtomicBoolean failed = new AtomicBoolean(false);
     CountDownLatch latch = new CountDownLatch(1);
-    getReadWriteSessionAsync(latch, failed);
+    getSessionAsync(latch, failed);
     insideCreation.await();
     pool.closeAsync(new SpannerImpl.ClosedException());
     releaseCreation.countDown();
@@ -447,51 +439,6 @@ public class SessionPoolTest extends BaseSessionPoolTest {
   }
 
   @Test
-  public void poolClosesEvenIfPreparationFails() throws Exception {
-    final SessionImpl session = mockSession();
-    doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(session);
-                      }
-                    });
-                return null;
-              }
-            })
-        .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
-    final CountDownLatch insidePrepare = new CountDownLatch(1);
-    final CountDownLatch releasePrepare = new CountDownLatch(1);
-    doAnswer(
-            new Answer<Session>() {
-              @Override
-              public Session answer(InvocationOnMock invocation) throws Throwable {
-                insidePrepare.countDown();
-                releasePrepare.await();
-                throw SpannerExceptionFactory.newSpannerException(new RuntimeException());
-              }
-            })
-        .when(session)
-        .prepareReadWriteTransaction();
-    pool = createPool();
-    AtomicBoolean failed = new AtomicBoolean(false);
-    CountDownLatch latch = new CountDownLatch(1);
-    getReadWriteSessionAsync(latch, failed);
-    insidePrepare.await();
-    ListenableFuture<Void> f = pool.closeAsync(new SpannerImpl.ClosedException());
-    releasePrepare.countDown();
-    f.get();
-    assertThat(f.isDone()).isTrue();
-  }
-
-  @Test
   public void poolClosureFailsNewRequests() {
     final SessionImpl session = mockSession();
     doAnswer(
@@ -513,13 +460,13 @@ public class SessionPoolTest extends BaseSessionPoolTest {
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
-    PooledSessionFuture leakedSession = pool.getReadSession();
+    PooledSessionFuture leakedSession = pool.get();
     leakedSession.get();
     // Suppress expected leakedSession warning.
     leakedSession.clearLeakedException();
     pool.closeAsync(new SpannerImpl.ClosedException());
     try {
-      pool.getReadSession();
+      pool.get();
       fail("Expected exception");
     } catch (IllegalStateException ex) {
       assertNotNull(ex.getMessage());
@@ -566,281 +513,11 @@ public class SessionPoolTest extends BaseSessionPoolTest {
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
     try {
-      pool.getReadSession().get();
+      pool.get().get();
       fail("Expected exception");
     } catch (SpannerException ex) {
       assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INTERNAL);
     }
-  }
-
-  @Test
-  public void creationExceptionPropagatesToReadWriteSession() {
-    doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    new Callable<Void>() {
-                      @Override
-                      public Void call() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionCreateFailure(
-                            SpannerExceptionFactory.newSpannerException(ErrorCode.INTERNAL, ""), 1);
-                        return null;
-                      }
-                    });
-                return null;
-              }
-            })
-        .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
-    pool = createPool();
-    try {
-      pool.getReadWriteSession().get();
-      fail("Expected exception");
-    } catch (SpannerException ex) {
-      assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INTERNAL);
-    }
-  }
-
-  @Test
-  public void prepareExceptionPropagatesToReadWriteSession() {
-    final SessionImpl session = mockSession();
-    doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(session);
-                      }
-                    });
-                return null;
-              }
-            })
-        .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
-    doThrow(SpannerExceptionFactory.newSpannerException(ErrorCode.INTERNAL, ""))
-        .when(session)
-        .prepareReadWriteTransaction();
-    pool = createPool();
-    try {
-      pool.getReadWriteSession().get();
-      fail("Expected exception");
-    } catch (SpannerException ex) {
-      assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INTERNAL);
-    }
-  }
-
-  @Test
-  public void getReadWriteSession() {
-    final SessionImpl mockSession = mockSession();
-    doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(mockSession);
-                      }
-                    });
-                return null;
-              }
-            })
-        .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
-    pool = createPool();
-    try (PooledSessionFuture session = pool.getReadWriteSession()) {
-      assertThat(session).isNotNull();
-      session.get();
-      verify(mockSession).prepareReadWriteTransaction();
-    }
-  }
-
-  @Test
-  public void getMultipleReadWriteSessions() throws Exception {
-    SessionImpl mockSession1 = mockSession();
-    SessionImpl mockSession2 = mockSession();
-    final LinkedList<SessionImpl> sessions =
-        new LinkedList<>(Arrays.asList(mockSession1, mockSession2));
-    doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(sessions.pop());
-                      }
-                    });
-                return null;
-              }
-            })
-        .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
-    pool = createPool();
-    PooledSessionFuture session1 = pool.getReadWriteSession();
-    PooledSessionFuture session2 = pool.getReadWriteSession();
-    session1.get();
-    session2.get();
-    verify(mockSession1).prepareReadWriteTransaction();
-    verify(mockSession2).prepareReadWriteTransaction();
-    session1.close();
-    session2.close();
-  }
-
-  @Test
-  public void getMultipleConcurrentReadWriteSessions() {
-    AtomicBoolean failed = new AtomicBoolean(false);
-    final SessionImpl session = mockSession();
-    doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(session);
-                      }
-                    });
-                return null;
-              }
-            })
-        .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
-
-    pool = createPool();
-    int numSessions = 5;
-    final CountDownLatch latch = new CountDownLatch(numSessions);
-    for (int i = 0; i < numSessions; i++) {
-      getReadWriteSessionAsync(latch, failed);
-    }
-    Uninterruptibles.awaitUninterruptibly(latch);
-  }
-
-  @Test
-  public void sessionIsPrePrepared() {
-    final SessionImpl mockSession1 = mockSession();
-    final SessionImpl mockSession2 = mockSession();
-    final CountDownLatch prepareLatch = new CountDownLatch(1);
-    doAnswer(
-            new Answer<Void>() {
-
-              @Override
-              public Void answer(InvocationOnMock arg0) {
-                prepareLatch.countDown();
-                return null;
-              }
-            })
-        .when(mockSession1)
-        .prepareReadWriteTransaction();
-    doAnswer(
-            new Answer<Void>() {
-
-              @Override
-              public Void answer(InvocationOnMock arg0) {
-                prepareLatch.countDown();
-                return null;
-              }
-            })
-        .when(mockSession2)
-        .prepareReadWriteTransaction();
-    doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(mockSession1);
-                        consumer.onSessionReady(mockSession2);
-                      }
-                    });
-                return null;
-              }
-            })
-        .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(2), Mockito.anyBoolean(), any(SessionConsumer.class));
-
-    options =
-        SessionPoolOptions.newBuilder()
-            .setMinSessions(2)
-            .setMaxSessions(2)
-            .setWriteSessionsFraction(0.5f)
-            .build();
-    pool = createPool();
-    // One of the sessions would be pre prepared.
-    Uninterruptibles.awaitUninterruptibly(prepareLatch);
-    PooledSession readSession = pool.getReadSession().get();
-    PooledSession writeSession = pool.getReadWriteSession().get();
-    verify(writeSession.delegate, times(1)).prepareReadWriteTransaction();
-    verify(readSession.delegate, never()).prepareReadWriteTransaction();
-    readSession.close();
-    writeSession.close();
-  }
-
-  @Test
-  public void getReadSessionFallsBackToWritePreparedSession() throws Exception {
-    final SessionImpl mockSession1 = mockSession();
-    final CountDownLatch prepareLatch = new CountDownLatch(2);
-    doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(InvocationOnMock arg0) {
-                prepareLatch.countDown();
-                return null;
-              }
-            })
-        .when(mockSession1)
-        .prepareReadWriteTransaction();
-    doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(mockSession1);
-                      }
-                    });
-                return null;
-              }
-            })
-        .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
-    options =
-        SessionPoolOptions.newBuilder()
-            .setMinSessions(minSessions)
-            .setMaxSessions(1)
-            .setWriteSessionsFraction(1.0f)
-            .build();
-    pool = createPool();
-    pool.getReadWriteSession().close();
-    prepareLatch.await();
-    // This session should also be write prepared.
-    PooledSession readSession = pool.getReadSession().get();
-    verify(readSession.delegate, times(2)).prepareReadWriteTransaction();
   }
 
   @Test
@@ -870,48 +547,17 @@ public class SessionPoolTest extends BaseSessionPoolTest {
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
-    Session session1 = pool.getReadSession();
+    Session session1 = pool.get();
     try {
-      pool.getReadSession();
+      pool.get();
       fail("Expected exception");
     } catch (SpannerException ex) {
       assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.RESOURCE_EXHAUSTED);
     }
     session1.close();
-    session1 = pool.getReadSession();
+    session1 = pool.get();
     assertThat(session1).isNotNull();
     session1.close();
-  }
-
-  @Test
-  public void poolWorksWhenSessionNotFound() {
-    SessionImpl mockSession1 = mockSession();
-    SessionImpl mockSession2 = mockSession();
-    final LinkedList<SessionImpl> sessions =
-        new LinkedList<>(Arrays.asList(mockSession1, mockSession2));
-    doThrow(SpannerExceptionFactoryTest.newSessionNotFoundException(sessionName))
-        .when(mockSession1)
-        .prepareReadWriteTransaction();
-    doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(sessions.pop());
-                      }
-                    });
-                return null;
-              }
-            })
-        .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
-    pool = createPool();
-    assertThat(pool.getReadWriteSession().get().delegate).isEqualTo(mockSession2);
   }
 
   @Test
@@ -953,12 +599,12 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     clock.currentTimeMillis = System.currentTimeMillis();
     pool = createPool(clock);
     // Make sure pool has been initialized
-    pool.getReadSession().close();
+    pool.get().close();
     runMaintainanceLoop(clock, pool, pool.poolMaintainer.numClosureCycles);
     assertThat(pool.numIdleSessionsRemoved()).isEqualTo(0L);
-    PooledSessionFuture readSession1 = pool.getReadSession();
-    PooledSessionFuture readSession2 = pool.getReadSession();
-    PooledSessionFuture readSession3 = pool.getReadSession();
+    PooledSessionFuture readSession1 = pool.get();
+    PooledSessionFuture readSession2 = pool.get();
+    PooledSessionFuture readSession3 = pool.get();
     // Wait until the sessions have actually been gotten in order to make sure they are in use in
     // parallel.
     readSession1.get();
@@ -973,9 +619,9 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     assertThat(pool.numIdleSessionsRemoved()).isEqualTo(0L);
     // Counters have now been reset
     // Use all 3 sessions sequentially
-    pool.getReadSession().close();
-    pool.getReadSession().close();
-    pool.getReadSession().close();
+    pool.get().close();
+    pool.get().close();
+    pool.get().close();
     // Advance the time by running the maintainer. This should cause
     // one session to be kept alive and two sessions to be removed.
     long cycles =
@@ -1017,8 +663,8 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     FakeClock clock = new FakeClock();
     clock.currentTimeMillis = System.currentTimeMillis();
     pool = createPool(clock);
-    PooledSessionFuture session1 = pool.getReadSession();
-    PooledSessionFuture session2 = pool.getReadSession();
+    PooledSessionFuture session1 = pool.get();
+    PooledSessionFuture session2 = pool.get();
     session1.get();
     session2.get();
     session1.close();
@@ -1029,7 +675,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     verify(session, times(2)).singleUse(any(TimestampBound.class));
     clock.currentTimeMillis +=
         clock.currentTimeMillis + (options.getKeepAliveIntervalMinutes() + 5) * 60 * 1000;
-    session1 = pool.getReadSession();
+    session1 = pool.get();
     session1.writeAtLeastOnce(new ArrayList<Mutation>());
     session1.close();
     runMaintainanceLoop(clock, pool, pool.poolMaintainer.numKeepAliveCycles);
@@ -1040,156 +686,53 @@ public class SessionPoolTest extends BaseSessionPoolTest {
   }
 
   @Test
-  public void testMaintainerKeepsWriteProportion() throws Exception {
+  public void blockAndTimeoutOnPoolExhaustion() throws Exception {
+    // Create a session pool with max 1 session and a low timeout for waiting for a session.
     options =
         SessionPoolOptions.newBuilder()
-            .setMinSessions(10)
-            .setMaxSessions(20)
-            .setWriteSessionsFraction(0.5f)
+            .setMinSessions(minSessions)
+            .setMaxSessions(1)
+            .setInitialWaitForSessionTimeoutMillis(20L)
             .build();
-    final SessionImpl session = mockSession();
-    mockKeepAlive(session);
-    // This is cheating as we are returning the same session each but it makes the verification
-    // easier.
-    doAnswer(
-            new Answer<Void>() {
+    setupMockSessionCreation();
+    pool = createPool();
+    // Take the only session that can be in the pool.
+    PooledSessionFuture checkedOutSession = pool.get();
+    checkedOutSession.get();
+    ExecutorService executor = Executors.newFixedThreadPool(1);
+    final CountDownLatch latch = new CountDownLatch(1);
+    // Then try asynchronously to take another session. This attempt should time out.
+    Future<Void> fut =
+        executor.submit(
+            new Callable<Void>() {
               @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        int sessionCount = invocation.getArgumentAt(0, Integer.class);
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        for (int i = 0; i < sessionCount; i++) {
-                          consumer.onSessionReady(session);
-                        }
-                      }
-                    });
+              public Void call() {
+                latch.countDown();
+                PooledSessionFuture session = pool.get();
+                session.close();
                 return null;
               }
-            })
-        .when(sessionClient)
-        .asyncBatchCreateSessions(anyInt(), Mockito.anyBoolean(), any(SessionConsumer.class));
-    FakeClock clock = new FakeClock();
-    clock.currentTimeMillis = System.currentTimeMillis();
-    pool = createPool(clock);
-    // Wait until all sessions have been created and prepared.
-    waitForExpectedSessionPool(options.getMinSessions(), options.getWriteSessionsFraction());
-    assertThat(pool.getNumberOfSessionsInPool()).isEqualTo(options.getMinSessions());
-    assertThat(pool.getNumberOfAvailableWritePreparedSessions())
-        .isEqualTo((int) Math.ceil(options.getMinSessions() * options.getWriteSessionsFraction()));
-
-    // Run maintainer numKeepAliveCycles. No pings should be executed during these.
-    runMaintainanceLoop(clock, pool, pool.poolMaintainer.numKeepAliveCycles);
-    verify(session, never()).singleUse(any(TimestampBound.class));
-    // Run maintainer numKeepAliveCycles again. All sessions should now be pinged.
-    runMaintainanceLoop(clock, pool, pool.poolMaintainer.numKeepAliveCycles);
-    verify(session, times(options.getMinSessions())).singleUse(any(TimestampBound.class));
-    // Verify that all sessions are still in the pool, and that the write fraction is maintained.
-    assertThat(pool.getNumberOfSessionsInPool()).isEqualTo(options.getMinSessions());
-    assertThat(pool.getNumberOfWriteSessionsInPool())
-        .isEqualTo(
-            (int) Math.ceil(pool.getNumberOfSessionsInPool() * options.getWriteSessionsFraction()));
-
-    // Check out MaxSessions sessions to add additional sessions to the pool.
-    List<Session> sessions = new ArrayList<>(options.getMaxSessions());
-    for (int i = 0; i < options.getMaxSessions(); i++) {
-      sessions.add(pool.getReadSession());
+            });
+    // Wait until the background thread is actually waiting for a session.
+    latch.await();
+    // Wait until the request has timed out.
+    int waitCount = 0;
+    while (pool.getNumWaiterTimeouts() == 0L && waitCount < 1000) {
+      Thread.sleep(5L);
+      waitCount++;
     }
-    for (Session s : sessions) {
-      s.close();
-    }
-    // There should be MaxSessions in the pool and the writeFraction should be respected.
-    waitForExpectedSessionPool(options.getMaxSessions(), options.getWriteSessionsFraction());
-    assertThat(pool.getNumberOfSessionsInPool()).isEqualTo(options.getMaxSessions());
-    assertThat(pool.getNumberOfAvailableWritePreparedSessions())
-        .isEqualTo((int) Math.ceil(options.getMaxSessions() * options.getWriteSessionsFraction()));
+    // Return the checked out session to the pool so the async request will get a session and
+    // finish.
+    checkedOutSession.close();
+    // Verify that the async request also succeeds.
+    fut.get(10L, TimeUnit.SECONDS);
+    executor.shutdown();
 
-    // Advance the clock to allow the sessions to time out or be kept alive.
-    clock.currentTimeMillis +=
-        clock.currentTimeMillis + (options.getKeepAliveIntervalMinutes() + 5) * 60 * 1000;
-    runMaintainanceLoop(clock, pool, pool.poolMaintainer.numKeepAliveCycles);
-    // The session pool only keeps MinSessions alive.
-    verify(session, times(options.getMinSessions())).singleUse(any(TimestampBound.class));
-    // Verify that MinSessions and WriteFraction are respected.
-    waitForExpectedSessionPool(options.getMinSessions(), options.getWriteSessionsFraction());
-    assertThat(pool.getNumberOfSessionsInPool()).isEqualTo(options.getMinSessions());
-    assertThat(pool.getNumberOfAvailableWritePreparedSessions())
-        .isEqualTo((int) Math.ceil(options.getMinSessions() * options.getWriteSessionsFraction()));
-
-    pool.closeAsync(new SpannerImpl.ClosedException()).get(5L, TimeUnit.SECONDS);
-  }
-
-  private void waitForExpectedSessionPool(int expectedSessions, float writeFraction)
-      throws InterruptedException {
-    Stopwatch watch = Stopwatch.createStarted();
-    while ((pool.getNumberOfSessionsInPool() < expectedSessions
-            || pool.getNumberOfAvailableWritePreparedSessions()
-                < Math.ceil(expectedSessions * writeFraction))
-        && watch.elapsed(TimeUnit.SECONDS) < 5) {
-      Thread.sleep(1L);
-    }
-  }
-
-  @Test
-  public void blockAndTimeoutOnPoolExhaustion() throws Exception {
-    // Try to take a read or a read/write session. These requests should block.
-    for (Boolean write : new Boolean[] {true, false}) {
-      // Create a session pool with max 1 session and a low timeout for waiting for a session.
-      options =
-          SessionPoolOptions.newBuilder()
-              .setMinSessions(minSessions)
-              .setMaxSessions(1)
-              .setInitialWaitForSessionTimeoutMillis(20L)
-              .build();
-      setupMockSessionCreation();
-      pool = createPool();
-      // Take the only session that can be in the pool.
-      PooledSessionFuture checkedOutSession = pool.getReadSession();
-      checkedOutSession.get();
-      final Boolean finWrite = write;
-      ExecutorService executor = Executors.newFixedThreadPool(1);
-      final CountDownLatch latch = new CountDownLatch(1);
-      // Then try asynchronously to take another session. This attempt should time out.
-      Future<Void> fut =
-          executor.submit(
-              new Callable<Void>() {
-                @Override
-                public Void call() {
-                  PooledSessionFuture session;
-                  latch.countDown();
-                  if (finWrite) {
-                    session = pool.getReadWriteSession();
-                  } else {
-                    session = pool.getReadSession();
-                  }
-                  session.close();
-                  return null;
-                }
-              });
-      // Wait until the background thread is actually waiting for a session.
-      latch.await();
-      // Wait until the request has timed out.
-      int waitCount = 0;
-      while (pool.getNumWaiterTimeouts() == 0L && waitCount < 1000) {
-        Thread.sleep(5L);
-        waitCount++;
-      }
-      // Return the checked out session to the pool so the async request will get a session and
-      // finish.
-      checkedOutSession.close();
-      // Verify that the async request also succeeds.
-      fut.get(10L, TimeUnit.SECONDS);
-      executor.shutdown();
-
-      // Verify that the session was returned to the pool and that we can get it again.
-      Session session = pool.getReadSession();
-      assertThat(session).isNotNull();
-      session.close();
-      assertThat(pool.getNumWaiterTimeouts()).isAtLeast(1L);
-    }
+    // Verify that the session was returned to the pool and that we can get it again.
+    Session session = pool.get();
+    assertThat(session).isNotNull();
+    session.close();
+    assertThat(pool.getNumWaiterTimeouts()).isAtLeast(1L);
   }
 
   @Test
@@ -1247,7 +790,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     FakeClock clock = new FakeClock();
     clock.currentTimeMillis = System.currentTimeMillis();
     pool = createPool(clock);
-    ReadContext context = pool.getReadSession().singleUse();
+    ReadContext context = pool.get().singleUse();
     ResultSet resultSet = context.executeQuery(statement);
     assertThat(resultSet.next()).isTrue();
   }
@@ -1303,7 +846,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     FakeClock clock = new FakeClock();
     clock.currentTimeMillis = System.currentTimeMillis();
     pool = createPool(clock);
-    ReadOnlyTransaction transaction = pool.getReadSession().readOnlyTransaction();
+    ReadOnlyTransaction transaction = pool.get().readOnlyTransaction();
     ResultSet resultSet = transaction.executeQuery(statement);
     assertThat(resultSet.next()).isTrue();
   }
@@ -1327,252 +870,169 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     for (ReadWriteTransactionTestStatementType statementType :
         ReadWriteTransactionTestStatementType.values()) {
       final ReadWriteTransactionTestStatementType executeStatementType = statementType;
-      for (boolean prepared : new boolean[] {true, false}) {
-        final boolean hasPreparedTransaction = prepared;
-        SpannerRpc.StreamingCall closedStreamingCall = mock(SpannerRpc.StreamingCall.class);
-        doThrow(sessionNotFound).when(closedStreamingCall).request(Mockito.anyInt());
-        SpannerRpc rpc = mock(SpannerRpc.class);
-        when(rpc.asyncDeleteSession(Mockito.anyString(), Mockito.anyMap()))
-            .thenReturn(ApiFutures.immediateFuture(Empty.getDefaultInstance()));
-        when(rpc.executeQuery(
-                any(ExecuteSqlRequest.class), any(ResultStreamConsumer.class), any(Map.class)))
-            .thenReturn(closedStreamingCall);
-        when(rpc.executeQuery(any(ExecuteSqlRequest.class), any(Map.class)))
-            .thenThrow(sessionNotFound);
-        when(rpc.executeBatchDml(any(ExecuteBatchDmlRequest.class), any(Map.class)))
-            .thenThrow(sessionNotFound);
-        when(rpc.commitAsync(any(CommitRequest.class), any(Map.class)))
-            .thenReturn(ApiFutures.<CommitResponse>immediateFailedFuture(sessionNotFound));
-        when(rpc.rollbackAsync(any(RollbackRequest.class), any(Map.class)))
-            .thenReturn(ApiFutures.<Empty>immediateFailedFuture(sessionNotFound));
-        final SessionImpl closedSession = mock(SessionImpl.class);
-        when(closedSession.getName())
-            .thenReturn("projects/dummy/instances/dummy/database/dummy/sessions/session-closed");
-        ByteString preparedTransactionId =
-            hasPreparedTransaction ? ByteString.copyFromUtf8("test-txn") : null;
-        final TransactionContextImpl closedTransactionContext =
-            TransactionContextImpl.newBuilder()
-                .setSession(closedSession)
-                .setTransactionId(preparedTransactionId)
-                .setRpc(rpc)
-                .build();
-        when(closedSession.asyncClose())
-            .thenReturn(ApiFutures.immediateFuture(Empty.getDefaultInstance()));
-        when(closedSession.newTransaction()).thenReturn(closedTransactionContext);
-        when(closedSession.beginTransactionAsync()).thenThrow(sessionNotFound);
-        TransactionRunnerImpl closedTransactionRunner =
-            new TransactionRunnerImpl(closedSession, rpc, 10, false);
-        closedTransactionRunner.setSpan(mock(Span.class));
-        when(closedSession.readWriteTransaction()).thenReturn(closedTransactionRunner);
+      SpannerRpc.StreamingCall closedStreamingCall = mock(SpannerRpc.StreamingCall.class);
+      doThrow(sessionNotFound).when(closedStreamingCall).request(Mockito.anyInt());
+      SpannerRpc rpc = mock(SpannerRpc.class);
+      when(rpc.asyncDeleteSession(Mockito.anyString(), Mockito.anyMap()))
+          .thenReturn(ApiFutures.immediateFuture(Empty.getDefaultInstance()));
+      when(rpc.executeQuery(
+              any(ExecuteSqlRequest.class), any(ResultStreamConsumer.class), any(Map.class)))
+          .thenReturn(closedStreamingCall);
+      when(rpc.executeQuery(any(ExecuteSqlRequest.class), any(Map.class)))
+          .thenThrow(sessionNotFound);
+      when(rpc.executeBatchDml(any(ExecuteBatchDmlRequest.class), any(Map.class)))
+          .thenThrow(sessionNotFound);
+      when(rpc.commitAsync(any(CommitRequest.class), any(Map.class)))
+          .thenReturn(ApiFutures.<CommitResponse>immediateFailedFuture(sessionNotFound));
+      when(rpc.rollbackAsync(any(RollbackRequest.class), any(Map.class)))
+          .thenReturn(ApiFutures.<Empty>immediateFailedFuture(sessionNotFound));
+      final SessionImpl closedSession = mock(SessionImpl.class);
+      when(closedSession.getName())
+          .thenReturn("projects/dummy/instances/dummy/database/dummy/sessions/session-closed");
+      final TransactionContextImpl closedTransactionContext =
+          TransactionContextImpl.newBuilder().setSession(closedSession).setRpc(rpc).build();
+      when(closedSession.asyncClose())
+          .thenReturn(ApiFutures.immediateFuture(Empty.getDefaultInstance()));
+      when(closedSession.newTransaction()).thenReturn(closedTransactionContext);
+      when(closedSession.beginTransactionAsync()).thenThrow(sessionNotFound);
+      TransactionRunnerImpl closedTransactionRunner =
+          new TransactionRunnerImpl(closedSession, rpc, 10);
+      closedTransactionRunner.setSpan(mock(Span.class));
+      when(closedSession.readWriteTransaction()).thenReturn(closedTransactionRunner);
 
-        final SessionImpl openSession = mock(SessionImpl.class);
-        when(openSession.asyncClose())
-            .thenReturn(ApiFutures.immediateFuture(Empty.getDefaultInstance()));
-        when(openSession.getName())
-            .thenReturn("projects/dummy/instances/dummy/database/dummy/sessions/session-open");
-        final TransactionContextImpl openTransactionContext = mock(TransactionContextImpl.class);
-        when(openSession.newTransaction()).thenReturn(openTransactionContext);
-        when(openSession.beginTransactionAsync())
-            .thenReturn(ApiFutures.immediateFuture(ByteString.copyFromUtf8("open-txn")));
-        TransactionRunnerImpl openTransactionRunner =
-            new TransactionRunnerImpl(openSession, mock(SpannerRpc.class), 10, false);
-        openTransactionRunner.setSpan(mock(Span.class));
-        when(openSession.readWriteTransaction()).thenReturn(openTransactionRunner);
+      final SessionImpl openSession = mock(SessionImpl.class);
+      when(openSession.asyncClose())
+          .thenReturn(ApiFutures.immediateFuture(Empty.getDefaultInstance()));
+      when(openSession.getName())
+          .thenReturn("projects/dummy/instances/dummy/database/dummy/sessions/session-open");
+      final TransactionContextImpl openTransactionContext = mock(TransactionContextImpl.class);
+      when(openSession.newTransaction()).thenReturn(openTransactionContext);
+      when(openSession.beginTransactionAsync())
+          .thenReturn(ApiFutures.immediateFuture(ByteString.copyFromUtf8("open-txn")));
+      TransactionRunnerImpl openTransactionRunner =
+          new TransactionRunnerImpl(openSession, mock(SpannerRpc.class), 10);
+      openTransactionRunner.setSpan(mock(Span.class));
+      when(openSession.readWriteTransaction()).thenReturn(openTransactionRunner);
 
-        ResultSet openResultSet = mock(ResultSet.class);
-        when(openResultSet.next()).thenReturn(true, false);
-        ResultSet planResultSet = mock(ResultSet.class);
-        when(planResultSet.getStats()).thenReturn(ResultSetStats.getDefaultInstance());
-        when(openTransactionContext.executeQuery(queryStatement)).thenReturn(openResultSet);
-        when(openTransactionContext.analyzeQuery(queryStatement, QueryAnalyzeMode.PLAN))
-            .thenReturn(planResultSet);
-        when(openTransactionContext.executeUpdate(updateStatement)).thenReturn(1L);
-        when(openTransactionContext.batchUpdate(Arrays.asList(updateStatement, updateStatement)))
-            .thenReturn(new long[] {1L, 1L});
-        SpannerImpl spanner = mock(SpannerImpl.class);
-        SessionClient sessionClient = mock(SessionClient.class);
-        when(spanner.getSessionClient(db)).thenReturn(sessionClient);
+      ResultSet openResultSet = mock(ResultSet.class);
+      when(openResultSet.next()).thenReturn(true, false);
+      ResultSet planResultSet = mock(ResultSet.class);
+      when(planResultSet.getStats()).thenReturn(ResultSetStats.getDefaultInstance());
+      when(openTransactionContext.executeQuery(queryStatement)).thenReturn(openResultSet);
+      when(openTransactionContext.analyzeQuery(queryStatement, QueryAnalyzeMode.PLAN))
+          .thenReturn(planResultSet);
+      when(openTransactionContext.executeUpdate(updateStatement)).thenReturn(1L);
+      when(openTransactionContext.batchUpdate(Arrays.asList(updateStatement, updateStatement)))
+          .thenReturn(new long[] {1L, 1L});
+      SpannerImpl spanner = mock(SpannerImpl.class);
+      SessionClient sessionClient = mock(SessionClient.class);
+      when(spanner.getSessionClient(db)).thenReturn(sessionClient);
 
-        doAnswer(
-                new Answer<Void>() {
-                  @Override
-                  public Void answer(final InvocationOnMock invocation) {
-                    executor.submit(
-                        new Runnable() {
-                          @Override
-                          public void run() {
-                            SessionConsumerImpl consumer =
-                                invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                            consumer.onSessionReady(closedSession);
-                          }
-                        });
-                    return null;
+      doAnswer(
+              new Answer<Void>() {
+                @Override
+                public Void answer(final InvocationOnMock invocation) {
+                  executor.submit(
+                      new Runnable() {
+                        @Override
+                        public void run() {
+                          SessionConsumerImpl consumer =
+                              invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                          consumer.onSessionReady(closedSession);
+                        }
+                      });
+                  return null;
+                }
+              })
+          .doAnswer(
+              new Answer<Void>() {
+                @Override
+                public Void answer(final InvocationOnMock invocation) {
+                  executor.submit(
+                      new Runnable() {
+                        @Override
+                        public void run() {
+                          SessionConsumerImpl consumer =
+                              invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                          consumer.onSessionReady(openSession);
+                        }
+                      });
+                  return null;
+                }
+              })
+          .when(sessionClient)
+          .asyncBatchCreateSessions(
+              Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
+      SessionPoolOptions options =
+          SessionPoolOptions.newBuilder()
+              .setMinSessions(0) // The pool should not auto-create any sessions
+              .setMaxSessions(2)
+              .setIncStep(1)
+              .setBlockIfPoolExhausted()
+              .build();
+      SpannerOptions spannerOptions = mock(SpannerOptions.class);
+      when(spannerOptions.getSessionPoolOptions()).thenReturn(options);
+      when(spannerOptions.getNumChannels()).thenReturn(4);
+      when(spanner.getOptions()).thenReturn(spannerOptions);
+      SessionPool pool =
+          SessionPool.createPool(options, new TestExecutorFactory(), spanner.getSessionClient(db));
+      try (PooledSessionFuture readWriteSession = pool.get()) {
+        TransactionRunner runner = readWriteSession.readWriteTransaction();
+        try {
+          runner.run(
+              new TransactionCallable<Integer>() {
+                private int callNumber = 0;
+
+                @Override
+                public Integer run(TransactionContext transaction) {
+                  callNumber++;
+                  if (callNumber == 1) {
+                    assertThat(transaction).isEqualTo(closedTransactionContext);
+                  } else {
+                    assertThat(transaction).isEqualTo(openTransactionContext);
                   }
-                })
-            .doAnswer(
-                new Answer<Void>() {
-                  @Override
-                  public Void answer(final InvocationOnMock invocation) {
-                    executor.submit(
-                        new Runnable() {
-                          @Override
-                          public void run() {
-                            SessionConsumerImpl consumer =
-                                invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                            consumer.onSessionReady(openSession);
-                          }
-                        });
-                    return null;
+                  switch (executeStatementType) {
+                    case QUERY:
+                      ResultSet resultSet = transaction.executeQuery(queryStatement);
+                      assertThat(resultSet.next()).isTrue();
+                      break;
+                    case ANALYZE:
+                      ResultSet planResultSet =
+                          transaction.analyzeQuery(queryStatement, QueryAnalyzeMode.PLAN);
+                      assertThat(planResultSet.next()).isFalse();
+                      assertThat(planResultSet.getStats()).isNotNull();
+                      break;
+                    case UPDATE:
+                      long updateCount = transaction.executeUpdate(updateStatement);
+                      assertThat(updateCount).isEqualTo(1L);
+                      break;
+                    case BATCH_UPDATE:
+                      long[] updateCounts =
+                          transaction.batchUpdate(Arrays.asList(updateStatement, updateStatement));
+                      assertThat(updateCounts).isEqualTo(new long[] {1L, 1L});
+                      break;
+                    case WRITE:
+                      transaction.buffer(Mutation.delete("FOO", Key.of(1L)));
+                      break;
+                    case EXCEPTION:
+                      throw new RuntimeException("rollback at call " + callNumber);
+                    default:
+                      fail("Unknown statement type: " + executeStatementType);
                   }
-                })
-            .when(sessionClient)
-            .asyncBatchCreateSessions(
-                Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
-        SessionPoolOptions options =
-            SessionPoolOptions.newBuilder()
-                .setMinSessions(0) // The pool should not auto-create any sessions
-                .setMaxSessions(2)
-                .setIncStep(1)
-                .setBlockIfPoolExhausted()
-                .build();
-        SpannerOptions spannerOptions = mock(SpannerOptions.class);
-        when(spannerOptions.getSessionPoolOptions()).thenReturn(options);
-        when(spannerOptions.getNumChannels()).thenReturn(4);
-        when(spanner.getOptions()).thenReturn(spannerOptions);
-        SessionPool pool =
-            SessionPool.createPool(
-                options, new TestExecutorFactory(), spanner.getSessionClient(db));
-        try (PooledSessionFuture readWriteSession = pool.getReadWriteSession()) {
-          TransactionRunner runner = readWriteSession.readWriteTransaction();
-          try {
-            runner.run(
-                new TransactionCallable<Integer>() {
-                  private int callNumber = 0;
-
-                  @Override
-                  public Integer run(TransactionContext transaction) {
-                    callNumber++;
-                    if (hasPreparedTransaction) {
-                      // If the session had a prepared read/write transaction, that transaction will
-                      // be given to the runner in the first place and the SessionNotFoundException
-                      // will occur on the first query / update statement.
-                      if (callNumber == 1) {
-                        assertThat(transaction).isEqualTo(closedTransactionContext);
-                      } else {
-                        assertThat(transaction).isEqualTo(openTransactionContext);
-                      }
-                    } else {
-                      // If the session did not have a prepared read/write transaction, the library
-                      // tried to create a new transaction before handing it to the transaction
-                      // runner. The creation of the new transaction failed with a
-                      // SessionNotFoundException, and the session was re-created before the run
-                      // method was called.
-                      assertThat(transaction).isEqualTo(openTransactionContext);
-                    }
-                    switch (executeStatementType) {
-                      case QUERY:
-                        ResultSet resultSet = transaction.executeQuery(queryStatement);
-                        assertThat(resultSet.next()).isTrue();
-                        break;
-                      case ANALYZE:
-                        ResultSet planResultSet =
-                            transaction.analyzeQuery(queryStatement, QueryAnalyzeMode.PLAN);
-                        assertThat(planResultSet.next()).isFalse();
-                        assertThat(planResultSet.getStats()).isNotNull();
-                        break;
-                      case UPDATE:
-                        long updateCount = transaction.executeUpdate(updateStatement);
-                        assertThat(updateCount).isEqualTo(1L);
-                        break;
-                      case BATCH_UPDATE:
-                        long[] updateCounts =
-                            transaction.batchUpdate(
-                                Arrays.asList(updateStatement, updateStatement));
-                        assertThat(updateCounts).isEqualTo(new long[] {1L, 1L});
-                        break;
-                      case WRITE:
-                        transaction.buffer(Mutation.delete("FOO", Key.of(1L)));
-                        break;
-                      case EXCEPTION:
-                        throw new RuntimeException("rollback at call " + callNumber);
-                      default:
-                        fail("Unknown statement type: " + executeStatementType);
-                    }
-                    return callNumber;
-                  }
-                });
-          } catch (Exception e) {
-            // The rollback will also cause a SessionNotFoundException, but this is caught, logged
-            // and further ignored by the library, meaning that the session will not be re-created
-            // for retry. Hence rollback at call 1.
-            assertThat(executeStatementType)
-                .isEqualTo(ReadWriteTransactionTestStatementType.EXCEPTION);
-            assertThat(e.getMessage()).contains("rollback at call 1");
-
-            //            assertThat(
-            //                    executeStatementType ==
-            // ReadWriteTransactionTestStatementType.EXCEPTION
-            //                        && e.getMessage().contains("rollback at call 1"))
-            //                .isTrue();
-          }
+                  return callNumber;
+                }
+              });
+        } catch (Exception e) {
+          // The rollback will also cause a SessionNotFoundException, but this is caught, logged
+          // and further ignored by the library, meaning that the session will not be re-created
+          // for retry. Hence rollback at call 1.
+          assertThat(executeStatementType)
+              .isEqualTo(ReadWriteTransactionTestStatementType.EXCEPTION);
+          assertThat(e.getMessage()).contains("rollback at call 1");
         }
-        pool.closeAsync(new SpannerImpl.ClosedException());
       }
+      pool.closeAsync(new SpannerImpl.ClosedException());
     }
-  }
-
-  @Test
-  public void testSessionNotFoundOnPrepareTransaction() {
-    final SpannerException sessionNotFound =
-        SpannerExceptionFactoryTest.newSessionNotFoundException(sessionName);
-    final SessionImpl closedSession = mock(SessionImpl.class);
-    when(closedSession.getName())
-        .thenReturn("projects/dummy/instances/dummy/database/dummy/sessions/session-closed");
-    when(closedSession.beginTransaction()).thenThrow(sessionNotFound);
-    doThrow(sessionNotFound).when(closedSession).prepareReadWriteTransaction();
-
-    final SessionImpl openSession = mock(SessionImpl.class);
-    when(openSession.getName())
-        .thenReturn("projects/dummy/instances/dummy/database/dummy/sessions/session-open");
-    doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(closedSession);
-                      }
-                    });
-                return null;
-              }
-            })
-        .doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(openSession);
-                      }
-                    });
-                return null;
-              }
-            })
-        .when(sessionClient)
-        .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
-    FakeClock clock = new FakeClock();
-    clock.currentTimeMillis = System.currentTimeMillis();
-    pool = createPool(clock);
-    PooledSession session = pool.getReadWriteSession().get();
-    assertThat(session.delegate).isEqualTo(openSession);
   }
 
   @Test
@@ -1623,7 +1083,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     FakeClock clock = new FakeClock();
     clock.currentTimeMillis = System.currentTimeMillis();
     pool = createPool(clock);
-    DatabaseClientImpl impl = new DatabaseClientImpl(pool, false);
+    DatabaseClientImpl impl = new DatabaseClientImpl(pool);
     assertThat(impl.write(mutations)).isNotNull();
   }
 
@@ -1674,7 +1134,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     FakeClock clock = new FakeClock();
     clock.currentTimeMillis = System.currentTimeMillis();
     pool = createPool(clock);
-    DatabaseClientImpl impl = new DatabaseClientImpl(pool, false);
+    DatabaseClientImpl impl = new DatabaseClientImpl(pool);
     assertThat(impl.writeAtLeastOnce(mutations)).isNotNull();
   }
 
@@ -1725,7 +1185,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     FakeClock clock = new FakeClock();
     clock.currentTimeMillis = System.currentTimeMillis();
     pool = createPool(clock);
-    DatabaseClientImpl impl = new DatabaseClientImpl(pool, false);
+    DatabaseClientImpl impl = new DatabaseClientImpl(pool);
     assertThat(impl.executePartitionedUpdate(statement)).isEqualTo(1L);
   }
 
@@ -1751,8 +1211,8 @@ public class SessionPoolTest extends BaseSessionPoolTest {
 
     setupMockSessionCreation();
     pool = createPool(clock, metricRegistry, labelValues);
-    PooledSessionFuture session1 = pool.getReadSession();
-    PooledSessionFuture session2 = pool.getReadSession();
+    PooledSessionFuture session1 = pool.get();
+    PooledSessionFuture session2 = pool.get();
     session1.get();
     session2.get();
 
@@ -1830,7 +1290,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void call() {
                 latch.countDown();
-                Session session = pool.getReadSession();
+                Session session = pool.get();
                 session.close();
                 return null;
               }
@@ -1888,30 +1348,11 @@ public class SessionPoolTest extends BaseSessionPoolTest {
             new Runnable() {
               @Override
               public void run() {
-                try (PooledSessionFuture future = pool.getReadSession()) {
+                try (PooledSessionFuture future = pool.get()) {
                   PooledSession session = future.get();
                   failed.compareAndSet(false, session == null);
                   Uninterruptibles.sleepUninterruptibly(10, TimeUnit.MILLISECONDS);
                 } catch (Throwable e) {
-                  failed.compareAndSet(false, true);
-                } finally {
-                  latch.countDown();
-                }
-              }
-            })
-        .start();
-  }
-
-  private void getReadWriteSessionAsync(final CountDownLatch latch, final AtomicBoolean failed) {
-    new Thread(
-            new Runnable() {
-              @Override
-              public void run() {
-                try (PooledSessionFuture future = pool.getReadWriteSession()) {
-                  PooledSession session = future.get();
-                  failed.compareAndSet(false, session == null);
-                  Uninterruptibles.sleepUninterruptibly(2, TimeUnit.MILLISECONDS);
-                } catch (SpannerException e) {
                   failed.compareAndSet(false, true);
                 } finally {
                   latch.countDown();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerGaxRetryTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerGaxRetryTest.java
@@ -360,7 +360,7 @@ public class SpannerGaxRetryTest {
               @Override
               public Long run(TransactionContext transaction) {
                 if (attempts.getAndIncrement() == 0) {
-                  mockSpanner.abortTransaction(transaction);
+                  mockSpanner.abortNextStatement();
                 }
                 return transaction.executeUpdate(UPDATE_STATEMENT);
               }
@@ -418,7 +418,7 @@ public class SpannerGaxRetryTest {
   @SuppressWarnings("resource")
   @Test
   public void transactionManagerTimeout() {
-    mockSpanner.setBeginTransactionExecutionTime(ONE_SECOND);
+    mockSpanner.setExecuteSqlExecutionTime(ONE_SECOND);
     try (TransactionManager txManager = clientWithTimeout.transactionManager()) {
       TransactionContext tx = txManager.begin();
       while (true) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerAbortedTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerAbortedTest.java
@@ -194,7 +194,7 @@ public class TransactionManagerAbortedTest {
         attempts++;
         try {
           if (attempts == 1) {
-            mockSpanner.abortAllTransactions();
+            mockSpanner.abortNextTransaction();
           }
           manager.commit();
           break;
@@ -219,7 +219,7 @@ public class TransactionManagerAbortedTest {
         attempts++;
         try {
           if (attempts == 1) {
-            mockSpanner.abortAllTransactions();
+            mockSpanner.abortNextTransaction();
           }
           long updateCount = txn.executeUpdate(UPDATE_STATEMENT);
           assertThat(updateCount, is(equalTo(UPDATE_COUNT)));
@@ -246,7 +246,7 @@ public class TransactionManagerAbortedTest {
         attempts++;
         try {
           if (attempts == 1) {
-            mockSpanner.abortAllTransactions();
+            mockSpanner.abortNextTransaction();
           }
           long[] updateCounts = txn.batchUpdate(Arrays.asList(UPDATE_STATEMENT, UPDATE_STATEMENT));
           assertThat(updateCounts, is(equalTo(new long[] {UPDATE_COUNT, UPDATE_COUNT})));
@@ -301,7 +301,7 @@ public class TransactionManagerAbortedTest {
         attempts++;
         try {
           if (attempts == 1) {
-            mockSpanner.abortAllTransactions();
+            mockSpanner.abortNextTransaction();
           }
           try (ResultSet rs = txn.executeQuery(SELECT1AND2)) {
             int rows = 0;
@@ -333,7 +333,7 @@ public class TransactionManagerAbortedTest {
         attempts++;
         try {
           if (attempts == 1) {
-            mockSpanner.abortAllTransactions();
+            mockSpanner.abortNextTransaction();
           }
           try (ResultSet rs = txn.read("FOO", KeySet.all(), Arrays.asList("BAR"))) {
             int rows = 0;
@@ -365,7 +365,7 @@ public class TransactionManagerAbortedTest {
         attempts++;
         try {
           if (attempts == 1) {
-            mockSpanner.abortAllTransactions();
+            mockSpanner.abortNextTransaction();
           }
           try (ResultSet rs =
               txn.readUsingIndex("FOO", "INDEX", KeySet.all(), Arrays.asList("BAR"))) {
@@ -398,7 +398,7 @@ public class TransactionManagerAbortedTest {
         attempts++;
         try {
           if (attempts == 1) {
-            mockSpanner.abortAllTransactions();
+            mockSpanner.abortNextTransaction();
           }
           Struct row = txn.readRow("FOO", Key.of(), Arrays.asList("BAR"));
           assertThat(row.getLong(0), is(equalTo(1L)));
@@ -425,7 +425,7 @@ public class TransactionManagerAbortedTest {
         attempts++;
         try {
           if (attempts == 1) {
-            mockSpanner.abortAllTransactions();
+            mockSpanner.abortNextTransaction();
           }
           Struct row = txn.readRowUsingIndex("FOO", "INDEX", Key.of(), Arrays.asList("BAR"));
           assertThat(row.getLong(0), is(equalTo(1L)));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
@@ -82,7 +82,7 @@ public class TransactionManagerImplTest {
   @Before
   public void setUp() {
     initMocks(this);
-    manager = new TransactionManagerImpl(session, mock(Span.class), false);
+    manager = new TransactionManagerImpl(session, mock(Span.class));
   }
 
   @Test
@@ -301,7 +301,6 @@ public class TransactionManagerImplTest {
     SessionPoolOptions sessionPoolOptions =
         SessionPoolOptions.newBuilder().setMinSessions(0).setIncStep(1).build();
     when(options.getSessionPoolOptions()).thenReturn(sessionPoolOptions);
-    when(options.isInlineBeginForReadWriteTransaction()).thenReturn(true);
     when(options.getSessionLabels()).thenReturn(Collections.<String, String>emptyMap());
     when(options.getDefaultQueryOptions(Mockito.any(DatabaseId.class)))
         .thenReturn(QueryOptions.getDefaultInstance());

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDMLTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDMLTest.java
@@ -30,7 +30,6 @@ import com.google.cloud.spanner.KeySet;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.ParallelIntegrationTest;
 import com.google.cloud.spanner.ResultSet;
-import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.Statement;
@@ -39,7 +38,6 @@ import com.google.cloud.spanner.TransactionContext;
 import com.google.cloud.spanner.TransactionRunner;
 import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import java.util.Arrays;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -54,6 +52,7 @@ import org.junit.runners.JUnit4;
 public final class ITDMLTest {
   @ClassRule public static IntegrationTestEnv env = new IntegrationTestEnv();
   private static Database db;
+  private static DatabaseClient client;
   /** Sequence for assigning unique keys to test cases. */
   private static int seq;
 
@@ -68,9 +67,6 @@ public final class ITDMLTest {
 
   private static boolean throwAbortOnce = false;
 
-  private Spanner spanner;
-  private DatabaseClient client;
-
   @BeforeClass
   public static void setUpDatabase() {
     db =
@@ -80,19 +76,13 @@ public final class ITDMLTest {
                     + "  K    STRING(MAX) NOT NULL,"
                     + "  V    INT64,"
                     + ") PRIMARY KEY (K)");
+    client = env.getTestHelper().getDatabaseClient(db);
   }
 
   @Before
-  public void setupClient() {
-    spanner = env.getTestHelper().getClient();
-    client = spanner.getDatabaseClient(db.getId());
+  public void increaseTestIdAndDeleteTestData() {
     client.writeAtLeastOnce(Arrays.asList(Mutation.delete("T", KeySet.all())));
     id++;
-  }
-
-  @After
-  public void teardownClient() {
-    spanner.close();
   }
 
   private static String uniqueKey() {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDMLTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDMLTest.java
@@ -39,7 +39,6 @@ import com.google.cloud.spanner.TransactionContext;
 import com.google.cloud.spanner.TransactionRunner;
 import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import java.util.Arrays;
-import java.util.Collection;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -47,13 +46,11 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.JUnit4;
 
 /** Integration tests for DML. */
 @Category(ParallelIntegrationTest.class)
-@RunWith(Parameterized.class)
+@RunWith(JUnit4.class)
 public final class ITDMLTest {
   @ClassRule public static IntegrationTestEnv env = new IntegrationTestEnv();
   private static Database db;
@@ -71,12 +68,6 @@ public final class ITDMLTest {
 
   private static boolean throwAbortOnce = false;
 
-  @Parameters(name = "InlineBeginTx = {0}")
-  public static Collection<Object[]> data() {
-    return Arrays.asList(new Object[][] {{false}, {true}});
-  }
-
-  @Parameter public boolean inlineBeginTx;
   private Spanner spanner;
   private DatabaseClient client;
 
@@ -93,13 +84,7 @@ public final class ITDMLTest {
 
   @Before
   public void setupClient() {
-    spanner =
-        env.getTestHelper()
-            .getOptions()
-            .toBuilder()
-            .setInlineBeginForReadWriteTransaction(inlineBeginTx)
-            .build()
-            .getService();
+    spanner = env.getTestHelper().getClient();
     client = spanner.getDatabaseClient(db.getId());
     client.writeAtLeastOnce(Arrays.asList(Mutation.delete("T", KeySet.all())));
     id++;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionManagerAsyncTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionManagerAsyncTest.java
@@ -64,19 +64,13 @@ public class ITTransactionManagerAsyncTest {
   @Parameter(0)
   public Executor executor;
 
-  @Parameter(1)
-  public boolean inlineBegin;
-
-  @Parameters(name = "executor = {0}, inlineBegin = {1}")
+  @Parameters(name = "executor = {0}")
   public static Collection<Object[]> data() {
     return Arrays.asList(
         new Object[][] {
-          {MoreExecutors.directExecutor(), false},
-          {MoreExecutors.directExecutor(), true},
-          {Executors.newSingleThreadExecutor(), false},
-          {Executors.newSingleThreadExecutor(), true},
-          {Executors.newFixedThreadPool(4), false},
-          {Executors.newFixedThreadPool(4), true}
+          {MoreExecutors.directExecutor()},
+          {Executors.newSingleThreadExecutor()},
+          {Executors.newFixedThreadPool(4)},
         });
   }
 
@@ -99,13 +93,7 @@ public class ITTransactionManagerAsyncTest {
 
   @Before
   public void clearTable() {
-    spanner =
-        env.getTestHelper()
-            .getOptions()
-            .toBuilder()
-            .setInlineBeginForReadWriteTransaction(inlineBegin)
-            .build()
-            .getService();
+    spanner = env.getTestHelper().getClient();
     client = spanner.getDatabaseClient(db.getId());
     client.write(ImmutableList.of(Mutation.delete("T", KeySet.all())));
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionManagerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionManagerTest.java
@@ -38,7 +38,6 @@ import com.google.cloud.spanner.TransactionManager;
 import com.google.cloud.spanner.TransactionManager.TransactionState;
 import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
-import java.util.Collection;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -46,21 +45,11 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.JUnit4;
 
 @Category(ParallelIntegrationTest.class)
-@RunWith(Parameterized.class)
+@RunWith(JUnit4.class)
 public class ITTransactionManagerTest {
-
-  @Parameter(0)
-  public boolean inlineBegin;
-
-  @Parameters(name = "inlineBegin = {0}")
-  public static Collection<Object[]> data() {
-    return Arrays.asList(new Object[][] {{false}, {true}});
-  }
 
   @ClassRule public static IntegrationTestEnv env = new IntegrationTestEnv();
   private static Database db;
@@ -81,13 +70,7 @@ public class ITTransactionManagerTest {
 
   @Before
   public void setupClient() {
-    spanner =
-        env.getTestHelper()
-            .getOptions()
-            .toBuilder()
-            .setInlineBeginForReadWriteTransaction(inlineBegin)
-            .build()
-            .getService();
+    spanner = env.getTestHelper().getClient();
     client = spanner.getDatabaseClient(db.getId());
     client.write(ImmutableList.of(Mutation.delete("T", KeySet.all())));
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionManagerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionManagerTest.java
@@ -30,7 +30,6 @@ import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.KeySet;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.ParallelIntegrationTest;
-import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.TransactionContext;
@@ -38,7 +37,6 @@ import com.google.cloud.spanner.TransactionManager;
 import com.google.cloud.spanner.TransactionManager.TransactionState;
 import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -53,8 +51,7 @@ public class ITTransactionManagerTest {
 
   @ClassRule public static IntegrationTestEnv env = new IntegrationTestEnv();
   private static Database db;
-  private Spanner spanner;
-  private DatabaseClient client;
+  private static DatabaseClient client;
 
   @BeforeClass
   public static void setUpDatabase() {
@@ -66,18 +63,12 @@ public class ITTransactionManagerTest {
                     + "  K                   STRING(MAX) NOT NULL,"
                     + "  BoolValue           BOOL,"
                     + ") PRIMARY KEY (K)");
+    client = env.getTestHelper().getDatabaseClient(db);
   }
 
   @Before
-  public void setupClient() {
-    spanner = env.getTestHelper().getClient();
-    client = spanner.getDatabaseClient(db.getId());
+  public void deleteTestData() {
     client.write(ImmutableList.of(Mutation.delete("T", KeySet.all())));
-  }
-
-  @After
-  public void closeClient() {
-    spanner.close();
   }
 
   @SuppressWarnings("resource")

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionTest.java
@@ -52,7 +52,6 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.google.common.util.concurrent.Uninterruptibles;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Vector;
 import java.util.concurrent.CountDownLatch;
@@ -64,22 +63,12 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.JUnit4;
 
 /** Integration tests for read-write transactions. */
 @Category(ParallelIntegrationTest.class)
-@RunWith(Parameterized.class)
+@RunWith(JUnit4.class)
 public class ITTransactionTest {
-
-  @Parameter(0)
-  public boolean inlineBegin;
-
-  @Parameters(name = "inlineBegin = {0}")
-  public static Collection<Object[]> data() {
-    return Arrays.asList(new Object[][] {{false}, {true}});
-  }
 
   @ClassRule public static IntegrationTestEnv env = new IntegrationTestEnv();
   private static Database db;
@@ -101,13 +90,7 @@ public class ITTransactionTest {
 
   @Before
   public void setupClient() {
-    spanner =
-        env.getTestHelper()
-            .getOptions()
-            .toBuilder()
-            .setInlineBeginForReadWriteTransaction(inlineBegin)
-            .build()
-            .getService();
+    spanner = env.getTestHelper().getClient();
     client = spanner.getDatabaseClient(db.getId());
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionTest.java
@@ -38,7 +38,6 @@ import com.google.cloud.spanner.PartitionOptions;
 import com.google.cloud.spanner.ReadContext;
 import com.google.cloud.spanner.ReadOnlyTransaction;
 import com.google.cloud.spanner.ResultSet;
-import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
@@ -56,8 +55,6 @@ import java.util.List;
 import java.util.Vector;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -69,11 +66,9 @@ import org.junit.runners.JUnit4;
 @Category(ParallelIntegrationTest.class)
 @RunWith(JUnit4.class)
 public class ITTransactionTest {
-
   @ClassRule public static IntegrationTestEnv env = new IntegrationTestEnv();
   private static Database db;
-  private Spanner spanner;
-  private DatabaseClient client;
+  private static DatabaseClient client;
   /** Sequence for assigning unique keys to test cases. */
   private static int seq;
 
@@ -86,18 +81,7 @@ public class ITTransactionTest {
                     + "  K    STRING(MAX) NOT NULL,"
                     + "  V    INT64,"
                     + ") PRIMARY KEY (K)");
-  }
-
-  @Before
-  public void setupClient() {
-    spanner = env.getTestHelper().getClient();
-    client = spanner.getDatabaseClient(db.getId());
-  }
-
-  @After
-  public void closeClient() {
-    client.writeAtLeastOnce(ImmutableList.of(Mutation.delete("T", KeySet.all())));
-    spanner.close();
+    client = env.getTestHelper().getDatabaseClient(db);
   }
 
   private static String uniqueKey() {


### PR DESCRIPTION
Removes the feature for preparing sessions in the session pool. This is step 2 of inlining `BeginTransaction` with the first statement of a transaction.