### PR TITLE
test: add option to track the statement that starts a transaction

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -348,6 +348,7 @@ class SessionImpl implements Session {
         .setSession(this)
         .setTransactionId(readyTransactionId)
         .setOptions(options)
+        .setTrackTransactionStarter(spanner.getOptions().isTrackTransactionStarter())
         .setRpc(spanner.getRpc())
         .setDefaultQueryOptions(spanner.getDefaultQueryOptions(databaseId))
         .setDefaultPrefetchChunks(spanner.getDefaultPrefetchChunks())

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/testing/RemoteSpannerHelper.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/testing/RemoteSpannerHelper.java
@@ -146,6 +146,7 @@ public class RemoteSpannerHelper {
         SpannerOptions.newBuilder()
             .setProjectId(instanceId.getProject())
             .setAutoThrottleAdministrativeRequests()
+            .setTrackTransactionStarter()
             .build();
     Spanner client = options.getService();
     return new RemoteSpannerHelper(options, instanceId, client);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GceTestEnvConfig.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GceTestEnvConfig.java
@@ -64,7 +64,9 @@ public class GceTestEnvConfig implements TestEnvConfig {
     boolean attemptDirectPath = Boolean.getBoolean(ATTEMPT_DIRECT_PATH);
     String directPathTestScenario = System.getProperty(DIRECT_PATH_TEST_SCENARIO, "");
     SpannerOptions.Builder builder =
-        SpannerOptions.newBuilder().setAutoThrottleAdministrativeRequests();
+        SpannerOptions.newBuilder()
+            .setAutoThrottleAdministrativeRequests()
+            .setTrackTransactionStarter();
     if (!projectId.isEmpty()) {
       builder.setProjectId(projectId);
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
@@ -311,6 +311,7 @@ public class TransactionRunnerImplTest {
     when(spanner.getRpc()).thenReturn(rpc);
     when(spanner.getDefaultQueryOptions(Mockito.any(DatabaseId.class)))
         .thenReturn(QueryOptions.getDefaultInstance());
+    when(spanner.getOptions()).thenReturn(mock(SpannerOptions.class));
     SessionImpl session =
         new SessionImpl(
             spanner, "projects/p/instances/i/databases/d/sessions/s", Collections.EMPTY_MAP) {


### PR DESCRIPTION
Adds an option to track the statement that starts a read/write transaction by inlining a `BeginTransaction` option with the request. This can be used to track down statements that do not return a transaction id in a timely fashon.