### PR TITLE
fix: session retry could cause infinite wait

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncTransactionManagerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncTransactionManagerImpl.java
@@ -98,6 +98,7 @@ final class AsyncTransactionManagerImpl
         new ApiFutureCallback<Void>() {
           @Override
           public void onFailure(Throwable t) {
+            onError(t);
             res.setException(SpannerExceptionFactory.newSpannerException(t));
           }
 
@@ -130,6 +131,7 @@ final class AsyncTransactionManagerImpl
     }
     ApiFuture<Timestamp> res = txn.commitAsync();
     txnState = TransactionState.COMMITTED;
+
     ApiFutures.addCallback(
         res,
         new ApiFutureCallback<Timestamp>() {
@@ -174,10 +176,6 @@ final class AsyncTransactionManagerImpl
 
   @Override
   public TransactionContextFuture resetForRetryAsync() {
-    if (txn == null || (!txn.isAborted() && txnState != TransactionState.ABORTED)) {
-      throw new IllegalStateException(
-          "resetForRetry can only be called if the previous attempt aborted");
-    }
     return new TransactionContextFutureImpl(this, internalBeginAsync(false));
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContextFutureImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContextFutureImpl.java
@@ -109,6 +109,7 @@ class TransactionContextFutureImpl extends ForwardingApiFuture<TransactionContex
             @Override
             public void onFailure(Throwable t) {
               mgr.onError(t);
+              statementResult.setException(t);
               txnResult.setException(t);
             }
 


### PR DESCRIPTION
A "Session not found" when using an AsyncTransactionManager could cause an infinite wait for an `ApiFuture` that would never be done.

Fixes #605
