### PR TITLE
fix: SessionNotFound was not retried for AsyncTransactionManager

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncTransactionManagerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncTransactionManagerImpl.java
@@ -66,7 +66,9 @@ final class AsyncTransactionManagerImpl
     if (txnState == TransactionState.STARTED) {
       res = rollbackAsync();
     }
-    txn.close();
+    if (txn != null) {
+      txn.close();
+    }
     return MoreObjects.firstNonNull(res, ApiFutures.<Void>immediateFuture(null));
   }
 
@@ -172,7 +174,7 @@ final class AsyncTransactionManagerImpl
 
   @Override
   public TransactionContextFuture resetForRetryAsync() {
-    if (txn == null || !txn.isAborted() && txnState != TransactionState.ABORTED) {
+    if (txn == null || (!txn.isAborted() && txnState != TransactionState.ABORTED)) {
       throw new IllegalStateException(
           "resetForRetry can only be called if the previous attempt aborted");
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerTest.java
@@ -36,6 +36,7 @@ import com.google.cloud.spanner.AsyncTransactionManager.TransactionContextFuture
 import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
 import com.google.cloud.spanner.Options.ReadOption;
+import com.google.cloud.spanner.SessionPool.SessionPoolTransactionContext;
 import com.google.cloud.spanner.TransactionRunnerImpl.TransactionContextImpl;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
@@ -191,7 +192,9 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
     AsyncTransactionManager manager = client().transactionManagerAsync();
     TransactionContext txn = manager.beginAsync().get();
     txn.executeUpdateAsync(UPDATE_STATEMENT).get();
-    final TransactionSelector selector = ((TransactionContextImpl) txn).getTransactionSelector();
+    final TransactionSelector selector =
+        ((TransactionContextImpl) ((SessionPoolTransactionContext) txn).delegate)
+            .getTransactionSelector();
 
     SpannerApiFutures.get(manager.closeAsync());
     // The mock server should already have the Rollback request, as we are waiting for the returned

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -20,6 +20,7 @@ import com.google.api.gax.grpc.testing.MockGrpcService;
 import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.spanner.AbstractResultSet.GrpcStruct;
+import com.google.cloud.spanner.SessionPool.SessionPoolTransactionContext;
 import com.google.cloud.spanner.TransactionRunnerImpl.TransactionContextImpl;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
@@ -664,6 +665,9 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
    */
   public void abortTransaction(TransactionContext transactionContext) {
     Preconditions.checkNotNull(transactionContext);
+    if (transactionContext instanceof SessionPoolTransactionContext) {
+      transactionContext = ((SessionPoolTransactionContext) transactionContext).delegate;
+    }
     if (transactionContext instanceof TransactionContextImpl) {
       TransactionContextImpl impl = (TransactionContextImpl) transactionContext;
       ByteString id =


### PR DESCRIPTION
`SessionNotFoundException` was not retried if these happened when using `AsyncTransactionManager`. These exceptions are now handled explicitly in the following way:
1. The underlying session that is used for the transaction is replaced with a new session from the pool.
1. The `SessionNotFoundException` is translated to an `AbortedException`, which again will be retried, assuming that the client application has implemented a normal retry loop, as is required when using an `AsyncTransactionManager`.
