### PR TITLE
fix: transaction retry could fail if tx contained failed statements

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/FailedBatchUpdate.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/FailedBatchUpdate.java
@@ -58,6 +58,9 @@ final class FailedBatchUpdate implements RetriableStatement {
             transaction);
     try {
       transaction.getReadContext().batchUpdate(statements);
+    } catch (AbortedException e) {
+      // Propagate abort to force a new retry.
+      throw e;
     } catch (SpannerBatchUpdateException e) {
       // Check that we got the same exception as in the original transaction.
       if (exception instanceof SpannerBatchUpdateException

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/FailedQuery.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/FailedQuery.java
@@ -69,6 +69,9 @@ final class FailedQuery implements RetriableStatement {
         // Do nothing with the results, we are only interested in whether the statement throws the
         // same exception as in the original transaction.
       }
+    } catch (AbortedException e) {
+      // Propagate abort to force a new retry.
+      throw e;
     } catch (SpannerException e) {
       // Check that we got the same exception as in the original transaction
       if (e.getErrorCode() == exception.getErrorCode()

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/FailedUpdate.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/FailedUpdate.java
@@ -54,6 +54,9 @@ final class FailedUpdate implements RetriableStatement {
           .getStatementExecutor()
           .invokeInterceptors(statement, StatementExecutionStep.RETRY_STATEMENT, transaction);
       transaction.getReadContext().executeUpdate(statement.getStatement());
+    } catch (AbortedException e) {
+      // Propagate abort to force a new retry.
+      throw e;
     } catch (SpannerException e) {
       // Check that we got the same exception as in the original transaction.
       if (e.getErrorCode() == exception.getErrorCode()


### PR DESCRIPTION
Transaction retries in the Connection API / JDBC driver could fail if the following happened:
1. The initial transaction contains a statement that returns an error that does not invalidate
   the transaction, such as for example a "Table not found" error, and that error is caught and
   handled by the application code.
2. The retry attempt tries to execute the failed statement to verify that the statement still
   returns the same error. If however the transaction that is used by the retry has been aborted
   immediately before the execution of this statement, the statement will now return Aborted
   instead of the original error. That would be seen as a different error than the initial
   error and would fail the retry attempt.

When the above happens, the Aborted error in the retry should be propagated and the retry attempt should be restarted.

Fixes #685
