### PR TITLE
deps: grpc-alts is only used for tests

### DIFF
--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -144,16 +144,6 @@
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
-      <artifactId>grpc-alts</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <!--
-      grpc-stub is needed directly by our tests and transitively by grpc-alts at runtime.
-      So it has to be declared as a direct dependency and to avoid overriding grpc-alts'
-      runtime requirement it has to be promoted to the runtime scope.
-    -->
-    <dependency>
-      <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
     </dependency>
     <dependency>
@@ -261,6 +251,13 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Test dependency for DirectPath -->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-alts</artifactId>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Adding `grpc-alts` as a runtime dependency causes the `maven-flatten-plugin` to add the compile time dependencies in the flattened pom. As far as I can tell, `grpc-alts` is (currently) only used for testing, so adding it as a `test` scoped dependency seems to make more sense to me.

Fixes the build error in https://github.com/googleapis/java-spanner-jdbc/pull/293