### PR TITLE
Trying Guava JRE flavor to see build failure

### DIFF
--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -222,6 +222,12 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>30.1-jre</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.checkerframework</groupId>
+          <artifactId>checker-qual</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>

--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -221,6 +221,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <version>30.1-jre</version>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>


### PR DESCRIPTION
Background: I'm checking repositories of the libraries in LTS can be built with other libraries in the same LTS. During preparation, I found that I cannot build this repository (java-spanner) with Guava's JRE flavor (which is to be added in LTS).