### PR TITLE
test: reduce administrative calls in samples

### DIFF
--- a/samples/snippets/src/test/java/com/example/spanner/AsyncExamplesIT.java
+++ b/samples/snippets/src/test/java/com/example/spanner/AsyncExamplesIT.java
@@ -72,7 +72,8 @@ public class AsyncExamplesIT {
 
   @BeforeClass
   public static void createTestDatabase() throws Exception {
-    SpannerOptions options = SpannerOptions.newBuilder().build();
+    SpannerOptions options =
+        SpannerOptions.newBuilder().setAutoThrottleAdministrativeRequests().build();
     spanner = options.getService();
     dbClient = spanner.getDatabaseAdminClient();
     if (instanceId == null) {

--- a/samples/snippets/src/test/java/com/example/spanner/QuickstartSampleIT.java
+++ b/samples/snippets/src/test/java/com/example/spanner/QuickstartSampleIT.java
@@ -19,12 +19,10 @@ package com.example.spanner;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.cloud.spanner.DatabaseAdminClient;
-import com.google.cloud.spanner.DatabaseNotFoundException;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerOptions;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
 import org.junit.After;
@@ -43,6 +41,7 @@ import org.junit.runners.JUnit4;
 public class QuickstartSampleIT {
   private static String instanceId = System.getProperty("spanner.test.instance");
   private static String dbId = formatForTest(System.getProperty("spanner.quickstart.database"));
+  private static Spanner spanner;
   private static DatabaseAdminClient dbClient;
 
   private ByteArrayOutputStream bout;
@@ -51,8 +50,9 @@ public class QuickstartSampleIT {
 
   @BeforeClass
   public static void createDatabase() {
-    final SpannerOptions options = SpannerOptions.newBuilder().build();
-    final Spanner spanner = options.getService();
+    final SpannerOptions options =
+        SpannerOptions.newBuilder().setAutoThrottleAdministrativeRequests().build();
+    spanner = options.getService();
     dbClient = spanner.getDatabaseAdminClient();
     dbClient.createDatabase(instanceId, dbId, Collections.emptyList());
   }
@@ -60,6 +60,7 @@ public class QuickstartSampleIT {
   @AfterClass
   public static void dropDatabase() {
     dbClient.dropDatabase(instanceId, dbId);
+    spanner.close();
   }
 
   @Before

--- a/samples/snippets/src/test/java/com/example/spanner/SpannerSampleIT.java
+++ b/samples/snippets/src/test/java/com/example/spanner/SpannerSampleIT.java
@@ -68,7 +68,8 @@ public class SpannerSampleIT {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    SpannerOptions options = SpannerOptions.newBuilder().build();
+    SpannerOptions options =
+        SpannerOptions.newBuilder().setAutoThrottleAdministrativeRequests().build();
     spanner = options.getService();
     dbClient = spanner.getDatabaseAdminClient();
     dbId = DatabaseId.of(options.getProjectId(), instanceId, databaseId);

--- a/samples/snippets/src/test/java/com/example/spanner/SpannerStandaloneExamplesIT.java
+++ b/samples/snippets/src/test/java/com/example/spanner/SpannerStandaloneExamplesIT.java
@@ -66,7 +66,8 @@ public class SpannerStandaloneExamplesIT {
 
   @BeforeClass
   public static void createTestDatabase() throws Exception {
-    SpannerOptions options = SpannerOptions.newBuilder().build();
+    SpannerOptions options =
+        SpannerOptions.newBuilder().setAutoThrottleAdministrativeRequests().build();
     spanner = options.getService();
     dbClient = spanner.getDatabaseAdminClient();
     if (instanceId == null) {


### PR DESCRIPTION
This change reduces the number of administrative requests that are executed by the samples integration tests, in order to prevent (or at least reduce) `RESOURCE_EXHAUSTED` errors caused by exceeding the [administrative requests limit](https://cloud.google.com/spanner/quotas#administrative_limits).