### PR TITLE
fix: safeguard against statement errors when requesting a transaction

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
@@ -78,7 +78,8 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
      * Called when transaction metadata is seen. This method may be invoked at most once. If the
      * method is invoked, it will precede {@link #onError(SpannerException)} or {@link #onDone()}.
      */
-    void onTransactionMetadata(Transaction transaction) throws SpannerException;
+    void onTransactionMetadata(Transaction transaction, boolean shouldIncludeId)
+        throws SpannerException;
 
     /** Called when the read finishes with an error. */
     void onError(SpannerException e, boolean withBeginTransaction);
@@ -117,12 +118,12 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
         if (currRow == null) {
           ResultSetMetadata metadata = iterator.getMetadata();
           if (metadata.hasTransaction()) {
-            listener.onTransactionMetadata(metadata.getTransaction());
+            listener.onTransactionMetadata(
+                metadata.getTransaction(), iterator.isWithBeginTransaction());
           } else if (iterator.isWithBeginTransaction()) {
             // The query should have returned a transaction.
             throw SpannerExceptionFactory.newSpannerException(
-                ErrorCode.FAILED_PRECONDITION,
-                "Query requested a transaction to be started, but no transaction was returned");
+                ErrorCode.FAILED_PRECONDITION, AbstractReadContext.NO_TRANSACTION_RETURNED_MSG);
           }
           currRow = new GrpcStruct(iterator.type(), new ArrayList<>());
         }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GrpcResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GrpcResultSetTest.java
@@ -56,7 +56,8 @@ public class GrpcResultSetTest {
 
   private static class NoOpListener implements AbstractResultSet.Listener {
     @Override
-    public void onTransactionMetadata(Transaction transaction) throws SpannerException {}
+    public void onTransactionMetadata(Transaction transaction, boolean shouldIncludeId)
+        throws SpannerException {}
 
     @Override
     public void onError(SpannerException e, boolean withBeginTransaction) {}

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -552,6 +552,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
   private ConcurrentMap<ByteString, Boolean> abortedTransactions = new ConcurrentHashMap<>();
   private final AtomicBoolean abortNextTransaction = new AtomicBoolean();
   private final AtomicBoolean abortNextStatement = new AtomicBoolean();
+  private final AtomicBoolean ignoreNextInlineBeginRequest = new AtomicBoolean();
   private ConcurrentMap<String, AtomicLong> transactionCounters = new ConcurrentHashMap<>();
   private ConcurrentMap<String, List<ByteString>> partitionTokens = new ConcurrentHashMap<>();
   private ConcurrentMap<ByteString, Instant> transactionLastUsed = new ConcurrentHashMap<>();
@@ -711,6 +712,10 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
     for (ByteString id : transactions.keySet()) {
       markAbortedTransaction(id);
     }
+  }
+
+  public void ignoreNextInlineBeginRequest() {
+    ignoreNextInlineBeginRequest.set(true);
   }
 
   public void freeze() {
@@ -973,7 +978,10 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
                             .build())
                     .setMetadata(
                         ResultSetMetadata.newBuilder()
-                            .setTransaction(Transaction.newBuilder().setId(transactionId).build())
+                            .setTransaction(
+                                ignoreNextInlineBeginRequest.getAndSet(false)
+                                    ? Transaction.getDefaultInstance()
+                                    : Transaction.newBuilder().setId(transactionId).build())
                             .build())
                     .build());
           }
@@ -999,7 +1007,10 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
       metadata =
           metadata
               .toBuilder()
-              .setTransaction(Transaction.newBuilder().setId(transactionId).build())
+              .setTransaction(
+                  ignoreNextInlineBeginRequest.getAndSet(false)
+                      ? Transaction.getDefaultInstance()
+                      : Transaction.newBuilder().setId(transactionId).build())
               .build();
     } else if (transactionSelector.hasBegin() || transactionSelector.hasSingleUse()) {
       Transaction transaction = getTemporaryTransactionOrNull(transactionSelector);
@@ -1085,7 +1096,10 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
                     ResultSetStats.newBuilder().setRowCountExact(res.getUpdateCount()).build())
                 .setMetadata(
                     ResultSetMetadata.newBuilder()
-                        .setTransaction(Transaction.newBuilder().setId(transactionId).build())
+                        .setTransaction(
+                            ignoreNextInlineBeginRequest.getAndSet(false)
+                                ? Transaction.getDefaultInstance()
+                                : Transaction.newBuilder().setId(transactionId).build())
                         .build())
                 .build());
       }
@@ -1508,7 +1522,10 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
       metadata =
           metadata
               .toBuilder()
-              .setTransaction(Transaction.newBuilder().setId(transactionId).build())
+              .setTransaction(
+                  ignoreNextInlineBeginRequest.getAndSet(false)
+                      ? Transaction.getDefaultInstance()
+                      : Transaction.newBuilder().setId(transactionId).build())
               .build();
     }
     resultSet = resultSet.toBuilder().setMetadata(metadata).build();
@@ -1550,7 +1567,10 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
               .setMetadata(
                   ResultSetMetadata.newBuilder()
                       .setRowType(StructType.newBuilder().addFields(field).build())
-                      .setTransaction(Transaction.newBuilder().setId(transaction.getId()).build())
+                      .setTransaction(
+                          ignoreNextInlineBeginRequest.getAndSet(false)
+                              ? Transaction.getDefaultInstance()
+                              : Transaction.newBuilder().setId(transaction.getId()).build())
                       .build())
               .setStats(ResultSetStats.newBuilder().setRowCountExact(updateCount).build())
               .build());
@@ -1560,7 +1580,10 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
               .setMetadata(
                   ResultSetMetadata.newBuilder()
                       .setRowType(StructType.newBuilder().addFields(field).build())
-                      .setTransaction(Transaction.newBuilder().setId(transaction.getId()).build())
+                      .setTransaction(
+                          ignoreNextInlineBeginRequest.getAndSet(false)
+                              ? Transaction.getDefaultInstance()
+                              : Transaction.newBuilder().setId(transaction.getId()).build())
                       .build())
               .setStats(ResultSetStats.newBuilder().setRowCountLowerBound(updateCount).build())
               .build());

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadFormatTestRunner.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadFormatTestRunner.java
@@ -44,7 +44,8 @@ public class ReadFormatTestRunner extends ParentRunner<JSONObject> {
 
   private static class NoOpListener implements AbstractResultSet.Listener {
     @Override
-    public void onTransactionMetadata(Transaction transaction) throws SpannerException {}
+    public void onTransactionMetadata(Transaction transaction, boolean shouldIncludeId)
+        throws SpannerException {}
 
     @Override
     public void onError(SpannerException e, boolean withBeginTransaction) {}


### PR DESCRIPTION
Adds a number of safeguards against hanging transactions if the first statement of a transaction for whatever reason fails to return a transaction ID, or otherwise returns an unexpected error. This PR contains the following safeguards:
1. If a statement requested a new transaction from Cloud Spanner and receives a response without a transaction ID, the statement will throw an exception. This should theoretically never happen. If it did happen, it would cause the second statement in the transaction to be 'stuck', as it would wait indefinitely for the first statement to return a transaction.
2. If the first statement of a transaction throws an unexpected error (a `Throwable` that is  not a `SpannerException`), the exception will be translated to a `SpannerException` and handled as such. This error will mark the transaction as unusable, as the first statement failed to return a transaction.
3. If the first statement fails to respond at all (no response, no error), the second statement will wait at most 60 seconds for a transaction ID to be returned, and then fail with a `ABORTED` error. This will cause the transaction to be retried automatically.

Fixes #799 