### PR TITLE
test: increase timeout to prevent flakiness

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementTimeoutTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementTimeoutTest.java
@@ -81,7 +81,7 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
    * still high enough that it would normally not be exceeded for a statement that is executed
    * directly.
    */
-  private static final int TIMEOUT_FOR_SLOW_STATEMENTS = 20;
+  private static final int TIMEOUT_FOR_SLOW_STATEMENTS = 50;
 
   ITConnection createConnection() {
     StringBuilder url = new StringBuilder(getBaseUrl());


### PR DESCRIPTION
The `StatementTimeoutTest.testTimeoutExceptionReadWriteTransactionMultipleStatements` had become flaky because of a combination of two other changes:
1. The first statement of a read/write transaction now includes a `BeginTransaction` option. If that statement fails with an error, the entire transaction will be retried, but then with an explicit `BeginTransaction` RPC. The latter is done to ensure that the statement that returned an error will be included in the transaction.
1. The Connection API did not correctly handle a situation where a statement first returned an error unequal to `Aborted`, and then during a retry would return `Aborted`.

The combination of the two above changes means that the first statement of a transaction can take longer than expected when it returns an error, as it will automatically trigger a retry of the transaction, and thereby also be executed twice without the client application knowing.

Fixes #708 
