### PR TITLE
fix: throw already exists exception when op exists

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -1068,15 +1068,12 @@ public class GapicSpannerRpc implements SpannerRpc {
             } catch (ExecutionException e) {
               Throwable t = e.getCause();
               SpannerException se = SpannerExceptionFactory.asSpannerException(t);
+              if (t instanceof AlreadyExistsException) {
+                throw se;
+              }
               if (se instanceof AdminRequestsPerMinuteExceededException) {
                 // Propagate this to trigger a retry.
                 throw se;
-              }
-              if (t instanceof AlreadyExistsException) {
-                String operationName =
-                    OPERATION_NAME_TEMPLATE.instantiate(
-                        "database", databaseName, "operation", updateId);
-                return callable.resumeFutureCall(operationName, context);
               }
             }
             return operationFuture;


### PR DESCRIPTION
All the other libraries and the rest API return / throw an error when the same operation id is used. In java, we used to piggy back on the existing operation instead. Here, we change the behaviour to be consistent with the other implementations.