### PR TITLE
cleanup: return instead of fallthrough + improve comment

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -463,7 +463,10 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
             // Aborted error if the call that included the BeginTransaction option fails. The
             // Aborted error will cause the entire transaction to be retried, and the retry will use
             // a separate BeginTransaction RPC.
-            TransactionSelector.newBuilder()
+            // If tx.get() returns successfully, this.transactionId will also have been set to a
+            // valid value as the latter is always set when a transaction id is returned by a
+            // statement.
+            return TransactionSelector.newBuilder()
                 .setId(tx.get(waitForTransactionTimeoutMillis, TimeUnit.MILLISECONDS))
                 .build();
           }


### PR DESCRIPTION
Return the TransactionSelector that is built instead of falling through to the end of the method. The behavior does not change by this, but it makes it easier to read and understand the code.

Fixes #830
