### PR TITLE
fix: closes pool maintainer on invalidation

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -2129,7 +2129,6 @@ class SessionPool {
       }
       if (isDatabaseOrInstanceNotFound(e)) {
         setResourceNotFoundException((ResourceNotFoundException) e);
-        pendingClosure += 1;
         poolMaintainer.close();
       }
     }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -2121,6 +2121,7 @@ class SessionPool {
       }
       if (isDatabaseOrInstanceNotFound(e)) {
         setResourceNotFoundException((ResourceNotFoundException) e);
+        poolMaintainer.close();
       }
     }
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -1617,10 +1617,12 @@ class SessionPool {
 
     void close() {
       synchronized (lock) {
-        closed = true;
-        scheduledFuture.cancel(false);
-        if (!running) {
-          decrementPendingClosures(1);
+        if (!closed) {
+          closed = true;
+          scheduledFuture.cancel(false);
+          if (!running) {
+            decrementPendingClosures(1);
+          }
         }
       }
     }
@@ -2188,11 +2190,11 @@ class SessionPool {
           closeSessionAsync(session);
         }
       }
-    }
 
-    // Nothing to be closed, mark as complete
-    if (pendingClosure == 0) {
-      closureFuture.set(null);
+      // Nothing to be closed, mark as complete
+      if (pendingClosure == 0) {
+        closureFuture.set(null);
+      }
     }
 
     retFuture.addListener(


### PR DESCRIPTION
When the session pool is marked as invalid, we immediately close the pool maintainer in order to keep it from trying to replenish the pool. This way we prevent useless batch create sessions requests.

Fixes #768
