### PR TITLE
docs: add sample for timeout for one RPC

### DIFF
--- a/samples/snippets/src/main/java/com/example/spanner/StatementTimeoutExample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/StatementTimeoutExample.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner;
+
+import com.google.api.gax.grpc.GrpcCallContext;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.DatabaseId;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.SpannerOptions;
+import com.google.cloud.spanner.SpannerOptions.CallContextConfigurator;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.TransactionContext;
+import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
+import com.google.spanner.v1.SpannerGrpc;
+import java.util.concurrent.TimeUnit;
+import io.grpc.CallOptions;
+import io.grpc.Context;
+import io.grpc.MethodDescriptor;
+
+class StatementTimeoutExample {
+
+  static void executeSqlWithTimeout() {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project";
+    String instanceId = "my-instance";
+    String databaseId = "my-database";
+
+    try (Spanner spanner =
+        SpannerOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      DatabaseClient client =
+          spanner.getDatabaseClient(DatabaseId.of(projectId, instanceId, databaseId));
+      executeSqlWithTimeout(client);
+    }
+  }
+
+  static void executeSqlWithTimeout(DatabaseClient client) {
+    CallContextConfigurator configurator =
+        new CallContextConfigurator() {
+          public <ReqT, RespT> ApiCallContext configure(
+              ApiCallContext context, ReqT request, MethodDescriptor<ReqT, RespT> method) {
+            // DML uses the ExecuteSql RPC.
+            if (method == SpannerGrpc.getExecuteSqlMethod()) {
+              return GrpcCallContext.createDefault()
+                  .withCallOptions(CallOptions.DEFAULT.withDeadlineAfter(60L, TimeUnit.SECONDS));
+            }
+            // Return null to indicate that the default should be used for other methods.
+            return null;
+          }
+        };
+    // Create a context that uses the custom call configuration.
+    Context context =
+        Context.current().withValue(SpannerOptions.CALL_CONTEXT_CONFIGURATOR_KEY, configurator);
+    // Run the transaction in the custom context.
+    context.run(
+        new Runnable() {
+          public void run() {
+            client
+                .readWriteTransaction()
+                .run(
+                    new TransactionCallable<long[]>() {
+                      public long[] run(TransactionContext transaction) throws Exception {
+                        String sql =
+                            "INSERT Singers (SingerId, FirstName, LastName)\n"
+                                + "VALUES (20, 'George', 'Washington')";
+                        long rowCount = transaction.executeUpdate(Statement.of(sql));
+                        System.out.printf("%d record inserted.%n", rowCount);
+                        return null;
+                      }
+                    });
+          }
+        });
+    }
+}

--- a/samples/snippets/src/main/java/com/example/spanner/StatementTimeoutExample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/StatementTimeoutExample.java
@@ -27,10 +27,10 @@ import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.TransactionContext;
 import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import com.google.spanner.v1.SpannerGrpc;
-import java.util.concurrent.TimeUnit;
 import io.grpc.CallOptions;
 import io.grpc.Context;
 import io.grpc.MethodDescriptor;
