### PR TITLE
chore: updates settings for 5.2.x branch

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -7,3 +7,7 @@ branches:
 - branch: 4.0.x
   releaseType: java-yoshi
   bumpMinorPreMajor: true
+- branch: 5.2.x
+  releaseType: java-yoshi
+  bumpMinorPreMajor: true
+

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -93,6 +93,33 @@ branchProtectionRules:
     - "Kokoro - Test: Integration"
     - "cla/google"
 
+# Identifies the protection rule pattern. Name of the branch to be protected.
+# Defaults to `master`
+- pattern: 5.2.x
+  # Can admins overwrite branch protection.
+  # Defaults to `true`
+  isAdminEnforced: true
+  # Number of approving reviews required to update matching branches.
+  # Defaults to `1`
+  requiredApprovingReviewCount: 1
+  # Are reviews from code owners required to update matching branches.
+  # Defaults to `false`
+  requiresCodeOwnerReviews: true
+  # Require up to date branches
+  requiresStrictStatusChecks: false
+  # List of required status check contexts that must pass for commits to be accepted to matching branches.
+  requiredStatusCheckContexts:
+    - "dependencies (8)"
+    - "dependencies (11)"
+    - "linkage-monitor"
+    - "lint"
+    - "clirr"
+    - "units (7)"
+    - "units (8)"
+    - "units (11)"
+    - "Kokoro - Test: Integration"
+    - "cla/google"
+
 # List of explicit permissions to add (additive only)
 permissionRules:
 - team: yoshi-admins


### PR DESCRIPTION
Sets branch 5.2.x as a protected branch. Configures CI and release please for such branch.