### PR TITLE
build: add 3.1.x branch as protected and releasable

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,6 @@
 releaseType: java-yoshi
 bumpMinorPreMajor: true
+branches:
+- branch: 3.1.x
+  releaseType: java-yoshi
+  bumpMinorPreMajor: true

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -39,6 +39,33 @@ branchProtectionRules:
     - "units (11)"
     - "Kokoro - Test: Integration"
     - "cla/google"
+
+# Identifies the protection rule pattern. Name of the branch to be protected.
+# Defaults to `master`
+- pattern: 3.1.x
+  # Can admins overwrite branch protection.
+  # Defaults to `true`
+  isAdminEnforced: true
+  # Number of approving reviews required to update matching branches.
+  # Defaults to `1`
+  requiredApprovingReviewCount: 1
+  # Are reviews from code owners required to update matching branches.
+  # Defaults to `false`
+  requiresCodeOwnerReviews: true
+  # Require up to date branches
+  requiresStrictStatusChecks: false
+  # List of required status check contexts that must pass for commits to be accepted to matching branches.
+  requiredStatusCheckContexts:
+    - "dependencies (8)"
+    - "dependencies (11)"
+    - "linkage-monitor"
+    - "lint"
+    - "clirr"
+    - "units (7)"
+    - "units (8)"
+    - "units (11)"
+    - "Kokoro - Test: Integration"
+    - "cla/google"
 # List of explicit permissions to add (additive only)
 permissionRules:
 - team: yoshi-admins

--- a/synth.py
+++ b/synth.py
@@ -89,4 +89,6 @@ java.common_templates(excludes=[
     'samples/snapshot/pom.xml',
     'samples/snippets/pom.xml',
     '.github/CODEOWNERS',
+    '.github/sync-repo-settings.yaml',
+    '.github/release-please.yml',
 ])


### PR DESCRIPTION
This should enable release-please on the 3.1.x branch