### PR TITLE
fix: make enums in the Connection API public

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AutocommitDmlMode.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AutocommitDmlMode.java
@@ -17,7 +17,7 @@
 package com.google.cloud.spanner.connection;
 
 /** Enum used to define the behavior of DML statements in autocommit mode */
-enum AutocommitDmlMode {
+public enum AutocommitDmlMode {
   TRANSACTIONAL,
   PARTITIONED_NON_ATOMIC;
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/TransactionMode.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/TransactionMode.java
@@ -17,7 +17,7 @@
 package com.google.cloud.spanner.connection;
 
 /** Enum used to define the transaction type of a {@link Connection} */
-enum TransactionMode {
+public enum TransactionMode {
   READ_ONLY_TRANSACTION("READ ONLY"),
   READ_WRITE_TRANSACTION("READ WRITE");
 


### PR DESCRIPTION
Some enums were defined as package-private, but these were used in the public API of the Connection API. That made the specific methods in the Connection API unusable from outside the Spanner client library.

Towards https://github.com/googleapis/java-spanner-jdbc/issues/253