### PR TITLE
feat: adds options to the write operations

### DIFF
--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -382,12 +382,12 @@
   <difference>
     <differenceType>7012</differenceType>
     <className>com/google/cloud/spanner/DatabaseClient</className>
-    <method>com.google.cloud.spanner.WriteResponse writeWithOptions(java.lang.Iterable, com.google.cloud.spanner.Options$WriteOption[])</method>
+    <method>com.google.cloud.spanner.CommitResponse writeWithOptions(java.lang.Iterable, com.google.cloud.spanner.Options$TransactionOption[])</method>
   </difference>
   <difference>
     <differenceType>7012</differenceType>
     <className>com/google/cloud/spanner/DatabaseClient</className>
-    <method>com.google.cloud.spanner.WriteResponse writeAtLeastOnceWithOptions(java.lang.Iterable, com.google.cloud.spanner.Options$WriteOption[])</method>
+    <method>com.google.cloud.spanner.CommitResponse writeAtLeastOnceWithOptions(java.lang.Iterable, com.google.cloud.spanner.Options$TransactionOption[])</method>
   </difference>
 
 </differences>

--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -377,4 +377,17 @@
     <className>com/google/cloud/spanner/AsyncTransactionManager</className>
     <method>com.google.api.core.ApiFuture closeAsync()</method>
   </difference>
+
+  <!-- Write with options API -->
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/DatabaseClient</className>
+    <method>com.google.cloud.spanner.WriteResponse writeWithOptions(java.lang.Iterable, com.google.cloud.spanner.Options$WriteOption[])</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/DatabaseClient</className>
+    <method>com.google.cloud.spanner.WriteResponse writeAtLeastOnceWithOptions(java.lang.Iterable, com.google.cloud.spanner.Options$WriteOption[])</method>
+  </difference>
+
 </differences>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/CommitResponse.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/CommitResponse.java
@@ -19,12 +19,12 @@ package com.google.cloud.spanner;
 import com.google.cloud.Timestamp;
 import java.util.Objects;
 
