### PR TITLE
fix: UNAVAILABLE error on first query could cause transaction to get stuck

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -555,7 +555,7 @@ abstract class AbstractReadContext
   }
 
   ExecuteSqlRequest.Builder getExecuteSqlRequestBuilder(
-      Statement statement, QueryMode queryMode, Options options) {
+      Statement statement, QueryMode queryMode, Options options, boolean withTransactionSelector) {
     ExecuteSqlRequest.Builder builder =
         ExecuteSqlRequest.newBuilder()
             .setSql(statement.getSql())
@@ -569,9 +569,11 @@ abstract class AbstractReadContext
         builder.putParamTypes(param.getKey(), param.getValue().getType().toProto());
       }
     }
-    TransactionSelector selector = getTransactionSelector();
-    if (selector != null) {
-      builder.setTransaction(selector);
+    if (withTransactionSelector) {
+      TransactionSelector selector = getTransactionSelector();
+      if (selector != null) {
+        builder.setTransaction(selector);
+      }
     }
     builder.setSeqno(getSeqNo());
     builder.setQueryOptions(buildQueryOptions(statement.getQueryOptions()));
@@ -616,18 +618,26 @@ abstract class AbstractReadContext
     beforeReadOrQuery();
     final int prefetchChunks =
         options.hasPrefetchChunks() ? options.prefetchChunks() : defaultPrefetchChunks;
+    final ExecuteSqlRequest.Builder request =
+        getExecuteSqlRequestBuilder(
+            statement, queryMode, options, /* withTransactionSelector = */ false);
     ResumableStreamIterator stream =
         new ResumableStreamIterator(MAX_BUFFERED_CHUNKS, SpannerImpl.QUERY, span) {
           @Override
           CloseableIterator<PartialResultSet> startStream(@Nullable ByteString resumeToken) {
             GrpcStreamIterator stream = new GrpcStreamIterator(statement, prefetchChunks);
-            final ExecuteSqlRequest.Builder request =
-                getExecuteSqlRequestBuilder(statement, queryMode, options);
             if (partitionToken != null) {
               request.setPartitionToken(partitionToken);
             }
+            TransactionSelector selector = null;
             if (resumeToken != null) {
               request.setResumeToken(resumeToken);
+              selector = getTransactionSelector();
+            } else if (!request.hasTransaction()) {
+              selector = getTransactionSelector();
+            }
+            if (selector != null) {
+              request.setTransaction(selector);
             }
             SpannerRpc.StreamingCall call =
                 rpc.executeQuery(request.build(), stream.consumer(), session.getOptions());
@@ -735,10 +745,13 @@ abstract class AbstractReadContext
           @Override
           CloseableIterator<PartialResultSet> startStream(@Nullable ByteString resumeToken) {
             GrpcStreamIterator stream = new GrpcStreamIterator(prefetchChunks);
+            TransactionSelector selector = null;
             if (resumeToken != null) {
               builder.setResumeToken(resumeToken);
+              selector = getTransactionSelector();
+            } else if (!builder.hasTransaction()) {
+              selector = getTransactionSelector();
             }
-            TransactionSelector selector = getTransactionSelector();
             if (selector != null) {
               builder.setTransaction(selector);
             }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
@@ -1079,6 +1079,7 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
                 backoffSleep(context, backOff);
               }
             }
+
             continue;
           }
           span.addAnnotation("Stream broken. Not safe to retry");

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -575,7 +575,10 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
       beforeReadOrQuery();
       final ExecuteSqlRequest.Builder builder =
           getExecuteSqlRequestBuilder(
-              statement, QueryMode.NORMAL, Options.fromUpdateOptions(options));
+              statement,
+              QueryMode.NORMAL,
+              Options.fromUpdateOptions(options),
+              /* withTransactionSelector = */ true);
       try {
         com.google.spanner.v1.ResultSet resultSet =
             rpc.executeQuery(builder.build(), session.getOptions());
@@ -599,7 +602,10 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
       beforeReadOrQuery();
       final ExecuteSqlRequest.Builder builder =
           getExecuteSqlRequestBuilder(
-              statement, QueryMode.NORMAL, Options.fromUpdateOptions(options));
+              statement,
+              QueryMode.NORMAL,
+              Options.fromUpdateOptions(options),
+              /* withTransactionSelector = */ true);
       final ApiFuture<com.google.spanner.v1.ResultSet> resultSet;
       try {
         // Register the update as an async operation that must finish before the transaction may

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractReadContextTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractReadContextTest.java
@@ -90,7 +90,10 @@ public class AbstractReadContextTest {
     ExecuteSqlRequest request =
         context
             .getExecuteSqlRequestBuilder(
-                Statement.of("SELECT FOO FROM BAR"), QueryMode.NORMAL, Options.fromQueryOptions())
+                Statement.of("SELECT FOO FROM BAR"),
+                QueryMode.NORMAL,
+                Options.fromQueryOptions(),
+                true)
             .build();
     assertThat(request.getSql()).isEqualTo("SELECT FOO FROM BAR");
     assertThat(request.getQueryOptions()).isEqualTo(defaultQueryOptions);
@@ -105,7 +108,8 @@ public class AbstractReadContextTest {
                     .withQueryOptions(QueryOptions.newBuilder().setOptimizerVersion("2.0").build())
                     .build(),
                 QueryMode.NORMAL,
-                Options.fromQueryOptions())
+                Options.fromQueryOptions(),
+                true)
             .build();
     assertThat(request.getSql()).isEqualTo("SELECT FOO FROM BAR");
     assertThat(request.getQueryOptions().getOptimizerVersion()).isEqualTo("2.0");


### PR DESCRIPTION
If the first query or read operation of a read/write transaction would return `UNAVAILABLE` for the first element of the result stream, the transaction could get stuck. This was caused by the internal retry mechanism that would wait for the initial attempt to return a transaction, which was never returned as the `UNAVAILABLE` exception was internally handled by the result stream
iterator.

Fixes #799
