### PR TITLE
test: fixes gapic spanner test

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
@@ -511,16 +511,17 @@ public class GapicSpannerRpcTest {
   @Test
   public void testDefaultUserAgent() {
     final SpannerOptions options = createSpannerOptions();
-    final Spanner spanner = options.getService();
-    final DatabaseClient databaseClient =
-        spanner.getDatabaseClient(DatabaseId.of("[PROJECT]", "[INSTANCE]", "[DATABASE]"));
+    try (final Spanner spanner = options.getService()) {
+      final DatabaseClient databaseClient =
+          spanner.getDatabaseClient(DatabaseId.of("[PROJECT]", "[INSTANCE]", "[DATABASE]"));
 
-    try (final ResultSet rs = databaseClient.singleUse().executeQuery(SELECT1AND2)) {
-      rs.next();
+      try (final ResultSet rs = databaseClient.singleUse().executeQuery(SELECT1AND2)) {
+        rs.next();
+      }
+
+      assertThat(seenHeaders.get(Key.of("user-agent", Metadata.ASCII_STRING_MARSHALLER)))
+          .contains(defaultUserAgent);
     }
-
-    assertThat(seenHeaders.get(Key.of("user-agent", Metadata.ASCII_STRING_MARSHALLER)))
-        .contains(defaultUserAgent);
   }
 
   @Test


### PR DESCRIPTION
We were not closing the spanner service instance after using it, causing threads not to be terminated. Here we make sure to close such service in a try with resources block.

Fixes #889 