-/** Represents a response from a write / writeAtLeast once operation. */
-public class WriteResponse {
+/** Represents a response from a commit operation. */
+public class CommitResponse {
 
   private final Timestamp commitTimestamp;
 
-  public WriteResponse(Timestamp commitTimestamp) {
+  public CommitResponse(Timestamp commitTimestamp) {
     this.commitTimestamp = commitTimestamp;
   }
 
@@ -41,7 +41,7 @@ public class WriteResponse {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    WriteResponse that = (WriteResponse) o;
+    CommitResponse that = (CommitResponse) o;
     return Objects.equals(commitTimestamp, that.commitTimestamp);
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClient.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spanner;
 
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Options.WriteOption;
 
 /**
  * Interface for all the APIs that are used to read/write data into a Cloud Spanner database. An
@@ -53,6 +54,35 @@ public interface DatabaseClient {
   Timestamp write(Iterable<Mutation> mutations) throws SpannerException;
 
   /**
+   * Writes the given mutations atomically to the database with the given options.
+   *
+   * <p>This method uses retries and replay protection internally, which means that the mutations
+   * are applied exactly once on success, or not at all if an error is returned, regardless of any
+   * failures in the underlying network. Note that if the call is cancelled or reaches deadline, it
+   * is not possible to know whether the mutations were applied without performing a subsequent
+   * database operation, but the mutations will have been applied at most once.
+   *
+   * <p>Example of blind write.
+   *
+   * <pre>{@code
+   * long singerId = my_singer_id;
+   * Mutation mutation = Mutation.newInsertBuilder("Singer")
+   *         .set("SingerId")
+   *         .to(singerId)
+   *         .set("FirstName")
+   *         .to("Billy")
+   *         .set("LastName")
+   *         .to("Joel")
+   *         .build();
+   * dbClient.writeWithOptions(Collections.singletonList(mutation));
+   * }</pre>
+   *
+   * @return a write response with the timestamp at which the write was committed
+   */
+  WriteResponse writeWithOptions(Iterable<Mutation> mutations, WriteOption... options)
+      throws SpannerException;
+
+  /**
    * Writes the given mutations atomically to the database without replay protection.
    *
    * <p>Since this method does not feature replay protection, it may attempt to apply {@code
@@ -82,6 +112,38 @@ public interface DatabaseClient {
    * @return the timestamp at which the write was committed
    */
   Timestamp writeAtLeastOnce(Iterable<Mutation> mutations) throws SpannerException;
+
+  /**
+   * Writes the given mutations atomically to the database without replay protection.
+   *
+   * <p>Since this method does not feature replay protection, it may attempt to apply {@code
+   * mutations} more than once; if the mutations are not idempotent, this may lead to a failure
+   * being reported when the mutation was applied once. For example, an insert may fail with {@link
+   * ErrorCode#ALREADY_EXISTS} even though the row did not exist before this method was called. For
+   * this reason, most users of the library will prefer to use {@link #write(Iterable)} instead.
+   * However, {@code writeAtLeastOnce()} requires only a single RPC, whereas {@code write()}
+   * requires two RPCs (one of which may be performed in advance), and so this method may be
+   * appropriate for latency sensitive and/or high throughput blind writing.
+   *
+   * <p>Example of unprotected blind write.
+   *
+   * <pre>{@code
+   * long singerId = my_singer_id;
+   * Mutation mutation = Mutation.newInsertBuilder("Singers")
+   *         .set("SingerId")
+   *         .to(singerId)
+   *         .set("FirstName")
+   *         .to("Billy")
+   *         .set("LastName")
+   *         .to("Joel")
+   *         .build();
+   * dbClient.writeAtLeastOnce(Collections.singletonList(mutation));
+   * }</pre>
+   *
+   * @return a write response with the timestamp at which the write was committed
+   */
+  WriteResponse writeAtLeastOnceWithOptions(Iterable<Mutation> mutations, WriteOption... options)
+      throws SpannerException;
 
   /**
    * Returns a context in which a single read can be performed using {@link TimestampBound#strong()}

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClient.java
@@ -17,7 +17,7 @@
 package com.google.cloud.spanner;
 
 import com.google.cloud.Timestamp;
-import com.google.cloud.spanner.Options.WriteOption;
+import com.google.cloud.spanner.Options.TransactionOption;
 
 /**
  * Interface for all the APIs that are used to read/write data into a Cloud Spanner database. An
@@ -77,9 +77,9 @@ public interface DatabaseClient {
    * dbClient.writeWithOptions(Collections.singletonList(mutation));
    * }</pre>
    *
-   * @return a write response with the timestamp at which the write was committed
+   * @return a response with the timestamp at which the write was committed
    */
-  WriteResponse writeWithOptions(Iterable<Mutation> mutations, WriteOption... options)
+  CommitResponse writeWithOptions(Iterable<Mutation> mutations, TransactionOption... options)
       throws SpannerException;
 
   /**
@@ -140,10 +140,10 @@ public interface DatabaseClient {
    * dbClient.writeAtLeastOnce(Collections.singletonList(mutation));
    * }</pre>
    *
-   * @return a write response with the timestamp at which the write was committed
+   * @return a response with the timestamp at which the write was committed
    */
-  WriteResponse writeAtLeastOnceWithOptions(Iterable<Mutation> mutations, WriteOption... options)
-      throws SpannerException;
+  CommitResponse writeAtLeastOnceWithOptions(
+      Iterable<Mutation> mutations, TransactionOption... options) throws SpannerException;
 
   /**
    * Returns a context in which a single read can be performed using {@link TimestampBound#strong()}

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spanner;
 
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Options.WriteOption;
 import com.google.cloud.spanner.SessionPool.PooledSessionFuture;
 import com.google.cloud.spanner.SpannerImpl.ClosedException;
 import com.google.common.annotations.VisibleForTesting;
@@ -82,6 +83,13 @@ class DatabaseClientImpl implements DatabaseClient {
   }
 
   @Override
+  public WriteResponse writeWithOptions(Iterable<Mutation> mutations, WriteOption... options)
+      throws SpannerException {
+    final Timestamp commitTimestamp = write(mutations);
+    return new WriteResponse(commitTimestamp);
+  }
+
+  @Override
   public Timestamp writeAtLeastOnce(final Iterable<Mutation> mutations) throws SpannerException {
     Span span = tracer.spanBuilder(READ_WRITE_TRANSACTION).startSpan();
     try (Scope s = tracer.withSpan(span)) {
@@ -99,6 +107,13 @@ class DatabaseClientImpl implements DatabaseClient {
     } finally {
       span.end(TraceUtil.END_SPAN_OPTIONS);
     }
+  }
+
+  @Override
+  public WriteResponse writeAtLeastOnceWithOptions(
+      Iterable<Mutation> mutations, WriteOption... options) throws SpannerException {
+    final Timestamp commitTimestamp = writeAtLeastOnce(mutations);
+    return new WriteResponse(commitTimestamp);
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
@@ -17,7 +17,7 @@
 package com.google.cloud.spanner;
 
 import com.google.cloud.Timestamp;
-import com.google.cloud.spanner.Options.WriteOption;
+import com.google.cloud.spanner.Options.TransactionOption;
 import com.google.cloud.spanner.SessionPool.PooledSessionFuture;
 import com.google.cloud.spanner.SpannerImpl.ClosedException;
 import com.google.common.annotations.VisibleForTesting;
@@ -83,10 +83,10 @@ class DatabaseClientImpl implements DatabaseClient {
   }
 
   @Override
-  public WriteResponse writeWithOptions(Iterable<Mutation> mutations, WriteOption... options)
+  public CommitResponse writeWithOptions(Iterable<Mutation> mutations, TransactionOption... options)
       throws SpannerException {
     final Timestamp commitTimestamp = write(mutations);
-    return new WriteResponse(commitTimestamp);
+    return new CommitResponse(commitTimestamp);
   }
 
   @Override
@@ -110,10 +110,10 @@ class DatabaseClientImpl implements DatabaseClient {
   }
 
   @Override
-  public WriteResponse writeAtLeastOnceWithOptions(
-      Iterable<Mutation> mutations, WriteOption... options) throws SpannerException {
+  public CommitResponse writeAtLeastOnceWithOptions(
+      Iterable<Mutation> mutations, TransactionOption... options) throws SpannerException {
     final Timestamp commitTimestamp = writeAtLeastOnce(mutations);
-    return new WriteResponse(commitTimestamp);
+    return new CommitResponse(commitTimestamp);
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
@@ -34,7 +34,7 @@ public final class Options implements Serializable {
   public interface QueryOption {}
 
   /** Marker interface to mark options applicable to write operations */
-  public interface WriteOption {}
+  public interface TransactionOption {}
 
   /** Marker interface to mark options applicable to list operations in admin API. */
   public interface ListOption {}

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
@@ -33,6 +33,9 @@ public final class Options implements Serializable {
   /** Marker interface to mark options applicable to query operation. */
   public interface QueryOption {}
 
+  /** Marker interface to mark options applicable to write operations */
+  public interface WriteOption {}
+
   /** Marker interface to mark options applicable to list operations in admin API. */
   public interface ListOption {}
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -25,7 +25,7 @@ import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.AbstractReadContext.MultiUseReadOnlyTransaction;
 import com.google.cloud.spanner.AbstractReadContext.SingleReadContext;
 import com.google.cloud.spanner.AbstractReadContext.SingleUseReadOnlyTransaction;
-import com.google.cloud.spanner.Options.WriteOption;
+import com.google.cloud.spanner.Options.TransactionOption;
 import com.google.cloud.spanner.SessionClient.SessionId;
 import com.google.cloud.spanner.TransactionRunnerImpl.TransactionContextImpl;
 import com.google.cloud.spanner.spi.v1.SpannerRpc;
@@ -36,7 +36,6 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
 import com.google.spanner.v1.BeginTransactionRequest;
 import com.google.spanner.v1.CommitRequest;
-import com.google.spanner.v1.CommitResponse;
 import com.google.spanner.v1.Transaction;
 import com.google.spanner.v1.TransactionOptions;
 import io.opencensus.common.Scope;
@@ -141,10 +140,10 @@ class SessionImpl implements Session {
   }
 
   @Override
-  public WriteResponse writeWithOptions(Iterable<Mutation> mutations, WriteOption... options)
+  public CommitResponse writeWithOptions(Iterable<Mutation> mutations, TransactionOption... options)
       throws SpannerException {
     final Timestamp commitTimestamp = write(mutations);
-    return new WriteResponse(commitTimestamp);
+    return new CommitResponse(commitTimestamp);
   }
 
   @Override
@@ -162,7 +161,7 @@ class SessionImpl implements Session {
             .build();
     Span span = tracer.spanBuilder(SpannerImpl.COMMIT).startSpan();
     try (Scope s = tracer.withSpan(span)) {
-      CommitResponse response = spanner.getRpc().commit(request, options);
+      com.google.spanner.v1.CommitResponse response = spanner.getRpc().commit(request, options);
       Timestamp t = Timestamp.fromProto(response.getCommitTimestamp());
       return t;
     } catch (IllegalArgumentException e) {
@@ -177,10 +176,10 @@ class SessionImpl implements Session {
   }
 
   @Override
-  public WriteResponse writeAtLeastOnceWithOptions(
-      Iterable<Mutation> mutations, WriteOption... options) throws SpannerException {
+  public CommitResponse writeAtLeastOnceWithOptions(
+      Iterable<Mutation> mutations, TransactionOption... options) throws SpannerException {
     final Timestamp commitTimestamp = writeAtLeastOnce(mutations);
-    return new WriteResponse(commitTimestamp);
+    return new CommitResponse(commitTimestamp);
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -25,6 +25,7 @@ import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.AbstractReadContext.MultiUseReadOnlyTransaction;
 import com.google.cloud.spanner.AbstractReadContext.SingleReadContext;
 import com.google.cloud.spanner.AbstractReadContext.SingleUseReadOnlyTransaction;
+import com.google.cloud.spanner.Options.WriteOption;
 import com.google.cloud.spanner.SessionClient.SessionId;
 import com.google.cloud.spanner.TransactionRunnerImpl.TransactionContextImpl;
 import com.google.cloud.spanner.spi.v1.SpannerRpc;
@@ -140,6 +141,13 @@ class SessionImpl implements Session {
   }
 
   @Override
+  public WriteResponse writeWithOptions(Iterable<Mutation> mutations, WriteOption... options)
+      throws SpannerException {
+    final Timestamp commitTimestamp = write(mutations);
+    return new WriteResponse(commitTimestamp);
+  }
+
+  @Override
   public Timestamp writeAtLeastOnce(Iterable<Mutation> mutations) throws SpannerException {
     setActive(null);
     List<com.google.spanner.v1.Mutation> mutationsProto = new ArrayList<>();
@@ -166,6 +174,13 @@ class SessionImpl implements Session {
     } finally {
       span.end(TraceUtil.END_SPAN_OPTIONS);
     }
+  }
+
+  @Override
+  public WriteResponse writeAtLeastOnceWithOptions(
+      Iterable<Mutation> mutations, WriteOption... options) throws SpannerException {
+    final Timestamp commitTimestamp = writeAtLeastOnce(mutations);
+    return new WriteResponse(commitTimestamp);
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -47,11 +47,10 @@ import com.google.cloud.grpc.GrpcTransportOptions;
 import com.google.cloud.grpc.GrpcTransportOptions.ExecutorFactory;
 import com.google.cloud.spanner.Options.QueryOption;
 import com.google.cloud.spanner.Options.ReadOption;
-import com.google.cloud.spanner.Options.WriteOption;
+import com.google.cloud.spanner.Options.TransactionOption;
 import com.google.cloud.spanner.SessionClient.SessionConsumer;
 import com.google.cloud.spanner.SpannerException.ResourceNotFoundException;
 import com.google.cloud.spanner.SpannerImpl.ClosedException;
-import com.google.cloud.spanner.TransactionManager.TransactionState;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
@@ -1105,10 +1104,10 @@ final class SessionPool {
     }
 
     @Override
-    public WriteResponse writeWithOptions(Iterable<Mutation> mutations, WriteOption... options)
-        throws SpannerException {
+    public CommitResponse writeWithOptions(
+        Iterable<Mutation> mutations, TransactionOption... options) throws SpannerException {
       final Timestamp commitTimestamp = write(mutations);
-      return new WriteResponse(commitTimestamp);
+      return new CommitResponse(commitTimestamp);
     }
 
     @Override
@@ -1121,10 +1120,10 @@ final class SessionPool {
     }
 
     @Override
-    public WriteResponse writeAtLeastOnceWithOptions(
-        Iterable<Mutation> mutations, WriteOption... options) throws SpannerException {
+    public CommitResponse writeAtLeastOnceWithOptions(
+        Iterable<Mutation> mutations, TransactionOption... options) throws SpannerException {
       final Timestamp commitTimestamp = writeAtLeastOnce(mutations);
-      return new WriteResponse(commitTimestamp);
+      return new CommitResponse(commitTimestamp);
     }
 
     @Override
@@ -1363,10 +1362,10 @@ final class SessionPool {
     }
 
     @Override
-    public WriteResponse writeWithOptions(Iterable<Mutation> mutations, WriteOption... options)
-        throws SpannerException {
+    public CommitResponse writeWithOptions(
+        Iterable<Mutation> mutations, TransactionOption... options) throws SpannerException {
       final Timestamp commitTimestamp = write(mutations);
-      return new WriteResponse(commitTimestamp);
+      return new CommitResponse(commitTimestamp);
     }
 
     @Override
@@ -1380,10 +1379,10 @@ final class SessionPool {
     }
 
     @Override
-    public WriteResponse writeAtLeastOnceWithOptions(
-        Iterable<Mutation> mutations, WriteOption... options) throws SpannerException {
+    public CommitResponse writeAtLeastOnceWithOptions(
+        Iterable<Mutation> mutations, TransactionOption... options) throws SpannerException {
       final Timestamp commitTimestamp = writeAtLeastOnce(mutations);
-      return new WriteResponse(commitTimestamp);
+      return new CommitResponse(commitTimestamp);
     }
 
     @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -47,6 +47,7 @@ import com.google.cloud.grpc.GrpcTransportOptions;
 import com.google.cloud.grpc.GrpcTransportOptions.ExecutorFactory;
 import com.google.cloud.spanner.Options.QueryOption;
 import com.google.cloud.spanner.Options.ReadOption;
+import com.google.cloud.spanner.Options.WriteOption;
 import com.google.cloud.spanner.SessionClient.SessionConsumer;
 import com.google.cloud.spanner.SpannerException.ResourceNotFoundException;
 import com.google.cloud.spanner.SpannerImpl.ClosedException;
@@ -1104,12 +1105,26 @@ final class SessionPool {
     }
 
     @Override
+    public WriteResponse writeWithOptions(Iterable<Mutation> mutations, WriteOption... options)
+        throws SpannerException {
+      final Timestamp commitTimestamp = write(mutations);
+      return new WriteResponse(commitTimestamp);
+    }
+
+    @Override
     public Timestamp writeAtLeastOnce(Iterable<Mutation> mutations) throws SpannerException {
       try {
         return get().writeAtLeastOnce(mutations);
       } finally {
         close();
       }
+    }
+
+    @Override
+    public WriteResponse writeAtLeastOnceWithOptions(
+        Iterable<Mutation> mutations, WriteOption... options) throws SpannerException {
+      final Timestamp commitTimestamp = writeAtLeastOnce(mutations);
+      return new WriteResponse(commitTimestamp);
     }
 
     @Override
@@ -1348,6 +1363,13 @@ final class SessionPool {
     }
 
     @Override
+    public WriteResponse writeWithOptions(Iterable<Mutation> mutations, WriteOption... options)
+        throws SpannerException {
+      final Timestamp commitTimestamp = write(mutations);
+      return new WriteResponse(commitTimestamp);
+    }
+
+    @Override
     public Timestamp writeAtLeastOnce(Iterable<Mutation> mutations) throws SpannerException {
       try {
         markUsed();
@@ -1355,6 +1377,13 @@ final class SessionPool {
       } catch (SpannerException e) {
         throw lastException = e;
       }
+    }
+
+    @Override
+    public WriteResponse writeAtLeastOnceWithOptions(
+        Iterable<Mutation> mutations, WriteOption... options) throws SpannerException {
+      final Timestamp commitTimestamp = writeAtLeastOnce(mutations);
+      return new WriteResponse(commitTimestamp);
     }
 
     @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/WriteResponse.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/WriteResponse.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+import com.google.cloud.Timestamp;
+import java.util.Objects;
+
+/** Represents a response from a write / writeAtLeast once operation. */
+public class WriteResponse {
+
+  private final Timestamp commitTimestamp;
+
+  public WriteResponse(Timestamp commitTimestamp) {
+    this.commitTimestamp = commitTimestamp;
+  }
+
+  /** Returns a {@link Timestamp} representing the commit time of the write operation. */
+  public Timestamp getCommitTimestamp() {
+    return commitTimestamp;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    WriteResponse that = (WriteResponse) o;
+    return Objects.equals(commitTimestamp, that.commitTimestamp);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(commitTimestamp);
+  }
+}


### PR DESCRIPTION
Adds the possibility of adding options to the write operations and encapsulates the write response into its own class so that we can augment the response with more fields than the commit timestamp.

At the moment, the new methods just delegate to the existing write methods. Once we add write option implementations we should change the definition of the added methods.