### PR TITLE
feat: introduce TransactionOptions and UpdateOptions

### DIFF
--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -406,4 +406,51 @@
     <className>com/google/cloud/spanner/AbstractLazyInitializer</className>
     <method>java.lang.Object initialize()</method>
   </difference>
+  
+  <!-- TransactionOptions and UpdateOptions -->
+  <difference>
+    <differenceType>7004</differenceType>
+    <className>com/google/cloud/spanner/DatabaseClient</className>
+    <method>long executePartitionedUpdate(com.google.cloud.spanner.Statement)</method>
+  </difference>
+  <difference>
+    <differenceType>7004</differenceType>
+    <className>com/google/cloud/spanner/DatabaseClient</className>
+    <method>com.google.cloud.spanner.TransactionRunner readWriteTransaction()</method>
+  </difference>
+  <difference>
+    <differenceType>7004</differenceType>
+    <className>com/google/cloud/spanner/DatabaseClient</className>
+    <method>com.google.cloud.spanner.AsyncRunner runAsync()</method>
+  </difference>
+  <difference>
+    <differenceType>7004</differenceType>
+    <className>com/google/cloud/spanner/DatabaseClient</className>
+    <method>com.google.cloud.spanner.TransactionManager transactionManager()</method>
+  </difference>
+  <difference>
+    <differenceType>7004</differenceType>
+    <className>com/google/cloud/spanner/DatabaseClient</className>
+    <method>com.google.cloud.spanner.AsyncTransactionManager transactionManagerAsync()</method>
+  </difference>
+  <difference>
+    <differenceType>7004</differenceType>
+    <className>com/google/cloud/spanner/TransactionContext</className>
+    <method>long[] batchUpdate(java.lang.Iterable)</method>
+  </difference>
+  <difference>
+    <differenceType>7004</differenceType>
+    <className>com/google/cloud/spanner/TransactionContext</className>
+    <method>com.google.api.core.ApiFuture batchUpdateAsync(java.lang.Iterable)</method>
+  </difference>
+  <difference>
+    <differenceType>7004</differenceType>
+    <className>com/google/cloud/spanner/TransactionContext</className>
+    <method>long executeUpdate(com.google.cloud.spanner.Statement)</method>
+  </difference>
+  <difference>
+    <differenceType>7004</differenceType>
+    <className>com/google/cloud/spanner/TransactionContext</className>
+    <method>com.google.api.core.ApiFuture executeUpdateAsync(com.google.cloud.spanner.Statement)</method>
+  </difference>
 </differences>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -554,7 +554,8 @@ abstract class AbstractReadContext
     return builder.build();
   }
 