+import java.util.concurrent.TimeUnit;
 
 class StatementTimeoutExample {
 

--- a/samples/snippets/src/main/java/com/example/spanner/StatementTimeoutExample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/StatementTimeoutExample.java
@@ -49,40 +49,34 @@ class StatementTimeoutExample {
   }
 
   static void executeSqlWithTimeout(DatabaseClient client) {
-    CallContextConfigurator configurator =
-        new CallContextConfigurator() {
-          public <ReqT, RespT> ApiCallContext configure(
-              ApiCallContext context, ReqT request, MethodDescriptor<ReqT, RespT> method) {
-            // DML uses the ExecuteSql RPC.
-            if (method == SpannerGrpc.getExecuteSqlMethod()) {
-              return GrpcCallContext.createDefault()
-                  .withCallOptions(CallOptions.DEFAULT.withDeadlineAfter(60L, TimeUnit.SECONDS));
-            }
-            // Return null to indicate that the default should be used for other methods.
-            return null;
-          }
-        };
+    CallContextConfigurator configurator = new CallContextConfigurator() {
+      public <ReqT, RespT> ApiCallContext configure(ApiCallContext context, ReqT request,
+          MethodDescriptor<ReqT, RespT> method) {
+        // DML uses the ExecuteSql RPC.
+        if (method == SpannerGrpc.getExecuteSqlMethod()) {
+          return GrpcCallContext.createDefault()
+              .withCallOptions(CallOptions.DEFAULT.withDeadlineAfter(60L, TimeUnit.SECONDS));
+        }
+        // Return null to indicate that the default should be used for other methods.
+        return null;
+      }
+    };
     // Create a context that uses the custom call configuration.
     Context context =
         Context.current().withValue(SpannerOptions.CALL_CONTEXT_CONFIGURATOR_KEY, configurator);
     // Run the transaction in the custom context.
-    context.run(
-        new Runnable() {
-          public void run() {
-            client
-                .readWriteTransaction()
-                .run(
-                    new TransactionCallable<long[]>() {
-                      public long[] run(TransactionContext transaction) throws Exception {
-                        String sql =
-                            "INSERT Singers (SingerId, FirstName, LastName)\n"
-                                + "VALUES (20, 'George', 'Washington')";
-                        long rowCount = transaction.executeUpdate(Statement.of(sql));
-                        System.out.printf("%d record inserted.%n", rowCount);
-                        return null;
-                      }
-                    });
+    context.run(new Runnable() {
+      public void run() {
+        client.readWriteTransaction().run(new TransactionCallable<long[]>() {
+          public long[] run(TransactionContext transaction) throws Exception {
+            String sql = "INSERT Singers (SingerId, FirstName, LastName)\n"
+                + "VALUES (20, 'George', 'Washington')";
+            long rowCount = transaction.executeUpdate(Statement.of(sql));
+            System.out.printf("%d record inserted.%n", rowCount);
+            return null;
           }
         });
-    }
+      }
+    });
+  }
 }

--- a/samples/snippets/src/test/java/com/example/spanner/SpannerSampleIT.java
+++ b/samples/snippets/src/test/java/com/example/spanner/SpannerSampleIT.java
@@ -68,7 +68,8 @@ public class SpannerSampleIT {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    SpannerOptions options = SpannerOptions.newBuilder().build();
+    SpannerOptions options =
+        SpannerOptions.newBuilder().setAutoThrottleAdministrativeRequests().build();
     spanner = options.getService();
     dbClient = spanner.getDatabaseAdminClient();
     dbId = DatabaseId.of(options.getProjectId(), instanceId, databaseId);

--- a/samples/snippets/src/test/java/com/example/spanner/SpannerStandaloneExamplesIT.java
+++ b/samples/snippets/src/test/java/com/example/spanner/SpannerStandaloneExamplesIT.java
@@ -121,6 +121,15 @@ public class SpannerStandaloneExamplesIT {
   }
 
   @Test
+  public void executeSqlWithTimeout_shouldWriteData() {
+    String projectId = spanner.getOptions().getProjectId();
+    DatabaseClient client =
+        spanner.getDatabaseClient(DatabaseId.of(projectId, instanceId, databaseId));
+    String out = runExample(() -> StatementTimeoutExample.executeSqlWithTimeout(client));
+    assertThat(out).contains("1 record inserted.");
+  }
+
+  @Test
   public void addNumericColumn_shouldSuccessfullyAddColumn()
       throws InterruptedException, ExecutionException {
     OperationFuture<Void, UpdateDatabaseDdlMetadata> operation =

--- a/samples/snippets/src/test/java/com/example/spanner/SpannerStandaloneExamplesIT.java
+++ b/samples/snippets/src/test/java/com/example/spanner/SpannerStandaloneExamplesIT.java
@@ -66,7 +66,8 @@ public class SpannerStandaloneExamplesIT {
 
   @BeforeClass
   public static void createTestDatabase() throws Exception {
-    SpannerOptions options = SpannerOptions.newBuilder().build();
+    SpannerOptions options =
+        SpannerOptions.newBuilder().setAutoThrottleAdministrativeRequests().build();
     spanner = options.getService();
     dbClient = spanner.getDatabaseAdminClient();
     if (instanceId == null) {

--- a/samples/snippets/src/test/java/com/example/spanner/SpannerStandaloneExamplesIT.java
+++ b/samples/snippets/src/test/java/com/example/spanner/SpannerStandaloneExamplesIT.java
@@ -106,6 +106,7 @@ public class SpannerStandaloneExamplesIT {
     String projectId = spanner.getOptions().getProjectId();
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(projectId, instanceId, databaseId));
+    client.write(Collections.singleton(Mutation.delete("Singers", KeySet.all())));
     client.write(Collections.singleton(Mutation.delete("Venues", KeySet.all())));
   }
 


### PR DESCRIPTION
Adds a sample for setting a timeout for a single RPC.

Fixes https://github.com/GoogleCloudPlatform/java-docs-samples/issues/3805