### PR TITLE
test: add profile for generating test sql scripts

### DIFF
--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -377,5 +377,38 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <!-- Profile for generating new sql test scripts. See ConnectionImplGeneratedSqlScriptTest 
+        for more information. -->
+      <id>generate-test-sql-scripts</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>generateTestScripts</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>java</goal>
+                </goals>
+                <configuration>
+                  <mainClass>com.google.cloud.spanner.connection.SqlTestScriptsGenerator</mainClass>
+                  <systemProperties>
+                    <systemProperty>
+                      <key>do_log_statements</key>
+                      <value>true</value>
+                    </systemProperty>
+                  </systemProperties>
+                  <classpathScope>test</classpathScope>
+                  <skip>false</skip>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Adds a profile for regenerating the SQL test files for the Connection API. This was forgotten when moving the Connection API code from the jdbc repository to the client library repository.