### PR TITLE
feat: allow session pool settings in connection url

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import java.util.Objects;
 import org.threeten.bp.Duration;
 
 /** Options for the session pool used by {@code DatabaseClient}. */
@@ -61,6 +62,48 @@ public class SessionPoolOptions {
     this.loopFrequency = builder.loopFrequency;
     this.keepAliveIntervalMinutes = builder.keepAliveIntervalMinutes;
     this.removeInactiveSessionAfter = builder.removeInactiveSessionAfter;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof SessionPoolOptions)) {
+      return false;
+    }
+    SessionPoolOptions other = (SessionPoolOptions) o;
+    return Objects.equals(this.minSessions, other.minSessions)
+        && Objects.equals(this.maxSessions, other.maxSessions)
+        && Objects.equals(this.incStep, other.incStep)
+        && Objects.equals(this.maxIdleSessions, other.maxIdleSessions)
+        && Objects.equals(this.writeSessionsFraction, other.writeSessionsFraction)
+        && Objects.equals(this.actionOnExhaustion, other.actionOnExhaustion)
+        && Objects.equals(this.actionOnSessionNotFound, other.actionOnSessionNotFound)
+        && Objects.equals(this.actionOnSessionLeak, other.actionOnSessionLeak)
+        && Objects.equals(
+            this.initialWaitForSessionTimeoutMillis, other.initialWaitForSessionTimeoutMillis)
+        && Objects.equals(this.loopFrequency, other.loopFrequency)
+        && Objects.equals(this.keepAliveIntervalMinutes, other.keepAliveIntervalMinutes)
+        && Objects.equals(this.removeInactiveSessionAfter, other.removeInactiveSessionAfter);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        this.minSessions,
+        this.maxSessions,
+        this.incStep,
+        this.maxIdleSessions,
+        this.writeSessionsFraction,
+        this.actionOnExhaustion,
+        this.actionOnSessionNotFound,
+        this.actionOnSessionLeak,
+        this.initialWaitForSessionTimeoutMillis,
+        this.loopFrequency,
+        this.keepAliveIntervalMinutes,
+        this.removeInactiveSessionAfter);
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
   }
 
   public int getMinSessions() {
@@ -164,6 +207,24 @@ public class SessionPoolOptions {
     private long loopFrequency = 10 * 1000L;
     private int keepAliveIntervalMinutes = 30;
     private Duration removeInactiveSessionAfter = Duration.ofMinutes(55L);
+
+    public Builder() {}
+
+    private Builder(SessionPoolOptions options) {
+      this.minSessionsSet = true;
+      this.minSessions = options.minSessions;
+      this.maxSessions = options.maxSessions;
+      this.incStep = options.incStep;
+      this.maxIdleSessions = options.maxIdleSessions;
+      this.writeSessionsFraction = options.writeSessionsFraction;
+      this.actionOnExhaustion = options.actionOnExhaustion;
+      this.initialWaitForSessionTimeoutMillis = options.initialWaitForSessionTimeoutMillis;
+      this.actionOnSessionNotFound = options.actionOnSessionNotFound;
+      this.actionOnSessionLeak = options.actionOnSessionLeak;
+      this.loopFrequency = options.loopFrequency;
+      this.keepAliveIntervalMinutes = options.keepAliveIntervalMinutes;
+      this.removeInactiveSessionAfter = options.removeInactiveSessionAfter;
+    }
 
     /**
      * Minimum number of sessions that this pool will always maintain. These will be created eagerly

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
@@ -148,7 +148,8 @@ public class SpannerPool {
     private final boolean usePlainText;
     private final String userAgent;
 
-    private static SpannerPoolKey of(ConnectionOptions options) {
+    @VisibleForTesting
+    static SpannerPoolKey of(ConnectionOptions options) {
       return new SpannerPoolKey(options);
     }
 
@@ -156,7 +157,10 @@ public class SpannerPool {
       this.host = options.getHost();
       this.projectId = options.getProjectId();
       this.credentialsKey = CredentialsKey.create(options);
-      this.sessionPoolOptions = options.getSessionPoolOptions();
+      this.sessionPoolOptions =
+          options.getSessionPoolOptions() == null
+              ? SessionPoolOptions.newBuilder().build()
+              : options.getSessionPoolOptions();
       this.numChannels = options.getNumChannels();
       this.usePlainText = options.isUsePlainText();
       this.userAgent = options.getUserAgent();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
@@ -421,4 +421,28 @@ public class ConnectionOptionsTest {
       assertThat(e.getMessage()).contains("bar");
     }
   }
+
+  @Test
+  public void testMinSessions() {
+    ConnectionOptions options =
+        ConnectionOptions.newBuilder()
+            .setUri(
+                "cloudspanner:/projects/test-project-123/instances/test-instance/databases/test-database?minSessions=400")
+            .setCredentialsUrl(FILE_TEST_PATH)
+            .build();
+    assertThat(options.getMinSessions()).isEqualTo(400);
+    assertThat(options.getSessionPoolOptions().getMinSessions()).isEqualTo(400);
+  }
+
+  @Test
+  public void testMaxSessions() {
+    ConnectionOptions options =
+        ConnectionOptions.newBuilder()
+            .setUri(
+                "cloudspanner:/projects/test-project-123/instances/test-instance/databases/test-database?maxSessions=4000")
+            .setCredentialsUrl(FILE_TEST_PATH)
+            .build();
+    assertThat(options.getMaxSessions()).isEqualTo(4000);
+    assertThat(options.getSessionPoolOptions().getMaxSessions()).isEqualTo(4000);
+  }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionTest.java
@@ -19,156 +19,241 @@ package com.google.cloud.spanner.connection;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
 import com.google.cloud.spanner.AbortedException;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.Statement;
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
+import com.google.protobuf.AbstractMessage;
+import com.google.spanner.v1.BatchCreateSessionsRequest;
 import com.google.spanner.v1.ExecuteSqlRequest;
 import com.google.spanner.v1.ExecuteSqlRequest.QueryOptions;
+import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.AfterClass;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
 
-public class ConnectionTest extends AbstractMockServerTest {
-  @Test
-  public void testDefaultOptimizerVersion() {
-    try (Connection connection = createConnection()) {
-      try (ResultSet rs =
-          connection.executeQuery(Statement.of("SHOW VARIABLE OPTIMIZER_VERSION"))) {
-        assertThat(rs.next()).isTrue();
-        assertThat(rs.getString("OPTIMIZER_VERSION")).isEqualTo("");
-        assertThat(rs.next()).isFalse();
-      }
-    }
-  }
+@RunWith(Enclosed.class)
+public class ConnectionTest {
 
-  @Test
-  public void testUseOptimizerVersionFromEnvironment() {
-    try {
-      SpannerOptions.useEnvironment(
-          new SpannerOptions.SpannerEnvironment() {
-            @Override
-            public String getOptimizerVersion() {
-              return "20";
-            }
-          });
+  public static class DefaultConnectionOptionsTest extends AbstractMockServerTest {
+    @Test
+    public void testDefaultOptimizerVersion() {
       try (Connection connection = createConnection()) {
-        // Do a query and verify that the version from the environment is used.
-        try (ResultSet rs = connection.executeQuery(SELECT_COUNT_STATEMENT)) {
-          assertThat(rs.next()).isTrue();
-          assertThat(rs.getLong(0)).isEqualTo(COUNT_BEFORE_INSERT);
-          assertThat(rs.next()).isFalse();
-          // Verify query options from the environment.
-          ExecuteSqlRequest request = getLastExecuteSqlRequest();
-          assertThat(request.getQueryOptions().getOptimizerVersion()).isEqualTo("20");
-        }
-        // Now set one of the query options on the connection. That option should be used in
-        // combination with the other option from the environment.
-        connection.execute(Statement.of("SET OPTIMIZER_VERSION='30'"));
-        try (ResultSet rs = connection.executeQuery(SELECT_COUNT_STATEMENT)) {
-          assertThat(rs.next()).isTrue();
-          assertThat(rs.getLong(0)).isEqualTo(COUNT_BEFORE_INSERT);
-          assertThat(rs.next()).isFalse();
-
-          ExecuteSqlRequest request = getLastExecuteSqlRequest();
-          // Optimizer version should come from the connection.
-          assertThat(request.getQueryOptions().getOptimizerVersion()).isEqualTo("30");
-        }
-        // Now specify options directly for the query. These should override both the environment
-        // and what is set on the connection.
         try (ResultSet rs =
-            connection.executeQuery(
-                Statement.newBuilder(SELECT_COUNT_STATEMENT.getSql())
-                    .withQueryOptions(
-                        QueryOptions.newBuilder()
-                            .setOptimizerVersion("user-defined-version")
-                            .build())
-                    .build())) {
+            connection.executeQuery(Statement.of("SHOW VARIABLE OPTIMIZER_VERSION"))) {
           assertThat(rs.next()).isTrue();
-          assertThat(rs.getLong(0)).isEqualTo(COUNT_BEFORE_INSERT);
+          assertThat(rs.getString("OPTIMIZER_VERSION")).isEqualTo("");
           assertThat(rs.next()).isFalse();
-
-          ExecuteSqlRequest request = getLastExecuteSqlRequest();
-          // Optimizer version should come from the query.
-          assertThat(request.getQueryOptions().getOptimizerVersion())
-              .isEqualTo("user-defined-version");
         }
       }
-    } finally {
-      SpannerOptions.useDefaultEnvironment();
     }
-  }
 
-  @Test
-  public void testExecuteInvalidBatchUpdate() {
-    try (Connection connection = createConnection()) {
+    @Test
+    public void testUseOptimizerVersionFromEnvironment() {
       try {
-        connection.executeBatchUpdate(ImmutableList.of(INSERT_STATEMENT, SELECT_RANDOM_STATEMENT));
-        fail("Missing expected exception");
-      } catch (SpannerException e) {
-        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
+        SpannerOptions.useEnvironment(
+            new SpannerOptions.SpannerEnvironment() {
+              @Override
+              public String getOptimizerVersion() {
+                return "20";
+              }
+            });
+        try (Connection connection = createConnection()) {
+          // Do a query and verify that the version from the environment is used.
+          try (ResultSet rs = connection.executeQuery(SELECT_COUNT_STATEMENT)) {
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getLong(0)).isEqualTo(COUNT_BEFORE_INSERT);
+            assertThat(rs.next()).isFalse();
+            // Verify query options from the environment.
+            ExecuteSqlRequest request = getLastExecuteSqlRequest();
+            assertThat(request.getQueryOptions().getOptimizerVersion()).isEqualTo("20");
+          }
+          // Now set one of the query options on the connection. That option should be used in
+          // combination with the other option from the environment.
+          connection.execute(Statement.of("SET OPTIMIZER_VERSION='30'"));
+          try (ResultSet rs = connection.executeQuery(SELECT_COUNT_STATEMENT)) {
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getLong(0)).isEqualTo(COUNT_BEFORE_INSERT);
+            assertThat(rs.next()).isFalse();
+
+            ExecuteSqlRequest request = getLastExecuteSqlRequest();
+            // Optimizer version should come from the connection.
+            assertThat(request.getQueryOptions().getOptimizerVersion()).isEqualTo("30");
+          }
+          // Now specify options directly for the query. These should override both the environment
+          // and what is set on the connection.
+          try (ResultSet rs =
+              connection.executeQuery(
+                  Statement.newBuilder(SELECT_COUNT_STATEMENT.getSql())
+                      .withQueryOptions(
+                          QueryOptions.newBuilder()
+                              .setOptimizerVersion("user-defined-version")
+                              .build())
+                      .build())) {
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getLong(0)).isEqualTo(COUNT_BEFORE_INSERT);
+            assertThat(rs.next()).isFalse();
+
+            ExecuteSqlRequest request = getLastExecuteSqlRequest();
+            // Optimizer version should come from the query.
+            assertThat(request.getQueryOptions().getOptimizerVersion())
+                .isEqualTo("user-defined-version");
+          }
+        }
+      } finally {
+        SpannerOptions.useDefaultEnvironment();
       }
     }
-  }
 
-  @Test
-  public void testQueryAborted() {
-    try (Connection connection = createConnection()) {
-      connection.setRetryAbortsInternally(false);
-      for (boolean abort : new Boolean[] {true, false}) {
+    @Test
+    public void testExecuteInvalidBatchUpdate() {
+      try (Connection connection = createConnection()) {
         try {
-          if (abort) {
-            mockSpanner.abortNextStatement();
+          connection.executeBatchUpdate(
+              ImmutableList.of(INSERT_STATEMENT, SELECT_RANDOM_STATEMENT));
+          fail("Missing expected exception");
+        } catch (SpannerException e) {
+          assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
+        }
+      }
+    }
+
+    @Test
+    public void testQueryAborted() {
+      try (Connection connection = createConnection()) {
+        connection.setRetryAbortsInternally(false);
+        for (boolean abort : new Boolean[] {true, false}) {
+          try {
+            if (abort) {
+              mockSpanner.abortNextStatement();
+            }
+            connection.executeQuery(SELECT_RANDOM_STATEMENT);
+            assertThat(abort).isFalse();
+            connection.commit();
+          } catch (AbortedException e) {
+            assertThat(abort).isTrue();
+            connection.rollback();
           }
-          connection.executeQuery(SELECT_RANDOM_STATEMENT);
-          assertThat(abort).isFalse();
-          connection.commit();
-        } catch (AbortedException e) {
-          assertThat(abort).isTrue();
-          connection.rollback();
+        }
+      }
+    }
+
+    @Test
+    public void testUpdateAborted() {
+      try (Connection connection = createConnection()) {
+        connection.setRetryAbortsInternally(false);
+        for (boolean abort : new Boolean[] {true, false}) {
+          try {
+            if (abort) {
+              mockSpanner.abortNextStatement();
+            }
+            connection.executeUpdate(INSERT_STATEMENT);
+            assertThat(abort).isFalse();
+            connection.commit();
+          } catch (AbortedException e) {
+            assertThat(abort).isTrue();
+            connection.rollback();
+          }
+        }
+      }
+    }
+
+    @Test
+    public void testBatchUpdateAborted() {
+      try (Connection connection = createConnection()) {
+        connection.setRetryAbortsInternally(false);
+        for (boolean abort : new Boolean[] {true, false}) {
+          try {
+            if (abort) {
+              mockSpanner.abortNextStatement();
+            }
+            connection.executeBatchUpdate(ImmutableList.of(INSERT_STATEMENT, INSERT_STATEMENT));
+            assertThat(abort).isFalse();
+            connection.commit();
+          } catch (AbortedException e) {
+            assertThat(abort).isTrue();
+            connection.rollback();
+          }
         }
       }
     }
   }
 
-  @Test
-  public void testUpdateAborted() {
-    try (Connection connection = createConnection()) {
-      connection.setRetryAbortsInternally(false);
-      for (boolean abort : new Boolean[] {true, false}) {
-        try {
-          if (abort) {
-            mockSpanner.abortNextStatement();
-          }
-          connection.executeUpdate(INSERT_STATEMENT);
-          assertThat(abort).isFalse();
-          connection.commit();
-        } catch (AbortedException e) {
-          assertThat(abort).isTrue();
-          connection.rollback();
-        }
+  public static class ConnectionMinSessionsTest extends AbstractMockServerTest {
+
+    @AfterClass
+    public static void reset() {
+      mockSpanner.reset();
+    }
+
+    protected String getBaseUrl() {
+      return super.getBaseUrl() + ";minSessions=1";
+    }
+
+    @Test
+    public void testMinSessions() throws InterruptedException, TimeoutException {
+      try (Connection connection = createConnection()) {
+        mockSpanner.waitForRequestsToContain(
+            new Predicate<AbstractMessage>() {
+              @Override
+              public boolean apply(AbstractMessage input) {
+                return input instanceof BatchCreateSessionsRequest
+                    && ((BatchCreateSessionsRequest) input).getSessionCount() == 1;
+              }
+            },
+            5000L);
       }
     }
   }
 
-  @Test
-  public void testBatchUpdateAborted() {
-    try (Connection connection = createConnection()) {
-      connection.setRetryAbortsInternally(false);
-      for (boolean abort : new Boolean[] {true, false}) {
-        try {
-          if (abort) {
-            mockSpanner.abortNextStatement();
-          }
-          connection.executeBatchUpdate(ImmutableList.of(INSERT_STATEMENT, INSERT_STATEMENT));
-          assertThat(abort).isFalse();
-          connection.commit();
-        } catch (AbortedException e) {
-          assertThat(abort).isTrue();
-          connection.rollback();
-        }
+  public static class ConnectionMaxSessionsTest extends AbstractMockServerTest {
+
+    @AfterClass
+    public static void reset() {
+      mockSpanner.reset();
+    }
+
+    protected String getBaseUrl() {
+      return super.getBaseUrl() + ";maxSessions=1";
+    }
+
+    @Test
+    public void testMaxSessions()
+        throws InterruptedException, TimeoutException, ExecutionException {
+      try (Connection connection1 = createConnection();
+          Connection connection2 = createConnection()) {
+        connection1.beginTransactionAsync();
+        connection2.beginTransactionAsync();
+
+        ApiFuture<Long> count1 = connection1.executeUpdateAsync(INSERT_STATEMENT);
+        ApiFuture<Long> count2 = connection2.executeUpdateAsync(INSERT_STATEMENT);
+
+        // Commit the transactions. Both should be able to finish, but both used the same session.
+        ApiFuture<Void> commit1 = connection1.commitAsync();
+        ApiFuture<Void> commit2 = connection2.commitAsync();
+
+        // At least one transaction must wait until the other has finished before it can get a
+        // session.
+        assertThat(count1.isDone() && count2.isDone()).isFalse();
+        assertThat(commit1.isDone() && commit2.isDone()).isFalse();
+
+        // Wait until both finishes.
+        ApiFutures.allAsList(Arrays.asList(commit1, commit2)).get(5L, TimeUnit.SECONDS);
+
+        assertThat(count1.isDone()).isTrue();
+        assertThat(count2.isDone()).isTrue();
       }
+      assertThat(mockSpanner.numSessionsCreated()).isEqualTo(1);
     }
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SpannerPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SpannerPoolTest.java
@@ -421,6 +421,7 @@ public class SpannerPoolTest {
         ConnectionOptions.newBuilder()
             .setUri(
                 "cloudspanner:/projects/p/instances/i/databases/d?minSessions=200;maxSessions=400")
+            .setCredentials(NoCredentials.getInstance())
             .build();
     // options2 equals the default session pool options, and is therefore equal to ConnectionOptions
     // without any session pool configuration.
@@ -428,10 +429,12 @@ public class SpannerPoolTest {
         ConnectionOptions.newBuilder()
             .setUri(
                 "cloudspanner:/projects/p/instances/i/databases/d?minSessions=100;maxSessions=400")
+            .setCredentials(NoCredentials.getInstance())
             .build();
     ConnectionOptions options3 =
         ConnectionOptions.newBuilder()
             .setUri("cloudspanner:/projects/p/instances/i/databases/d")
+            .setCredentials(NoCredentials.getInstance())
             .build();
 
     SpannerPoolKey key1 = SpannerPoolKey.of(options1);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SpannerPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SpannerPoolTest.java
@@ -16,10 +16,7 @@
 
 package com.google.cloud.spanner.connection;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -33,6 +30,7 @@ import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.connection.ConnectionImpl.LeakedConnectionException;
 import com.google.cloud.spanner.connection.SpannerPool.CheckAndCloseSpannersMode;
+import com.google.cloud.spanner.connection.SpannerPool.SpannerPoolKey;
 import com.google.common.base.Ticker;
 import com.google.common.testing.FakeTicker;
 import java.io.ByteArrayOutputStream;
@@ -108,40 +106,40 @@ public class SpannerPoolTest {
     // assert equal
     spanner1 = pool.getSpanner(options1, connection1);
     spanner2 = pool.getSpanner(options1, connection2);
-    assertThat(spanner1, is(equalTo(spanner2)));
+    assertThat(spanner1).isEqualTo(spanner2);
     spanner1 = pool.getSpanner(options2, connection1);
     spanner2 = pool.getSpanner(options2, connection2);
-    assertThat(spanner1, is(equalTo(spanner2)));
+    assertThat(spanner1).isEqualTo(spanner2);
     spanner1 = pool.getSpanner(options3, connection1);
     spanner2 = pool.getSpanner(options3, connection2);
-    assertThat(spanner1, is(equalTo(spanner2)));
+    assertThat(spanner1).isEqualTo(spanner2);
     spanner1 = pool.getSpanner(options4, connection1);
     spanner2 = pool.getSpanner(options4, connection2);
-    assertThat(spanner1, is(equalTo(spanner2)));
+    assertThat(spanner1).isEqualTo(spanner2);
     // Options 5 and 6 both use default credentials.
     spanner1 = pool.getSpanner(options5, connection1);
     spanner2 = pool.getSpanner(options6, connection2);
-    assertThat(spanner1, is(equalTo(spanner2)));
+    assertThat(spanner1).isEqualTo(spanner2);
 
     // assert not equal
     spanner1 = pool.getSpanner(options1, connection1);
     spanner2 = pool.getSpanner(options2, connection2);
-    assertThat(spanner1, not(equalTo(spanner2)));
+    assertThat(spanner1).isNotEqualTo(spanner2);
     spanner1 = pool.getSpanner(options1, connection1);
     spanner2 = pool.getSpanner(options3, connection2);
-    assertThat(spanner1, not(equalTo(spanner2)));
+    assertThat(spanner1).isNotEqualTo(spanner2);
     spanner1 = pool.getSpanner(options1, connection1);
     spanner2 = pool.getSpanner(options4, connection2);
-    assertThat(spanner1, not(equalTo(spanner2)));
+    assertThat(spanner1).isNotEqualTo(spanner2);
     spanner1 = pool.getSpanner(options2, connection1);
     spanner2 = pool.getSpanner(options3, connection2);
-    assertThat(spanner1, not(equalTo(spanner2)));
+    assertThat(spanner1).isNotEqualTo(spanner2);
     spanner1 = pool.getSpanner(options2, connection1);
     spanner2 = pool.getSpanner(options4, connection2);
-    assertThat(spanner1, not(equalTo(spanner2)));
+    assertThat(spanner1).isNotEqualTo(spanner2);
     spanner1 = pool.getSpanner(options3, connection1);
     spanner2 = pool.getSpanner(options4, connection2);
-    assertThat(spanner1, not(equalTo(spanner2)));
+    assertThat(spanner1).isNotEqualTo(spanner2);
   }
 
   @Test
@@ -153,17 +151,17 @@ public class SpannerPoolTest {
     // assert equal
     spanner1 = pool.getSpanner(options1, connection1);
     spanner2 = pool.getSpanner(options1, connection2);
-    assertThat(spanner1, is(equalTo(spanner2)));
+    assertThat(spanner1).isEqualTo(spanner2);
     // one connection removed, assert that we would still get the same Spanner
     pool.removeConnection(options1, connection1);
     spanner1 = pool.getSpanner(options1, connection1);
-    assertThat(spanner1, is(equalTo(spanner2)));
+    assertThat(spanner1).isEqualTo(spanner2);
     // remove two connections, assert that we would still get the same Spanner, as Spanners are not
     // directly closed and removed.
     pool.removeConnection(options1, connection1);
     pool.removeConnection(options1, connection2);
     spanner1 = pool.getSpanner(options1, connection1);
-    assertThat(spanner1, is(equalTo(spanner2)));
+    assertThat(spanner1).isEqualTo(spanner2);
     // remove the last connection again
     pool.removeConnection(options1, connection1);
   }
@@ -200,7 +198,7 @@ public class SpannerPoolTest {
     pool.getSpanner(options1, connection1);
     pool.removeConnection(options2, connection1);
     String capturedLog = getTestCapturedLog();
-    assertThat(capturedLog.contains(expectedLogPart), is(true));
+    assertThat(capturedLog.contains(expectedLogPart)).isTrue();
   }
 
   @Test
@@ -211,7 +209,7 @@ public class SpannerPoolTest {
     pool.getSpanner(options1, connection1);
     pool.removeConnection(options1, connection2);
     String capturedLog = getTestCapturedLog();
-    assertThat(capturedLog.contains(expectedLogPart), is(true));
+    assertThat(capturedLog.contains(expectedLogPart)).isTrue();
   }
 
   @Test
@@ -223,7 +221,7 @@ public class SpannerPoolTest {
     pool.removeConnection(options1, connection1);
     pool.removeConnection(options1, connection1);
     String capturedLog = getTestCapturedLog();
-    assertThat(capturedLog.contains(expectedLogPart), is(true));
+    assertThat(capturedLog.contains(expectedLogPart)).isTrue();
   }
 
   @Test
@@ -237,7 +235,7 @@ public class SpannerPoolTest {
     } catch (SpannerException e) {
       exception = e.getErrorCode() == ErrorCode.FAILED_PRECONDITION;
     }
-    assertThat(exception, is(true));
+    assertThat(exception).isTrue();
 
     // remove the connection and verify that it is possible to close
     pool.removeConnection(options1, connection1);
@@ -249,7 +247,7 @@ public class SpannerPoolTest {
     Spanner spanner2 = pool.getSpanner(options1, connection1);
     pool.checkAndCloseSpanners(CheckAndCloseSpannersMode.WARN);
     String capturedLog = getTestCapturedLog();
-    assertThat(capturedLog.contains(expectedLogPart), is(true));
+    assertThat(capturedLog.contains(expectedLogPart)).isTrue();
     verify(spanner2, never()).close();
 
     // remove the connection and verify that it is possible to close
@@ -273,11 +271,11 @@ public class SpannerPoolTest {
       ConnectionOptions.closeSpanner();
       fail("missing expected exception");
     } catch (SpannerException e) {
-      assertThat(e.getErrorCode(), is(equalTo(ErrorCode.FAILED_PRECONDITION)));
+      assertThat(e.getErrorCode()).isEqualTo(ErrorCode.FAILED_PRECONDITION);
     }
     String capturedLog = getTestCapturedLog();
-    assertThat(capturedLog.contains(LeakedConnectionException.class.getName()), is(true));
-    assertThat(capturedLog.contains("testLeakedConnection"), is(true));
+    assertThat(capturedLog.contains(LeakedConnectionException.class.getName())).isTrue();
+    assertThat(capturedLog.contains("testLeakedConnection")).isTrue();
     // Now close the connection to avoid trouble with other test cases.
     connection.close();
   }
@@ -292,7 +290,7 @@ public class SpannerPoolTest {
     // create two connections that use the same Spanner
     spanner1 = pool.getSpanner(options1, connection1);
     spanner2 = pool.getSpanner(options1, connection2);
-    assertThat(spanner1, is(equalTo(spanner2)));
+    assertThat(spanner1).isEqualTo(spanner2);
 
     // all spanners are in use, this should have no effect
     pool.closeUnusedSpanners(-1L);
@@ -312,8 +310,8 @@ public class SpannerPoolTest {
     spanner1 = pool.getSpanner(options1, connection1);
     spanner2 = pool.getSpanner(options2, connection2);
     spanner3 = pool.getSpanner(options2, connection3);
-    assertThat(spanner1, not(equalTo(spanner2)));
-    assertThat(spanner2, is(equalTo(spanner3)));
+    assertThat(spanner1).isNotEqualTo(spanner2);
+    assertThat(spanner2).isEqualTo(spanner3);
 
     // all spanners are in use, this should have no effect
     pool.closeUnusedSpanners(-1L);
@@ -359,7 +357,7 @@ public class SpannerPoolTest {
     // create two connections that use the same Spanner
     spanner1 = pool.getSpanner(options1, connection1);
     spanner2 = pool.getSpanner(options1, connection2);
-    assertThat(spanner1, is(equalTo(spanner2)));
+    assertThat(spanner1).isEqualTo(spanner2);
 
     // all spanners are in use, this should have no effect
     ticker.advance(TEST_AUTOMATIC_CLOSE_TIMEOUT_NANOS + MILLISECOND);
@@ -382,8 +380,8 @@ public class SpannerPoolTest {
     spanner1 = pool.getSpanner(options1, connection1);
     spanner2 = pool.getSpanner(options2, connection2);
     spanner3 = pool.getSpanner(options2, connection3);
-    assertThat(spanner1, not(equalTo(spanner2)));
-    assertThat(spanner2, is(equalTo(spanner3)));
+    assertThat(spanner1).isNotEqualTo(spanner2);
+    assertThat(spanner2).isEqualTo(spanner3);
 
     // all spanners are in use, this should have no effect
     ticker.advance(TEST_AUTOMATIC_CLOSE_TIMEOUT_NANOS + MILLISECOND);
@@ -415,5 +413,33 @@ public class SpannerPoolTest {
     verify(spanner1).close();
     verify(spanner2).close();
     verify(spanner3).close();
+  }
+
+  @Test
+  public void testSpannerPoolKeyEquality() {
+    ConnectionOptions options1 =
+        ConnectionOptions.newBuilder()
+            .setUri(
+                "cloudspanner:/projects/p/instances/i/databases/d?minSessions=200;maxSessions=400")
+            .build();
+    // options2 equals the default session pool options, and is therefore equal to ConnectionOptions
+    // without any session pool configuration.
+    ConnectionOptions options2 =
+        ConnectionOptions.newBuilder()
+            .setUri(
+                "cloudspanner:/projects/p/instances/i/databases/d?minSessions=100;maxSessions=400")
+            .build();
+    ConnectionOptions options3 =
+        ConnectionOptions.newBuilder()
+            .setUri("cloudspanner:/projects/p/instances/i/databases/d")
+            .build();
+
+    SpannerPoolKey key1 = SpannerPoolKey.of(options1);
+    SpannerPoolKey key2 = SpannerPoolKey.of(options2);
+    SpannerPoolKey key3 = SpannerPoolKey.of(options3);
+
+    assertThat(key1).isNotEqualTo(key2);
+    assertThat(key2).isEqualTo(key3);
+    assertThat(key1).isNotEqualTo(key3);
   }
 }


### PR DESCRIPTION
Allows min/max sessions for the backing `SessionPool` to be specified in the connection URL.

Towards https://github.com/googleapis/java-spanner-jdbc/issues/334