### PR TITLE
test: reduce number of stress test runs

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplStressTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplStressTest.java
@@ -55,7 +55,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
 public class AsyncResultSetImplStressTest {
-  private static final int TEST_RUNS = 1000;
+  private static final int TEST_RUNS = 25;
 
   /** Timeout is applied to each test case individually. */
   @Rule public Timeout timeout = new Timeout(120, TimeUnit.SECONDS);


### PR DESCRIPTION
Reduces the number of test runs for `AsyncResultSetImplStressTest` to improve build/test time (reduces total build time with approx 10 seconds). The class has been stable for quite some time, so reducing the number of test runs should be safe.