### PR TITLE
feat: allow lenient mode for connection properties

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
@@ -393,6 +393,7 @@ public class ConnectionOptionsTest {
         ConnectionOptions.newBuilder()
             .setUri(
                 "cloudspanner:/projects/test-project-123/instances/test-instance/databases/test-database?lenient=true;foo=bar")
+            .setCredentialsUrl(FILE_TEST_PATH)
             .build();
     assertThat(options.getWarnings()).isNotNull();
     assertThat(options.getWarnings()).contains("foo");
@@ -402,6 +403,7 @@ public class ConnectionOptionsTest {
         ConnectionOptions.newBuilder()
             .setUri(
                 "cloudspanner:/projects/test-project-123/instances/test-instance/databases/test-database?bar=foo;lenient=true")
+            .setCredentialsUrl(FILE_TEST_PATH)
             .build();
     assertThat(options.getWarnings()).isNotNull();
     assertThat(options.getWarnings()).contains("bar");
@@ -412,6 +414,7 @@ public class ConnectionOptionsTest {
           ConnectionOptions.newBuilder()
               .setUri(
                   "cloudspanner:/projects/test-project-123/instances/test-instance/databases/test-database?bar=foo")
+              .setCredentialsUrl(FILE_TEST_PATH)
               .build();
       fail("missing expected exception");
     } catch (IllegalArgumentException e) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
@@ -386,4 +386,36 @@ public class ConnectionOptionsTest {
       assertThat(e.getMessage()).contains("Cannot specify both credentials and an OAuth token");
     }
   }
+
+  @Test
+  public void testLenient() {
+    ConnectionOptions options =
+        ConnectionOptions.newBuilder()
+            .setUri(
+                "cloudspanner:/projects/test-project-123/instances/test-instance/databases/test-database?lenient=true;foo=bar")
+            .build();
+    assertThat(options.getWarnings()).isNotNull();
+    assertThat(options.getWarnings()).contains("foo");
+    assertThat(options.getWarnings()).doesNotContain("lenient");
+
+    options =
+        ConnectionOptions.newBuilder()
+            .setUri(
+                "cloudspanner:/projects/test-project-123/instances/test-instance/databases/test-database?bar=foo;lenient=true")
+            .build();
+    assertThat(options.getWarnings()).isNotNull();
+    assertThat(options.getWarnings()).contains("bar");
+    assertThat(options.getWarnings()).doesNotContain("lenient");
+
+    try {
+      options =
+          ConnectionOptions.newBuilder()
+              .setUri(
+                  "cloudspanner:/projects/test-project-123/instances/test-instance/databases/test-database?bar=foo")
+              .build();
+      fail("missing expected exception");
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage()).contains("bar");
+    }
+  }
 }


### PR DESCRIPTION
Some applications automatically add additional properties to connection strings that are unknown to the Spanner Connection API (and thereby also the Spanner JDBC driver). This causes the connection attempt to fail. This change allows a user to specify 'lenient' mode where unknown properties only generate a warning instead of an error.

Needed for https://github.com/dropwizard/dropwizard/issues/3461
Needed for https://github.com/googleapis/google-cloud-java/issues/6671
Needed for https://github.com/googleapis/java-spanner-jdbc/issues/283
