### PR TITLE
fix: plain text when testing emulator connection

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/LocalConnectionChecker.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/LocalConnectionChecker.java
@@ -58,7 +58,14 @@ class LocalConnectionChecker {
             InstanceAdminStubSettings.newBuilder()
                 .setCredentialsProvider(NoCredentialsProvider.create())
                 .setTransportChannelProvider(
-                    InstantiatingGrpcChannelProvider.newBuilder().setEndpoint(host).build());
+                    InstantiatingGrpcChannelProvider.newBuilder()
+                        .setEndpoint(host)
+                        .setChannelConfigurator(
+                            input -> {
+                              input.usePlaintext();
+                              return input;
+                            })
+                        .build());
         testEmulatorSettings
             .listInstanceConfigsSettings()
             .setSimpleTimeoutNoRetries(Duration.ofSeconds(10L));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerTestUtil.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerTestUtil.java
@@ -26,7 +26,7 @@ import com.google.spanner.v1.TypeCode;
 import java.util.Arrays;
 
 public class MockSpannerTestUtil {
-  static final Statement SELECT1 = Statement.of("SELECT 1 AS COL1");
+  public static final Statement SELECT1 = Statement.of("SELECT 1 AS COL1");
   private static final ResultSetMetadata SELECT1_METADATA =
       ResultSetMetadata.newBuilder()
           .setRowType(
@@ -41,7 +41,7 @@ public class MockSpannerTestUtil {
                           .build())
                   .build())
           .build();
-  static final com.google.spanner.v1.ResultSet SELECT1_RESULTSET =
+  public static final com.google.spanner.v1.ResultSet SELECT1_RESULTSET =
       com.google.spanner.v1.ResultSet.newBuilder()
           .addRows(
               ListValue.newBuilder()

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/LocalConnectionCheckerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/LocalConnectionCheckerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.spanner.connection;
 
 import static com.google.cloud.spanner.MockSpannerTestUtil.SELECT1;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/LocalConnectionCheckerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/LocalConnectionCheckerTest.java
@@ -1,0 +1,51 @@
+package com.google.cloud.spanner.connection;
+
+import static com.google.cloud.spanner.MockSpannerTestUtil.SELECT1;
+import static com.google.cloud.spanner.MockSpannerTestUtil.SELECT1_RESULTSET;
+
+import com.google.cloud.spanner.MockSpannerServiceImpl;
+import com.google.cloud.spanner.ResultSet;
+import io.grpc.Server;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
+import java.net.InetSocketAddress;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LocalConnectionCheckerTest {
+
+  private MockSpannerServiceImpl mockSpanner;
+  private Server server;
+  private InetSocketAddress address;
+
+  @Before
+  public void setUp() throws Exception {
+    mockSpanner = new MockSpannerServiceImpl();
+    mockSpanner.setAbortProbability(0.0D); // We don't want any unpredictable aborted transactions.
+    address = new InetSocketAddress("localhost", 0);
+    server = NettyServerBuilder.forAddress(address).addService(mockSpanner).build();
+    server.start();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    server.shutdown();
+    server.awaitTermination();
+  }
+
+  @Test
+  public void localConnectionCheckerWorksWithMockSpanner() {
+    final String uri =
+        String.format(
+            "cloudspanner://localhost:%d/projects/proj/instances/inst/databases/db?usePlainText=true",
+            server.getPort());
+    final ConnectionOptions connectionOptions = ConnectionOptions.newBuilder().setUri(uri).build();
+    mockSpanner.putStatementResult(
+        MockSpannerServiceImpl.StatementResult.query(SELECT1, SELECT1_RESULTSET));
+
+    try (Connection connection = connectionOptions.getConnection();
+        ResultSet resultSet = connection.executeQuery(SELECT1)) {
+      while (resultSet.next()) {}
+    }
+  }
+}


### PR DESCRIPTION
Uses plain text, instead of ssl when testing for local connections. This fixes connection checks when using the `MockSpannerServiceImpl` and it works with the emulator as well.

Without this fix we would get a transport error when testing the `getConnection` when using the `MockSpannerServiceImpl`, since the client would expect `TLS`, while the server would be serving `plainText`.