### PR TITLE
fix: adds api spanner team as samples code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,4 +9,4 @@
 **/*.java               @googleapis/api-spanner-java
 
 # The java-samples-reviewers team is the default owner for samples changes
-samples/**/*.java       @googleapis/java-samples-reviewers
+samples/**/*.java       @googleapis/java-samples-reviewers @googleapis/api-spanner-java


### PR DESCRIPTION
Adds api spanner java team as samples code owners