### PR TITLE
feat: add support for JSON data type

### DIFF
--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -637,4 +637,46 @@
     <method>void setOptimizerStatisticsPackage(java.lang.String)</method>
   </difference>
 
+  <!-- Add support for JSON data type -->
+  <difference>
+    <differenceType>7013</differenceType>
+    <className>com/google/cloud/spanner/AbstractStructReader</className>
+    <method>java.lang.String getJsonInternal(int)</method>
+  </difference>
+  <difference>
+    <differenceType>7013</differenceType>
+    <className>com/google/cloud/spanner/AbstractStructReader</className>
+    <method>java.util.List getJsonListInternal(int)</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/StructReader</className>
+    <method>java.lang.String getJson(int)</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/StructReader</className>
+    <method>java.lang.String getJson(java.lang.String)</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/StructReader</className>
+    <method>java.util.List getJsonList(int)</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/StructReader</className>
+    <method>java.util.List getJsonList(java.lang.String)</method>
+  </difference>
+  <difference>
+    <differenceType>7013</differenceType>
+    <className>com/google/cloud/spanner/Value</className>
+    <method>java.lang.String getJson()</method>
+  </difference>
+  <difference>
+    <differenceType>7013</differenceType>
+    <className>com/google/cloud/spanner/Value</className>
+    <method>java.util.List getJsonArray()</method>
+  </difference>
+
 </differences>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
@@ -378,6 +378,9 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
           case STRING:
             builder.set(fieldName).to((String) value);
             break;
+          case JSON:
+            builder.set(fieldName).to(Value.json((String) value));
+            break;
           case BYTES:
             builder.set(fieldName).to((ByteArray) value);
             break;
@@ -403,6 +406,9 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
                 break;
               case STRING:
                 builder.set(fieldName).toStringArray((Iterable<String>) value);
+                break;
+              case JSON:
+                builder.set(fieldName).toJsonArray((Iterable<String>) value);
                 break;
               case BYTES:
                 builder.set(fieldName).toBytesArray((Iterable<ByteArray>) value);
@@ -480,6 +486,7 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
         case NUMERIC:
           return new BigDecimal(proto.getStringValue());
         case STRING:
+        case JSON:
           checkType(fieldType, proto, KindCase.STRING_VALUE);
           return proto.getStringValue();
         case BYTES:
@@ -543,6 +550,7 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
             return list;
           }
         case STRING:
+        case JSON:
           return Lists.transform(
               listValue.getValuesList(),
               input -> input.getKindCase() == KindCase.NULL_VALUE ? null : input.getStringValue());
@@ -651,6 +659,11 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
 
     @Override
     protected String getStringInternal(int columnIndex) {
+      return (String) rowData.get(columnIndex);
+    }
+
+    @Override
+    protected String getJsonInternal(int columnIndex) {
       return (String) rowData.get(columnIndex);
     }
 
@@ -779,6 +792,12 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
     @Override
     @SuppressWarnings("unchecked") // We know ARRAY<STRING> produces a List<String>.
     protected List<String> getStringListInternal(int columnIndex) {
+      return Collections.unmodifiableList((List<String>) rowData.get(columnIndex));
+    }
+
+    @Override
+    @SuppressWarnings("unchecked") // We know ARRAY<String> produces a List<String>.
+    protected List<String> getJsonListInternal(int columnIndex) {
       return Collections.unmodifiableList((List<String>) rowData.get(columnIndex));
     }
 
@@ -1309,6 +1328,11 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
   }
 
   @Override
+  protected String getJsonInternal(int columnIndex) {
+    return currRow().getJsonInternal(columnIndex);
+  }
+
+  @Override
   protected ByteArray getBytesInternal(int columnIndex) {
     return currRow().getBytesInternal(columnIndex);
   }
