### PR TITLE
fix(3.1.x): blanks span for session keepAlive traces

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -112,6 +112,10 @@ class SessionImpl implements Session {
     currentSpan = span;
   }
 
+  Span getCurrentSpan() {
+    return currentSpan;
+  }
+
   @Override
   public long executePartitionedUpdate(Statement stmt) {
     setActive(null);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -76,6 +76,7 @@ import io.opencensus.metrics.MetricRegistry;
 import io.opencensus.metrics.Metrics;
 import io.opencensus.trace.Annotation;
 import io.opencensus.trace.AttributeValue;
+import io.opencensus.trace.BlankSpan;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.Status;
 import io.opencensus.trace.Tracer;
@@ -1463,11 +1464,15 @@ final class SessionPool {
 
     private void keepAlive() {
       markUsed();
+      final Span previousSpan = delegate.getCurrentSpan();
+      delegate.setCurrentSpan(BlankSpan.INSTANCE);
       try (ResultSet resultSet =
           delegate
               .singleUse(TimestampBound.ofMaxStaleness(60, TimeUnit.SECONDS))
               .executeQuery(Statement.newBuilder("SELECT 1").build())) {
         resultSet.next();
+      } finally {
+        delegate.setCurrentSpan(previousSpan);
       }
     }
 


### PR DESCRIPTION
The keepAlive traces were being tracked along with the parent span set by the client, which clutters the tracing stack. Here, we set the tracing to blank before issuing the keepAlive query.