### PR TITLE
docs: cleanup inner region tags

### DIFF
--- a/samples/snippets/src/main/java/com/example/spanner/SpannerSample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/SpannerSample.java
@@ -1622,6 +1622,7 @@ public class SpannerSample {
   }
   // [END spanner_create_backup]
 
+  // [START spanner_cancel_backup_create]
   // [START spanner_cancel_create_backup]
   static void cancelCreateBackup(
       DatabaseAdminClient dbAdminClient, DatabaseId databaseId, BackupId backupId) {
@@ -1666,6 +1667,7 @@ public class SpannerSample {
     }
   }
   // [END spanner_cancel_create_backup]
+  // [END spanner_cancel_backup_create]
 
   // [START spanner_list_backup_operations]
   static void listBackupOperations(InstanceAdminClient instanceAdminClient, DatabaseId databaseId) {

--- a/samples/snippets/src/main/java/com/example/spanner/SpannerSample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/SpannerSample.java
@@ -1623,7 +1623,6 @@ public class SpannerSample {
   // [END spanner_create_backup]
 
   // [START spanner_cancel_backup_create]
-  // [START spanner_cancel_create_backup]
   static void cancelCreateBackup(
       DatabaseAdminClient dbAdminClient, DatabaseId databaseId, BackupId backupId) {
     // Set expire time to 14 days from now.
@@ -1666,7 +1665,6 @@ public class SpannerSample {
       throw SpannerExceptionFactory.propagateInterrupt(e);
     }
   }
-  // [END spanner_cancel_create_backup]
   // [END spanner_cancel_backup_create]
 
   // [START spanner_list_backup_operations]


### PR DESCRIPTION
This is the final clean-up from https://github.com/googleapis/java-spanner/pull/752. New tagging is now live in docs.