### PR TITLE
fix(3.1.x): UNAVAILABLE error on first query could cause transaction to get stuck

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -535,6 +535,8 @@ abstract class AbstractReadContext
    *   <li>Specific {@link QueryOptions} passed in for this query.
    *   <li>Any value specified in a valid environment variable when the {@link SpannerOptions}
    *       instance was created.
+   *   <li>The default {@link SpannerOptions#getDefaultQueryOptions()} specified for the database
+   *       where the query is executed.
    * </ol>
    */
   @VisibleForTesting

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -616,8 +616,7 @@ abstract class AbstractReadContext
     final int prefetchChunks =
         options.hasPrefetchChunks() ? options.prefetchChunks() : defaultPrefetchChunks;
     final ExecuteSqlRequest.Builder request =
-        getExecuteSqlRequestBuilder(
-            statement, queryMode, /* withTransactionSelector = */ false);
+        getExecuteSqlRequestBuilder(statement, queryMode, /* withTransactionSelector = */ false);
     ResumableStreamIterator stream =
         new ResumableStreamIterator(MAX_BUFFERED_CHUNKS, SpannerImpl.QUERY, span) {
           @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
@@ -1071,6 +1071,7 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
                 backoffSleep(context, backOff);
               }
             }
+
             continue;
           }
           span.addAnnotation("Stream broken. Not safe to retry");

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
@@ -1071,7 +1071,6 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
                 backoffSleep(context, backOff);
               }
             }