@@ -1366,6 +1390,11 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
   @Override
   protected List<String> getStringListInternal(int columnIndex) {
     return currRow().getStringListInternal(columnIndex);
+  }
+
+  @Override
+  protected List<String> getJsonListInternal(int columnIndex) {
+    return currRow().getJsonListInternal(columnIndex);
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractStructReader.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractStructReader.java
@@ -43,7 +43,9 @@ public abstract class AbstractStructReader implements StructReader {
 
   protected abstract String getStringInternal(int columnIndex);
 
-  protected abstract String getJsonInternal(int columnIndex);
+  protected String getJsonInternal(int columnIndex) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
 
   protected abstract ByteArray getBytesInternal(int columnIndex);
 
@@ -71,7 +73,9 @@ public abstract class AbstractStructReader implements StructReader {
 
   protected abstract List<String> getStringListInternal(int columnIndex);
 
-  protected abstract List<String> getJsonListInternal(int columnIndex);
+  protected List<String> getJsonListInternal(int columnIndex) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
 
   protected abstract List<ByteArray> getBytesListInternal(int columnIndex);
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractStructReader.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractStructReader.java
@@ -43,6 +43,8 @@ public abstract class AbstractStructReader implements StructReader {
 
   protected abstract String getStringInternal(int columnIndex);
 
+  protected abstract String getJsonInternal(int columnIndex);
+
   protected abstract ByteArray getBytesInternal(int columnIndex);
 
   protected abstract Timestamp getTimestampInternal(int columnIndex);
@@ -68,6 +70,8 @@ public abstract class AbstractStructReader implements StructReader {
   protected abstract List<BigDecimal> getBigDecimalListInternal(int columnIndex);
 
   protected abstract List<String> getStringListInternal(int columnIndex);
+
+  protected abstract List<String> getJsonListInternal(int columnIndex);
 
   protected abstract List<ByteArray> getBytesListInternal(int columnIndex);
 
@@ -160,6 +164,19 @@ public abstract class AbstractStructReader implements StructReader {
     int columnIndex = getColumnIndex(columnName);
     checkNonNullOfType(columnIndex, Type.string(), columnName);
     return getStringInternal(columnIndex);
+  }
+
+  @Override
+  public String getJson(int columnIndex) {
+    checkNonNullOfType(columnIndex, Type.json(), columnIndex);
+    return getJsonInternal(columnIndex);
+  }
+
+  @Override
+  public String getJson(String columnName) {
+    int columnIndex = getColumnIndex(columnName);
+    checkNonNullOfType(columnIndex, Type.json(), columnName);
+    return getJsonInternal(columnIndex);
   }
 
   @Override
@@ -315,6 +332,19 @@ public abstract class AbstractStructReader implements StructReader {
     int columnIndex = getColumnIndex(columnName);
     checkNonNullOfType(columnIndex, Type.array(Type.string()), columnName);
     return getStringListInternal(columnIndex);
+  }
+
+  @Override
+  public List<String> getJsonList(int columnIndex) {
+    checkNonNullOfType(columnIndex, Type.array(Type.json()), columnIndex);
+    return getJsonListInternal(columnIndex);
+  }
+
+  @Override
+  public List<String> getJsonList(String columnName) {
+    int columnIndex = getColumnIndex(columnName);
+    checkNonNullOfType(columnIndex, Type.array(Type.json()), columnName);
+    return getJsonListInternal(columnIndex);
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ForwardingStructReader.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ForwardingStructReader.java
@@ -157,6 +157,18 @@ public class ForwardingStructReader implements StructReader {
   }
 
   @Override
+  public String getJson(int columnIndex) {
+    checkValidState();
+    return delegate.get().getJson(columnIndex);
+  }
+
+  @Override
+  public String getJson(String columnName) {
+    checkValidState();
+    return delegate.get().getJson(columnName);
+  }
+
+  @Override
   public ByteArray getBytes(int columnIndex) {
     checkValidState();
     return delegate.get().getBytes(columnIndex);
@@ -284,6 +296,18 @@ public class ForwardingStructReader implements StructReader {
   public List<String> getStringList(String columnName) {
     checkValidState();
     return delegate.get().getStringList(columnName);
+  }
+
+  @Override
+  public List<String> getJsonList(int columnIndex) {
+    checkValidState();
+    return delegate.get().getJsonList(columnIndex);
+  }
+
+  @Override
+  public List<String> getJsonList(String columnName) {
+    checkValidState();
+    return delegate.get().getJsonList(columnName);
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Key.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Key.java
@@ -65,6 +65,7 @@ public final class Key implements Serializable {
    *   <li>{@code Float}, {@code Double} for the {@code FLOAT64} Cloud Spanner type
    *   <li>{@code BigDecimal} for the {@code NUMERIC} Cloud Spanner type
    *   <li>{@code String} for the {@code STRING} Cloud Spanner type
+   *   <li>{@code String} for the {@code JSON} Cloud Spanner type
    *   <li>{@link ByteArray} for the {@code BYTES} Cloud Spanner type
    *   <li>{@link Timestamp} for the {@code TIMESTAMP} Cloud Spanner type
    *   <li>{@link Date} for the {@code DATE} Cloud Spanner type
@@ -228,6 +229,7 @@ public final class Key implements Serializable {
    *   <li>{@code FLOAT64} is represented by {@code Double}
    *   <li>{@code NUMERIC} is represented by {@code BigDecimal}
    *   <li>{@code STRING} is represented by {@code String}
+   *   <li>{@code JSON} is represented by {@code String}
    *   <li>{@code BYTES} is represented by {@link ByteArray}
    *   <li>{@code TIMESTAMP} is represented by {@link Timestamp}
    *   <li>{@code DATE} is represented by {@link Date}

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ResultSets.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ResultSets.java
@@ -244,6 +244,16 @@ public final class ResultSets {
     }
 
     @Override
+    public String getJson(int columnIndex) {
+      return getCurrentRowAsStruct().getJson(columnIndex);
+    }
+
+    @Override
+    public String getJson(String columnName) {
+      return getCurrentRowAsStruct().getJson(columnName);
+    }
+
+    @Override
     public ByteArray getBytes(int columnIndex) {
       return getCurrentRowAsStruct().getBytes(columnIndex);
     }
@@ -361,6 +371,16 @@ public final class ResultSets {
     @Override
     public List<String> getStringList(String columnName) {
       return getCurrentRowAsStruct().getStringList(columnName);
+    }
+
+    @Override
+    public List<String> getJsonList(int columnIndex) {
+      return getCurrentRowAsStruct().getJsonList(columnIndex);
+    }
+
+    @Override
+    public List<String> getJsonList(String columnName) {
+      return getCurrentRowAsStruct().getJsonList(columnName);
     }
 
     @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Struct.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Struct.java
@@ -193,6 +193,11 @@ public abstract class Struct extends AbstractStructReader implements Serializabl
     }
 
     @Override
+    protected String getJsonInternal(int columnIndex) {
+      return values.get(columnIndex).getJson();
+    }
+
+    @Override
     protected ByteArray getBytesInternal(int columnIndex) {
       return values.get(columnIndex).getBytes();
     }
@@ -255,6 +260,11 @@ public abstract class Struct extends AbstractStructReader implements Serializabl
     @Override
     protected List<String> getStringListInternal(int columnIndex) {
       return values.get(columnIndex).getStringArray();
+    }
+
+    @Override
+    protected List<String> getJsonListInternal(int columnIndex) {
+      return values.get(columnIndex).getJsonArray();
     }
 
     @Override
@@ -341,6 +351,8 @@ public abstract class Struct extends AbstractStructReader implements Serializabl
         return getBigDecimalInternal(columnIndex);
       case STRING:
         return getStringInternal(columnIndex);
+      case JSON:
+        return getJsonInternal(columnIndex);
       case BYTES:
         return getBytesInternal(columnIndex);
       case TIMESTAMP:
@@ -361,6 +373,8 @@ public abstract class Struct extends AbstractStructReader implements Serializabl
             return getBigDecimalListInternal(columnIndex);
           case STRING:
             return getStringListInternal(columnIndex);
+          case JSON:
+            return getJsonListInternal(columnIndex);
           case BYTES:
             return getBytesListInternal(columnIndex);
           case TIMESTAMP:

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/StructReader.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/StructReader.java
@@ -117,7 +117,7 @@ public interface StructReader {
   };
 
   /** Returns the value of a non-{@code NULL} column with type {@link Type#string()}. */
-  default String getJson(int columnIndex){
+  default String getJson(int columnIndex) {
     throw new UnsupportedOperationException("method should be overwritten");
   };
 
@@ -239,12 +239,12 @@ public interface StructReader {
   List<String> getStringList(String columnName);
 
   /** Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.string())}. */
-  default List<String> getJsonList(int columnIndex){
+  default List<String> getJsonList(int columnIndex) {
     throw new UnsupportedOperationException("method should be overwritten");
   };
 
   /** Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.string())}. */
-  default List<String> getJsonList(String columnName){
+  default List<String> getJsonList(String columnName) {
     throw new UnsupportedOperationException("method should be overwritten");
   };
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/StructReader.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/StructReader.java
@@ -112,17 +112,17 @@ public interface StructReader {
   String getString(int columnIndex);
 
   /** Returns the value of a non-{@code NULL} column with type {@link Type#string()}. */
-  default String getString(String columnName) {
-    throw new UnsupportedOperationException("method should be overwritten");
-  };
+  String getString(String columnName);
 
   /** Returns the value of a non-{@code NULL} column with type {@link Type#string()}. */
   default String getJson(int columnIndex) {
     throw new UnsupportedOperationException("method should be overwritten");
-  };
+  }
 
   /** Returns the value of a non-{@code NULL} column with type {@link Type#string()}. */
-  String getJson(String columnName);
+  default String getJson(String columnName) {
+    throw new UnsupportedOperationException("method should be overwritten");
+  }
 
   /** Returns the value of a non-{@code NULL} column with type {@link Type#bytes()}. */
   ByteArray getBytes(int columnIndex);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/StructReader.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/StructReader.java
@@ -112,10 +112,14 @@ public interface StructReader {
   String getString(int columnIndex);
 
   /** Returns the value of a non-{@code NULL} column with type {@link Type#string()}. */
-  String getString(String columnName);
+  default String getString(String columnName) {
+    throw new UnsupportedOperationException("method should be overwritten");
+  };
 
   /** Returns the value of a non-{@code NULL} column with type {@link Type#string()}. */
-  String getJson(int columnIndex);
+  default String getJson(int columnIndex){
+    throw new UnsupportedOperationException("method should be overwritten");
+  };
 
   /** Returns the value of a non-{@code NULL} column with type {@link Type#string()}. */
   String getJson(String columnName);
@@ -235,10 +239,14 @@ public interface StructReader {
   List<String> getStringList(String columnName);
 
   /** Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.string())}. */
-  List<String> getJsonList(int columnIndex);
+  default List<String> getJsonList(int columnIndex){
+    throw new UnsupportedOperationException("method should be overwritten");
+  };
 
   /** Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.string())}. */
-  List<String> getJsonList(String columnName);
+  default List<String> getJsonList(String columnName){
+    throw new UnsupportedOperationException("method should be overwritten");
+  };
 
   /** Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.bytes())}. */
   List<ByteArray> getBytesList(int columnIndex);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/StructReader.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/StructReader.java
@@ -114,6 +114,12 @@ public interface StructReader {
   /** Returns the value of a non-{@code NULL} column with type {@link Type#string()}. */
   String getString(String columnName);
 
+  /** Returns the value of a non-{@code NULL} column with type {@link Type#string()}. */
+  String getJson(int columnIndex);
+
+  /** Returns the value of a non-{@code NULL} column with type {@link Type#string()}. */
+  String getJson(String columnName);
+
   /** Returns the value of a non-{@code NULL} column with type {@link Type#bytes()}. */
   ByteArray getBytes(int columnIndex);
 
@@ -227,6 +233,12 @@ public interface StructReader {
 
   /** Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.string())}. */
   List<String> getStringList(String columnName);
+
+  /** Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.string())}. */
+  List<String> getJsonList(int columnIndex);
+
+  /** Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.string())}. */
+  List<String> getJsonList(String columnName);
 
   /** Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.bytes())}. */
   List<ByteArray> getBytesList(int columnIndex);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Type.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Type.java
@@ -46,6 +46,7 @@ public final class Type implements Serializable {
   private static final Type TYPE_FLOAT64 = new Type(Code.FLOAT64, null, null);
   private static final Type TYPE_NUMERIC = new Type(Code.NUMERIC, null, null);
   private static final Type TYPE_STRING = new Type(Code.STRING, null, null);
+  private static final Type TYPE_JSON = new Type(Code.JSON, null, null);
   private static final Type TYPE_BYTES = new Type(Code.BYTES, null, null);
   private static final Type TYPE_TIMESTAMP = new Type(Code.TIMESTAMP, null, null);
   private static final Type TYPE_DATE = new Type(Code.DATE, null, null);
@@ -54,6 +55,7 @@ public final class Type implements Serializable {
   private static final Type TYPE_ARRAY_FLOAT64 = new Type(Code.ARRAY, TYPE_FLOAT64, null);
   private static final Type TYPE_ARRAY_NUMERIC = new Type(Code.ARRAY, TYPE_NUMERIC, null);
   private static final Type TYPE_ARRAY_STRING = new Type(Code.ARRAY, TYPE_STRING, null);
+  private static final Type TYPE_ARRAY_JSON = new Type(Code.ARRAY, TYPE_JSON, null);
   private static final Type TYPE_ARRAY_BYTES = new Type(Code.ARRAY, TYPE_BYTES, null);
   private static final Type TYPE_ARRAY_TIMESTAMP = new Type(Code.ARRAY, TYPE_TIMESTAMP, null);
   private static final Type TYPE_ARRAY_DATE = new Type(Code.ARRAY, TYPE_DATE, null);
@@ -94,6 +96,11 @@ public final class Type implements Serializable {
     return TYPE_STRING;
   }
 
+  /** Returns the descriptor for the {@code JSON} type. */
+  public static Type json() {
+    return TYPE_JSON;
+  }
+
   /** Returns the descriptor for the {@code BYTES} type: a variable-length byte string. */
   public static Type bytes() {
     return TYPE_BYTES;
@@ -129,6 +136,8 @@ public final class Type implements Serializable {
         return TYPE_ARRAY_NUMERIC;
       case STRING:
         return TYPE_ARRAY_STRING;
+      case JSON:
+        return TYPE_ARRAY_JSON;
       case BYTES:
         return TYPE_ARRAY_BYTES;
       case TIMESTAMP:
@@ -182,6 +191,7 @@ public final class Type implements Serializable {
     NUMERIC(TypeCode.NUMERIC),
     FLOAT64(TypeCode.FLOAT64),
     STRING(TypeCode.STRING),
+    JSON(TypeCode.JSON),
     BYTES(TypeCode.BYTES),
     TIMESTAMP(TypeCode.TIMESTAMP),
     DATE(TypeCode.DATE),
@@ -394,6 +404,8 @@ public final class Type implements Serializable {
         return numeric();
       case STRING:
         return string();
+      case JSON:
+        return json();
       case BYTES:
         return bytes();
       case TIMESTAMP:

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Value.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Value.java
@@ -167,6 +167,15 @@ public abstract class Value implements Serializable {
   }
 
   /**
+   * Returns a {@code STRING} value.
+   *
+   * @param v the value, which may be null
+   */
+  public static Value json(@Nullable String v) {
+    return new JsonImpl(v == null, v);
+  }
+
+  /**
    * Returns a {@code BYTES} value.
    *
    * @param v the value, which may be null
@@ -340,6 +349,16 @@ public abstract class Value implements Serializable {
   }
 
   /**
+   * Returns an {@code ARRAY<STRING>} value.
+   *
+   * @param v the source of element values. This may be {@code null} to produce a value for which
+   *     {@code isNull()} is {@code true}. Individual elements may also be {@code null}.
+   */
+  public static Value jsonArray(@Nullable Iterable<String> v) {
+    return new JsonArrayImpl(v == null, v == null ? null : immutableCopyOf(v));
+  }
+
+  /**
    * Returns an {@code ARRAY<BYTES>} value.
    *
    * @param v the source of element values. This may be {@code null} to produce a value for which
@@ -442,6 +461,13 @@ public abstract class Value implements Serializable {
   public abstract String getString();
 
   /**
+   * Returns the value of a {@code JSON}-typed instance.
+   *
+   * @throws IllegalStateException if {@code isNull()} or the value is not of the expected type
+   */
+  public abstract String getJson();
+
+  /**
    * Returns the value of a {@code BYTES}-typed instance.
    *
    * @throws IllegalStateException if {@code isNull()} or the value is not of the expected type
@@ -512,6 +538,14 @@ public abstract class Value implements Serializable {
    * @throws IllegalStateException if {@code isNull()} or the value is not of the expected type
    */
   public abstract List<String> getStringArray();
+
+  /**
+   * Returns the value of an {@code ARRAY<JSON>}-typed instance. While the returned list itself will
+   * never be {@code null}, elements of that list may be null.
+   *
+   * @throws IllegalStateException if {@code isNull()} or the value is not of the expected type
+   */
+  public abstract List<String> getJsonArray();
 
   /**
    * Returns the value of an {@code ARRAY<BYTES>}-typed instance. While the returned list itself
@@ -721,6 +755,11 @@ public abstract class Value implements Serializable {
     }
 
     @Override
+    public String getJson() {
+      throw defaultGetter(Type.json());
+    }
+
+    @Override
     public ByteArray getBytes() {
       throw defaultGetter(Type.bytes());
     }
@@ -767,6 +806,11 @@ public abstract class Value implements Serializable {
     @Override
     public List<String> getStringArray() {
       throw defaultGetter(Type.array(Type.string()));
+    }
+
+    @Override
+    public List<String> getJsonArray() {
+      throw defaultGetter(Type.array(Type.json()));
     }
 
     @Override
@@ -1042,6 +1086,29 @@ public abstract class Value implements Serializable {
     @Override
     public String getString() {
       checkType(Type.string());
+      checkNotNull();
+      return value;
+    }
+
+    @Override
+    void valueToString(StringBuilder b) {
+      if (value.length() > MAX_DEBUG_STRING_LENGTH) {
+        b.append(value, 0, MAX_DEBUG_STRING_LENGTH - ELLIPSIS.length()).append(ELLIPSIS);
+      } else {
+        b.append(value);
+      }
+    }
+  }
+
+  private static class JsonImpl extends AbstractObjectValue<String> {
+
+    private JsonImpl(boolean isNull, @Nullable String value) {
+      super(isNull, Type.json(), value);
+    }
+
+    @Override
+    public String getJson() {
+      checkType(Type.json());
       checkNotNull();
       return value;
     }
@@ -1410,6 +1477,25 @@ public abstract class Value implements Serializable {
     }
   }
 
+  private static class JsonArrayImpl extends AbstractArrayValue<String> {
+
+    private JsonArrayImpl(boolean isNull, @Nullable List<String> values) {
+      super(isNull, Type.json(), values);
+    }
+
+    @Override
+    public List<String> getJsonArray() {
+      checkType(getType());
+      checkNotNull();
+      return value;
+    }
+
+    @Override
+    void appendElement(StringBuilder b, String element) {
+      b.append(element);
+    }
+  }
+
   private static class BytesArrayImpl extends AbstractArrayValue<ByteArray> {
     private BytesArrayImpl(boolean isNull, @Nullable List<ByteArray> values) {
       super(isNull, Type.bytes(), values);
@@ -1533,6 +1619,8 @@ public abstract class Value implements Serializable {
           return Value.int64(value.getLong(fieldIndex));
         case STRING:
           return Value.string(value.getString(fieldIndex));
+        case JSON:
+          return Value.json(value.getJson(fieldIndex));
         case BYTES:
           return Value.bytes(value.getBytes(fieldIndex));
         case FLOAT64:
@@ -1555,6 +1643,8 @@ public abstract class Value implements Serializable {
                 return Value.int64Array(value.getLongList(fieldIndex));
               case STRING:
                 return Value.stringArray(value.getStringList(fieldIndex));
+              case JSON:
+                return Value.jsonArray(value.getJsonList(fieldIndex));
               case BYTES:
                 return Value.bytesArray(value.getBytesList(fieldIndex));
               case FLOAT64:

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Value.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Value.java
@@ -465,7 +465,9 @@ public abstract class Value implements Serializable {
    *
    * @throws IllegalStateException if {@code isNull()} or the value is not of the expected type
    */
-  public abstract String getJson();
+  public String getJson() {
+    throw new UnsupportedOperationException("Not implemented");
+  }
 
   /**
    * Returns the value of a {@code BYTES}-typed instance.
@@ -545,7 +547,9 @@ public abstract class Value implements Serializable {
    *
    * @throws IllegalStateException if {@code isNull()} or the value is not of the expected type
    */
-  public abstract List<String> getJsonArray();
+  public List<String> getJsonArray() {
+    throw new UnsupportedOperationException("Not implemented");
+  }
 
   /**
    * Returns the value of an {@code ARRAY<BYTES>}-typed instance. While the returned list itself

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ValueBinder.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ValueBinder.java
@@ -178,6 +178,11 @@ public abstract class ValueBinder<R> {
     return handle(Value.stringArray(values));
   }
 
+  /** Binds to {@code Value.jsonArray(values)} */
+  public R toJsonArray(@Nullable Iterable<String> values) {
+    return handle(Value.jsonArray(values));
+  }
+
   /** Binds to {@code Value.bytesArray(values)} */
   public R toBytesArray(@Nullable Iterable<ByteArray> values) {
     return handle(Value.bytesArray(values));

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ChecksumResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ChecksumResultSet.java
@@ -242,6 +242,9 @@ class ChecksumResultSet extends ReplaceableForwardingResultSet implements Retria
             case STRING:
               funnelValue(type, row.getString(i), into);
               break;
+            case JSON:
+              funnelValue(type, row.getJson(i), into);
+              break;
             case TIMESTAMP:
               funnelValue(type, row.getTimestamp(i), into);
               break;
@@ -300,6 +303,12 @@ class ChecksumResultSet extends ReplaceableForwardingResultSet implements Retria
             funnelValue(Code.STRING, value, into);
           }
           break;
+        case JSON:
+          into.putInt(row.getJsonList(columnIndex).size());
+          for (String value : row.getJsonList(columnIndex)) {
+            funnelValue(Code.JSON, value, into);
+          }
+          break;
         case TIMESTAMP:
           into.putInt(row.getTimestampList(columnIndex).size());
           for (Timestamp value : row.getTimestampList(columnIndex)) {
@@ -350,6 +359,7 @@ class ChecksumResultSet extends ReplaceableForwardingResultSet implements Retria
             into.putLong((Long) value);
             break;
           case STRING:
+          case JSON:
             String stringValue = (String) value;
             into.putInt(stringValue.length());
             into.putUnencodedChars(stringValue);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DirectExecuteResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DirectExecuteResultSet.java
@@ -197,6 +197,18 @@ class DirectExecuteResultSet implements ResultSet {
   }
 
   @Override
+  public String getJson(int columnIndex) {
+    Preconditions.checkState(nextCalledByClient, MISSING_NEXT_CALL);
+    return delegate.getJson(columnIndex);
+  }
+
+  @Override
+  public String getJson(String columnName) {
+    Preconditions.checkState(nextCalledByClient, MISSING_NEXT_CALL);
+    return delegate.getJson(columnName);
+  }
+
+  @Override
   public ByteArray getBytes(int columnIndex) {
     Preconditions.checkState(nextCalledByClient, MISSING_NEXT_CALL);
     return delegate.getBytes(columnIndex);
@@ -338,6 +350,18 @@ class DirectExecuteResultSet implements ResultSet {
   public List<String> getStringList(String columnName) {
     Preconditions.checkState(nextCalledByClient, MISSING_NEXT_CALL);
     return delegate.getStringList(columnName);
+  }
+
+  @Override
+  public List<String> getJsonList(int columnIndex) {
+    Preconditions.checkState(nextCalledByClient, MISSING_NEXT_CALL);
+    return delegate.getJsonList(columnIndex);
+  }
+
+  @Override
+  public List<String> getJsonList(String columnName) {
+    Preconditions.checkState(nextCalledByClient, MISSING_NEXT_CALL);
+    return delegate.getJsonList(columnName);
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ReplaceableForwardingResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ReplaceableForwardingResultSet.java
@@ -197,6 +197,18 @@ class ReplaceableForwardingResultSet implements ResultSet {
   }
 
   @Override
+  public String getJson(int columnIndex) {
+    checkClosed();
+    return delegate.getJson(columnIndex);
+  }
+
+  @Override
+  public String getJson(String columnName) {
+    checkClosed();
+    return delegate.getJson(columnName);
+  }
+
+  @Override
   public ByteArray getBytes(int columnIndex) {
     checkClosed();
     return delegate.getBytes(columnIndex);
@@ -338,6 +350,18 @@ class ReplaceableForwardingResultSet implements ResultSet {
   public List<String> getStringList(String columnName) {
     checkClosed();
     return delegate.getStringList(columnName);
+  }
+
+  @Override
+  public List<String> getJsonList(int columnIndex) {
+    checkClosed();
+    return delegate.getJsonList(columnIndex);
+  }
+
+  @Override
+  public List<String> getJsonList(String columnName) {
+    checkClosed();
+    return delegate.getJsonList(columnName);
   }
 
   @Override

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractStructReaderTypesTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractStructReaderTypesTest.java
@@ -71,6 +71,11 @@ public class AbstractStructReaderTypesTest {
     }
 
     @Override
+    protected String getJsonInternal(int columnIndex) {
+      return null;
+    }
+
+    @Override
     protected ByteArray getBytesInternal(int columnIndex) {
       return null;
     }
@@ -127,6 +132,11 @@ public class AbstractStructReaderTypesTest {
 
     @Override
     protected List<String> getStringListInternal(int columnIndex) {
+      return null;
+    }
+
+    @Override
+    protected List<String> getJsonListInternal(int columnIndex) {
       return null;
     }
 
@@ -205,6 +215,13 @@ public class AbstractStructReaderTypesTest {
             Collections.singletonList("getValue")
           },
           {
+            Type.json(),
+            "getJsonInternal",
+            "{\"color\":\"red\",\"value\":\"#f00\"}",
+            "getJson",
+            Collections.singletonList("getValue")
+          },
+          {
             Type.timestamp(),
             "getTimestampInternal",
             Timestamp.parseTimestamp("2015-09-15T00:00:00Z"),
@@ -272,6 +289,13 @@ public class AbstractStructReaderTypesTest {
             "getStringListInternal",
             Arrays.asList("a", "b", "c"),
             "getStringList",
+            Collections.singletonList("getValue")
+          },
+          {
+            Type.array(Type.json()),
+            "getJsonListInternal",
+            Arrays.asList("{}", "{\"color\":\"red\",\"value\":\"#f00\"}", "[]"),
+            "getJsonList",
             Collections.singletonList("getValue")
           },
           {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/KeyTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/KeyTest.java
@@ -51,6 +51,7 @@ public class KeyTest {
     String numeric = "3.141592";
     String timestamp = "2015-09-15T00:00:00Z";
     String date = "2015-09-15";
+    String json = "{\"color\":\"red\",\"value\":\"#f00\"}";
     k =
         Key.of(
             null,
@@ -61,10 +62,11 @@ public class KeyTest {
             4.0d,
             new BigDecimal(numeric),
             "x",
+            json,
             ByteArray.copyFrom("y"),
             Timestamp.parseTimestamp(timestamp),
             Date.parseDate(date));
-    assertThat(k.size()).isEqualTo(11);
+    assertThat(k.size()).isEqualTo(12);
     assertThat(k.getParts())
         .containsExactly(
             null,
@@ -75,6 +77,7 @@ public class KeyTest {
             4.0d,
             BigDecimal.valueOf(3141592, 6),
             "x",
+            json,
             ByteArray.copyFrom("y"),
             Timestamp.parseTimestamp(timestamp),
             Date.parseDate(date))
@@ -91,6 +94,7 @@ public class KeyTest {
     String numeric = "3.141592";
     String timestamp = "2015-09-15T00:00:00Z";
     String date = "2015-09-15";
+    String json = "{\"color\":\"red\",\"value\":\"#f00\"}";
     Key k =
         Key.newBuilder()
             .append((Boolean) null)
@@ -101,11 +105,12 @@ public class KeyTest {
             .append(4.0d)
             .append(new BigDecimal(numeric))
             .append("x")
+            .append(json)
             .append(ByteArray.copyFrom("y"))
             .append(Timestamp.parseTimestamp(timestamp))
             .append(Date.parseDate(date))
             .build();
-    assertThat(k.size()).isEqualTo(11);
+    assertThat(k.size()).isEqualTo(12);
     assertThat(k.getParts())
         .containsExactly(
             null,
@@ -116,6 +121,7 @@ public class KeyTest {
             4.0d,
             BigDecimal.valueOf(3141592, 6),
             "x",
+            json,
             ByteArray.copyFrom("y"),
             Timestamp.parseTimestamp(timestamp),
             Date.parseDate(date))
@@ -138,6 +144,8 @@ public class KeyTest {
     assertThat(Key.of(2.0).toString()).isEqualTo("[2.0]");
     assertThat(Key.of(new BigDecimal("3.14")).toString()).isEqualTo("[3.14]");
     assertThat(Key.of("xyz").toString()).isEqualTo("[xyz]");
+    assertThat(Key.of("{\"color\":\"red\",\"value\":\"#f00\"}").toString())
+        .isEqualTo("[{\"color\":\"red\",\"value\":\"#f00\"}]");
     ByteArray b = ByteArray.copyFrom("xyz");
     assertThat(Key.of(b).toString()).isEqualTo("[" + b.toString() + "]");
     String timestamp = "2015-09-15T00:00:00Z";
@@ -182,6 +190,9 @@ public class KeyTest {
     tester.addEqualityGroup(Key.of("a", "b", "c"));
     tester.addEqualityGroup(
         Key.of(ByteArray.copyFrom("a")), Key.newBuilder().append(ByteArray.copyFrom("a")).build());
+    tester.addEqualityGroup(
+        Key.of("{\"color\":\"red\",\"value\":\"#f00\"}"),
+        Key.newBuilder().append("{\"color\":\"red\",\"value\":\"#f00\"}").build());
     Timestamp t = Timestamp.parseTimestamp("2015-09-15T00:00:00Z");
     tester.addEqualityGroup(Key.of(t), Key.newBuilder().append(t).build());
     Date d = Date.parseDate("2016-09-15");
@@ -200,6 +211,7 @@ public class KeyTest {
     reserializeAndAssert(Key.of(2.0));
     reserializeAndAssert(Key.of(new BigDecimal("3.141592")));
     reserializeAndAssert(Key.of("xyz"));
+    reserializeAndAssert(Key.of("{\"color\":\"red\",\"value\":\"#f00\"}"));
     reserializeAndAssert(Key.of(ByteArray.copyFrom("xyz")));
     reserializeAndAssert(Key.of(Timestamp.parseTimestamp("2015-09-15T00:00:00Z")));
     reserializeAndAssert(Key.of(Date.parseDate("2015-09-15")));
@@ -220,6 +232,7 @@ public class KeyTest {
             .append(4.0d)
             .append(new BigDecimal("6.62607004e-34"))
             .append("x")
+            .append("{\"color\":\"red\",\"value\":\"#f00\"}")
             .append(ByteArray.copyFrom("y"))
             .append(Timestamp.parseTimestamp(timestamp))
             .append(Date.parseDate(date))
@@ -233,6 +246,7 @@ public class KeyTest {
     builder.addValuesBuilder().setNumberValue(4.0d);
     builder.addValuesBuilder().setStringValue("6.62607004E-34");
     builder.addValuesBuilder().setStringValue("x");
+    builder.addValuesBuilder().setStringValue("{\"color\":\"red\",\"value\":\"#f00\"}");
     builder.addValuesBuilder().setStringValue("eQ==");
     builder.addValuesBuilder().setStringValue(timestamp);
     builder.addValuesBuilder().setStringValue(date);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -1202,6 +1202,9 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
               case TIMESTAMP:
                 builder.bind(entry.getKey()).toTimestampArray(null);
                 break;
+              case JSON:
+                builder.bind(entry.getKey()).toJsonArray(null);
+                break;
               case STRUCT:
               case TYPE_CODE_UNSPECIFIED:
               case UNRECOGNIZED:
@@ -1234,6 +1237,9 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
             break;
           case TIMESTAMP:
             builder.bind(entry.getKey()).to((com.google.cloud.Timestamp) null);
+            break;
+          case JSON:
+            builder.bind(entry.getKey()).to(Value.json((String) null));
             break;
           case TYPE_CODE_UNSPECIFIED:
           case UNRECOGNIZED:
@@ -1301,6 +1307,14 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
                             GrpcStruct.decodeArrayValue(
                                 com.google.cloud.spanner.Type.timestamp(), value.getListValue()));
                 break;
+              case JSON:
+                builder
+                    .bind(entry.getKey())
+                    .toJsonArray(
+                        (Iterable<String>)
+                            GrpcStruct.decodeArrayValue(
+                                com.google.cloud.spanner.Type.json(), value.getListValue()));
+                break;
               case STRUCT:
               case TYPE_CODE_UNSPECIFIED:
               case UNRECOGNIZED:
@@ -1334,6 +1348,9 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
             builder
                 .bind(entry.getKey())
                 .to(com.google.cloud.Timestamp.parseTimestamp(value.getStringValue()));
+            break;
+          case JSON:
+            builder.bind(entry.getKey()).to(Value.json(value.getStringValue()));
             break;
           case TYPE_CODE_UNSPECIFIED:
           case UNRECOGNIZED:

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadFormatTestRunner.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadFormatTestRunner.java
@@ -158,6 +158,9 @@ public class ReadFormatTestRunner extends ParentRunner<JSONObject> {
           case STRING:
             assertThat(actualRow.getString(i)).isEqualTo(expectedRow.getString(i));
             break;
+          case JSON:
+            assertThat(actualRow.getJson(i)).isEqualTo(expectedRow.getString(i));
+            break;
           case INT64:
             assertThat(actualRow.getLong(i)).isEqualTo(expectedRow.getLong(i));
             break;
@@ -189,6 +192,9 @@ public class ReadFormatTestRunner extends ParentRunner<JSONObject> {
           break;
         case STRING:
           rawList = actualRow.getStringList(index);
+          break;
+        case JSON:
+          rawList = actualRow.getJsonList(index);
           break;
         case BYTES:
           rawList = actualRow.getBytesList(index);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TypeTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TypeTest.java
@@ -22,6 +22,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
+import com.google.cloud.spanner.Type.Code;
 import com.google.spanner.v1.TypeCode;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
@@ -110,6 +111,16 @@ public class TypeTest {
       @Override
       Type newType() {
         return Type.string();
+      }
+    }.test();
+  }
+
+  @Test
+  public void json() {
+    new ScalarTypeTester(Code.JSON, TypeCode.JSON) {
+      @Override
+      Type newType() {
+        return Type.json();
       }
     }.test();
   }
@@ -229,6 +240,16 @@ public class TypeTest {
       @Override
       Type newElementType() {
         return Type.string();
+      }
+    }.test();
+  }
+
+  @Test
+  public void jsonArray() {
+    new ArrayTypeTester(Code.JSON, TypeCode.JSON, true) {
+      @Override
+      Type newElementType() {
+        return Type.json();
       }
     }.test();
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueBinderTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueBinderTest.java
@@ -115,7 +115,7 @@ public class ValueBinderTest {
       } else if (binderMethod.getParameterTypes().length == 1) {
         // Test unary null.
         if (!binderMethod.getParameterTypes()[0].isPrimitive()) {
-          if (method.getName().toLowerCase().equals(JSON_METHOD_NAME)) {
+          if (method.getName().equalsIgnoreCase(JSON_METHOD_NAME)) {
             // Special case for json to change the method from ValueBinder.to(String) to
             // ValueBinder.to(Value)
             binderMethod = ValueBinder.class.getMethod("to", Value.class);
@@ -131,7 +131,7 @@ public class ValueBinderTest {
         }
         // Test unary non-null.
         Object defaultObject;
-        if (method.getName().toLowerCase().equals(JSON_METHOD_NAME)) {
+        if (method.getName().equalsIgnoreCase(JSON_METHOD_NAME)) {
           defaultObject = defaultJson();
           binderMethod = ValueBinder.class.getMethod("to", Value.class);
           assertThat(binderMethod.invoke(binder, Value.json(defaultJson())))

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueBinderTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueBinderTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spanner;
 
+import static com.google.cloud.spanner.ValueBinderTest.DefaultValues.defaultJson;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
@@ -35,6 +36,8 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link com.google.cloud.spanner.ValueBinder}. */
 @RunWith(JUnit4.class)
 public class ValueBinderTest {
+  private static final String JSON_METHOD_NAME = "json";
+
   private Value lastValue;
   private int lastReturnValue;
   private ValueBinder<Integer> binder = new BinderImpl();
@@ -48,7 +51,8 @@ public class ValueBinderTest {
   }
 
   @Test
-  public void reflection() throws InvocationTargetException, IllegalAccessException {
+  public void reflection()
+      throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
     // Test that every Value factory method has a counterpart in ValueBinder, and that invoking it
     // produces the expected Value.
     for (Method method : Value.class.getMethods()) {
@@ -111,17 +115,32 @@ public class ValueBinderTest {
       } else if (binderMethod.getParameterTypes().length == 1) {
         // Test unary null.
         if (!binderMethod.getParameterTypes()[0].isPrimitive()) {
+          if (method.getName().toLowerCase().equals(JSON_METHOD_NAME)) {
+            // Special case for json to change the method from ValueBinder.to(String) to
+            // ValueBinder.to(Value)
+            binderMethod = ValueBinder.class.getMethod("to", Value.class);
+            assertThat(binderMethod.invoke(binder, Value.json(null))).isEqualTo(lastReturnValue);
+          } else {
+            assertThat(binderMethod.invoke(binder, (Object) null)).isEqualTo(lastReturnValue);
+          }
           Value expected = (Value) method.invoke(Value.class, (Object) null);
-          assertThat(binderMethod.invoke(binder, (Object) null)).isEqualTo(lastReturnValue);
           assertThat(lastValue).isEqualTo(expected);
 
           assertThat(binder.to(expected)).isEqualTo(lastReturnValue);
           assertThat(lastValue).isEqualTo(expected);
         }
         // Test unary non-null.
-        Object defaultObject = DefaultValues.getDefault(method.getGenericParameterTypes()[0]);
+        Object defaultObject;
+        if (method.getName().toLowerCase().equals(JSON_METHOD_NAME)) {
+          defaultObject = defaultJson();
+          binderMethod = ValueBinder.class.getMethod("to", Value.class);
+          assertThat(binderMethod.invoke(binder, Value.json(defaultJson())))
+              .isEqualTo(lastReturnValue);
+        } else {
+          defaultObject = DefaultValues.getDefault(method.getGenericParameterTypes()[0]);
+          assertThat(binderMethod.invoke(binder, defaultObject)).isEqualTo(lastReturnValue);
+        }
         Value expected = (Value) method.invoke(Value.class, defaultObject);
-        assertThat(binderMethod.invoke(binder, defaultObject)).isEqualTo(lastReturnValue);
         assertThat(lastValue).isEqualTo(expected);
 
         assertThat(binder.to(expected)).isEqualTo(lastReturnValue);
@@ -195,6 +214,10 @@ public class ValueBinderTest {
       return "x";
     }
 
+    public static String defaultJson() {
+      return "{\"color\":\"red\",\"value\":\"#f00\"}";
+    }
+
     public static ByteArray defaultByteArray() {
       return ByteArray.copyFrom(new byte[] {'x'});
     }
@@ -237,6 +260,10 @@ public class ValueBinderTest {
 
     public static Iterable<String> defaultStringIterable() {
       return Arrays.asList("a", "b");
+    }
+
+    public static Iterable<String> defaultJsonIterable() {
+      return Arrays.asList("{}", "[]", "{\"color\":\"red\",\"value\":\"#f00\"}");
     }
 
     public static Iterable<ByteArray> defaultByteArrayIterable() {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueTest.java
@@ -20,7 +20,10 @@ import static com.google.common.testing.SerializableTester.reserializeAndAssert;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
@@ -358,6 +361,59 @@ public class ValueTest {
   }
 
   @Test
+  public void json() {
+    String json = "{\"color\":\"red\",\"value\":\"#f00\"}";
+    Value v = Value.json(json);
+    assertEquals(Type.json(), v.getType());
+    assertFalse(v.isNull());
+    assertEquals(json, v.getJson());
+  }
+
+  @Test
+  public void jsonNull() {
+    Value v = Value.json(null);
+    assertEquals(Type.json(), v.getType());
+    assertTrue(v.isNull());
+    assertEquals(NULL_STRING, v.toString());
+    try {
+      v.getJson();
+      fail("Expected exception");
+    } catch (IllegalStateException e) {
+      assertThat(e.getMessage().contains("null value"));
+    }
+  }
+
+  @Test
+  public void jsonEmpty() {
+    String json = "{}";
+    Value v = Value.json(json);
+    assertEquals(json, v.getJson());
+  }
+
+  @Test
+  public void jsonWithEmptyArray() {
+    String json = "[]";
+    Value v = Value.json(json);
+    assertEquals(json, v.getJson());
+  }
+
+  @Test
+  public void jsonWithArray() {
+    String json =
+        "[{\"color\":\"red\",\"value\":\"#f00\"},{\"color\":\"green\",\"value\":\"#0f0\"},{\"color\":\"blue\",\"value\":\"#00f\"},{\"color\":\"cyan\",\"value\":\"#0ff\"},{\"color\":\"magenta\",\"value\":\"#f0f\"},{\"color\":\"yellow\",\"value\":\"#ff0\"},{\"color\":\"black\",\"value\":\"#000\"}]";
+    Value v = Value.json(json);
+    assertEquals(json, v.getJson());
+  }
+
+  @Test
+  public void jsonNested() {
+    String json =
+        "[{\"id\":\"0001\",\"type\":\"donut\",\"name\":\"Cake\",\"ppu\":0.55,\"batters\":{\"batter\":[{\"id\":\"1001\",\"type\":\"Regular\"},{\"id\":\"1002\",\"type\":\"Chocolate\"},{\"id\":\"1003\",\"type\":\"Blueberry\"},{\"id\":\"1004\",\"type\":\"Devil's Food\"}]},\"topping\":[{\"id\":\"5001\",\"type\":\"None\"},{\"id\":\"5002\",\"type\":\"Glazed\"},{\"id\":\"5005\",\"type\":\"Sugar\"},{\"id\":\"5007\",\"type\":\"Powdered Sugar\"},{\"id\":\"5006\",\"type\":\"Chocolate with Sprinkles\"},{\"id\":\"5003\",\"type\":\"Chocolate\"},{\"id\":\"5004\",\"type\":\"Maple\"}]},{\"id\":\"0002\",\"type\":\"donut\",\"name\":\"Raised\",\"ppu\":0.55,\"batters\":{\"batter\":[{\"id\":\"1001\",\"type\":\"Regular\"}]},\"topping\":[{\"id\":\"5001\",\"type\":\"None\"},{\"id\":\"5002\",\"type\":\"Glazed\"},{\"id\":\"5005\",\"type\":\"Sugar\"},{\"id\":\"5003\",\"type\":\"Chocolate\"},{\"id\":\"5004\",\"type\":\"Maple\"}]},{\"id\":\"0003\",\"type\":\"donut\",\"name\":\"Old Fashioned\",\"ppu\":0.55,\"batters\":{\"batter\":[{\"id\":\"1001\",\"type\":\"Regular\"},{\"id\":\"1002\",\"type\":\"Chocolate\"}]},\"topping\":[{\"id\":\"5001\",\"type\":\"None\"},{\"id\":\"5002\",\"type\":\"Glazed\"},{\"id\":\"5003\",\"type\":\"Chocolate\"},{\"id\":\"5004\",\"type\":\"Maple\"}]}]";
+    Value v = Value.json(json);
+    assertEquals(json, v.getJson());
+  }
+
+  @Test
   public void bytes() {
     ByteArray bytes = newByteArray("abc");
     Value v = Value.bytes(bytes);
@@ -674,6 +730,52 @@ public class ValueTest {
   }
 
   @Test
+  public void jsonArray() {
+    String one = "{}";
+    String two = null;
+    String three = "{\"color\":\"red\",\"value\":\"#f00\"}";
+    Value v = Value.jsonArray(Arrays.asList(one, two, three));
+    assertFalse(v.isNull());
+    assertThat(v.getJsonArray()).containsExactly(one, two, three).inOrder();
+    assertEquals("[{},NULL,{\"color\":\"red\",\"value\":\"#f00\"}]", v.toString());
+  }
+
+  @Test
+  public void jsonArrayNull() {
+    Value v = Value.jsonArray(null);
+    assertTrue(v.isNull());
+    assertEquals(NULL_STRING, v.toString());
+    try {
+      v.getJsonArray();
+      fail("Expected exception");
+    } catch (IllegalStateException e) {
+      assertThat(e.getMessage().contains("null value"));
+    }
+  }
+
+  @Test
+  public void jsonArrayTryGetBytesArray() {
+    Value value = Value.jsonArray(Arrays.asList("{}"));
+    try {
+      value.getBytesArray();
+      fail("Expected exception");
+    } catch (IllegalStateException e) {
+      assertThat(e.getMessage().contains("Expected: ARRAY<BYTES> actual: ARRAY<JSON>"));
+    }
+  }
+
+  @Test
+  public void jsonArrayTryGetStringArray() {
+    Value value = Value.jsonArray(Arrays.asList("{}"));
+    try {
+      value.getStringArray();
+      fail("Expected exception");
+    } catch (IllegalStateException e) {
+      assertThat(e.getMessage().contains("Expected: ARRAY<STRING> actual: ARRAY<JSON>"));
+    }
+  }
+
+  @Test
   public void bytesArray() {
     ByteArray a = newByteArray("a");
     ByteArray c = newByteArray("c");
@@ -929,6 +1031,13 @@ public class ValueTest {
         Value.string(null).toProto());
 
     assertEquals(
+        com.google.protobuf.Value.newBuilder().setStringValue("{}").build(),
+        Value.json("{}").toProto());
+    assertEquals(
+        com.google.protobuf.Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build(),
+        Value.json(null).toProto());
+
+    assertEquals(
         com.google.protobuf.Value.newBuilder()
             .setStringValue(ByteArray.copyFrom("test").toBase64())
             .build(),
@@ -1010,6 +1119,18 @@ public class ValueTest {
                                 .build())))
             .build(),
         Value.stringArray(Arrays.asList("test", null)).toProto());
+    assertEquals(
+        com.google.protobuf.Value.newBuilder()
+            .setListValue(
+                ListValue.newBuilder()
+                    .addAllValues(
+                        Arrays.asList(
+                            com.google.protobuf.Value.newBuilder().setStringValue("{}").build(),
+                            com.google.protobuf.Value.newBuilder()
+                                .setNullValue(NullValue.NULL_VALUE)
+                                .build())))
+            .build(),
+        Value.jsonArray(Arrays.asList("{}", null)).toProto());
     assertEquals(
         com.google.protobuf.Value.newBuilder()
             .setListValue(
@@ -1271,6 +1392,8 @@ public class ValueTest {
   @Test
   public void testEqualsHashCode() {
     EqualsTester tester = new EqualsTester();
+    String emptyJson = "{}";
+    String simpleJson = "{\"color\":\"red\",\"value\":\"#f00\"}";
 
     tester.addEqualityGroup(Value.bool(true), Value.bool(Boolean.TRUE));
     tester.addEqualityGroup(Value.bool(false));
@@ -1292,6 +1415,11 @@ public class ValueTest {
     tester.addEqualityGroup(Value.string("abc"), Value.string("abc"));
     tester.addEqualityGroup(Value.string("def"));
     tester.addEqualityGroup(Value.string(null));
+
+    tester.addEqualityGroup(Value.json(simpleJson), Value.json(simpleJson));
+    tester.addEqualityGroup(Value.json("{}"));
+    tester.addEqualityGroup(Value.json("[]"));
+    tester.addEqualityGroup(Value.json(null));
 
     tester.addEqualityGroup(Value.bytes(newByteArray("abc")), Value.bytes(newByteArray("abc")));
     tester.addEqualityGroup(Value.bytes(newByteArray("def")));
@@ -1356,6 +1484,12 @@ public class ValueTest {
     tester.addEqualityGroup(Value.stringArray(null));
 
     tester.addEqualityGroup(
+        Value.jsonArray(Arrays.asList(emptyJson, simpleJson)),
+        Value.jsonArray(Arrays.asList(emptyJson, simpleJson)));
+    tester.addEqualityGroup(Value.jsonArray(Arrays.asList("[]")));
+    tester.addEqualityGroup(Value.jsonArray(null));
+
+    tester.addEqualityGroup(
         Value.bytesArray(Arrays.asList(newByteArray("a"), newByteArray("b"))),
         Value.bytesArray(Arrays.asList(newByteArray("a"), newByteArray("b"))));
     tester.addEqualityGroup(Value.bytesArray(Collections.singletonList(newByteArray("c"))));
@@ -1405,6 +1539,9 @@ public class ValueTest {
     reserializeAndAssert(Value.string("abc"));
     reserializeAndAssert(Value.string(null));
 
+    reserializeAndAssert(Value.json("{\"color\":\"red\",\"value\":\"#f00\"}"));
+    reserializeAndAssert(Value.json(null));
+
     reserializeAndAssert(Value.bytes(newByteArray("abc")));
     reserializeAndAssert(Value.bytes(null));
 
@@ -1451,6 +1588,11 @@ public class ValueTest {
     BrokenSerializationList<String> of = BrokenSerializationList.of("a", "b");
     reserializeAndAssert(Value.stringArray(of));
     reserializeAndAssert(Value.stringArray(null));
+
+    BrokenSerializationList<String> json =
+        BrokenSerializationList.of("{}", "{\"color\":\"red\",\"value\":\"#f00\"}");
+    reserializeAndAssert(Value.jsonArray(json));
+    reserializeAndAssert(Value.jsonArray(null));
 
     reserializeAndAssert(
         Value.bytesArray(BrokenSerializationList.of(newByteArray("a"), newByteArray("b"))));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DirectExecuteResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DirectExecuteResultSetTest.java
@@ -230,6 +230,15 @@ public class DirectExecuteResultSetTest {
     subject.getStringList("test2");
     verify(delegate).getStringList("test2");
 
+    subject.getJson(0);
+    verify(delegate).getJson(0);
+    subject.getJson("test0");
+    verify(delegate).getJson("test0");
+    subject.getJsonList(2);
+    verify(delegate).getJsonList(2);
+    subject.getJsonList("test2");
+    verify(delegate).getJsonList("test2");
+
     subject.getStructList(0);
     subject.getStructList("test0");
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/RandomResultSetGenerator.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/RandomResultSetGenerator.java
@@ -44,6 +44,7 @@ public class RandomResultSetGenerator {
         Type.newBuilder().setCode(TypeCode.FLOAT64).build(),
         Type.newBuilder().setCode(TypeCode.NUMERIC).build(),
         Type.newBuilder().setCode(TypeCode.STRING).build(),
+        Type.newBuilder().setCode(TypeCode.JSON).build(),
         Type.newBuilder().setCode(TypeCode.BYTES).build(),
         Type.newBuilder().setCode(TypeCode.DATE).build(),
         Type.newBuilder().setCode(TypeCode.TIMESTAMP).build(),
@@ -66,6 +67,10 @@ public class RandomResultSetGenerator {
         Type.newBuilder()
             .setCode(TypeCode.ARRAY)
             .setArrayElementType(Type.newBuilder().setCode(TypeCode.STRING))
+            .build(),
+        Type.newBuilder()
+            .setCode(TypeCode.ARRAY)
+            .setArrayElementType(Type.newBuilder().setCode(TypeCode.JSON))
             .build(),
         Type.newBuilder()
             .setCode(TypeCode.ARRAY)
@@ -138,6 +143,9 @@ public class RandomResultSetGenerator {
           byte[] bytes = new byte[random.nextInt(200)];
           random.nextBytes(bytes);
           builder.setStringValue(Base64.encodeBase64String(bytes));
+          break;
+        case JSON:
+          builder.setStringValue("\"" + random.nextInt(200) + "\":\"" + random.nextInt(200) + "\"");
           break;
         case DATE:
           Date date =

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ReadWriteTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ReadWriteTransactionTest.java
@@ -49,6 +49,7 @@ import com.google.cloud.spanner.TransactionManager;
 import com.google.cloud.spanner.TransactionManager.TransactionState;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.StructField;
+import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.connection.StatementParser.ParsedStatement;
 import com.google.cloud.spanner.connection.StatementParser.StatementType;
 import com.google.rpc.RetryInfo;
@@ -493,12 +494,18 @@ public class ReadWriteTransactionTest {
     ParsedStatement parsedStatement = mock(ParsedStatement.class);
     Statement statement = Statement.of("SELECT * FROM FOO");
     when(parsedStatement.getStatement()).thenReturn(statement);
+
+    String arrayJson =
+        "[{\"color\":\"red\",\"value\":\"#f00\"},{\"color\":\"green\",\"value\":\"#0f0\"},{\"color\":\"blue\",\"value\":\"#00f\"},{\"color\":\"cyan\",\"value\":\"#0ff\"},{\"color\":\"magenta\",\"value\":\"#f0f\"},{\"color\":\"yellow\",\"value\":\"#ff0\"},{\"color\":\"black\",\"value\":\"#000\"}]";
+    String emptyArrayJson = "[]";
+    String simpleJson = "{\"color\":\"red\",\"value\":\"#f00\"}";
     ResultSet delegate1 =
         ResultSets.forRows(
             Type.struct(
                 StructField.of("ID", Type.int64()),
                 StructField.of("NAME", Type.string()),
-                StructField.of("AMOUNT", Type.numeric())),
+                StructField.of("AMOUNT", Type.numeric()),
+                StructField.of("JSON", Type.json())),
             Arrays.asList(
                 Struct.newBuilder()
                     .set("ID")
@@ -507,6 +514,8 @@ public class ReadWriteTransactionTest {
                     .to("TEST 1")
                     .set("AMOUNT")
                     .to(BigDecimal.valueOf(550, 2))
+                    .set("JSON")
+                    .to(Value.json(simpleJson))
                     .build(),
                 Struct.newBuilder()
                     .set("ID")
@@ -515,6 +524,8 @@ public class ReadWriteTransactionTest {
                     .to("TEST 2")
                     .set("AMOUNT")
                     .to(BigDecimal.valueOf(750, 2))
+                    .set("JSON")
+                    .to(Value.json(arrayJson))
                     .build()));
     ChecksumResultSet rs1 =
         transaction.createChecksumResultSet(delegate1, parsedStatement, AnalyzeMode.NONE);
@@ -523,7 +534,8 @@ public class ReadWriteTransactionTest {
             Type.struct(
                 StructField.of("ID", Type.int64()),
                 StructField.of("NAME", Type.string()),
-                StructField.of("AMOUNT", Type.numeric())),
+                StructField.of("AMOUNT", Type.numeric()),
+                StructField.of("JSON", Type.json())),
             Arrays.asList(
                 Struct.newBuilder()
                     .set("ID")
@@ -532,6 +544,8 @@ public class ReadWriteTransactionTest {
                     .to("TEST 1")
                     .set("AMOUNT")
                     .to(new BigDecimal("5.50"))
+                    .set("JSON")
+                    .to(Value.json(simpleJson))
                     .build(),
                 Struct.newBuilder()
                     .set("ID")
@@ -540,6 +554,8 @@ public class ReadWriteTransactionTest {
                     .to("TEST 2")
                     .set("AMOUNT")
                     .to(new BigDecimal("7.50"))
+                    .set("JSON")
+                    .to(Value.json(arrayJson))
                     .build()));
     ChecksumResultSet rs2 =
         transaction.createChecksumResultSet(delegate2, parsedStatement, AnalyzeMode.NONE);
@@ -549,7 +565,8 @@ public class ReadWriteTransactionTest {
             Type.struct(
                 StructField.of("ID", Type.int64()),
                 StructField.of("NAME", Type.string()),
-                StructField.of("AMOUNT", Type.numeric())),
+                StructField.of("AMOUNT", Type.numeric()),
+                StructField.of("JSON", Type.json())),
             Arrays.asList(
                 Struct.newBuilder()
                     .set("ID")
@@ -558,6 +575,8 @@ public class ReadWriteTransactionTest {
                     .to("TEST 2")
                     .set("AMOUNT")
                     .to(new BigDecimal("7.50"))
+                    .set("JSON")
+                    .to(Value.json(arrayJson))
                     .build(),
                 Struct.newBuilder()
                     .set("ID")
@@ -566,6 +585,8 @@ public class ReadWriteTransactionTest {
                     .to("TEST 1")
                     .set("AMOUNT")
                     .to(new BigDecimal("5.50"))
+                    .set("JSON")
+                    .to(Value.json(simpleJson))
                     .build()));
     ChecksumResultSet rs3 =
         transaction.createChecksumResultSet(delegate3, parsedStatement, AnalyzeMode.NONE);
@@ -576,7 +597,8 @@ public class ReadWriteTransactionTest {
             Type.struct(
                 StructField.of("ID", Type.int64()),
                 StructField.of("NAME", Type.string()),
-                StructField.of("AMOUNT", Type.numeric())),
+                StructField.of("AMOUNT", Type.numeric()),
+                StructField.of("JSON", Type.json())),
             Arrays.asList(
                 Struct.newBuilder()
                     .set("ID")
@@ -585,6 +607,8 @@ public class ReadWriteTransactionTest {
                     .to("TEST 1")
                     .set("AMOUNT")
                     .to(new BigDecimal("5.50"))
+                    .set("JSON")
+                    .to(Value.json(simpleJson))
                     .build(),
                 Struct.newBuilder()
                     .set("ID")
@@ -593,6 +617,8 @@ public class ReadWriteTransactionTest {
                     .to("TEST 2")
                     .set("AMOUNT")
                     .to(new BigDecimal("7.50"))
+                    .set("JSON")
+                    .to(Value.json(arrayJson))
                     .build(),
                 Struct.newBuilder()
                     .set("ID")
@@ -601,6 +627,8 @@ public class ReadWriteTransactionTest {
                     .to("TEST 3")
                     .set("AMOUNT")
                     .to(new BigDecimal("9.99"))
+                    .set("JSON")
+                    .to(Value.json(emptyArrayJson))
                     .build()));
     ChecksumResultSet rs4 =
         transaction.createChecksumResultSet(delegate4, parsedStatement, AnalyzeMode.NONE);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ReplaceableForwardingResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ReplaceableForwardingResultSetTest.java
@@ -284,6 +284,15 @@ public class ReplaceableForwardingResultSetTest {
       subject.getStringList("test2");
       verify(delegate).getStringList("test2");
 
+      subject.getJson(0);
+      verify(delegate).getJson(0);
+      subject.getJson("test0");
+      verify(delegate).getJson("test0");
+      subject.getJsonList(2);
+      verify(delegate).getJsonList(2);
+      subject.getJsonList("test2");
+      verify(delegate).getJsonList("test2");
+
       subject.getStructList(0);
       subject.getStructList("test0");
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITQueryTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITQueryTest.java
@@ -230,6 +230,36 @@ public class ITQueryTest {
   }
 
   @Test
+  public void bindJson() {
+    assumeFalse("Emulator does not yet support JSON", EmulatorSpannerHelper.isUsingEmulator());
+    Struct row =
+        execute(
+            Statement.newBuilder("SELECT @v")
+                .bind("v")
+                .to(Value.json("{\"rating\":9,\"open\":true}")),
+            Type.json());
+    assertThat(row.isNull(0)).isFalse();
+    assertThat(row.getJson(0)).isEqualTo("{\"open\":true,\"rating\":9}");
+  }
+
+  @Test
+  public void bindJsonEmpty() {
+    assumeFalse("Emulator does not yet support JSON", EmulatorSpannerHelper.isUsingEmulator());
+    Struct row =
+        execute(Statement.newBuilder("SELECT @v").bind("v").to(Value.json("{}")), Type.json());
+    assertThat(row.isNull(0)).isFalse();
+    assertThat(row.getJson(0)).isEqualTo("{}");
+  }
+
+  @Test
+  public void bindJsonNull() {
+    assumeFalse("Emulator does not yet support JSON", EmulatorSpannerHelper.isUsingEmulator());
+    Struct row =
+        execute(Statement.newBuilder("SELECT @v").bind("v").to(Value.json(null)), Type.json());
+    assertThat(row.isNull(0)).isTrue();
+  }
+
+  @Test
   public void bindBytes() {
     Struct row =
         execute(
@@ -428,6 +458,41 @@ public class ITQueryTest {
         execute(
             Statement.newBuilder("SELECT @v").bind("v").toStringArray(null),
             Type.array(Type.string()));
+    assertThat(row.isNull(0)).isTrue();
+  }
+
+  @Test
+  public void bindJsonArray() {
+    assumeFalse("Emulator does not yet support JSON", EmulatorSpannerHelper.isUsingEmulator());
+    Struct row =
+        execute(
+            Statement.newBuilder("SELECT @v")
+                .bind("v")
+                .toJsonArray(asList("{}", "[]", "{\"rating\":9,\"open\":true}", null)),
+            Type.array(Type.json()));
+    assertThat(row.isNull(0)).isFalse();
+    assertThat(row.getJsonList(0))
+        .containsExactly("{}", "[]", "{\"open\":true,\"rating\":9}", null)
+        .inOrder();
+  }
+
+  @Test
+  public void bindJsonArrayEmpty() {
+    assumeFalse("Emulator does not yet support JSON", EmulatorSpannerHelper.isUsingEmulator());
+    Struct row =
+        execute(
+            Statement.newBuilder("SELECT @v").bind("v").toJsonArray(Collections.emptyList()),
+            Type.array(Type.json()));
+    assertThat(row.isNull(0)).isFalse();
+    assertThat(row.getJsonList(0)).isEqualTo(Collections.emptyList());
+  }
+
+  @Test
+  public void bindJsonArrayNull() {
+    assumeFalse("Emulator does not yet support JSON", EmulatorSpannerHelper.isUsingEmulator());
+    Struct row =
+        execute(
+            Statement.newBuilder("SELECT @v").bind("v").toJsonArray(null), Type.array(Type.json()));
     assertThat(row.isNull(0)).isTrue();
   }
 

--- a/google-cloud-spanner/src/test/resources/com/google/cloud/spanner/read_tests.json
+++ b/google-cloud-spanner/src/test/resources/com/google/cloud/spanner/read_tests.json
@@ -3,6 +3,7 @@
     "result": {"value": [[
       true,
       "abc",
+      "{\"color\":\"red\",\"value\":\"#f00\"}",
       "100",
       1.1,
       "3.141592",
@@ -19,7 +20,7 @@
         ["ghi"]
       ]
     ]]},
-    "chunks": ["{\n  \"metadata\": {\n    \"rowType\": {\n      \"fields\": [{\n        \"name\": \"f1\",\n        \"type\": {\n          \"code\": \"BOOL\"\n        }\n      }, {\n        \"name\": \"f2\",\n        \"type\": {\n          \"code\": \"STRING\"\n        }\n      }, {\n        \"name\": \"f3\",\n        \"type\": {\n          \"code\": \"INT64\"\n        }\n      }, {\n        \"name\": \"f4\",\n        \"type\": {\n          \"code\": \"FLOAT64\"\n        }\n      }, {\n        \"name\": \"f5\",\n        \"type\": {\n          \"code\": \"NUMERIC\"\n        }\n      }, {\n        \"name\": \"f6\",\n        \"type\": {\n          \"code\": \"BYTES\"\n        }\n      }, {\n        \"name\": \"f7\",\n        \"type\": {\n          \"code\": \"ARRAY\",\n          \"arrayElementType\": {\n            \"code\": \"STRING\"\n          }\n        }\n      }, {\n        \"name\": \"f8\",\n        \"type\": {\n          \"code\": \"ARRAY\",\n          \"arrayElementType\": {\n            \"code\": \"STRUCT\",\n            \"structType\": {\n              \"fields\": [{\n                \"name\": \"f81\",\n                \"type\": {\n                  \"code\": \"STRING\"\n                }\n              }]\n            }\n          }\n        }\n      }]\n    }\n  },\n  \"values\": [true, \"abc\", \"100\", 1.1, \"3.141592\", \"YWJj\", [\"abc\", \"def\", null, \"ghi\"], [[\"abc\"], [\"def\"], [\"ghi\"]]]\n}"],
+    "chunks": ["{\n  \"metadata\": {\n    \"rowType\": {\n      \"fields\": [{\n        \"name\": \"f1\",\n        \"type\": {\n          \"code\": \"BOOL\"\n        }\n      }, {\n        \"name\": \"f2\",\n        \"type\": {\n          \"code\": \"STRING\"\n        }\n      }, {\n        \"name\": \"f3\",\n        \"type\": {\n          \"code\": \"JSON\"\n        }\n      }, {\n        \"name\": \"f4\",\n        \"type\": {\n          \"code\": \"INT64\"\n        }\n      }, {\n        \"name\": \"f5\",\n        \"type\": {\n          \"code\": \"FLOAT64\"\n        }\n      }, {\n        \"name\": \"f6\",\n        \"type\": {\n          \"code\": \"NUMERIC\"\n        }\n      }, {\n        \"name\": \"f7\",\n        \"type\": {\n          \"code\": \"BYTES\"\n        }\n      }, {\n        \"name\": \"f8\",\n        \"type\": {\n          \"code\": \"ARRAY\",\n          \"arrayElementType\": {\n            \"code\": \"STRING\"\n          }\n        }\n      }, {\n        \"name\": \"f9\",\n        \"type\": {\n          \"code\": \"ARRAY\",\n          \"arrayElementType\": {\n            \"code\": \"STRUCT\",\n            \"structType\": {\n              \"fields\": [{\n                \"name\": \"f81\",\n                \"type\": {\n                  \"code\": \"STRING\"\n                }\n              }]\n            }\n          }\n        }\n      }]\n    }\n  },\n  \"values\": [true, \"abc\", \"{\\\"color\\\":\\\"red\\\",\\\"value\\\":\\\"#f00\\\"}\", \"100\", 1.1, \"3.141592\", \"YWJj\", [\"abc\", \"def\", null, \"ghi\"], [[\"abc\"], [\"def\"], [\"ghi\"]]]\n}"],
     "name": "Basic Test"
   },
   {
@@ -83,6 +84,14 @@
       "{\n  \"values\": [[\"ghi\"]]\n}"
     ],
     "name": "String Array Chunking Test With One Large String"
+  },
+  {
+    "result": {"value": [[["{}", "{\"color\":\"red\",\"value\":\"#f00\"}"]]]},
+    "chunks": [
+      "{\n  \"metadata\": {\n    \"rowType\": {\n      \"fields\": [{\n        \"name\": \"f1\",\n        \"type\": {\n          \"code\": \"ARRAY\",\n          \"arrayElementType\": {\n            \"code\": \"JSON\"\n          }\n        }\n      }]\n    }\n  },\n  \"values\": [[\"{}\", \"{\\\"color\\\":\\\"red\\\"\"]],\n  \"chunkedValue\": true\n}",
+      "{\n  \"values\": [[\",\\\"value\\\":\\\"#f00\\\"}\"]],\n  \"chunkedValue\": false\n}"
+    ],
+    "name": "JSON Array Chunking Test"
   },
   {
     "result": {"value": [[[


### PR DESCRIPTION
Allow users to read and write to Cloud Spanner databases using the JSON type through the client libraries.

Integration tests here: https://github.com/zoercai/java-spanner/pull/1