### PR TITLE
test: fix flaky InlineBeginTransactionTest

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
@@ -1248,14 +1248,13 @@ public class InlineBeginTransactionTest {
     // id returned by the update.
     assertThat(mockSpanner.countRequestsOfType(BeginTransactionRequest.class)).isEqualTo(0L);
     assertThat(mockSpanner.countRequestsOfType(ExecuteSqlRequest.class)).isEqualTo(2L);
+    assertThat(mockSpanner.countRequestsOfType(CommitRequest.class)).isEqualTo(1L);
     assertThat(countTransactionsStarted()).isEqualTo(1);
-    List<AbstractMessage> requests = mockSpanner.getRequests();
-    requests = requests.subList(requests.size() - 3, requests.size());
+    List<AbstractMessage> requests = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class);
     assertThat(requests.get(0)).isInstanceOf(ExecuteSqlRequest.class);
     assertThat(((ExecuteSqlRequest) requests.get(0)).getSql()).isEqualTo(UPDATE_STATEMENT.getSql());
     assertThat(requests.get(1)).isInstanceOf(ExecuteSqlRequest.class);
     assertThat(((ExecuteSqlRequest) requests.get(1)).getSql()).isEqualTo(SELECT1.getSql());
-    assertThat(requests.get(2)).isInstanceOf(CommitRequest.class);
   }
 
   private int countRequests(Class<? extends AbstractMessage> requestType) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -1905,6 +1905,20 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
     return new ArrayList<>(this.requests);
   }
 
+  public void clearRequests() {
+    this.requests.clear();
+  }
+
+  public List<AbstractMessage> getRequestsOfType(Class<? extends AbstractMessage> type) {
+    List<AbstractMessage> res = new ArrayList<>();
+    for (AbstractMessage m : this.requests) {
+      if (m.getClass().equals(type)) {
+        res.add(m);
+      }
+    }
+    return res;
+  }
+
   public Iterable<Class<? extends AbstractMessage>> getRequestTypes() {
     List<Class<? extends AbstractMessage>> res = new LinkedList<>();
     for (AbstractMessage m : this.requests) {


### PR DESCRIPTION
The query_ThenUpdate_ThenConsumeResultSet did not take into account that the session pool initialization will execute 4 BatchCreateSessions requests. These will normally be executed before the test transaction, but sometimes at least one of those requests might arrive after the transaction has started. That could cause the last 3 requests on the mock server to be
different from what the test expected.
