### PR TITLE
feat!: add closeAsync() method to Connection

### DIFF
--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -504,4 +504,11 @@
     <className>com/google/cloud/spanner/DatabaseAdminClient</className>
     <method>com.google.api.gax.longrunning.OperationFuture createBackup(com.google.cloud.spanner.Backup)</method>
   </difference>
+  
+  <!-- Connection#closeAsync() -->
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/connection/Connection</className>
+    <method>com.google.api.core.ApiFuture closeAsync()</method>
+  </difference>
 </differences>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
@@ -139,9 +139,18 @@ import java.util.concurrent.TimeUnit;
  */
 @InternalApi
 public interface Connection extends AutoCloseable {
-  /** Closes this connection. This is a no-op if the {@link Connection} has alread been closed. */
+
+  /** Closes this connection. This is a no-op if the {@link Connection} has already been closed. */
   @Override
   void close();
+
+  /**
+   * Closes this connection without blocking. This is a no-op if the {@link Connection} has already
+   * been closed. The {@link Connection} is no longer usable directly after calling this method. The
+   * returned {@link ApiFuture} is done when the running statement(s) (if any) on the connection
+   * have finished.
+   */
+  ApiFuture<Void> closeAsync();
 
   /** @return <code>true</code> if this connection has been closed. */
   boolean isClosed();


### PR DESCRIPTION
Adds a non-blocking close method to `Connection` to support APIs that should offer only non-blocking methods to consumers (e.g. R2DBC).

The `Connection` interface is marked with `InternalApi` and documented with `Internal connection API for Google Cloud Spanner. This interface may introduce breaking changes without prior notice.` 

cc @elefeint 