### PR TITLE
fix: query could hang transaction if ResultSet#next() is not called

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -267,7 +267,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
       final SettableApiFuture<Void> finishOps;
       CommitRequest.Builder builder = CommitRequest.newBuilder().setSession(session.getName());
       synchronized (lock) {
-        if (transactionIdFuture == null && transactionId == null) {
+        if (transactionIdFuture == null && transactionId == null && runningAsyncOperations == 0) {
           finishOps = SettableApiFuture.create();
           createTxnAsync(finishOps);
         } else {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GrpcResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GrpcResultSetTest.java
@@ -75,13 +75,14 @@ public class GrpcResultSetTest {
 
           @Override
           public void request(int numMessages) {}
-        });
+        },
+        false);
     consumer = stream.consumer();
-    resultSet = new AbstractResultSet.GrpcResultSet(stream, new NoOpListener(), false);
+    resultSet = new AbstractResultSet.GrpcResultSet(stream, new NoOpListener());
   }
 
   public AbstractResultSet.GrpcResultSet resultSetWithMode(QueryMode queryMode) {
-    return new AbstractResultSet.GrpcResultSet(stream, new NoOpListener(), false);
+    return new AbstractResultSet.GrpcResultSet(stream, new NoOpListener());
   }
 
   @Test
@@ -642,7 +643,7 @@ public class GrpcResultSetTest {
 
   private void verifySerialization(
       Function<Value, com.google.protobuf.Value> protoFn, Value... values) {
-    resultSet = new AbstractResultSet.GrpcResultSet(stream, new NoOpListener(), false);
+    resultSet = new AbstractResultSet.GrpcResultSet(stream, new NoOpListener());
     PartialResultSet.Builder builder = PartialResultSet.newBuilder();
     List<Type.StructField> types = new ArrayList<>();
     for (Value value : values) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadFormatTestRunner.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadFormatTestRunner.java
@@ -117,9 +117,10 @@ public class ReadFormatTestRunner extends ParentRunner<JSONObject> {
 
             @Override
             public void request(int numMessages) {}
-          });
+          },
+          false);
       consumer = stream.consumer();
-      resultSet = new AbstractResultSet.GrpcResultSet(stream, new NoOpListener(), false);
+      resultSet = new AbstractResultSet.GrpcResultSet(stream, new NoOpListener());
 
       JSONArray chunks = testCase.getJSONArray("chunks");
       JSONObject expectedResult = testCase.getJSONObject("result");

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ResumableStreamIteratorTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ResumableStreamIteratorTest.java
@@ -116,6 +116,11 @@ public class ResumableStreamIteratorTest {
     public void close(@Nullable String message) {
       stream.close();
     }
+
+    @Override
+    public boolean isWithBeginTransaction() {
+      return false;
+    }
   }
 
   Starter starter = Mockito.mock(Starter.class);


### PR DESCRIPTION
If the first statement of a read/write transaction was a query or a read operation, and the application would not call `ResultSet#next()` on the return result, the transaction would hang indefinitely as the query would be marked as the one that should initiate the transaction (inline the `BeginTransaction` option). The query would however never be executed, as the actual query execution is deferred until the first call to `ResultSet#next()`.

Fixes #641