-  ExecuteSqlRequest.Builder getExecuteSqlRequestBuilder(Statement statement, QueryMode queryMode) {
+  ExecuteSqlRequest.Builder getExecuteSqlRequestBuilder(
+      Statement statement, QueryMode queryMode, Options options) {
     ExecuteSqlRequest.Builder builder =
         ExecuteSqlRequest.newBuilder()
             .setSql(statement.getSql())
@@ -577,7 +578,8 @@ abstract class AbstractReadContext
     return builder;
   }
 
-  ExecuteBatchDmlRequest.Builder getExecuteBatchDmlRequestBuilder(Iterable<Statement> statements) {
+  ExecuteBatchDmlRequest.Builder getExecuteBatchDmlRequestBuilder(
+      Iterable<Statement> statements, Options options) {
     ExecuteBatchDmlRequest.Builder builder =
         ExecuteBatchDmlRequest.newBuilder().setSession(session.getName());
     int idx = 0;
@@ -609,7 +611,7 @@ abstract class AbstractReadContext
   ResultSet executeQueryInternalWithOptions(
       final Statement statement,
       final com.google.spanner.v1.ExecuteSqlRequest.QueryMode queryMode,
-      Options options,
+      final Options options,
       final ByteString partitionToken) {
     beforeReadOrQuery();
     final int prefetchChunks =
@@ -620,7 +622,7 @@ abstract class AbstractReadContext
           CloseableIterator<PartialResultSet> startStream(@Nullable ByteString resumeToken) {
             GrpcStreamIterator stream = new GrpcStreamIterator(statement, prefetchChunks);
             final ExecuteSqlRequest.Builder request =
-                getExecuteSqlRequestBuilder(statement, queryMode);
+                getExecuteSqlRequestBuilder(statement, queryMode, options);
             if (partitionToken != null) {
               request.setPartitionToken(partitionToken);
             }
@@ -707,7 +709,7 @@ abstract class AbstractReadContext
       @Nullable String index,
       KeySet keys,
       Iterable<String> columns,
-      Options readOptions,
+      final Options readOptions,
       ByteString partitionToken) {
     beforeReadOrQuery();
     final ReadRequest.Builder builder =

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncTransactionManagerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncTransactionManagerImpl.java
@@ -22,6 +22,7 @@ import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
 import com.google.api.core.SettableApiFuture;
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Options.TransactionOption;
 import com.google.cloud.spanner.SessionImpl.SessionTransaction;
 import com.google.cloud.spanner.TransactionContextFutureImpl.CommittableAsyncTransactionManager;
 import com.google.cloud.spanner.TransactionManager.TransactionState;
@@ -40,14 +41,16 @@ final class AsyncTransactionManagerImpl
 
   private final SessionImpl session;
   private Span span;
+  private final Options options;
 
   private TransactionRunnerImpl.TransactionContextImpl txn;
   private TransactionState txnState;
   private final SettableApiFuture<Timestamp> commitTimestamp = SettableApiFuture.create();
 
-  AsyncTransactionManagerImpl(SessionImpl session, Span span) {
+  AsyncTransactionManagerImpl(SessionImpl session, Span span, TransactionOption... options) {
     this.session = session;
     this.span = span;
+    this.options = Options.fromTransactionOptions(options);
   }
 
   @Override
@@ -82,7 +85,7 @@ final class AsyncTransactionManagerImpl
 
   private ApiFuture<TransactionContext> internalBeginAsync(boolean firstAttempt) {
     txnState = TransactionState.STARTED;
-    txn = session.newTransaction();
+    txn = session.newTransaction(options);
     if (firstAttempt) {
       session.setActive(this);
     }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClient.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner;
 
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Options.TransactionOption;
+import com.google.cloud.spanner.Options.UpdateOption;
 
 /**
  * Interface for all the APIs that are used to read/write data into a Cloud Spanner database. An
@@ -308,7 +309,7 @@ public interface DatabaseClient {
    *     });
    * </code></pre>
    */
-  TransactionRunner readWriteTransaction();
+  TransactionRunner readWriteTransaction(TransactionOption... options);
 
   /**
    * Returns a transaction manager which allows manual management of transaction lifecycle. This API
@@ -338,7 +339,7 @@ public interface DatabaseClient {
    * }
    * }</pre>
    */
-  TransactionManager transactionManager();
+  TransactionManager transactionManager(TransactionOption... options);
 
   /**
    * Returns an asynchronous transaction runner for executing a single logical transaction with
@@ -371,7 +372,7 @@ public interface DatabaseClient {
    *         executor);
    * </code></pre>
    */
-  AsyncRunner runAsync();
+  AsyncRunner runAsync(TransactionOption... options);
 
   /**
    * Returns an asynchronous transaction manager which allows manual management of transaction
@@ -459,7 +460,7 @@ public interface DatabaseClient {
    * }
    * }</pre>
    */
-  AsyncTransactionManager transactionManagerAsync();
+  AsyncTransactionManager transactionManagerAsync(TransactionOption... options);
 
   /**
    * Returns the lower bound of rows modified by this DML statement.
@@ -508,5 +509,5 @@ public interface DatabaseClient {
    * <p>Given the above, Partitioned DML is good fit for large, database-wide, operations that are
    * idempotent, such as deleting old rows from a very large table.
    */
-  long executePartitionedUpdate(Statement stmt);
+  long executePartitionedUpdate(Statement stmt, UpdateOption... options);
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner;
 
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Options.TransactionOption;
+import com.google.cloud.spanner.Options.UpdateOption;
 import com.google.cloud.spanner.SessionPool.PooledSessionFuture;
 import com.google.cloud.spanner.SpannerImpl.ClosedException;
 import com.google.common.annotations.VisibleForTesting;
@@ -54,13 +55,20 @@ class DatabaseClientImpl implements DatabaseClient {
 
   @Override
   public Timestamp write(final Iterable<Mutation> mutations) throws SpannerException {
+    return writeWithOptions(mutations).getCommitTimestamp();
+  }
+
+  @Override
+  public CommitResponse writeWithOptions(
+      final Iterable<Mutation> mutations, final TransactionOption... options)
+      throws SpannerException {
     Span span = tracer.spanBuilder(READ_WRITE_TRANSACTION).startSpan();
     try (Scope s = tracer.withSpan(span)) {
       return runWithSessionRetry(
-          new Function<Session, Timestamp>() {
+          new Function<Session, CommitResponse>() {
             @Override
-            public Timestamp apply(Session session) {
-              return session.write(mutations);
+            public CommitResponse apply(Session session) {
+              return session.writeWithOptions(mutations, options);
             }
           });
     } catch (RuntimeException e) {
@@ -69,24 +77,24 @@ class DatabaseClientImpl implements DatabaseClient {
     } finally {
       span.end(TraceUtil.END_SPAN_OPTIONS);
     }
-  }
-
-  @Override
-  public CommitResponse writeWithOptions(Iterable<Mutation> mutations, TransactionOption... options)
-      throws SpannerException {
-    final Timestamp commitTimestamp = write(mutations);
-    return new CommitResponse(commitTimestamp);
   }
 
   @Override
   public Timestamp writeAtLeastOnce(final Iterable<Mutation> mutations) throws SpannerException {
+    return writeAtLeastOnceWithOptions(mutations).getCommitTimestamp();
+  }
+
+  @Override
+  public CommitResponse writeAtLeastOnceWithOptions(
+      final Iterable<Mutation> mutations, final TransactionOption... options)
+      throws SpannerException {
     Span span = tracer.spanBuilder(READ_WRITE_TRANSACTION).startSpan();
     try (Scope s = tracer.withSpan(span)) {
       return runWithSessionRetry(
-          new Function<Session, Timestamp>() {
+          new Function<Session, CommitResponse>() {
             @Override
-            public Timestamp apply(Session session) {
-              return session.writeAtLeastOnce(mutations);
+            public CommitResponse apply(Session session) {
+              return session.writeAtLeastOnceWithOptions(mutations, options);
             }
           });
     } catch (RuntimeException e) {
@@ -95,13 +103,6 @@ class DatabaseClientImpl implements DatabaseClient {
     } finally {
       span.end(TraceUtil.END_SPAN_OPTIONS);
     }
-  }
-
-  @Override
-  public CommitResponse writeAtLeastOnceWithOptions(
-      Iterable<Mutation> mutations, TransactionOption... options) throws SpannerException {
-    final Timestamp commitTimestamp = writeAtLeastOnce(mutations);
-    return new CommitResponse(commitTimestamp);
   }
 
   @Override
@@ -171,10 +172,10 @@ class DatabaseClientImpl implements DatabaseClient {
   }
 
   @Override
-  public TransactionRunner readWriteTransaction() {
+  public TransactionRunner readWriteTransaction(TransactionOption... options) {
     Span span = tracer.spanBuilder(READ_WRITE_TRANSACTION).startSpan();
     try (Scope s = tracer.withSpan(span)) {
-      return getSession().readWriteTransaction();
+      return getSession().readWriteTransaction(options);
     } catch (RuntimeException e) {
       TraceUtil.endSpanWithFailure(span, e);
       throw e;
@@ -184,10 +185,10 @@ class DatabaseClientImpl implements DatabaseClient {
   }
 
   @Override
-  public TransactionManager transactionManager() {
+  public TransactionManager transactionManager(TransactionOption... options) {
     Span span = tracer.spanBuilder(READ_WRITE_TRANSACTION).startSpan();
     try (Scope s = tracer.withSpan(span)) {
-      return getSession().transactionManager();
+      return getSession().transactionManager(options);
     } catch (RuntimeException e) {
       TraceUtil.endSpanWithFailure(span, e);
       throw e;
@@ -195,10 +196,10 @@ class DatabaseClientImpl implements DatabaseClient {
   }
 
   @Override
-  public AsyncRunner runAsync() {
+  public AsyncRunner runAsync(TransactionOption... options) {
     Span span = tracer.spanBuilder(READ_WRITE_TRANSACTION).startSpan();
     try (Scope s = tracer.withSpan(span)) {
-      return getSession().runAsync();
+      return getSession().runAsync(options);
     } catch (RuntimeException e) {
       TraceUtil.endSpanWithFailure(span, e);
       throw e;
@@ -206,10 +207,10 @@ class DatabaseClientImpl implements DatabaseClient {
   }
 
   @Override
-  public AsyncTransactionManager transactionManagerAsync() {
+  public AsyncTransactionManager transactionManagerAsync(TransactionOption... options) {
     Span span = tracer.spanBuilder(READ_WRITE_TRANSACTION).startSpan();
     try (Scope s = tracer.withSpan(span)) {
-      return getSession().transactionManagerAsync();
+      return getSession().transactionManagerAsync(options);
     } catch (RuntimeException e) {
       TraceUtil.endSpanWithFailure(span, e);
       throw e;
@@ -217,14 +218,14 @@ class DatabaseClientImpl implements DatabaseClient {
   }
 
   @Override
-  public long executePartitionedUpdate(final Statement stmt) {
+  public long executePartitionedUpdate(final Statement stmt, final UpdateOption... options) {
     Span span = tracer.spanBuilder(PARTITION_DML_TRANSACTION).startSpan();
     try (Scope s = tracer.withSpan(span)) {
       return runWithSessionRetry(
           new Function<Session, Long>() {
             @Override
             public Long apply(Session session) {
-              return session.executePartitionedUpdate(stmt);
+              return session.executePartitionedUpdate(stmt, options);
             }
           });
     } catch (RuntimeException e) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
@@ -30,11 +30,18 @@ public final class Options implements Serializable {
   /** Marker interface to mark options applicable to read operation */
   public interface ReadOption {}
 
+  /** Marker interface to mark options applicable to Read, Query, Update and Write operations */
+  public interface ReadQueryUpdateTransactionOption
+      extends ReadOption, QueryOption, UpdateOption, TransactionOption {}
+
   /** Marker interface to mark options applicable to query operation. */
   public interface QueryOption {}
 
   /** Marker interface to mark options applicable to write operations */
   public interface TransactionOption {}
+
+  /** Marker interface to mark options applicable to update operation. */
+  public interface UpdateOption {}
 
   /** Marker interface to mark options applicable to list operations in admin API. */
   public interface ListOption {}
@@ -285,6 +292,26 @@ public final class Options implements Serializable {
       }
     }
     return readOptions;
+  }
+
+  static Options fromUpdateOptions(UpdateOption... options) {
+    Options updateOptions = new Options();
+    for (UpdateOption option : options) {
+      if (option instanceof InternalOption) {
+        ((InternalOption) option).appendToOptions(updateOptions);
+      }
+    }
+    return updateOptions;
+  }
+
+  static Options fromTransactionOptions(TransactionOption... options) {
+    Options transactionOptions = new Options();
+    for (TransactionOption option : options) {
+      if (option instanceof InternalOption) {
+        ((InternalOption) option).appendToOptions(transactionOptions);
+      }
+    }
+    return transactionOptions;
   }
 
   static Options fromListOptions(ListOption... options) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -26,6 +26,7 @@ import com.google.cloud.spanner.AbstractReadContext.MultiUseReadOnlyTransaction;
 import com.google.cloud.spanner.AbstractReadContext.SingleReadContext;
 import com.google.cloud.spanner.AbstractReadContext.SingleUseReadOnlyTransaction;
 import com.google.cloud.spanner.Options.TransactionOption;
+import com.google.cloud.spanner.Options.UpdateOption;
 import com.google.cloud.spanner.SessionClient.SessionId;
 import com.google.cloud.spanner.TransactionRunnerImpl.TransactionContextImpl;
 import com.google.cloud.spanner.spi.v1.SpannerRpc;
@@ -113,17 +114,23 @@ class SessionImpl implements Session {
   }
 
   @Override
-  public long executePartitionedUpdate(Statement stmt) {
+  public long executePartitionedUpdate(Statement stmt, UpdateOption... options) {
     setActive(null);
     PartitionedDmlTransaction txn =
         new PartitionedDmlTransaction(this, spanner.getRpc(), Ticker.systemTicker());
     return txn.executeStreamingPartitionedUpdate(
-        stmt, spanner.getOptions().getPartitionedDmlTimeout());
+        stmt, spanner.getOptions().getPartitionedDmlTimeout(), options);
   }
 
   @Override
   public Timestamp write(Iterable<Mutation> mutations) throws SpannerException {
-    TransactionRunner runner = readWriteTransaction();
+    return writeWithOptions(mutations).getCommitTimestamp();
+  }
+
+  @Override
+  public CommitResponse writeWithOptions(Iterable<Mutation> mutations, TransactionOption... options)
+      throws SpannerException {
+    TransactionRunner runner = readWriteTransaction(options);
     final Collection<Mutation> finalMutations =
         mutations instanceof java.util.Collection<?>
             ? (Collection<Mutation>) mutations
@@ -136,18 +143,18 @@ class SessionImpl implements Session {
             return null;
           }
         });
-    return runner.getCommitTimestamp();
-  }
-
-  @Override
-  public CommitResponse writeWithOptions(Iterable<Mutation> mutations, TransactionOption... options)
-      throws SpannerException {
-    final Timestamp commitTimestamp = write(mutations);
-    return new CommitResponse(commitTimestamp);
+    return new CommitResponse(runner.getCommitTimestamp());
   }
 
   @Override
   public Timestamp writeAtLeastOnce(Iterable<Mutation> mutations) throws SpannerException {
+    return writeAtLeastOnceWithOptions(mutations).getCommitTimestamp();
+  }
+
+  @Override
+  public CommitResponse writeAtLeastOnceWithOptions(
+      Iterable<Mutation> mutations, TransactionOption... transactionOptions)
+      throws SpannerException {
     setActive(null);
     List<com.google.spanner.v1.Mutation> mutationsProto = new ArrayList<>();
     Mutation.toProto(mutations, mutationsProto);
@@ -161,9 +168,10 @@ class SessionImpl implements Session {
             .build();
     Span span = tracer.spanBuilder(SpannerImpl.COMMIT).startSpan();
     try (Scope s = tracer.withSpan(span)) {
-      com.google.spanner.v1.CommitResponse response = spanner.getRpc().commit(request, options);
+      com.google.spanner.v1.CommitResponse response =
+          spanner.getRpc().commit(request, this.options);
       Timestamp t = Timestamp.fromProto(response.getCommitTimestamp());
-      return t;
+      return new CommitResponse(t);
     } catch (IllegalArgumentException e) {
       TraceUtil.setWithFailure(span, e);
       throw newSpannerException(ErrorCode.INTERNAL, "Could not parse commit timestamp", e);
@@ -173,13 +181,6 @@ class SessionImpl implements Session {
     } finally {
       span.end(TraceUtil.END_SPAN_OPTIONS);
     }
-  }
-
-  @Override
-  public CommitResponse writeAtLeastOnceWithOptions(
-      Iterable<Mutation> mutations, TransactionOption... options) throws SpannerException {
-    final Timestamp commitTimestamp = writeAtLeastOnce(mutations);
-    return new CommitResponse(commitTimestamp);
   }
 
   @Override
@@ -240,26 +241,28 @@ class SessionImpl implements Session {
   }
 
   @Override
-  public TransactionRunner readWriteTransaction() {
+  public TransactionRunner readWriteTransaction(TransactionOption... options) {
     return setActive(
-        new TransactionRunnerImpl(this, spanner.getRpc(), spanner.getDefaultPrefetchChunks()));
+        new TransactionRunnerImpl(
+            this, spanner.getRpc(), spanner.getDefaultPrefetchChunks(), options));
   }
 
   @Override
-  public AsyncRunner runAsync() {
+  public AsyncRunner runAsync(TransactionOption... options) {
     return new AsyncRunnerImpl(
         setActive(
-            new TransactionRunnerImpl(this, spanner.getRpc(), spanner.getDefaultPrefetchChunks())));
+            new TransactionRunnerImpl(
+                this, spanner.getRpc(), spanner.getDefaultPrefetchChunks(), options)));
   }
 
   @Override
-  public TransactionManager transactionManager() {
-    return new TransactionManagerImpl(this, currentSpan);
+  public TransactionManager transactionManager(TransactionOption... options) {
+    return new TransactionManagerImpl(this, currentSpan, options);
   }
 
   @Override
-  public AsyncTransactionManagerImpl transactionManagerAsync() {
-    return new AsyncTransactionManagerImpl(this, currentSpan);
+  public AsyncTransactionManagerImpl transactionManagerAsync(TransactionOption... options) {
+    return new AsyncTransactionManagerImpl(this, currentSpan, options);
   }
 
   @Override
@@ -340,10 +343,11 @@ class SessionImpl implements Session {
     return res;
   }
 
-  TransactionContextImpl newTransaction() {
+  TransactionContextImpl newTransaction(Options options) {
     return TransactionContextImpl.newBuilder()
         .setSession(this)
         .setTransactionId(readyTransactionId)
+        .setOptions(options)
         .setRpc(spanner.getRpc())
         .setDefaultQueryOptions(spanner.getDefaultQueryOptions(databaseId))
         .setDefaultPrefetchChunks(spanner.getDefaultPrefetchChunks())

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContext.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spanner;
 
 import com.google.api.core.ApiFuture;
+import com.google.cloud.spanner.Options.UpdateOption;
 
 /**
  * Context for a single attempt of a locking read-write transaction. This type of transaction is the
@@ -102,7 +103,7 @@ public interface TransactionContext extends ReadContext {
    * it will result in an {@code IllegalArgumentException}. The effects of the DML statement will be
    * visible to subsequent operations in the transaction.
    */
-  long executeUpdate(Statement statement);
+  long executeUpdate(Statement statement, UpdateOption... options);
 
   /**
    * Same as {@link #executeUpdate(Statement)}, but is guaranteed to be non-blocking. If multiple
@@ -113,7 +114,7 @@ public interface TransactionContext extends ReadContext {
    * parallel. If you rely on the results of a previous statement, you should block until the result
    * of that statement is known and has been returned to the client.
    */
-  ApiFuture<Long> executeUpdateAsync(Statement statement);
+  ApiFuture<Long> executeUpdateAsync(Statement statement, UpdateOption... options);
 
   /**
    * Executes a list of DML statements in a single request. The statements will be executed in order
@@ -130,7 +131,7 @@ public interface TransactionContext extends ReadContext {
    * 2nd statement, and an array of length 1 that contains the number of rows modified by the 1st
    * statement. The 3rd statement will not run.
    */
-  long[] batchUpdate(Iterable<Statement> statements);
+  long[] batchUpdate(Iterable<Statement> statements, UpdateOption... options);
 
   /**
    * Same as {@link #batchUpdate(Iterable)}, but is guaranteed to be non-blocking. If multiple
@@ -141,5 +142,5 @@ public interface TransactionContext extends ReadContext {
    * parallel. If you rely on the results of a previous statement, you should block until the result
    * of that statement is known and has been returned to the client.
    */
-  ApiFuture<long[]> batchUpdateAsync(Iterable<Statement> statements);
+  ApiFuture<long[]> batchUpdateAsync(Iterable<Statement> statements, UpdateOption... options);
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -28,9 +28,12 @@ import com.google.api.core.SettableApiFuture;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Options.QueryOption;
 import com.google.cloud.spanner.Options.ReadOption;
+import com.google.cloud.spanner.Options.TransactionOption;
+import com.google.cloud.spanner.Options.UpdateOption;
 import com.google.cloud.spanner.SessionImpl.SessionTransaction;
 import com.google.cloud.spanner.spi.v1.SpannerRpc;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
@@ -72,6 +75,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
   static class TransactionContextImpl extends AbstractReadContext implements TransactionContext {
     static class Builder extends AbstractReadContext.Builder<Builder, TransactionContextImpl> {
       private ByteString transactionId;
+      private Options options;
 
       private Builder() {}
 
@@ -80,8 +84,14 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
         return self();
       }
 
+      Builder setOptions(Options options) {
+        this.options = Preconditions.checkNotNull(options);
+        return self();
+      }
+
       @Override
       TransactionContextImpl build() {
+        Preconditions.checkState(this.options != null, "Options must be set");
         return new TransactionContextImpl(this);
       }
     }
@@ -147,6 +157,8 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
     @GuardedBy("lock")
     private boolean aborted;
 
+    private final Options options;
+
     /** Default to -1 to indicate not available. */
     @GuardedBy("lock")
     private long retryDelayInMillis = -1L;
@@ -165,6 +177,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
     private TransactionContextImpl(Builder builder) {
       super(builder);
       this.transactionId = builder.transactionId;
+      this.options = builder.options;
       this.finishedAsyncOperations.set(null);
     }
 
@@ -512,10 +525,11 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
     }
 
     @Override
-    public long executeUpdate(Statement statement) {
+    public long executeUpdate(Statement statement, UpdateOption... options) {
       beforeReadOrQuery();
       final ExecuteSqlRequest.Builder builder =
-          getExecuteSqlRequestBuilder(statement, QueryMode.NORMAL);
+          getExecuteSqlRequestBuilder(
+              statement, QueryMode.NORMAL, Options.fromUpdateOptions(options));
       try {
         com.google.spanner.v1.ResultSet resultSet =
             rpc.executeQuery(builder.build(), session.getOptions());
@@ -535,10 +549,11 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
     }
 
     @Override
-    public ApiFuture<Long> executeUpdateAsync(Statement statement) {
+    public ApiFuture<Long> executeUpdateAsync(Statement statement, UpdateOption... options) {
       beforeReadOrQuery();
       final ExecuteSqlRequest.Builder builder =
-          getExecuteSqlRequestBuilder(statement, QueryMode.NORMAL);
+          getExecuteSqlRequestBuilder(
+              statement, QueryMode.NORMAL, Options.fromUpdateOptions(options));
       final ApiFuture<com.google.spanner.v1.ResultSet> resultSet;
       try {
         // Register the update as an async operation that must finish before the transaction may
@@ -598,9 +613,10 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
     }
 
     @Override
-    public long[] batchUpdate(Iterable<Statement> statements) {
+    public long[] batchUpdate(Iterable<Statement> statements, UpdateOption... options) {
       beforeReadOrQuery();
-      final ExecuteBatchDmlRequest.Builder builder = getExecuteBatchDmlRequestBuilder(statements);
+      final ExecuteBatchDmlRequest.Builder builder =
+          getExecuteBatchDmlRequestBuilder(statements, Options.fromUpdateOptions(options));
       try {
         com.google.spanner.v1.ExecuteBatchDmlResponse response =
             rpc.executeBatchDml(builder.build(), session.getOptions());
@@ -631,9 +647,11 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
     }
 
     @Override
-    public ApiFuture<long[]> batchUpdateAsync(Iterable<Statement> statements) {
+    public ApiFuture<long[]> batchUpdateAsync(
+        Iterable<Statement> statements, UpdateOption... options) {
       beforeReadOrQuery();
-      final ExecuteBatchDmlRequest.Builder builder = getExecuteBatchDmlRequestBuilder(statements);
+      final ExecuteBatchDmlRequest.Builder builder =
+          getExecuteBatchDmlRequestBuilder(statements, Options.fromUpdateOptions(options));
       ApiFuture<com.google.spanner.v1.ExecuteBatchDmlResponse> response;
       try {
         // Register the update as an async operation that must finish before the transaction may
@@ -723,6 +741,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
 
   private boolean blockNestedTxn = true;
   private final SessionImpl session;
+  private final Options options;
   private Span span;
   private TransactionContextImpl txn;
   private volatile boolean isValid = true;
@@ -733,9 +752,14 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
     return this;
   }
 
-  TransactionRunnerImpl(SessionImpl session, SpannerRpc rpc, int defaultPrefetchChunks) {
+  TransactionRunnerImpl(
+      SessionImpl session,
+      SpannerRpc rpc,
+      int defaultPrefetchChunks,
+      TransactionOption... options) {
     this.session = session;
-    this.txn = session.newTransaction();
+    this.options = Options.fromTransactionOptions(options);
+    this.txn = session.newTransaction(this.options);
   }
 
   @Override
@@ -773,7 +797,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
               // Do not inline the BeginTransaction during a retry if the initial attempt did not
               // actually start a transaction.
               useInlinedBegin = txn.transactionId != null;
-              txn = session.newTransaction();
+              txn = session.newTransaction(options);
             }
             checkState(
                 isValid,

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractReadContextTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractReadContextTest.java
@@ -89,7 +89,8 @@ public class AbstractReadContextTest {
   public void executeSqlRequestBuilderWithoutQueryOptions() {
     ExecuteSqlRequest request =
         context
-            .getExecuteSqlRequestBuilder(Statement.of("SELECT FOO FROM BAR"), QueryMode.NORMAL)
+            .getExecuteSqlRequestBuilder(
+                Statement.of("SELECT FOO FROM BAR"), QueryMode.NORMAL, Options.fromQueryOptions())
             .build();
     assertThat(request.getSql()).isEqualTo("SELECT FOO FROM BAR");
     assertThat(request.getQueryOptions()).isEqualTo(defaultQueryOptions);
@@ -103,7 +104,8 @@ public class AbstractReadContextTest {
                 Statement.newBuilder("SELECT FOO FROM BAR")
                     .withQueryOptions(QueryOptions.newBuilder().setOptimizerVersion("2.0").build())
                     .build(),
-                QueryMode.NORMAL)
+                QueryMode.NORMAL,
+                Options.fromQueryOptions())
             .build();
     assertThat(request.getSql()).isEqualTo("SELECT FOO FROM BAR");
     assertThat(request.getQueryOptions().getOptimizerVersion()).isEqualTo("2.0");

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BaseSessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BaseSessionPoolTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.google.api.core.ApiFutures;
+import com.google.cloud.Timestamp;
 import com.google.cloud.grpc.GrpcTransportOptions.ExecutorFactory;
 import com.google.cloud.spanner.SessionPool.Clock;
 import com.google.protobuf.Empty;
@@ -58,12 +59,17 @@ abstract class BaseSessionPoolTest {
     }
   }
 
+  @SuppressWarnings("unchecked")
   SessionImpl mockSession() {
     final SessionImpl session = mock(SessionImpl.class);
     when(session.getName())
         .thenReturn(
             "projects/dummy/instances/dummy/database/dummy/sessions/session" + sessionIndex);
     when(session.asyncClose()).thenReturn(ApiFutures.immediateFuture(Empty.getDefaultInstance()));
+    when(session.writeWithOptions(any(Iterable.class)))
+        .thenReturn(new CommitResponse(Timestamp.now()));
+    when(session.writeAtLeastOnceWithOptions(any(Iterable.class)))
+        .thenReturn(new CommitResponse(Timestamp.now()));
     sessionIndex++;
     return session;
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -19,6 +19,9 @@ package com.google.cloud.spanner;
 import static com.google.cloud.spanner.MockSpannerTestUtil.SELECT1;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
@@ -31,7 +34,9 @@ import com.google.cloud.spanner.AsyncResultSet.ReadyCallback;
 import com.google.cloud.spanner.AsyncRunner.AsyncWork;
 import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.cloud.spanner.Options.TransactionOption;
 import com.google.cloud.spanner.ReadContext.QueryAnalyzeMode;
+import com.google.cloud.spanner.SessionPool.PooledSessionFuture;
 import com.google.cloud.spanner.SpannerOptions.SpannerCallContextTimeoutConfigurator;
 import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import com.google.common.base.Stopwatch;
@@ -1482,5 +1487,57 @@ public class DatabaseClientImplTest {
     } finally {
       mockSpanner.setBatchCreateSessionsExecutionTime(SimulatedExecutionTime.none());
     }
+  }
+
+  @Test
+  public void testReadWriteTransaction_usesOptions() {
+    SessionPool pool = mock(SessionPool.class);
+    PooledSessionFuture session = mock(PooledSessionFuture.class);
+    when(pool.getSession()).thenReturn(session);
+    TransactionOption option = mock(TransactionOption.class);
+
+    DatabaseClientImpl client = new DatabaseClientImpl(pool);
+    client.readWriteTransaction(option);
+
+    verify(session).readWriteTransaction(option);
+  }
+
+  @Test
+  public void testTransactionManager_usesOptions() {
+    SessionPool pool = mock(SessionPool.class);
+    PooledSessionFuture session = mock(PooledSessionFuture.class);
+    when(pool.getSession()).thenReturn(session);
+    TransactionOption option = mock(TransactionOption.class);
+
+    DatabaseClientImpl client = new DatabaseClientImpl(pool);
+    client.transactionManager(option);
+
+    verify(session).transactionManager(option);
+  }
+
+  @Test
+  public void testRunAsync_usesOptions() {
+    SessionPool pool = mock(SessionPool.class);
+    PooledSessionFuture session = mock(PooledSessionFuture.class);
+    when(pool.getSession()).thenReturn(session);
+    TransactionOption option = mock(TransactionOption.class);
+
+    DatabaseClientImpl client = new DatabaseClientImpl(pool);
+    client.runAsync(option);
+
+    verify(session).runAsync(option);
+  }
+
+  @Test
+  public void testTransactionManagerAsync_usesOptions() {
+    SessionPool pool = mock(SessionPool.class);
+    PooledSessionFuture session = mock(PooledSessionFuture.class);
+    when(pool.getSession()).thenReturn(session);
+    TransactionOption option = mock(TransactionOption.class);
+
+    DatabaseClientImpl client = new DatabaseClientImpl(pool);
+    client.transactionManagerAsync(option);
+
+    verify(session).transactionManagerAsync(option);
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OptionsTest.java
@@ -219,4 +219,42 @@ public class OptionsTest {
     o3 = Options.fromReadOptions(Options.prefetchChunks(2));
     assertThat(o2.equals(o3)).isFalse();
   }
+
+  @Test
+  public void testFromTransactionOptions() {
+    Options opts = Options.fromTransactionOptions();
+    assertThat(opts.toString()).isEqualTo("");
+  }
+
+  @Test
+  public void testTransactionOptionsEquality() {
+    Options o1;
+    Options o2;
+
+    o1 = Options.fromTransactionOptions();
+    o2 = Options.fromTransactionOptions();
+    assertThat(o1.equals(o2)).isTrue();
+
+    o2 = Options.fromReadOptions(Options.prefetchChunks(1));
+    assertThat(o1.equals(o2)).isFalse();
+  }
+
+  @Test
+  public void testFromUpdateOptions() {
+    Options opts = Options.fromUpdateOptions();
+    assertThat(opts.toString()).isEqualTo("");
+  }
+
+  @Test
+  public void testUpdateOptionsEquality() {
+    Options o1;
+    Options o2;
+
+    o1 = Options.fromUpdateOptions();
+    o2 = Options.fromUpdateOptions();
+    assertThat(o1.equals(o2)).isTrue();
+
+    o2 = Options.fromReadOptions(Options.prefetchChunks(1));
+    assertThat(o1.equals(o2)).isFalse();
+  }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -890,10 +890,15 @@ public class SessionPoolTest extends BaseSessionPoolTest {
       when(closedSession.getName())
           .thenReturn("projects/dummy/instances/dummy/database/dummy/sessions/session-closed");
       final TransactionContextImpl closedTransactionContext =
-          TransactionContextImpl.newBuilder().setSession(closedSession).setRpc(rpc).build();
+          TransactionContextImpl.newBuilder()
+              .setSession(closedSession)
+              .setOptions(Options.fromTransactionOptions())
+              .setRpc(rpc)
+              .build();
       when(closedSession.asyncClose())
           .thenReturn(ApiFutures.immediateFuture(Empty.getDefaultInstance()));
-      when(closedSession.newTransaction()).thenReturn(closedTransactionContext);
+      when(closedSession.newTransaction(Options.fromTransactionOptions()))
+          .thenReturn(closedTransactionContext);
       when(closedSession.beginTransactionAsync()).thenThrow(sessionNotFound);
       TransactionRunnerImpl closedTransactionRunner =
           new TransactionRunnerImpl(closedSession, rpc, 10);
@@ -906,7 +911,8 @@ public class SessionPoolTest extends BaseSessionPoolTest {
       when(openSession.getName())
           .thenReturn("projects/dummy/instances/dummy/database/dummy/sessions/session-open");
       final TransactionContextImpl openTransactionContext = mock(TransactionContextImpl.class);
-      when(openSession.newTransaction()).thenReturn(openTransactionContext);
+      when(openSession.newTransaction(Options.fromTransactionOptions()))
+          .thenReturn(openTransactionContext);
       when(openSession.beginTransactionAsync())
           .thenReturn(ApiFutures.immediateFuture(ByteString.copyFromUtf8("open-txn")));
       TransactionRunnerImpl openTransactionRunner =

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionContextImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionContextImplTest.java
@@ -63,6 +63,7 @@ public class TransactionContextImplTest {
             .setSession(session)
             .setRpc(rpc)
             .setTransactionId(ByteString.copyFromUtf8("test"))
+            .setOptions(Options.fromTransactionOptions())
             .build()) {
       impl.batchUpdate(Arrays.asList(statement));
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
@@ -87,7 +87,7 @@ public class TransactionManagerImplTest {
 
   @Test
   public void beginCalledTwiceFails() {
-    when(session.newTransaction()).thenReturn(txn);
+    when(session.newTransaction(Options.fromTransactionOptions())).thenReturn(txn);
     assertThat(manager.begin()).isEqualTo(txn);
     assertThat(manager.getState()).isEqualTo(TransactionState.STARTED);
     try {
@@ -130,7 +130,7 @@ public class TransactionManagerImplTest {
 
   @Test
   public void transactionRolledBackOnClose() {
-    when(session.newTransaction()).thenReturn(txn);
+    when(session.newTransaction(Options.fromTransactionOptions())).thenReturn(txn);
     when(txn.isAborted()).thenReturn(false);
     manager.begin();
     manager.close();
@@ -139,7 +139,7 @@ public class TransactionManagerImplTest {
 
   @Test
   public void commitSucceeds() {
-    when(session.newTransaction()).thenReturn(txn);
+    when(session.newTransaction(Options.fromTransactionOptions())).thenReturn(txn);
     Timestamp commitTimestamp = Timestamp.ofTimeMicroseconds(1);
     when(txn.commitTimestamp()).thenReturn(commitTimestamp);
     manager.begin();
@@ -150,7 +150,7 @@ public class TransactionManagerImplTest {
 
   @Test
   public void resetAfterSuccessfulCommitFails() {
-    when(session.newTransaction()).thenReturn(txn);
+    when(session.newTransaction(Options.fromTransactionOptions())).thenReturn(txn);
     manager.begin();
     manager.commit();
     try {
@@ -163,7 +163,7 @@ public class TransactionManagerImplTest {
 
   @Test
   public void resetAfterAbortSucceeds() {
-    when(session.newTransaction()).thenReturn(txn);
+    when(session.newTransaction(Options.fromTransactionOptions())).thenReturn(txn);
     manager.begin();
     doThrow(SpannerExceptionFactory.newSpannerException(ErrorCode.ABORTED, "")).when(txn).commit();
     try {
@@ -173,14 +173,14 @@ public class TransactionManagerImplTest {
       assertThat(manager.getState()).isEqualTo(TransactionState.ABORTED);
     }
     txn = Mockito.mock(TransactionRunnerImpl.TransactionContextImpl.class);
-    when(session.newTransaction()).thenReturn(txn);
+    when(session.newTransaction(Options.fromTransactionOptions())).thenReturn(txn);
     assertThat(manager.resetForRetry()).isEqualTo(txn);
     assertThat(manager.getState()).isEqualTo(TransactionState.STARTED);
   }
 
   @Test
   public void resetAfterErrorFails() {
-    when(session.newTransaction()).thenReturn(txn);
+    when(session.newTransaction(Options.fromTransactionOptions())).thenReturn(txn);
     manager.begin();
     doThrow(SpannerExceptionFactory.newSpannerException(ErrorCode.UNKNOWN, "")).when(txn).commit();
     try {
@@ -199,7 +199,7 @@ public class TransactionManagerImplTest {
 
   @Test
   public void rollbackAfterCommitFails() {
-    when(session.newTransaction()).thenReturn(txn);
+    when(session.newTransaction(Options.fromTransactionOptions())).thenReturn(txn);
     manager.begin();
     manager.commit();
     try {
@@ -212,7 +212,7 @@ public class TransactionManagerImplTest {
 
   @Test
   public void commitAfterRollbackFails() {
-    when(session.newTransaction()).thenReturn(txn);
+    when(session.newTransaction(Options.fromTransactionOptions())).thenReturn(txn);
     manager.begin();
     manager.rollback();
     try {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
@@ -101,7 +101,7 @@ public class TransactionRunnerImplTest {
   public void setUp() {
     MockitoAnnotations.initMocks(this);
     firstRun = true;
-    when(session.newTransaction()).thenReturn(txn);
+    when(session.newTransaction(Options.fromTransactionOptions())).thenReturn(txn);
     when(rpc.executeQuery(Mockito.any(ExecuteSqlRequest.class), Mockito.anyMap()))
         .thenAnswer(
             new Answer<ResultSet>() {
@@ -347,9 +347,10 @@ public class TransactionRunnerImplTest {
         TransactionContextImpl.newBuilder()
             .setSession(session)
             .setTransactionId(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
+            .setOptions(Options.fromTransactionOptions())
             .setRpc(rpc)
             .build();
-    when(session.newTransaction()).thenReturn(transaction);
+    when(session.newTransaction(Options.fromTransactionOptions())).thenReturn(transaction);
     when(session.beginTransactionAsync())
         .thenReturn(
             ApiFutures.immediateFuture(ByteString.copyFromUtf8(UUID.randomUUID().toString())));


### PR DESCRIPTION
Adds TransactionOptions and UpdateOptions for read/write transactions and statements. These can be used in the future to specify options to affect how transactions and statements will be executed.

These changes can be used as the basis for #676 and #576 to ensure both changes use the same approach, and to prevent enormous merge conflicts.