### PR TITLE
test: close Spanner instance after test

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
@@ -536,16 +536,17 @@ public class GapicSpannerRpcTest {
         };
     final SpannerOptions options =
         createSpannerOptions().toBuilder().setHeaderProvider(userAgentHeaderProvider).build();
-    final Spanner spanner = options.getService();
-    final DatabaseClient databaseClient =
-        spanner.getDatabaseClient(DatabaseId.of("[PROJECT]", "[INSTANCE]", "[DATABASE]"));
+    try (Spanner spanner = options.getService()) {
+      final DatabaseClient databaseClient =
+          spanner.getDatabaseClient(DatabaseId.of("[PROJECT]", "[INSTANCE]", "[DATABASE]"));
 
-    try (final ResultSet rs = databaseClient.singleUse().executeQuery(SELECT1AND2)) {
-      rs.next();
+      try (final ResultSet rs = databaseClient.singleUse().executeQuery(SELECT1AND2)) {
+        rs.next();
+      }
+
+      assertThat(seenHeaders.get(Key.of("user-agent", Metadata.ASCII_STRING_MARSHALLER)))
+          .contains("test-agent " + defaultUserAgent);
     }
-
-    assertThat(seenHeaders.get(Key.of("user-agent", Metadata.ASCII_STRING_MARSHALLER)))
-        .contains("test-agent " + defaultUserAgent);
   }
 
   @SuppressWarnings("rawtypes")


### PR DESCRIPTION
The `SpannerGapicRpcTest.testCustomUserAgent` test opened a new `Spanner` instance that was not closed after the test had finished. This would cause the threads that were used by that instance to remain active until the entire test run had finished. If this test happened to be executed before one of the tests that verify that all threads are closed when a `Spanner` instance is closed, the test would fail as it would detect the threads that were still active from the other test case.

Fixes #889