### PR TITLE
fix: grpc-alts is used not only in tests

### DIFF
--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -144,6 +144,16 @@
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
+      <artifactId>grpc-alts</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <!--
+      grpc-stub is needed directly by our tests and transitively by grpc-alts at runtime.
+      So it has to be declared as a direct dependency and to avoid overriding grpc-alts'
+      runtime requirement it has to be promoted to the runtime scope.
+    -->
+    <dependency>
+      <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
     </dependency>
     <dependency>
@@ -251,13 +261,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <!-- Test dependency for DirectPath -->
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-alts</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -256,6 +256,11 @@
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-credentials</artifactId>
     </dependency>
+    <!-- Dependency for DirectPath -->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-alts</artifactId>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -144,16 +144,6 @@
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
-      <artifactId>grpc-alts</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <!--
-      grpc-stub is needed directly by our tests and transitively by grpc-alts at runtime.
-      So it has to be declared as a direct dependency and to avoid overriding grpc-alts'
-      runtime requirement it has to be promoted to the runtime scope.
-    -->
-    <dependency>
-      <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
This reverts commit c8ef46f2637b58cc71d023764cdc11a7414d855f.

Without having grpc-alts in `runtime` / `compile` scope I get the following error when running the client library:

```
Exception in thread "main" java.lang.NoClassDefFoundError: io/grpc/alts/ComputeEngineChannelBuilder
	at com.google.cloud.spanner.v1.stub.SpannerStubSettings.defaultGrpcTransportProviderBuilder(SpannerStubSettings.java:304)
	at com.google.cloud.spanner.v1.stub.SpannerStubSettings.defaultTransportChannelProvider(SpannerStubSettings.java:309)
	at com.google.cloud.spanner.v1.stub.SpannerStubSettings$Builder.createDefault(SpannerStubSettings.java:531)
	at com.google.cloud.spanner.v1.stub.SpannerStubSettings$Builder.access$100(SpannerStubSettings.java:356)
	at com.google.cloud.spanner.v1.stub.SpannerStubSettings.newBuilder(SpannerStubSettings.java:322)
	at com.google.cloud.spanner.SpannerOptions$Builder.<init>(SpannerOptions.java:628)
	at com.google.cloud.spanner.SpannerOptions$Builder.<init>(SpannerOptions.java:605)
	at com.google.cloud.spanner.SpannerOptions.newBuilder(SpannerOptions.java:1020)
	at com.google.cloud.spanner.Main.main(Main.java:33)
Caused by: java.lang.ClassNotFoundException: io.grpc.alts.ComputeEngineChannelBuilder
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:583)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	... 9 more
```