### PR TITLE
fix: all throwables should be ignored in shutdown hook

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
@@ -104,7 +104,7 @@ public class SpannerPool {
     public void run() {
       try {
         checkAndCloseSpanners(CheckAndCloseSpannersMode.WARN);
-      } catch (Exception e) {
+      } catch (Throwable e) {
         // ignore
       }
     }


### PR DESCRIPTION
All throwables (and not just exceptions) should be ignored in the shutdown hook. Failing to close these resources during shutdown is not a major problem, as they will be garbage collected by the backend anyways. Without this wide catch, some
applications will log a ClassNotFoundException when shutting down, which can be confusing for end users.

Fixes #949

Also fixes https://github.com/cloudspannerecosystem/liquibase-spanner/issues/66#issuecomment-794765002