### PR TITLE
docs: add descriptions for connection URL properties

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
@@ -183,18 +183,36 @@ public class ConnectionOptions {
           new HashSet<>(
               Arrays.asList(
                   ConnectionProperty.createBooleanProperty(
-                      AUTOCOMMIT_PROPERTY_NAME, "", DEFAULT_AUTOCOMMIT),
+                      AUTOCOMMIT_PROPERTY_NAME,
+                      "Should the connection start in autocommit (true/false)",
+                      DEFAULT_AUTOCOMMIT),
                   ConnectionProperty.createBooleanProperty(
-                      READONLY_PROPERTY_NAME, "", DEFAULT_READONLY),
+                      READONLY_PROPERTY_NAME,
+                      "Should the connection start in read-only mode (true/false)",
+                      DEFAULT_READONLY),
                   ConnectionProperty.createBooleanProperty(
-                      RETRY_ABORTS_INTERNALLY_PROPERTY_NAME, "", DEFAULT_RETRY_ABORTS_INTERNALLY),
-                  ConnectionProperty.createStringProperty(CREDENTIALS_PROPERTY_NAME, ""),
-                  ConnectionProperty.createStringProperty(OAUTH_TOKEN_PROPERTY_NAME, ""),
-                  ConnectionProperty.createStringProperty(NUM_CHANNELS_PROPERTY_NAME, ""),
+                      RETRY_ABORTS_INTERNALLY_PROPERTY_NAME,
+                      "Should the connection automatically retry Aborted errors (true/false)",
+                      DEFAULT_RETRY_ABORTS_INTERNALLY),
+                  ConnectionProperty.createStringProperty(
+                      CREDENTIALS_PROPERTY_NAME,
+                      "The location of the credentials file to use for this connection. If this property is not set, the connection will use the default Google Cloud credentials for the runtime environment."),
+                  ConnectionProperty.createStringProperty(
+                      OAUTH_TOKEN_PROPERTY_NAME,
+                      "A valid pre-existing OAuth token to use for authentication for this connection. Setting this property will take precedence over any value set for a credentials file."),
+                  ConnectionProperty.createStringProperty(
+                      NUM_CHANNELS_PROPERTY_NAME,
+                      "The number of gRPC channels to use to communicate with Cloud Spanner. The default is 4."),
                   ConnectionProperty.createBooleanProperty(
-                      USE_PLAIN_TEXT_PROPERTY_NAME, "", DEFAULT_USE_PLAIN_TEXT),
-                  ConnectionProperty.createStringProperty(USER_AGENT_PROPERTY_NAME, ""),
-                  ConnectionProperty.createStringProperty(OPTIMIZER_VERSION_PROPERTY_NAME, ""))));
+                      USE_PLAIN_TEXT_PROPERTY_NAME,
+                      "Use a plain text communication channel (i.e. non-TLS) for communicating with the server (true/false). Set this value to true for communication with the Cloud Spanner emulator.",
+                      DEFAULT_USE_PLAIN_TEXT),
+                  ConnectionProperty.createStringProperty(
+                      USER_AGENT_PROPERTY_NAME,
+                      "The custom user-agent property name to use when communicating with Cloud Spanner. This property is intended for internal library usage, and should not be set by applications."),
+                  ConnectionProperty.createStringProperty(
+                      OPTIMIZER_VERSION_PROPERTY_NAME,
+                      "Sets the default query optimizer version to use for this connection."))));
 
   private static final Set<ConnectionProperty> INTERNAL_PROPERTIES =
       Collections.unmodifiableSet(


### PR DESCRIPTION
Adds descriptions for the supported connection URL properties. These can be picked up by the JDBC driver and shown as descriptions for java.sql.DriverPropertyInfo.
