### PR TITLE
fix: retry cancelled error on first statement in transaction

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -701,7 +701,9 @@ abstract class AbstractReadContext
   public void onTransactionMetadata(Transaction transaction, boolean shouldIncludeId) {}
 
   @Override
-  public void onError(SpannerException e, boolean withBeginTransaction) {}
+  public SpannerException onError(SpannerException e, boolean withBeginTransaction) {
+    return e;
+  }
 
   @Override
   public void onDone(boolean withBeginTransaction) {}

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
@@ -81,8 +81,8 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
     void onTransactionMetadata(Transaction transaction, boolean shouldIncludeId)
         throws SpannerException;
 
-    /** Called when the read finishes with an error. */
-    void onError(SpannerException e, boolean withBeginTransaction);
+    /** Called when the read finishes with an error. Returns the error that should be thrown. */
+    SpannerException onError(SpannerException e, boolean withBeginTransaction);
 
     /** Called when the read finishes normally. */
     void onDone(boolean withBeginTransaction);
@@ -159,9 +159,9 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
     }
 
     private SpannerException yieldError(SpannerException e, boolean beginTransaction) {
-      listener.onError(e, beginTransaction);
+      SpannerException toThrow = listener.onError(e, beginTransaction);
       close();
-      throw e;
+      throw toThrow;
     }
   }
   /**

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GrpcResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GrpcResultSetTest.java
@@ -60,7 +60,9 @@ public class GrpcResultSetTest {
         throws SpannerException {}
 
     @Override
-    public void onError(SpannerException e, boolean withBeginTransaction) {}
+    public SpannerException onError(SpannerException e, boolean withBeginTransaction) {
+      return e;
+    }
 
     @Override
     public void onDone(boolean withBeginTransaction) {}

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadFormatTestRunner.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadFormatTestRunner.java
@@ -48,7 +48,9 @@ public class ReadFormatTestRunner extends ParentRunner<JSONObject> {
         throws SpannerException {}
 
     @Override
-    public void onError(SpannerException e, boolean withBeginTransaction) {}
+    public SpannerException onError(SpannerException e, boolean withBeginTransaction) {
+      return e;
+    }
 
     @Override
     public void onDone(boolean withBeginTransaction) {}


### PR DESCRIPTION
If the first statement of a read/write transaction fails with a `CANCELLED` error and the error message is `Read/query was cancelled due to the enclosing transaction being invalidated by a later transaction in the same session.`, then the transaction should be retried, as the error could be caused by a previous statement that was abandoned by the client but still executed by the backend. This could be the case if the statement timed out (on the client) or was cancelled.

Fixes #938
