### PR TITLE
samples: PITR samples backup fix

### DIFF
--- a/samples/snippets/src/main/java/com/example/spanner/SpannerSample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/SpannerSample.java
@@ -1585,14 +1585,20 @@ public class SpannerSample {
 
   // [START spanner_create_backup]
   static void createBackup(
-      DatabaseAdminClient dbAdminClient, DatabaseId databaseId, BackupId backupId) {
+      DatabaseClient databaseClient, DatabaseAdminClient dbAdminClient, DatabaseId databaseId,
+      BackupId backupId) {
     Database databaseToBackup = dbAdminClient
         .getDatabase(databaseId.getInstanceId().getInstance(), databaseId.getDatabase());
     // Set expire time to 14 days from now.
     Timestamp expireTime = Timestamp.ofTimeMicroseconds(TimeUnit.MICROSECONDS.convert(
         System.currentTimeMillis() + TimeUnit.DAYS.toMillis(14), TimeUnit.MILLISECONDS));
     // Sets the version time to the current time.
-    Timestamp versionTime = databaseToBackup.getEarliestVersionTime();
+    Timestamp versionTime;
+    try (ResultSet resultSet = databaseClient.singleUse()
+        .executeQuery(Statement.of("SELECT CURRENT_TIMESTAMP()"))) {
+      resultSet.next();
+      versionTime = resultSet.getTimestamp(0);
+    }
     Backup backup =
         dbAdminClient
             .newBackupBuilder(backupId)
@@ -2058,7 +2064,7 @@ public class SpannerSample {
         queryWithQueryOptions(dbClient);
         break;
       case "createbackup":
-        createBackup(dbAdminClient, database, backup);
+        createBackup(dbClient, dbAdminClient, database, backup);
         break;
       case "cancelcreatebackup":
         cancelCreateBackup(

--- a/samples/snippets/src/main/java/com/example/spanner/SpannerSample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/SpannerSample.java
@@ -1587,8 +1587,6 @@ public class SpannerSample {
   static void createBackup(
       DatabaseClient databaseClient, DatabaseAdminClient dbAdminClient, DatabaseId databaseId,
       BackupId backupId) {
-    Database databaseToBackup = dbAdminClient
-        .getDatabase(databaseId.getInstanceId().getInstance(), databaseId.getDatabase());
     // Set expire time to 14 days from now.
     Timestamp expireTime = Timestamp.ofTimeMicroseconds(TimeUnit.MICROSECONDS.convert(
         System.currentTimeMillis() + TimeUnit.DAYS.toMillis(14), TimeUnit.MILLISECONDS));


### PR DESCRIPTION
Instead of using the earliest version time of the database, uses the current time (from spanner). If we used the earliest version time of the database instead we would be creating an empty backup, since the database we are backing up is not 1 hour old (default version retention period).