### PR TITLE
Revert "fix: skip failing backup tests for now"

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDatabaseAdminTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDatabaseAdminTest.java
@@ -63,7 +63,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -270,7 +269,6 @@ public class ITDatabaseAdminTest {
     }
   }
 
-  @Ignore("Skipping until list backup operations bug is fixed: b/169431286")
   @Test
   public void testRetryNonIdempotentRpcsReturningLongRunningOperations() throws Exception {
     assumeFalse(


### PR DESCRIPTION
These tests were previously disabled due to a bug in production, which has been fixed.