### PR TITLE
fix: blanks span for session keepAlive traces

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -113,6 +113,10 @@ class SessionImpl implements Session {
     currentSpan = span;
   }
 
+  Span getCurrentSpan() {
+    return currentSpan;
+  }
+
   @Override
   public long executePartitionedUpdate(Statement stmt, UpdateOption... options) {
     setActive(null);


### PR DESCRIPTION
The keepAlive traces were being tracked along with the parent span set by the client, which clutters the tracing stack. Here, we set the tracing to blank before issuing the keepAlive query.