### PR TITLE
chore: sets the min version of the repo as Java 8

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -7,6 +7,7 @@
   "issue_tracker": "https://issuetracker.google.com/issues?q=componentid:190851%2B%20status:open",
   "release_level": "ga",
   "language": "java",
+  "min_java_version": 8,
   "repo": "googleapis/java-spanner",
   "repo_short": "java-spanner",
   "distribution_name": "com.google.cloud:google-cloud-spanner",
@@ -15,3 +16,4 @@
   "requires_billing": true,
   "codeowner_team": "@googleapis/api-spanner-java"
 }
+


### PR DESCRIPTION
This is used by autosynth to generate files such as the README.