### PR TITLE
docs: homogenize region tags

### DIFF
--- a/samples/snippets/src/main/java/com/example/spanner/SpannerSample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/SpannerSample.java
@@ -1622,6 +1622,7 @@ public class SpannerSample {
   }
   // [END spanner_create_backup]
 
+  // [START spanner_cancel_backup_create]
   // [START spanner_cancel_create_backup]
   static void cancelCreateBackup(
       DatabaseAdminClient dbAdminClient, DatabaseId databaseId, BackupId backupId) {
@@ -1666,6 +1667,7 @@ public class SpannerSample {
     }
   }
   // [END spanner_cancel_create_backup]
+  // [END spanner_cancel_backup_create]
 
   // [START spanner_list_backup_operations]
   static void listBackupOperations(InstanceAdminClient instanceAdminClient, DatabaseId databaseId) {


### PR DESCRIPTION
These samples' region tags slightly differ from identical snippets in different languages. The following is the remedy:

1. Merge this PR to fix GitHub source (keep old tag for now)
2. Fix doc code includes to represent the better region tag
3. Submit a second PR to clean-up redundant region tag wrapping