### PR TITLE
fix: does not generate codeowners

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -88,4 +88,5 @@ java.common_templates(excludes=[
     'samples/install-without-bom/pom.xml',
     'samples/snapshot/pom.xml',
     'samples/snippets/pom.xml',
+    '.github/CODEOWNERS',
 ])


### PR DESCRIPTION
Prevents the re-generation of the github CODEOWNERS file, since we have updated the owners for the samples directory.