-
             continue;
           }
           span.addAnnotation("Stream broken. Not safe to retry");

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -516,9 +516,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
       beforeReadOrQuery();
       final ExecuteSqlRequest.Builder builder =
           getExecuteSqlRequestBuilder(
-              statement,
-              QueryMode.NORMAL,
-              /* withTransactionSelector = */ true);
+              statement, QueryMode.NORMAL, /* withTransactionSelector = */ true);
       try {
         com.google.spanner.v1.ResultSet resultSet =
             rpc.executeQuery(builder.build(), session.getOptions());
@@ -542,9 +540,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
       beforeReadOrQuery();
       final ExecuteSqlRequest.Builder builder =
           getExecuteSqlRequestBuilder(
-              statement,
-              QueryMode.NORMAL,
-              /* withTransactionSelector = */ true);
+              statement, QueryMode.NORMAL, /* withTransactionSelector = */ true);
       final ApiFuture<com.google.spanner.v1.ResultSet> resultSet;
       try {
         // Register the update as an async operation that must finish before the transaction may

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -515,7 +515,10 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
     public long executeUpdate(Statement statement) {
       beforeReadOrQuery();
       final ExecuteSqlRequest.Builder builder =
-          getExecuteSqlRequestBuilder(statement, QueryMode.NORMAL);
+          getExecuteSqlRequestBuilder(
+              statement,
+              QueryMode.NORMAL,
+              /* withTransactionSelector = */ true);
       try {
         com.google.spanner.v1.ResultSet resultSet =
             rpc.executeQuery(builder.build(), session.getOptions());
@@ -538,7 +541,10 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
     public ApiFuture<Long> executeUpdateAsync(Statement statement) {
       beforeReadOrQuery();
       final ExecuteSqlRequest.Builder builder =
-          getExecuteSqlRequestBuilder(statement, QueryMode.NORMAL);
+          getExecuteSqlRequestBuilder(
+              statement,
+              QueryMode.NORMAL,
+              /* withTransactionSelector = */ true);
       final ApiFuture<com.google.spanner.v1.ResultSet> resultSet;
       try {
         // Register the update as an async operation that must finish before the transaction may

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractReadContextTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractReadContextTest.java
@@ -89,7 +89,10 @@ public class AbstractReadContextTest {
   public void executeSqlRequestBuilderWithoutQueryOptions() {
     ExecuteSqlRequest request =
         context
-            .getExecuteSqlRequestBuilder(Statement.of("SELECT FOO FROM BAR"), QueryMode.NORMAL)
+            .getExecuteSqlRequestBuilder(
+                Statement.of("SELECT FOO FROM BAR"),
+                QueryMode.NORMAL,
+                true)
             .build();
     assertThat(request.getSql()).isEqualTo("SELECT FOO FROM BAR");
     assertThat(request.getQueryOptions()).isEqualTo(defaultQueryOptions);
@@ -103,7 +106,8 @@ public class AbstractReadContextTest {
                 Statement.newBuilder("SELECT FOO FROM BAR")
                     .withQueryOptions(QueryOptions.newBuilder().setOptimizerVersion("2.0").build())
                     .build(),
-                QueryMode.NORMAL)
+                QueryMode.NORMAL,
+                true)
             .build();
     assertThat(request.getSql()).isEqualTo("SELECT FOO FROM BAR");
     assertThat(request.getQueryOptions().getOptimizerVersion()).isEqualTo("2.0");

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractReadContextTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractReadContextTest.java
@@ -90,9 +90,7 @@ public class AbstractReadContextTest {
     ExecuteSqlRequest request =
         context
             .getExecuteSqlRequestBuilder(
-                Statement.of("SELECT FOO FROM BAR"),
-                QueryMode.NORMAL,
-                true)
+                Statement.of("SELECT FOO FROM BAR"), QueryMode.NORMAL, true)
             .build();
     assertThat(request.getSql()).isEqualTo("SELECT FOO FROM BAR");
     assertThat(request.getQueryOptions()).isEqualTo(defaultQueryOptions);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
@@ -252,6 +252,130 @@ public class InlineBeginTransactionTest {
   }
 
   @Test
+  public void testInlinedBeginFirstUpdateAborts() {
+    DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+    long updateCount =
+        client
+            .readWriteTransaction()
+            .run(
+                new TransactionCallable<Long>() {
+                  boolean firstAttempt = true;
+
+                  @Override
+                  public Long run(TransactionContext transaction) throws Exception {
+                    if (firstAttempt) {
+                      firstAttempt = false;
+                      mockSpanner.putStatementResult(
+                          StatementResult.exception(
+                              UPDATE_STATEMENT,
+                              mockSpanner.createAbortedException(
+                                  ByteString.copyFromUtf8("some-tx"))));
+                    } else {
+                      mockSpanner.putStatementResult(
+                          StatementResult.update(UPDATE_STATEMENT, UPDATE_COUNT));
+                    }
+                    return transaction.executeUpdate(UPDATE_STATEMENT);
+                  }
+                });
+    assertThat(updateCount).isEqualTo(UPDATE_COUNT);
+    assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(1);
+    assertThat(countRequests(ExecuteSqlRequest.class)).isEqualTo(2);
+    assertThat(countRequests(CommitRequest.class)).isEqualTo(1);
+  }
+
+  @Test
+  public void testInlinedBeginFirstQueryAborts() {
+    DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+    long updateCount =
+        client
+            .readWriteTransaction()
+            .run(
+                new TransactionCallable<Long>() {
+                  boolean firstAttempt = true;
+
+                  @Override
+                  public Long run(TransactionContext transaction) throws Exception {
+                    if (firstAttempt) {
+                      firstAttempt = false;
+                      mockSpanner.putStatementResult(
+                          StatementResult.exception(
+                              SELECT1,
+                              mockSpanner.createAbortedException(
+                                  ByteString.copyFromUtf8("some-tx"))));
+                    } else {
+                      mockSpanner.putStatementResult(
+                          StatementResult.query(SELECT1, SELECT1_RESULTSET));
+                    }
+                    try (ResultSet rs = transaction.executeQuery(SELECT1)) {
+                      while (rs.next()) {
+                        return rs.getLong(0);
+                      }
+                    }
+                    return 0L;
+                  }
+                });
+    assertThat(updateCount).isEqualTo(1L);
+    assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(1);
+    assertThat(countRequests(ExecuteSqlRequest.class)).isEqualTo(2);
+    assertThat(countRequests(CommitRequest.class)).isEqualTo(1);
+  }
+
+  @Test
+  public void testInlinedBeginFirstQueryReturnsUnavailable() {
+    DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+    mockSpanner.setExecuteStreamingSqlExecutionTime(
+        SimulatedExecutionTime.ofStreamException(Status.UNAVAILABLE.asRuntimeException(), 0));
+    long value =
+        client
+            .readWriteTransaction()
+            .run(
+                new TransactionCallable<Long>() {
+                  @Override
+                  public Long run(TransactionContext transaction) throws Exception {
+                    // The first attempt will return UNAVAILABLE and retry internally.
+                    try (ResultSet rs = transaction.executeQuery(SELECT1)) {
+                      while (rs.next()) {
+                        return rs.getLong(0);
+                      }
+                    }
+                    return 0L;
+                  }
+                });
+    assertThat(value).isEqualTo(1L);
+    assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(0);
+    assertThat(countRequests(ExecuteSqlRequest.class)).isEqualTo(2);
+    assertThat(countRequests(CommitRequest.class)).isEqualTo(1);
+  }
+
+  @Test
+  public void testInlinedBeginFirstReadReturnsUnavailable() {
+    DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+    mockSpanner.setStreamingReadExecutionTime(
+        SimulatedExecutionTime.ofStreamException(Status.UNAVAILABLE.asRuntimeException(), 0));
+    long value =
+        client
+            .readWriteTransaction()
+            .run(
+                new TransactionCallable<Long>() {
+                  @Override
+                  public Long run(TransactionContext transaction) throws Exception {
+                    // The first attempt will return UNAVAILABLE and retry internally.
+                    try (ResultSet rs =
+                        transaction.read("FOO", KeySet.all(), Arrays.asList("ID"))) {
+                      while (rs.next()) {
+                        return rs.getLong(0);
+                      }
+                    }
+                    return 0L;
+                  }
+                });
+    assertThat(value).isEqualTo(1L);
+    assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(0);
+    assertThat(countRequests(ReadRequest.class)).isEqualTo(2);
+    assertThat(countRequests(CommitRequest.class)).isEqualTo(1);
+  }
+
+  @Test
   public void testInlinedBeginTxWithQuery() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of("[PROJECT]", "[INSTANCE]", "[DATABASE]"));
@@ -279,8 +403,7 @@ public class InlineBeginTransactionTest {
 
   @Test
   public void testInlinedBeginTxWithRead() {
-    DatabaseClient client =
-        spanner.getDatabaseClient(DatabaseId.of("[PROJECT]", "[INSTANCE]", "[DATABASE]"));
+    DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
     long updateCount =
         client
             .readWriteTransaction()


### PR DESCRIPTION
If the first query or read operation of a read/write transaction would return UNAVAILABLE for the first element of the result stream, the transaction could get stuck. This was caused by the internal retry mechanism that would wait for the initial attempt to return a transaction, which was never returned as the UNAVAILABLE exception was internally handled by the result stream iterator.

Fixes #799 