### PR TITLE
fix!: initialize should be protected

### DIFF
--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -377,4 +377,21 @@
     <className>com/google/cloud/spanner/AsyncTransactionManager</className>
     <method>com.google.api.core.ApiFuture closeAsync()</method>
   </difference>
+
+  <!-- Note: The following change for the LazySpannerInitializer.initialize() method must be specified twice, both with return type java.lang.Object and with com.google.cloud.spanner.Spanner. -->
+  <difference>
+    <differenceType>7009</differenceType>
+    <className>com/google/cloud/spanner/LazySpannerInitializer</className>
+    <method>com.google.cloud.spanner.Spanner initialize()</method>
+  </difference>
+  <difference>
+    <differenceType>7009</differenceType>
+    <className>com/google/cloud/spanner/LazySpannerInitializer</className>
+    <method>java.lang.Object initialize()</method>
+  </difference>
+  <difference>
+    <differenceType>7009</differenceType>
+    <className>com/google/cloud/spanner/AbstractLazyInitializer</className>
+    <method>java.lang.Object initialize()</method>
+  </difference>
 </differences>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractLazyInitializer.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractLazyInitializer.java
@@ -51,5 +51,5 @@ public abstract class AbstractLazyInitializer<T> {
    * Initializes the actual object that should be returned. Is called once the first time an
    * instance of T is required.
    */
-  public abstract T initialize() throws Exception;
+  protected abstract T initialize() throws Exception;
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/LazySpannerInitializer.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/LazySpannerInitializer.java
@@ -23,7 +23,7 @@ public class LazySpannerInitializer extends AbstractLazyInitializer<Spanner> {
    * custom configuration.
    */
   @Override
-  public Spanner initialize() throws Exception {
+  protected Spanner initialize() throws Exception {
     return SpannerOptions.newBuilder().build().getService();
   }
 }


### PR DESCRIPTION
The `AbstractLazyInitializer#initialize()` method should be `protected`.