### PR TITLE
test: fixes DatabaseClientImpl stuck test

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -92,7 +92,7 @@ public class DatabaseClientImplTest {
   private static final long UPDATE_COUNT = 1L;
   private Spanner spanner;
   private Spanner spannerWithEmptySessionPool;
-  private ExecutorService executor;
+  private static ExecutorService executor;
 
   @BeforeClass
   public static void startStaticServer() throws IOException {
@@ -106,6 +106,7 @@ public class DatabaseClientImplTest {
             INVALID_UPDATE_STATEMENT,
             Status.INVALID_ARGUMENT.withDescription("invalid statement").asRuntimeException()));
 
+    executor = Executors.newSingleThreadExecutor();
     String uniqueName = InProcessServerBuilder.generateName();
     server =
         InProcessServerBuilder.forName(uniqueName)
@@ -121,6 +122,7 @@ public class DatabaseClientImplTest {
   public static void stopServer() throws InterruptedException {
     server.shutdown();
     server.awaitTermination();
+    executor.shutdown();
   }
 
   @Before
@@ -141,7 +143,6 @@ public class DatabaseClientImplTest {
                 SessionPoolOptions.newBuilder().setMinSessions(0).setFailOnSessionLeak().build())
             .build()
             .getService();
-    executor = Executors.newSingleThreadExecutor();
   }
 
   @After
@@ -151,7 +152,6 @@ public class DatabaseClientImplTest {
     spannerWithEmptySessionPool.close();
     mockSpanner.reset();
     mockSpanner.removeAllExecutionTimes();
-    executor.shutdown();
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -92,7 +92,7 @@ public class DatabaseClientImplTest {
   private static final long UPDATE_COUNT = 1L;
   private Spanner spanner;
   private Spanner spannerWithEmptySessionPool;
-  private static final ExecutorService executor = Executors.newSingleThreadExecutor();
+  private ExecutorService executor;
 
   @BeforeClass
   public static void startStaticServer() throws IOException {
@@ -121,7 +121,6 @@ public class DatabaseClientImplTest {
   public static void stopServer() throws InterruptedException {
     server.shutdown();
     server.awaitTermination();
-    executor.shutdown();
   }
 
   @Before
@@ -142,6 +141,7 @@ public class DatabaseClientImplTest {
                 SessionPoolOptions.newBuilder().setMinSessions(0).setFailOnSessionLeak().build())
             .build()
             .getService();
+    executor = Executors.newSingleThreadExecutor();
   }
 
   @After
@@ -151,6 +151,7 @@ public class DatabaseClientImplTest {
     spannerWithEmptySessionPool.close();
     mockSpanner.reset();
     mockSpanner.removeAllExecutionTimes();
+    executor.shutdown();
   }
 
   @Test


### PR DESCRIPTION
The DatabaseClientImpl#singleUseBoundAsync is sometimes getting stuck during the execution. This is simple to reproduce by executing the test class multiple times.
This is due to the static single threaded executor that is shared among all the test cases.
In this fix, we create an executor in the setup method, avoiding the sharing of the same among different tests.