### PR TITLE
feat: transaction callable as functional interface

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncRunnerImpl.java
@@ -23,7 +23,6 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.core.SettableApiFuture;
 import com.google.cloud.Timestamp;
-import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.concurrent.ExecutionException;
@@ -60,16 +59,13 @@ class AsyncRunnerImpl implements AsyncRunner {
 
   private <R> R runTransaction(final AsyncWork<R> work) {
     return delegate.run(
-        new TransactionCallable<R>() {
-          @Override
-          public R run(TransactionContext transaction) throws Exception {
-            try {
-              return work.doWorkAsync(transaction).get();
-            } catch (ExecutionException e) {
-              throw SpannerExceptionFactory.newSpannerException(e.getCause());
-            } catch (InterruptedException e) {
-              throw SpannerExceptionFactory.propagateInterrupt(e);
-            }
+        transaction -> {
+          try {
+            return work.doWorkAsync(transaction).get();
+          } catch (ExecutionException e) {
+            throw SpannerExceptionFactory.newSpannerException(e.getCause());
+          } catch (InterruptedException e) {
+            throw SpannerExceptionFactory.propagateInterrupt(e);
           }
         });
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -141,12 +141,9 @@ class SessionImpl implements Session {
             ? (Collection<Mutation>) mutations
             : Lists.newArrayList(mutations);
     runner.run(
-        new TransactionRunner.TransactionCallable<Void>() {
-          @Override
-          public Void run(TransactionContext ctx) {
-            ctx.buffer(finalMutations);
-            return null;
-          }
+        ctx -> {
+          ctx.buffer(finalMutations);
+          return null;
         });
     return runner.getCommitResponse();
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunner.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunner.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
  */
 public interface TransactionRunner {
   /** A unit of work to be performed in the context of a transaction. */
+  @FunctionalInterface
   interface TransactionCallable<T> {
     /**
      * Invoked by the library framework to perform a single attempt of a transaction. This method

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SingleUseTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SingleUseTransaction.java
@@ -34,9 +34,7 @@ import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.TimestampBound;
-import com.google.cloud.spanner.TransactionContext;
 import com.google.cloud.spanner.TransactionRunner;
-import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import com.google.cloud.spanner.connection.StatementParser.ParsedStatement;
 import com.google.cloud.spanner.connection.StatementParser.StatementType;
 import com.google.common.base.Function;
@@ -357,12 +355,7 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
               writeTransaction = createWriteTransaction();
               Long res =
                   writeTransaction.run(
-                      new TransactionCallable<Long>() {
-                        @Override
-                        public Long run(TransactionContext transaction) throws Exception {
-                          return transaction.executeUpdate(update.getStatement());
-                        }
-                      });
+                      transaction -> transaction.executeUpdate(update.getStatement()));
               state = UnitOfWorkState.COMMITTED;
               return res;
             } catch (Throwable t) {
@@ -404,31 +397,28 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
           public long[] call() throws Exception {
             writeTransaction = createWriteTransaction();
             return writeTransaction.run(
-                new TransactionCallable<long[]>() {
-                  @Override
-                  public long[] run(TransactionContext transaction) throws Exception {
-                    try {
-                      long[] res =
-                          transaction.batchUpdate(
-                              Iterables.transform(
-                                  updates,
-                                  new Function<ParsedStatement, Statement>() {
-                                    @Override
-                                    public Statement apply(ParsedStatement input) {
-                                      return input.getStatement();
-                                    }
-                                  }));
+                transaction -> {
+                  try {
+                    long[] res =
+                        transaction.batchUpdate(
+                            Iterables.transform(
+                                updates,
+                                new Function<ParsedStatement, Statement>() {
+                                  @Override
+                                  public Statement apply(ParsedStatement input) {
+                                    return input.getStatement();
+                                  }
+                                }));
+                    state = UnitOfWorkState.COMMITTED;
+                    return res;
+                  } catch (Throwable t) {
+                    if (t instanceof SpannerBatchUpdateException) {
+                      // Batch update exceptions does not cause a rollback.
                       state = UnitOfWorkState.COMMITTED;
-                      return res;
-                    } catch (Throwable t) {
-                      if (t instanceof SpannerBatchUpdateException) {
-                        // Batch update exceptions does not cause a rollback.
-                        state = UnitOfWorkState.COMMITTED;
-                      } else {
-                        state = UnitOfWorkState.COMMIT_FAILED;
-                      }
-                      throw t;
+                    } else {
+                      state = UnitOfWorkState.COMMIT_FAILED;
                     }
+                    throw t;
                   }
                 });
           }
@@ -455,12 +445,9 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
               writeTransaction = createWriteTransaction();
               Void res =
                   writeTransaction.run(
-                      new TransactionCallable<Void>() {
-                        @Override
-                        public Void run(TransactionContext transaction) throws Exception {
-                          transaction.buffer(mutations);
-                          return null;
-                        }
+                      transaction -> {
+                        transaction.buffer(mutations);
+                        return null;
                       });
               state = UnitOfWorkState.COMMITTED;
               return res;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BackendExhaustedTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BackendExhaustedTest.java
@@ -24,7 +24,6 @@ import com.google.cloud.grpc.GrpcTransportOptions;
 import com.google.cloud.grpc.GrpcTransportOptions.ExecutorFactory;
 import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
-import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import com.google.protobuf.ListValue;
 import com.google.spanner.v1.ResultSetMetadata;
 import com.google.spanner.v1.StructType;
@@ -205,13 +204,7 @@ public class BackendExhaustedTest {
     @Override
     public void run() {
       TransactionRunner runner = client.readWriteTransaction();
-      runner.run(
-          new TransactionCallable<Long>() {
-            @Override
-            public Long run(TransactionContext transaction) {
-              return transaction.executeUpdate(UPDATE_STATEMENT);
-            }
-          });
+      runner.run(transaction -> transaction.executeUpdate(UPDATE_STATEMENT));
     }
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginBenchmark.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginBenchmark.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.NoCredentials;
-import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import com.google.common.base.Stopwatch;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -195,13 +194,8 @@ public class InlineBeginBenchmark {
                   Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
                   TransactionRunner runner = server.client.readWriteTransaction();
                   return runner.run(
-                      new TransactionCallable<Long>() {
-                        @Override
-                        public Long run(TransactionContext transaction) throws Exception {
-                          return transaction.executeUpdate(
-                              StandardBenchmarkMockServer.UPDATE_STATEMENT);
-                        }
-                      });
+                      transaction ->
+                          transaction.executeUpdate(StandardBenchmarkMockServer.UPDATE_STATEMENT));
                 }
               }));
     }
@@ -231,13 +225,8 @@ public class InlineBeginBenchmark {
                   Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
                   TransactionRunner runner = server.client.readWriteTransaction();
                   return runner.run(
-                      new TransactionCallable<Long>() {
-                        @Override
-                        public Long run(TransactionContext transaction) throws Exception {
-                          return transaction.executeUpdate(
-                              StandardBenchmarkMockServer.UPDATE_STATEMENT);
-                        }
-                      });
+                      transaction ->
+                          transaction.executeUpdate(StandardBenchmarkMockServer.UPDATE_STATEMENT));
                 }
               }));
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
@@ -539,13 +539,7 @@ public class InlineBeginTransactionTest {
       long updateCount =
           client
               .readWriteTransaction()
-              .run(
-                  new TransactionCallable<Long>() {
-                    @Override
-                    public Long run(TransactionContext transaction) throws Exception {
-                      return transaction.executeUpdate(UPDATE_STATEMENT);
-                    }
-                  });
+              .run(transaction -> transaction.executeUpdate(UPDATE_STATEMENT));
       assertThat(updateCount).isEqualTo(UPDATE_COUNT);
       assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(0);
       assertThat(countRequests(ExecuteSqlRequest.class)).isEqualTo(1);
@@ -562,15 +556,12 @@ public class InlineBeginTransactionTest {
           client
               .readWriteTransaction()
               .run(
-                  new TransactionCallable<Long>() {
-                    @Override
-                    public Long run(TransactionContext transaction) throws Exception {
-                      long res = transaction.executeUpdate(UPDATE_STATEMENT);
-                      if (firstAttempt.getAndSet(false)) {
-                        mockSpanner.abortTransaction(transaction);
-                      }
-                      return res;
+                  transaction -> {
+                    long res = transaction.executeUpdate(UPDATE_STATEMENT);
+                    if (firstAttempt.getAndSet(false)) {
+                      mockSpanner.abortTransaction(transaction);
                     }
+                    return res;
                   });
       assertThat(updateCount).isEqualTo(UPDATE_COUNT);
       assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(0);
@@ -658,17 +649,14 @@ public class InlineBeginTransactionTest {
           client
               .readWriteTransaction()
               .run(
-                  new TransactionCallable<Long>() {
-                    @Override
-                    public Long run(TransactionContext transaction) throws Exception {
-                      // The first attempt will return UNAVAILABLE and retry internally.
-                      try (ResultSet rs = transaction.executeQuery(SELECT1)) {
-                        while (rs.next()) {
-                          return rs.getLong(0);
-                        }
+                  transaction -> {
+                    // The first attempt will return UNAVAILABLE and retry internally.
+                    try (ResultSet rs = transaction.executeQuery(SELECT1)) {
+                      while (rs.next()) {
+                        return rs.getLong(0);
                       }
-                      return 0L;
                     }
+                    return 0L;
                   });
       assertThat(value).isEqualTo(1L);
       assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(0);
@@ -685,18 +673,15 @@ public class InlineBeginTransactionTest {
           client
               .readWriteTransaction()
               .run(
-                  new TransactionCallable<Long>() {
-                    @Override
-                    public Long run(TransactionContext transaction) throws Exception {
-                      // The first attempt will return UNAVAILABLE and retry internally.
-                      try (ResultSet rs =
-                          transaction.read("FOO", KeySet.all(), Arrays.asList("ID"))) {
-                        while (rs.next()) {
-                          return rs.getLong(0);
-                        }
+                  transaction -> {
+                    // The first attempt will return UNAVAILABLE and retry internally.
+                    try (ResultSet rs =
+                        transaction.read("FOO", KeySet.all(), Arrays.asList("ID"))) {
+                      while (rs.next()) {
+                        return rs.getLong(0);
                       }
-                      return 0L;
                     }
+                    return 0L;
                   });
       assertThat(value).isEqualTo(1L);
       assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(0);
@@ -712,16 +697,13 @@ public class InlineBeginTransactionTest {
           client
               .readWriteTransaction()
               .run(
-                  new TransactionCallable<Long>() {
-                    @Override
-                    public Long run(TransactionContext transaction) throws Exception {
-                      try (ResultSet rs = transaction.executeQuery(SELECT1)) {
-                        while (rs.next()) {
-                          return rs.getLong(0);
-                        }
+                  transaction -> {
+                    try (ResultSet rs = transaction.executeQuery(SELECT1)) {
+                      while (rs.next()) {
+                        return rs.getLong(0);
                       }
-                      return 0L;
                     }
+                    return 0L;
                   });
       assertThat(updateCount).isEqualTo(1L);
       assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(0);
@@ -737,17 +719,14 @@ public class InlineBeginTransactionTest {
           client
               .readWriteTransaction()
               .run(
-                  new TransactionCallable<Long>() {
-                    @Override
-                    public Long run(TransactionContext transaction) throws Exception {
-                      try (ResultSet rs =
-                          transaction.read("FOO", KeySet.all(), Arrays.asList("ID"))) {
-                        while (rs.next()) {
-                          return rs.getLong(0);
-                        }
+                  transaction -> {
+                    try (ResultSet rs =
+                        transaction.read("FOO", KeySet.all(), Arrays.asList("ID"))) {
+                      while (rs.next()) {
+                        return rs.getLong(0);
                       }
-                      return 0L;
                     }
+                    return 0L;
                   });
       assertThat(updateCount).isEqualTo(1L);
       assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(0);
@@ -764,13 +743,8 @@ public class InlineBeginTransactionTest {
           client
               .readWriteTransaction()
               .run(
-                  new TransactionCallable<long[]>() {
-                    @Override
-                    public long[] run(TransactionContext transaction) throws Exception {
-                      return transaction.batchUpdate(
-                          Arrays.asList(UPDATE_STATEMENT, UPDATE_STATEMENT));
-                    }
-                  });
+                  transaction ->
+                      transaction.batchUpdate(Arrays.asList(UPDATE_STATEMENT, UPDATE_STATEMENT)));
       assertThat(updateCounts).asList().containsExactly(UPDATE_COUNT, UPDATE_COUNT);
       assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(0);
       assertThat(countRequests(ExecuteBatchDmlRequest.class)).isEqualTo(1);
@@ -786,17 +760,14 @@ public class InlineBeginTransactionTest {
           client
               .readWriteTransaction()
               .run(
-                  new TransactionCallable<Long>() {
-                    @Override
-                    public Long run(TransactionContext transaction) throws Exception {
-                      try {
-                        transaction.executeUpdate(INVALID_UPDATE_STATEMENT);
-                        fail("missing expected exception");
-                      } catch (SpannerException e) {
-                        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
-                      }
-                      return transaction.executeUpdate(UPDATE_STATEMENT);
+                  transaction -> {
+                    try {
+                      transaction.executeUpdate(INVALID_UPDATE_STATEMENT);
+                      fail("missing expected exception");
+                    } catch (SpannerException e) {
+                      assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
                     }
+                    return transaction.executeUpdate(UPDATE_STATEMENT);
                   });
       assertThat(updateCount).isEqualTo(UPDATE_COUNT);
       // The transaction will be retried because the first statement that also tried to include the
@@ -831,17 +802,14 @@ public class InlineBeginTransactionTest {
         client
             .readWriteTransaction()
             .run(
-                new TransactionCallable<Void>() {
-                  @Override
-                  public Void run(TransactionContext transaction) throws Exception {
-                    try {
-                      transaction.executeUpdate(INVALID_UPDATE_STATEMENT);
-                      fail("missing expected exception");
-                    } catch (SpannerException e) {
-                      assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
-                    }
-                    return null;
+                transaction -> {
+                  try {
+                    transaction.executeUpdate(INVALID_UPDATE_STATEMENT);
+                    fail("missing expected exception");
+                  } catch (SpannerException e) {
+                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
                   }
+                  return null;
                 });
         fail("Missing expected exception");
       } catch (SpannerException e) {
@@ -865,13 +833,7 @@ public class InlineBeginTransactionTest {
       try {
         client
             .readWriteTransaction()
-            .run(
-                new TransactionCallable<Long>() {
-                  @Override
-                  public Long run(TransactionContext transaction) throws Exception {
-                    return transaction.executeUpdate(INVALID_UPDATE_STATEMENT);
-                  }
-                });
+            .run(transaction -> transaction.executeUpdate(INVALID_UPDATE_STATEMENT));
         fail("missing expected exception");
       } catch (SpannerException e) {
         assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
@@ -896,14 +858,11 @@ public class InlineBeginTransactionTest {
         client
             .readWriteTransaction()
             .run(
-                new TransactionCallable<Long>() {
-                  @Override
-                  public Long run(TransactionContext transaction) throws Exception {
-                    // This statement will start a transaction.
-                    transaction.executeUpdate(UPDATE_STATEMENT);
-                    // This statement will fail and cause a rollback as the exception is not caught.
-                    return transaction.executeUpdate(INVALID_UPDATE_STATEMENT);
-                  }
+                transaction -> {
+                  // This statement will start a transaction.
+                  transaction.executeUpdate(UPDATE_STATEMENT);
+                  // This statement will fail and cause a rollback as the exception is not caught.
+                  return transaction.executeUpdate(INVALID_UPDATE_STATEMENT);
                 });
         fail("missing expected exception");
       } catch (SpannerException e) {
@@ -924,19 +883,16 @@ public class InlineBeginTransactionTest {
           client
               .readWriteTransaction()
               .run(
-                  new TransactionCallable<Void>() {
-                    @Override
-                    public Void run(TransactionContext transaction) throws Exception {
-                      try {
-                        transaction.batchUpdate(
-                            ImmutableList.of(INVALID_UPDATE_STATEMENT, UPDATE_STATEMENT));
-                        fail("missing expected exception");
-                      } catch (SpannerBatchUpdateException e) {
-                        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
-                        assertThat(e.getUpdateCounts()).hasLength(0);
-                      }
-                      return null;
+                  transaction -> {
+                    try {
+                      transaction.batchUpdate(
+                          ImmutableList.of(INVALID_UPDATE_STATEMENT, UPDATE_STATEMENT));
+                      fail("missing expected exception");
+                    } catch (SpannerBatchUpdateException e) {
+                      assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
+                      assertThat(e.getUpdateCounts()).hasLength(0);
                     }
+                    return null;
                   });
       assertThat(res).isNull();
       // The first statement failed and could not return a transaction. The entire transaction is
@@ -955,21 +911,18 @@ public class InlineBeginTransactionTest {
           client
               .readWriteTransaction()
               .run(
-                  new TransactionCallable<Long>() {
-                    @Override
-                    public Long run(TransactionContext transaction) throws Exception {
-                      try {
-                        transaction.batchUpdate(
-                            ImmutableList.of(UPDATE_STATEMENT, INVALID_UPDATE_STATEMENT));
-                        fail("missing expected exception");
-                        // The following line is needed as the compiler does not know that this is
-                        // unreachable.
-                        return -1L;
-                      } catch (SpannerBatchUpdateException e) {
-                        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
-                        assertThat(e.getUpdateCounts()).hasLength(1);
-                        return e.getUpdateCounts()[0];
-                      }
+                  transaction -> {
+                    try {
+                      transaction.batchUpdate(
+                          ImmutableList.of(UPDATE_STATEMENT, INVALID_UPDATE_STATEMENT));
+                      fail("missing expected exception");
+                      // The following line is needed as the compiler does not know that this is
+                      // unreachable.
+                      return -1L;
+                    } catch (SpannerBatchUpdateException e) {
+                      assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
+                      assertThat(e.getUpdateCounts()).hasLength(1);
+                      return e.getUpdateCounts()[0];
                     }
                   });
       assertThat(updateCount).isEqualTo(UPDATE_COUNT);
@@ -990,17 +943,14 @@ public class InlineBeginTransactionTest {
           client
               .readWriteTransaction()
               .run(
-                  new TransactionCallable<Void>() {
-                    @Override
-                    public Void run(TransactionContext transaction) throws Exception {
-                      try (ResultSet rs = transaction.executeQuery(INVALID_SELECT)) {
-                        while (rs.next()) {}
-                        fail("missing expected exception");
-                      } catch (SpannerException e) {
-                        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
-                      }
-                      return null;
+                  transaction -> {
+                    try (ResultSet rs = transaction.executeQuery(INVALID_SELECT)) {
+                      while (rs.next()) {}
+                      fail("missing expected exception");
+                    } catch (SpannerException e) {
+                      assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
                     }
+                    return null;
                   });
       assertThat(res).isNull();
       // The transaction will be retried because the first statement that also tried to include the
@@ -1031,17 +981,14 @@ public class InlineBeginTransactionTest {
           client
               .readWriteTransaction()
               .run(
-                  new TransactionCallable<Void>() {
-                    @Override
-                    public Void run(TransactionContext transaction) throws Exception {
-                      try (ResultSet rs = transaction.executeQuery(statement)) {
-                        while (rs.next()) {}
-                        fail("missing expected exception");
-                      } catch (SpannerException e) {
-                        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.DATA_LOSS);
-                      }
-                      return null;
+                  transaction -> {
+                    try (ResultSet rs = transaction.executeQuery(statement)) {
+                      while (rs.next()) {}
+                      fail("missing expected exception");
+                    } catch (SpannerException e) {
+                      assertThat(e.getErrorCode()).isEqualTo(ErrorCode.DATA_LOSS);
                     }
+                    return null;
                   });
       assertThat(res).isNull();
       // The transaction will not be retried, as the first PartialResultSet returns the transaction
@@ -1062,31 +1009,28 @@ public class InlineBeginTransactionTest {
           client
               .readWriteTransaction()
               .run(
-                  new TransactionCallable<Long>() {
-                    @Override
-                    public Long run(final TransactionContext transaction) throws Exception {
-                      List<Future<Long>> futures = new ArrayList<>(numQueries);
-                      for (int i = 0; i < numQueries; i++) {
-                        futures.add(
-                            executor.submit(
-                                new Callable<Long>() {
-                                  @Override
-                                  public Long call() throws Exception {
-                                    try (ResultSet rs = transaction.executeQuery(SELECT1)) {
-                                      while (rs.next()) {
-                                        return rs.getLong(0);
-                                      }
+                  transaction -> {
+                    List<Future<Long>> futures = new ArrayList<>(numQueries);
+                    for (int i = 0; i < numQueries; i++) {
+                      futures.add(
+                          executor.submit(
+                              new Callable<Long>() {
+                                @Override
+                                public Long call() throws Exception {
+                                  try (ResultSet rs = transaction.executeQuery(SELECT1)) {
+                                    while (rs.next()) {
+                                      return rs.getLong(0);
                                     }
-                                    return 0L;
                                   }
-                                }));
-                      }
-                      Long res = 0L;
-                      for (Future<Long> f : futures) {
-                        res += f.get();
-                      }
-                      return res;
+                                  return 0L;
+                                }
+                              }));
                     }
+                    Long res = 0L;
+                    for (Future<Long> f : futures) {
+                      res += f.get();
+                    }
+                    return res;
                   });
       assertThat(updateCount).isEqualTo(1L * numQueries);
       assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(0);
@@ -1100,15 +1044,12 @@ public class InlineBeginTransactionTest {
       client
           .readWriteTransaction()
           .run(
-              new TransactionCallable<Void>() {
-                @Override
-                public Void run(TransactionContext transaction) throws Exception {
-                  transaction.buffer(
-                      Arrays.asList(
-                          Mutation.newInsertBuilder("FOO").set("ID").to(1L).build(),
-                          Mutation.delete("FOO", Key.of(1L))));
-                  return null;
-                }
+              transaction -> {
+                transaction.buffer(
+                    Arrays.asList(
+                        Mutation.newInsertBuilder("FOO").set("ID").to(1L).build(),
+                        Mutation.delete("FOO", Key.of(1L))));
+                return null;
               });
       // There should be 1 call to BeginTransaction because there is no statement that we can use to
       // inline the BeginTransaction call with.
@@ -1305,15 +1246,12 @@ public class InlineBeginTransactionTest {
       assertThat(
               client
                   .readWriteTransaction()
-                  .run(
-                      new TransactionCallable<Long>() {
-                        @Override
-                        public Long run(TransactionContext transaction) throws Exception {
-                          // This will not actually send an RPC, so it will also not request a
-                          // transaction.
-                          transaction.executeQuery(SELECT1);
-                          return transaction.executeUpdate(UPDATE_STATEMENT);
-                        }
+                  .<Long>run(
+                      transaction -> {
+                        // This will not actually send an RPC, so it will also not request a
+                        // transaction.
+                        transaction.executeQuery(SELECT1);
+                        return transaction.executeUpdate(UPDATE_STATEMENT);
                       }))
           .isEqualTo(UPDATE_COUNT);
       assertThat(mockSpanner.countRequestsOfType(BeginTransactionRequest.class)).isEqualTo(0L);
@@ -1327,13 +1265,10 @@ public class InlineBeginTransactionTest {
       assertThat(
               client
                   .readWriteTransaction()
-                  .run(
-                      new TransactionCallable<Long>() {
-                        @Override
-                        public Long run(TransactionContext transaction) throws Exception {
-                          transaction.executeQueryAsync(SELECT1);
-                          return transaction.executeUpdate(UPDATE_STATEMENT);
-                        }
+                  .<Long>run(
+                      transaction -> {
+                        transaction.executeQueryAsync(SELECT1);
+                        return transaction.executeUpdate(UPDATE_STATEMENT);
                       }))
           .isEqualTo(UPDATE_COUNT);
       assertThat(mockSpanner.countRequestsOfType(BeginTransactionRequest.class)).isEqualTo(0L);
@@ -1347,13 +1282,10 @@ public class InlineBeginTransactionTest {
       assertThat(
               client
                   .readWriteTransaction()
-                  .run(
-                      new TransactionCallable<Long>() {
-                        @Override
-                        public Long run(TransactionContext transaction) throws Exception {
-                          transaction.read("FOO", KeySet.all(), Arrays.asList("ID"));
-                          return transaction.executeUpdate(UPDATE_STATEMENT);
-                        }
+                  .<Long>run(
+                      transaction -> {
+                        transaction.read("FOO", KeySet.all(), Arrays.asList("ID"));
+                        return transaction.executeUpdate(UPDATE_STATEMENT);
                       }))
           .isEqualTo(UPDATE_COUNT);
       assertThat(mockSpanner.countRequestsOfType(BeginTransactionRequest.class)).isEqualTo(0L);
@@ -1368,13 +1300,10 @@ public class InlineBeginTransactionTest {
       assertThat(
               client
                   .readWriteTransaction()
-                  .run(
-                      new TransactionCallable<Long>() {
-                        @Override
-                        public Long run(TransactionContext transaction) throws Exception {
-                          transaction.readAsync("FOO", KeySet.all(), Arrays.asList("ID"));
-                          return transaction.executeUpdate(UPDATE_STATEMENT);
-                        }
+                  .<Long>run(
+                      transaction -> {
+                        transaction.readAsync("FOO", KeySet.all(), Arrays.asList("ID"));
+                        return transaction.executeUpdate(UPDATE_STATEMENT);
                       }))
           .isEqualTo(UPDATE_COUNT);
       assertThat(mockSpanner.countRequestsOfType(BeginTransactionRequest.class)).isEqualTo(0L);
@@ -1390,16 +1319,13 @@ public class InlineBeginTransactionTest {
       assertThat(
               client
                   .readWriteTransaction()
-                  .run(
-                      new TransactionCallable<Long>() {
-                        @Override
-                        public Long run(TransactionContext transaction) throws Exception {
-                          ResultSet rs = transaction.executeQuery(SELECT1);
-                          long updateCount = transaction.executeUpdate(UPDATE_STATEMENT);
-                          // Consume the result set.
-                          while (rs.next()) {}
-                          return updateCount;
-                        }
+                  .<Long>run(
+                      transaction -> {
+                        ResultSet rs = transaction.executeQuery(SELECT1);
+                        long updateCount = transaction.executeUpdate(UPDATE_STATEMENT);
+                        // Consume the result set.
+                        while (rs.next()) {}
+                        return updateCount;
                       }))
           .isEqualTo(UPDATE_COUNT);
       // The update statement should start the transaction, and the query should use the transaction
@@ -1425,14 +1351,11 @@ public class InlineBeginTransactionTest {
       client
           .readWriteTransaction()
           .run(
-              new TransactionCallable<Void>() {
-                @Override
-                public Void run(TransactionContext transaction) throws Exception {
-                  try (ResultSet rs = transaction.executeQuery(SELECT1_UNION_ALL_SELECT2)) {
-                    while (rs.next()) {}
-                  }
-                  return null;
+              transaction -> {
+                try (ResultSet rs = transaction.executeQuery(SELECT1_UNION_ALL_SELECT2)) {
+                  while (rs.next()) {}
                 }
+                return null;
               });
       assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(0);
       assertThat(countRequests(ExecuteSqlRequest.class)).isEqualTo(2);
@@ -1509,14 +1432,11 @@ public class InlineBeginTransactionTest {
         client
             .readWriteTransaction()
             .run(
-                new TransactionCallable<Void>() {
-                  @Override
-                  public Void run(TransactionContext transaction) throws Exception {
-                    try (ResultSet rs = transaction.executeQuery(SELECT1_UNION_ALL_SELECT2)) {
-                      while (rs.next()) {}
-                    }
-                    return null;
+                transaction -> {
+                  try (ResultSet rs = transaction.executeQuery(SELECT1_UNION_ALL_SELECT2)) {
+                    while (rs.next()) {}
                   }
+                  return null;
                 });
         fail("missing expected exception");
       } catch (SpannerException e) {
@@ -1538,12 +1458,9 @@ public class InlineBeginTransactionTest {
         client
             .readWriteTransaction()
             .run(
-                new TransactionCallable<Void>() {
-                  @Override
-                  public Void run(TransactionContext transaction) throws Exception {
-                    transaction.readRow("FOO", Key.of(1L), Arrays.asList("BAR"));
-                    return null;
-                  }
+                transaction -> {
+                  transaction.readRow("FOO", Key.of(1L), Arrays.asList("BAR"));
+                  return null;
                 });
         fail("missing expected exception");
       } catch (SpannerException e) {
@@ -1565,12 +1482,9 @@ public class InlineBeginTransactionTest {
         client
             .readWriteTransaction()
             .run(
-                new TransactionCallable<Void>() {
-                  @Override
-                  public Void run(TransactionContext transaction) throws Exception {
-                    transaction.executeUpdate(UPDATE_STATEMENT);
-                    return null;
-                  }
+                transaction -> {
+                  transaction.executeUpdate(UPDATE_STATEMENT);
+                  return null;
                 });
         fail("missing expected exception");
       } catch (SpannerException e) {
@@ -1592,12 +1506,9 @@ public class InlineBeginTransactionTest {
         client
             .readWriteTransaction()
             .run(
-                new TransactionCallable<Void>() {
-                  @Override
-                  public Void run(TransactionContext transaction) throws Exception {
-                    transaction.batchUpdate(Arrays.asList(UPDATE_STATEMENT));
-                    return null;
-                  }
+                transaction -> {
+                  transaction.batchUpdate(Arrays.asList(UPDATE_STATEMENT));
+                  return null;
                 });
         fail("missing expected exception");
       } catch (SpannerException e) {
@@ -1620,34 +1531,31 @@ public class InlineBeginTransactionTest {
         client
             .readWriteTransaction()
             .run(
-                new TransactionCallable<Void>() {
-                  @Override
-                  public Void run(TransactionContext transaction) throws Exception {
-                    try (AsyncResultSet rs =
-                        transaction.executeQueryAsync(SELECT1_UNION_ALL_SELECT2)) {
-                      return SpannerApiFutures.get(
-                          rs.setCallback(
-                              executor,
-                              new ReadyCallback() {
-                                @Override
-                                public CallbackResponse cursorReady(AsyncResultSet resultSet) {
-                                  try {
-                                    while (true) {
-                                      switch (resultSet.tryNext()) {
-                                        case OK:
-                                          break;
-                                        case DONE:
-                                          return CallbackResponse.DONE;
-                                        case NOT_READY:
-                                          return CallbackResponse.CONTINUE;
-                                      }
+                transaction -> {
+                  try (AsyncResultSet rs =
+                      transaction.executeQueryAsync(SELECT1_UNION_ALL_SELECT2)) {
+                    return SpannerApiFutures.get(
+                        rs.setCallback(
+                            executor,
+                            new ReadyCallback() {
+                              @Override
+                              public CallbackResponse cursorReady(AsyncResultSet resultSet) {
+                                try {
+                                  while (true) {
+                                    switch (resultSet.tryNext()) {
+                                      case OK:
+                                        break;
+                                      case DONE:
+                                        return CallbackResponse.DONE;
+                                      case NOT_READY:
+                                        return CallbackResponse.CONTINUE;
                                     }
-                                  } catch (SpannerException e) {
-                                    return CallbackResponse.DONE;
                                   }
+                                } catch (SpannerException e) {
+                                  return CallbackResponse.DONE;
                                 }
-                              }));
-                    }
+                              }
+                            }));
                   }
                 });
         fail("missing expected exception");
@@ -1670,12 +1578,8 @@ public class InlineBeginTransactionTest {
         client
             .readWriteTransaction()
             .run(
-                new TransactionCallable<Long>() {
-                  @Override
-                  public Long run(TransactionContext transaction) throws Exception {
-                    return SpannerApiFutures.get(transaction.executeUpdateAsync(UPDATE_STATEMENT));
-                  }
-                });
+                transaction ->
+                    SpannerApiFutures.get(transaction.executeUpdateAsync(UPDATE_STATEMENT)));
         fail("missing expected exception");
       } catch (SpannerException e) {
         assertThat(e.getErrorCode()).isEqualTo(ErrorCode.FAILED_PRECONDITION);
@@ -1696,13 +1600,9 @@ public class InlineBeginTransactionTest {
         client
             .readWriteTransaction()
             .run(
-                new TransactionCallable<long[]>() {
-                  @Override
-                  public long[] run(TransactionContext transaction) throws Exception {
-                    return SpannerApiFutures.get(
-                        transaction.batchUpdateAsync(Arrays.asList(UPDATE_STATEMENT)));
-                  }
-                });
+                transaction ->
+                    SpannerApiFutures.get(
+                        transaction.batchUpdateAsync(Arrays.asList(UPDATE_STATEMENT))));
         fail("missing expected exception");
       } catch (SpannerException e) {
         assertThat(e.getErrorCode()).isEqualTo(ErrorCode.FAILED_PRECONDITION);
@@ -1774,15 +1674,7 @@ public class InlineBeginTransactionTest {
       // The CANCELLED error is thrown both on the first and second attempt. The second attempt will
       // not be retried, as it did not include a BeginTransaction option.
       try {
-        client
-            .readWriteTransaction()
-            .run(
-                new TransactionCallable<Long>() {
-                  @Override
-                  public Long run(TransactionContext transaction) throws Exception {
-                    return transaction.executeUpdate(statement);
-                  }
-                });
+        client.readWriteTransaction().run(transaction -> transaction.executeUpdate(statement));
         fail("missing expected exception");
       } catch (SpannerException e) {
         assertEquals(ErrorCode.CANCELLED, e.getErrorCode());

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -174,14 +174,9 @@ import org.threeten.bp.Instant;
  * long updateCount =
  *     dbClient
  *         .readWriteTransaction()
- *         .run(
- *             new TransactionCallable<Long>() {
- *               @Override
- *               public Long run(TransactionContext transaction) throws Exception {
- *                 return transaction.executeUpdate(
- *                     Statement.of("UPDATE FOO SET BAR=1 WHERE BAZ=2"));
- *               }
- *             });
+ *         .run(transaction ->
+ *             transaction.executeUpdate(Statement.of("UPDATE FOO SET BAR=1 WHERE BAZ=2"))
+ *          );
  * System.out.println("Update count: " + updateCount);
  * spannerClient.close();
  * }</pre>

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
@@ -28,7 +28,6 @@ import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.Timestamp;
 import com.google.cloud.grpc.GrpcTransportOptions;
 import com.google.cloud.grpc.GrpcTransportOptions.ExecutorFactory;
-import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import com.google.cloud.spanner.spi.v1.SpannerRpc;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
@@ -124,21 +123,10 @@ public class SessionImplTest {
     session
         .readWriteTransaction()
         .run(
-            new TransactionCallable<Void>() {
-              @Override
-              public Void run(TransactionContext transaction) throws SpannerException {
-                session
-                    .readWriteTransaction()
-                    .run(
-                        new TransactionCallable<Void>() {
-                          @Override
-                          public Void run(TransactionContext transaction) {
-                            return null;
-                          }
-                        });
+            transaction -> {
+              session.readWriteTransaction().run(transaction1 -> null);
 
-                return null;
-              }
+              return null;
             });
   }
 
@@ -159,13 +147,10 @@ public class SessionImplTest {
       session
           .readWriteTransaction()
           .run(
-              new TransactionCallable<Void>() {
-                @Override
-                public Void run(TransactionContext transaction) throws SpannerException {
-                  session.readOnlyTransaction().getReadTimestamp();
+              transaction -> {
+                session.readOnlyTransaction().getReadTimestamp();
 
-                  return null;
-                }
+                return null;
               });
       fail("Expected exception");
     } catch (SpannerException e) {
@@ -180,12 +165,9 @@ public class SessionImplTest {
       session
           .readWriteTransaction()
           .run(
-              new TransactionCallable<Void>() {
-                @Override
-                public Void run(TransactionContext transaction) throws SpannerException {
-                  session.singleUseReadOnlyTransaction();
-                  return null;
-                }
+              transaction -> {
+                session.singleUseReadOnlyTransaction();
+                return null;
               });
       fail("Expected exception");
     } catch (SpannerException e) {
@@ -200,12 +182,9 @@ public class SessionImplTest {
         .readWriteTransaction()
         .allowNestedTransaction()
         .run(
-            new TransactionCallable<Void>() {
-              @Override
-              public Void run(TransactionContext transaction) throws SpannerException {
-                session.singleUseReadOnlyTransaction();
-                return null;
-              }
+            transaction -> {
+              session.singleUseReadOnlyTransaction();
+              return null;
             });
   }
 
@@ -371,13 +350,9 @@ public class SessionImplTest {
     session.singleUse(TimestampBound.strong());
     try {
       runner.run(
-          new TransactionRunner.TransactionCallable<Void>() {
-            @Nullable
-            @Override
-            public Void run(TransactionContext transaction) throws SpannerException {
-              fail("Unexpected call to transaction body");
-              return null;
-            }
+          transaction -> {
+            fail("Unexpected call to transaction body");
+            return null;
           });
       fail("Expected exception");
     } catch (IllegalStateException ex) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolBenchmark.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolBenchmark.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.NoCredentials;
-import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
@@ -199,13 +198,8 @@ public class SessionPoolBenchmark {
                   Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
                   TransactionRunner runner = client.readWriteTransaction();
                   return runner.run(
-                      new TransactionCallable<Long>() {
-                        @Override
-                        public Long run(TransactionContext transaction) throws Exception {
-                          return transaction.executeUpdate(
-                              StandardBenchmarkMockServer.UPDATE_STATEMENT);
-                        }
-                      });
+                      transaction ->
+                          transaction.executeUpdate(StandardBenchmarkMockServer.UPDATE_STATEMENT));
                 }
               }));
     }
@@ -236,13 +230,8 @@ public class SessionPoolBenchmark {
                   Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
                   TransactionRunner runner = client.readWriteTransaction();
                   return runner.run(
-                      new TransactionCallable<Long>() {
-                        @Override
-                        public Long run(TransactionContext transaction) throws Exception {
-                          return transaction.executeUpdate(
-                              StandardBenchmarkMockServer.UPDATE_STATEMENT);
-                        }
-                      });
+                      transaction ->
+                          transaction.executeUpdate(StandardBenchmarkMockServer.UPDATE_STATEMENT));
                 }
               }));
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolLeakTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolLeakTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.fail;
 import com.google.api.gax.grpc.testing.LocalChannelProvider;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
-import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import io.grpc.Server;
 import io.grpc.StatusRuntimeException;
 import io.grpc.inprocess.InProcessServerBuilder;
@@ -125,15 +124,7 @@ public class SessionPoolLeakTest {
     assertThat(pool.getNumberOfSessionsInPool(), is(equalTo(0)));
     setup.run();
     try {
-      client
-          .readWriteTransaction()
-          .run(
-              new TransactionCallable<Void>() {
-                @Override
-                public Void run(TransactionContext transaction) {
-                  return null;
-                }
-              });
+      client.readWriteTransaction().run(transaction -> null);
       fail("missing FAILED_PRECONDITION exception");
     } catch (SpannerException e) {
       assertThat(e.getErrorCode(), is(equalTo(ErrorCode.FAILED_PRECONDITION)));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerBenchmark.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerBenchmark.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.NoCredentials;
-import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
@@ -196,13 +195,8 @@ public class SessionPoolMaintainerBenchmark {
                   Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
                   TransactionRunner runner = client.readWriteTransaction();
                   return runner.run(
-                      new TransactionCallable<Long>() {
-                        @Override
-                        public Long run(TransactionContext transaction) throws Exception {
-                          return transaction.executeUpdate(
-                              StandardBenchmarkMockServer.UPDATE_STATEMENT);
-                        }
-                      });
+                      transaction ->
+                          transaction.executeUpdate(StandardBenchmarkMockServer.UPDATE_STATEMENT));
                 }
               }));
     }
@@ -235,13 +229,8 @@ public class SessionPoolMaintainerBenchmark {
                   Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
                   TransactionRunner runner = client.readWriteTransaction();
                   return runner.run(
-                      new TransactionCallable<Long>() {
-                        @Override
-                        public Long run(TransactionContext transaction) throws Exception {
-                          return transaction.executeUpdate(
-                              StandardBenchmarkMockServer.UPDATE_STATEMENT);
-                        }
-                      });
+                      transaction ->
+                          transaction.executeUpdate(StandardBenchmarkMockServer.UPDATE_STATEMENT));
                 }
               }));
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpanTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpanTest.java
@@ -26,7 +26,6 @@ import com.google.api.gax.rpc.UnaryCallSettings.Builder;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
-import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import com.google.protobuf.ListValue;
 import com.google.spanner.v1.ResultSetMetadata;
 import com.google.spanner.v1.StructType;
@@ -270,12 +269,9 @@ public class SpanTest {
   public void transactionRunner() {
     TransactionRunner runner = client.readWriteTransaction();
     runner.run(
-        new TransactionCallable<Void>() {
-          @Override
-          public Void run(TransactionContext transaction) {
-            transaction.executeUpdate(UPDATE_STATEMENT);
-            return null;
-          }
+        transaction -> {
+          transaction.executeUpdate(UPDATE_STATEMENT);
+          return null;
         });
     Map<String, Boolean> spans = failOnOverkillTraceComponent.getSpans();
     assertThat(spans).containsEntry("CloudSpanner.ReadWriteTransaction", true);
@@ -290,12 +286,9 @@ public class SpanTest {
     TransactionRunner runner = client.readWriteTransaction();
     try {
       runner.run(
-          new TransactionCallable<Void>() {
-            @Override
-            public Void run(TransactionContext transaction) {
-              transaction.executeUpdate(INVALID_UPDATE_STATEMENT);
-              return null;
-            }
+          transaction -> {
+            transaction.executeUpdate(INVALID_UPDATE_STATEMENT);
+            return null;
           });
       fail("missing expected exception");
     } catch (SpannerException e) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBatchDmlTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBatchDmlTest.java
@@ -27,7 +27,6 @@ import com.google.cloud.spanner.ParallelIntegrationTest;
 import com.google.cloud.spanner.SpannerBatchUpdateException;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.Statement;
-import com.google.cloud.spanner.TransactionContext;
 import com.google.cloud.spanner.TransactionRunner;
 import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
@@ -82,21 +81,18 @@ public final class ITBatchDmlTest {
   @Test
   public void noStatementsInRequest() {
     final TransactionCallable<long[]> callable =
-        new TransactionCallable<long[]>() {
-          @Override
-          public long[] run(TransactionContext transaction) {
-            List<Statement> stmts = new ArrayList<>();
-            long[] rowCounts;
-            try {
-              rowCounts = transaction.batchUpdate(stmts);
-              Assert.fail("Expecting an exception.");
-            } catch (SpannerException e) {
-              assertThat(e instanceof SpannerBatchUpdateException).isFalse();
-              assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
-              rowCounts = new long[0];
-            }
-            return rowCounts;
+        transaction -> {
+          List<Statement> stmts = new ArrayList<>();
+          long[] rowCounts;
+          try {
+            rowCounts = transaction.batchUpdate(stmts);
+            Assert.fail("Expecting an exception.");
+          } catch (SpannerException e) {
+            assertThat(e instanceof SpannerBatchUpdateException).isFalse();
+            assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
+            rowCounts = new long[0];
           }
+          return rowCounts;
         };
     TransactionRunner runner = client.readWriteTransaction();
     long[] rowCounts = runner.run(callable);
@@ -106,15 +102,12 @@ public final class ITBatchDmlTest {
   @Test
   public void batchDml() {
     final TransactionCallable<long[]> callable =
-        new TransactionCallable<long[]>() {
-          @Override
-          public long[] run(TransactionContext transaction) {
-            List<Statement> stmts = new ArrayList<>();
-            stmts.add(Statement.of(INSERT_DML));
-            stmts.add(Statement.of(UPDATE_DML));
-            stmts.add(Statement.of(DELETE_DML));
-            return transaction.batchUpdate(stmts);
-          }
+        transaction -> {
+          List<Statement> stmts = new ArrayList<>();
+          stmts.add(Statement.of(INSERT_DML));
+          stmts.add(Statement.of(UPDATE_DML));
+          stmts.add(Statement.of(DELETE_DML));
+          return transaction.batchUpdate(stmts);
         };
     TransactionRunner runner = client.readWriteTransaction();
     long[] rowCounts = runner.run(callable);
@@ -127,19 +120,16 @@ public final class ITBatchDmlTest {
   @Test
   public void mixedBatchDmlAndDml() {
     final TransactionCallable<long[]> callable =
-        new TransactionCallable<long[]>() {
-          @Override
-          public long[] run(TransactionContext transaction) {
-            long rowCount = transaction.executeUpdate(Statement.of(INSERT_DML));
-            List<Statement> stmts = new ArrayList<>();
-            stmts.add(Statement.of(UPDATE_DML));
-            stmts.add(Statement.of(DELETE_DML));
-            long[] batchRowCounts = transaction.batchUpdate(stmts);
-            long[] rowCounts = new long[batchRowCounts.length + 1];
-            System.arraycopy(batchRowCounts, 0, rowCounts, 0, batchRowCounts.length);
-            rowCounts[batchRowCounts.length] = rowCount;
-            return rowCounts;
-          }
+        transaction -> {
+          long rowCount = transaction.executeUpdate(Statement.of(INSERT_DML));
+          List<Statement> stmts = new ArrayList<>();
+          stmts.add(Statement.of(UPDATE_DML));
+          stmts.add(Statement.of(DELETE_DML));
+          long[] batchRowCounts = transaction.batchUpdate(stmts);
+          long[] rowCounts = new long[batchRowCounts.length + 1];
+          System.arraycopy(batchRowCounts, 0, rowCounts, 0, batchRowCounts.length);
+          rowCounts[batchRowCounts.length] = rowCount;
+          return rowCounts;
         };
     TransactionRunner runner = client.readWriteTransaction();
     long[] rowCounts = runner.run(callable);
@@ -152,15 +142,12 @@ public final class ITBatchDmlTest {
   @Test
   public void errorBatchDmlIllegalStatement() {
     final TransactionCallable<long[]> callable =
-        new TransactionCallable<long[]>() {
-          @Override
-          public long[] run(TransactionContext transaction) {
-            List<Statement> stmts = new ArrayList<>();
-            stmts.add(Statement.of(INSERT_DML));
-            stmts.add(Statement.of("some illegal statement"));
-            stmts.add(Statement.of(UPDATE_DML));
-            return transaction.batchUpdate(stmts);
-          }
+        transaction -> {
+          List<Statement> stmts = new ArrayList<>();
+          stmts.add(Statement.of(INSERT_DML));
+          stmts.add(Statement.of("some illegal statement"));
+          stmts.add(Statement.of(UPDATE_DML));
+          return transaction.batchUpdate(stmts);
         };
     TransactionRunner runner = client.readWriteTransaction();
     try {
@@ -180,15 +167,12 @@ public final class ITBatchDmlTest {
   @Test
   public void errorBatchDmlAlreadyExist() {
     final TransactionCallable<long[]> callable =
-        new TransactionCallable<long[]>() {
-          @Override
-          public long[] run(TransactionContext transaction) {
-            List<Statement> stmts = new ArrayList<>();
-            stmts.add(Statement.of(INSERT_DML));
-            stmts.add(Statement.of(INSERT_DML)); // should fail
-            stmts.add(Statement.of(UPDATE_DML));
-            return transaction.batchUpdate(stmts);
-          }
+        transaction -> {
+          List<Statement> stmts = new ArrayList<>();
+          stmts.add(Statement.of(INSERT_DML));
+          stmts.add(Statement.of(INSERT_DML)); // should fail
+          stmts.add(Statement.of(UPDATE_DML));
+          return transaction.batchUpdate(stmts);
         };
     TransactionRunner runner = client.readWriteTransaction();
     try {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITClosedSessionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITClosedSessionTest.java
@@ -33,7 +33,6 @@ import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.TransactionContext;
 import com.google.cloud.spanner.TransactionManager;
 import com.google.cloud.spanner.TransactionRunner;
-import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -200,18 +199,15 @@ public class ITClosedSessionTest {
     for (int run = 0; run < RUNS_PER_TEST_CASE; run++) {
       TransactionRunner txn = client.readWriteTransaction();
       txn.run(
-          new TransactionCallable<Void>() {
-            @Override
-            public Void run(TransactionContext transaction) {
-              for (int i = 0; i < 2; i++) {
-                try (ResultSet rs = transaction.executeQuery(Statement.of("SELECT 1"))) {
-                  assertThat(rs.next()).isTrue();
-                  assertThat(rs.getLong(0)).isEqualTo(1L);
-                  assertThat(rs.next()).isFalse();
-                }
+          transaction -> {
+            for (int i = 0; i < 2; i++) {
+              try (ResultSet rs = transaction.executeQuery(Statement.of("SELECT 1"))) {
+                assertThat(rs.next()).isTrue();
+                assertThat(rs.getLong(0)).isEqualTo(1L);
+                assertThat(rs.next()).isFalse();
               }
-              return null;
             }
+            return null;
           });
     }
   }
@@ -223,15 +219,12 @@ public class ITClosedSessionTest {
     try {
       TransactionRunner txn = client.readWriteTransaction();
       txn.run(
-          new TransactionCallable<Void>() {
-            @Override
-            public Void run(TransactionContext transaction) {
-              try (ResultSet rs = transaction.executeQuery(Statement.of("SELECT 1"))) {
-                rs.next();
-                fail("Expected exception");
-              }
-              return null;
+          transaction -> {
+            try (ResultSet rs = transaction.executeQuery(Statement.of("SELECT 1"))) {
+              rs.next();
+              fail("Expected exception");
             }
+            return null;
           });
       fail("Expected exception");
     } catch (SessionNotFoundException ex) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITQueryOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITQueryOptionsTest.java
@@ -30,8 +30,6 @@ import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.Statement;
-import com.google.cloud.spanner.TransactionContext;
-import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import com.google.spanner.v1.ExecuteSqlRequest.QueryOptions;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -109,11 +107,9 @@ public class ITQueryOptionsTest {
     assertThat(
             client
                 .readWriteTransaction()
-                .run(
-                    new TransactionCallable<Long>() {
-                      @Override
-                      public Long run(TransactionContext transaction) {
-                        return transaction.executeUpdate(
+                .<Long>run(
+                    transaction ->
+                        transaction.executeUpdate(
                             Statement.newBuilder("INSERT INTO TEST (ID, NAME) VALUES (@id, @name)")
                                 .bind("id")
                                 .to(1L)
@@ -121,20 +117,16 @@ public class ITQueryOptionsTest {
                                 .to("One")
                                 .withQueryOptions(
                                     QueryOptions.newBuilder().setOptimizerVersion("1").build())
-                                .build());
-                      }
-                    }))
+                                .build())))
         .isEqualTo(1L);
 
     // Version 'latest' should also work.
     assertThat(
             client
                 .readWriteTransaction()
-                .run(
-                    new TransactionCallable<Long>() {
-                      @Override
-                      public Long run(TransactionContext transaction) {
-                        return transaction.executeUpdate(
+                .<Long>run(
+                    transaction ->
+                        transaction.executeUpdate(
                             Statement.newBuilder("INSERT INTO TEST (ID, NAME) VALUES (@id, @name)")
                                 .bind("id")
                                 .to(2L)
@@ -142,9 +134,7 @@ public class ITQueryOptionsTest {
                                 .to("Two")
                                 .withQueryOptions(
                                     QueryOptions.newBuilder().setOptimizerVersion("latest").build())
-                                .build());
-                      }
-                    }))
+                                .build())))
         .isEqualTo(1L);
 
     // Version '100000' is an invalid value and should cause an error.
@@ -152,10 +142,8 @@ public class ITQueryOptionsTest {
       client
           .readWriteTransaction()
           .run(
-              new TransactionCallable<Long>() {
-                @Override
-                public Long run(TransactionContext transaction) {
-                  return transaction.executeUpdate(
+              transaction ->
+                  transaction.executeUpdate(
                       Statement.newBuilder("INSERT INTO TEST (ID, NAME) VALUES (@id, @name)")
                           .bind("id")
                           .to(3L)
@@ -163,9 +151,7 @@ public class ITQueryOptionsTest {
                           .to("Three")
                           .withQueryOptions(
                               QueryOptions.newBuilder().setOptimizerVersion("100000").build())
-                          .build());
-                }
-              });
+                          .build()));
       fail("missing expected exception");
     } catch (SpannerException e) {
       assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
@@ -45,8 +45,6 @@ import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.SpannerOptions.CallContextConfigurator;
 import com.google.cloud.spanner.SpannerOptions.CallCredentialsProvider;
 import com.google.cloud.spanner.Statement;
-import com.google.cloud.spanner.TransactionContext;
-import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import com.google.cloud.spanner.admin.database.v1.MockDatabaseAdminImpl;
 import com.google.cloud.spanner.admin.instance.v1.MockInstanceAdminImpl;
 import com.google.cloud.spanner.spi.v1.GapicSpannerRpc.AdminRequestsLimitExceededRetryAlgorithm;
@@ -437,13 +435,7 @@ public class GapicSpannerRpcTest {
                 timeoutHolder.timeout = Duration.ofNanos(1L);
                 client
                     .readWriteTransaction()
-                    .run(
-                        new TransactionCallable<Long>() {
-                          @Override
-                          public Long run(TransactionContext transaction) throws Exception {
-                            return transaction.executeUpdate(UPDATE_FOO_STATEMENT);
-                          }
-                        });
+                    .run(transaction -> transaction.executeUpdate(UPDATE_FOO_STATEMENT));
                 fail("missing expected timeout exception");
               } catch (SpannerException e) {
                 assertThat(e.getErrorCode()).isEqualTo(ErrorCode.DEADLINE_EXCEEDED);
@@ -454,13 +446,7 @@ public class GapicSpannerRpcTest {
               Long updateCount =
                   client
                       .readWriteTransaction()
-                      .run(
-                          new TransactionCallable<Long>() {
-                            @Override
-                            public Long run(TransactionContext transaction) throws Exception {
-                              return transaction.executeUpdate(UPDATE_FOO_STATEMENT);
-                            }
-                          });
+                      .run(transaction -> transaction.executeUpdate(UPDATE_FOO_STATEMENT));
               assertThat(updateCount).isEqualTo(1L);
             }
           });

--- a/samples/snippets/src/main/java/com/example/spanner/CustomTimeoutAndRetrySettingsExample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/CustomTimeoutAndRetrySettingsExample.java
@@ -17,6 +17,7 @@
 package com.example.spanner;
 
 //[START spanner_set_custom_timeout_and_retry]
+
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.cloud.spanner.DatabaseClient;
@@ -24,8 +25,6 @@ import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.Statement;
-import com.google.cloud.spanner.TransactionContext;
-import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import org.threeten.bp.Duration;
 
 class CustomTimeoutAndRetrySettingsExample {
@@ -70,18 +69,14 @@ class CustomTimeoutAndRetrySettingsExample {
           spanner.getDatabaseClient(DatabaseId.of(projectId, instanceId, databaseId));
       client
           .readWriteTransaction()
-          .run(
-              new TransactionCallable<Void>() {
-                @Override
-                public Void run(TransactionContext transaction) throws Exception {
-                  String sql =
-                      "INSERT Singers (SingerId, FirstName, LastName)\n"
-                          + "VALUES (20, 'George', 'Washington')";
-                  long rowCount = transaction.executeUpdate(Statement.of(sql));
-                  System.out.printf("%d record inserted.%n", rowCount);
-                  return null;
-                }
-              });
+          .run(transaction -> {
+            String sql =
+                "INSERT Singers (SingerId, FirstName, LastName)\n"
+                    + "VALUES (20, 'George', 'Washington')";
+            long rowCount = transaction.executeUpdate(Statement.of(sql));
+            System.out.printf("%d record inserted.%n", rowCount);
+            return null;
+          });
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/spanner/SpannerSample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/SpannerSample.java
@@ -16,7 +16,6 @@
 
 package com.example.spanner;
 
-import static com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import static com.google.cloud.spanner.Type.StructField;
 
 import com.google.api.gax.longrunning.OperationFuture;
@@ -52,7 +51,6 @@ import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.TimestampBound;
-import com.google.cloud.spanner.TransactionContext;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Value;
 import com.google.common.io.BaseEncoding;
@@ -490,48 +488,44 @@ public class SpannerSample {
   static void writeWithTransaction(DatabaseClient dbClient) {
     dbClient
         .readWriteTransaction()
-        .run(
-            new TransactionCallable<Void>() {
-              @Override
-              public Void run(TransactionContext transaction) throws Exception {
-                // Transfer marketing budget from one album to another. We do it in a transaction to
-                // ensure that the transfer is atomic.
-                Struct row =
-                    transaction.readRow("Albums", Key.of(2, 2), Arrays.asList("MarketingBudget"));
-                long album2Budget = row.getLong(0);
-                // Transaction will only be committed if this condition still holds at the time of
-                // commit. Otherwise it will be aborted and the callable will be rerun by the
-                // client library.
-                long transfer = 200000;
-                if (album2Budget >= transfer) {
-                  long album1Budget =
-                      transaction
-                          .readRow("Albums", Key.of(1, 1), Arrays.asList("MarketingBudget"))
-                          .getLong(0);
-                  album1Budget += transfer;
-                  album2Budget -= transfer;
-                  transaction.buffer(
-                      Mutation.newUpdateBuilder("Albums")
-                          .set("SingerId")
-                          .to(1)
-                          .set("AlbumId")
-                          .to(1)
-                          .set("MarketingBudget")
-                          .to(album1Budget)
-                          .build());
-                  transaction.buffer(
-                      Mutation.newUpdateBuilder("Albums")
-                          .set("SingerId")
-                          .to(2)
-                          .set("AlbumId")
-                          .to(2)
-                          .set("MarketingBudget")
-                          .to(album2Budget)
-                          .build());
-                }
-                return null;
-              }
-            });
+        .run(transaction -> {
+          // Transfer marketing budget from one album to another. We do it in a transaction to
+          // ensure that the transfer is atomic.
+          Struct row =
+              transaction.readRow("Albums", Key.of(2, 2), Arrays.asList("MarketingBudget"));
+          long album2Budget = row.getLong(0);
+          // Transaction will only be committed if this condition still holds at the time of
+          // commit. Otherwise it will be aborted and the callable will be rerun by the
+          // client library.
+          long transfer = 200000;
+          if (album2Budget >= transfer) {
+            long album1Budget =
+                transaction
+                    .readRow("Albums", Key.of(1, 1), Arrays.asList("MarketingBudget"))
+                    .getLong(0);
+            album1Budget += transfer;
+            album2Budget -= transfer;
+            transaction.buffer(
+                Mutation.newUpdateBuilder("Albums")
+                    .set("SingerId")
+                    .to(1)
+                    .set("AlbumId")
+                    .to(1)
+                    .set("MarketingBudget")
+                    .to(album1Budget)
+                    .build());
+            transaction.buffer(
+                Mutation.newUpdateBuilder("Albums")
+                    .set("SingerId")
+                    .to(2)
+                    .set("AlbumId")
+                    .to(2)
+                    .set("MarketingBudget")
+                    .to(album2Budget)
+                    .build());
+          }
+          return null;
+        });
   }
   // [END spanner_read_write_transaction]
 
@@ -1004,18 +998,14 @@ public class SpannerSample {
   static void insertUsingDml(DatabaseClient dbClient) {
     dbClient
         .readWriteTransaction()
-        .run(
-            new TransactionCallable<Void>() {
-              @Override
-              public Void run(TransactionContext transaction) throws Exception {
-                String sql =
-                    "INSERT INTO Singers (SingerId, FirstName, LastName) "
-                        + " VALUES (10, 'Virginia', 'Watson')";
-                long rowCount = transaction.executeUpdate(Statement.of(sql));
-                System.out.printf("%d record inserted.\n", rowCount);
-                return null;
-              }
-            });
+        .run(transaction -> {
+          String sql =
+              "INSERT INTO Singers (SingerId, FirstName, LastName) "
+                  + " VALUES (10, 'Virginia', 'Watson')";
+          long rowCount = transaction.executeUpdate(Statement.of(sql));
+          System.out.printf("%d record inserted.\n", rowCount);
+          return null;
+        });
   }
   // [END spanner_dml_standard_insert]
 
@@ -1023,19 +1013,15 @@ public class SpannerSample {
   static void updateUsingDml(DatabaseClient dbClient) {
     dbClient
         .readWriteTransaction()
-        .run(
-            new TransactionCallable<Void>() {
-              @Override
-              public Void run(TransactionContext transaction) throws Exception {
-                String sql =
-                    "UPDATE Albums "
-                        + "SET MarketingBudget = MarketingBudget * 2 "
-                        + "WHERE SingerId = 1 and AlbumId = 1";
-                long rowCount = transaction.executeUpdate(Statement.of(sql));
-                System.out.printf("%d record updated.\n", rowCount);
-                return null;
-              }
-            });
+        .run(transaction -> {
+          String sql =
+              "UPDATE Albums "
+                  + "SET MarketingBudget = MarketingBudget * 2 "
+                  + "WHERE SingerId = 1 and AlbumId = 1";
+          long rowCount = transaction.executeUpdate(Statement.of(sql));
+          System.out.printf("%d record updated.\n", rowCount);
+          return null;
+        });
   }
   // [END spanner_dml_standard_update]
 
@@ -1043,16 +1029,12 @@ public class SpannerSample {
   static void deleteUsingDml(DatabaseClient dbClient) {
     dbClient
         .readWriteTransaction()
-        .run(
-            new TransactionCallable<Void>() {
-              @Override
-              public Void run(TransactionContext transaction) throws Exception {
-                String sql = "DELETE FROM Singers WHERE FirstName = 'Alice'";
-                long rowCount = transaction.executeUpdate(Statement.of(sql));
-                System.out.printf("%d record deleted.\n", rowCount);
-                return null;
-              }
-            });
+        .run(transaction -> {
+          String sql = "DELETE FROM Singers WHERE FirstName = 'Alice'";
+          long rowCount = transaction.executeUpdate(Statement.of(sql));
+          System.out.printf("%d record deleted.\n", rowCount);
+          return null;
+        });
   }
   // [END spanner_dml_standard_delete]
 
@@ -1060,18 +1042,14 @@ public class SpannerSample {
   static void updateUsingDmlWithTimestamp(DatabaseClient dbClient) {
     dbClient
         .readWriteTransaction()
-        .run(
-            new TransactionCallable<Void>() {
-              @Override
-              public Void run(TransactionContext transaction) throws Exception {
-                String sql =
-                    "UPDATE Albums "
-                        + "SET LastUpdateTime = PENDING_COMMIT_TIMESTAMP() WHERE SingerId = 1";
-                long rowCount = transaction.executeUpdate(Statement.of(sql));
-                System.out.printf("%d records updated.\n", rowCount);
-                return null;
-              }
-            });
+        .run(transaction -> {
+          String sql =
+              "UPDATE Albums "
+                  + "SET LastUpdateTime = PENDING_COMMIT_TIMESTAMP() WHERE SingerId = 1";
+          long rowCount = transaction.executeUpdate(Statement.of(sql));
+          System.out.printf("%d records updated.\n", rowCount);
+          return null;
+        });
   }
   // [END spanner_dml_standard_update_with_timestamp]
 
@@ -1079,30 +1057,26 @@ public class SpannerSample {
   static void writeAndReadUsingDml(DatabaseClient dbClient) {
     dbClient
         .readWriteTransaction()
-        .run(
-            new TransactionCallable<Void>() {
-              @Override
-              public Void run(TransactionContext transaction) throws Exception {
-                // Insert record.
-                String sql =
-                    "INSERT INTO Singers (SingerId, FirstName, LastName) "
-                        + " VALUES (11, 'Timothy', 'Campbell')";
-                long rowCount = transaction.executeUpdate(Statement.of(sql));
-                System.out.printf("%d record inserted.\n", rowCount);
-                // Read newly inserted record.
-                sql = "SELECT FirstName, LastName FROM Singers WHERE SingerId = 11";
-                // We use a try-with-resource block to automatically release resources held by
-                // ResultSet.
-                try (ResultSet resultSet = transaction.executeQuery(Statement.of(sql))) {
-                  while (resultSet.next()) {
-                    System.out.printf(
-                        "%s %s\n",
-                        resultSet.getString("FirstName"), resultSet.getString("LastName"));
-                  }
-                }
-                return null;
-              }
-            });
+        .run(transaction -> {
+          // Insert record.
+          String sql =
+              "INSERT INTO Singers (SingerId, FirstName, LastName) "
+                  + " VALUES (11, 'Timothy', 'Campbell')";
+          long rowCount = transaction.executeUpdate(Statement.of(sql));
+          System.out.printf("%d record inserted.\n", rowCount);
+          // Read newly inserted record.
+          sql = "SELECT FirstName, LastName FROM Singers WHERE SingerId = 11";
+          // We use a try-with-resource block to automatically release resources held by
+          // ResultSet.
+          try (ResultSet resultSet = transaction.executeQuery(Statement.of(sql))) {
+            while (resultSet.next()) {
+              System.out.printf(
+                  "%s %s\n",
+                  resultSet.getString("FirstName"), resultSet.getString("LastName"));
+            }
+          }
+          return null;
+        });
   }
   // [END spanner_dml_write_then_read]
 
@@ -1120,15 +1094,11 @@ public class SpannerSample {
             .build();
     dbClient
         .readWriteTransaction()
-        .run(
-            new TransactionCallable<Void>() {
-              @Override
-              public Void run(TransactionContext transaction) throws Exception {
-                long rowCount = transaction.executeUpdate(s);
-                System.out.printf("%d record updated.\n", rowCount);
-                return null;
-              }
-            });
+        .run(transaction -> {
+          long rowCount = transaction.executeUpdate(s);
+          System.out.printf("%d record updated.\n", rowCount);
+          return null;
+        });
   }
   // [END spanner_dml_structs]
 
@@ -1137,21 +1107,17 @@ public class SpannerSample {
     // Insert 4 singer records
     dbClient
         .readWriteTransaction()
-        .run(
-            new TransactionCallable<Void>() {
-              @Override
-              public Void run(TransactionContext transaction) throws Exception {
-                String sql =
-                    "INSERT INTO Singers (SingerId, FirstName, LastName) VALUES "
-                        + "(12, 'Melissa', 'Garcia'), "
-                        + "(13, 'Russell', 'Morales'), "
-                        + "(14, 'Jacqueline', 'Long'), "
-                        + "(15, 'Dylan', 'Shaw')";
-                long rowCount = transaction.executeUpdate(Statement.of(sql));
-                System.out.printf("%d records inserted.\n", rowCount);
-                return null;
-              }
-            });
+        .run(transaction -> {
+          String sql =
+              "INSERT INTO Singers (SingerId, FirstName, LastName) VALUES "
+                  + "(12, 'Melissa', 'Garcia'), "
+                  + "(13, 'Russell', 'Morales'), "
+                  + "(14, 'Jacqueline', 'Long'), "
+                  + "(15, 'Dylan', 'Shaw')";
+          long rowCount = transaction.executeUpdate(Statement.of(sql));
+          System.out.printf("%d records inserted.\n", rowCount);
+          return null;
+        });
   }
   // [END spanner_dml_getting_started_insert]
 
@@ -1181,55 +1147,51 @@ public class SpannerSample {
   static void writeWithTransactionUsingDml(DatabaseClient dbClient) {
     dbClient
         .readWriteTransaction()
-        .run(
-            new TransactionCallable<Void>() {
-              @Override
-              public Void run(TransactionContext transaction) throws Exception {
-                // Transfer marketing budget from one album to another. We do it in a transaction to
-                // ensure that the transfer is atomic.
-                String sql1 =
-                    "SELECT MarketingBudget from Albums WHERE SingerId = 2 and AlbumId = 2";
-                ResultSet resultSet = transaction.executeQuery(Statement.of(sql1));
-                long album2Budget = 0;
-                while (resultSet.next()) {
-                  album2Budget = resultSet.getLong("MarketingBudget");
-                }
-                // Transaction will only be committed if this condition still holds at the time of
-                // commit. Otherwise it will be aborted and the callable will be rerun by the
-                // client library.
-                long transfer = 200000;
-                if (album2Budget >= transfer) {
-                  String sql2 =
-                      "SELECT MarketingBudget from Albums WHERE SingerId = 1 and AlbumId = 1";
-                  ResultSet resultSet2 = transaction.executeQuery(Statement.of(sql2));
-                  long album1Budget = 0;
-                  while (resultSet2.next()) {
-                    album1Budget = resultSet2.getLong("MarketingBudget");
-                  }
-                  album1Budget += transfer;
-                  album2Budget -= transfer;
-                  Statement updateStatement =
-                      Statement.newBuilder(
-                              "UPDATE Albums "
-                                  + "SET MarketingBudget = @AlbumBudget "
-                                  + "WHERE SingerId = 1 and AlbumId = 1")
-                          .bind("AlbumBudget")
-                          .to(album1Budget)
-                          .build();
-                  transaction.executeUpdate(updateStatement);
-                  Statement updateStatement2 =
-                      Statement.newBuilder(
-                              "UPDATE Albums "
-                                  + "SET MarketingBudget = @AlbumBudget "
-                                  + "WHERE SingerId = 2 and AlbumId = 2")
-                          .bind("AlbumBudget")
-                          .to(album2Budget)
-                          .build();
-                  transaction.executeUpdate(updateStatement2);
-                }
-                return null;
-              }
-            });
+        .run(transaction -> {
+          // Transfer marketing budget from one album to another. We do it in a transaction to
+          // ensure that the transfer is atomic.
+          String sql1 =
+              "SELECT MarketingBudget from Albums WHERE SingerId = 2 and AlbumId = 2";
+          ResultSet resultSet = transaction.executeQuery(Statement.of(sql1));
+          long album2Budget = 0;
+          while (resultSet.next()) {
+            album2Budget = resultSet.getLong("MarketingBudget");
+          }
+          // Transaction will only be committed if this condition still holds at the time of
+          // commit. Otherwise it will be aborted and the callable will be rerun by the
+          // client library.
+          long transfer = 200000;
+          if (album2Budget >= transfer) {
+            String sql2 =
+                "SELECT MarketingBudget from Albums WHERE SingerId = 1 and AlbumId = 1";
+            ResultSet resultSet2 = transaction.executeQuery(Statement.of(sql2));
+            long album1Budget = 0;
+            while (resultSet2.next()) {
+              album1Budget = resultSet2.getLong("MarketingBudget");
+            }
+            album1Budget += transfer;
+            album2Budget -= transfer;
+            Statement updateStatement =
+                Statement.newBuilder(
+                    "UPDATE Albums "
+                        + "SET MarketingBudget = @AlbumBudget "
+                        + "WHERE SingerId = 1 and AlbumId = 1")
+                    .bind("AlbumBudget")
+                    .to(album1Budget)
+                    .build();
+            transaction.executeUpdate(updateStatement);
+            Statement updateStatement2 =
+                Statement.newBuilder(
+                    "UPDATE Albums "
+                        + "SET MarketingBudget = @AlbumBudget "
+                        + "WHERE SingerId = 2 and AlbumId = 2")
+                    .bind("AlbumBudget")
+                    .to(album2Budget)
+                    .build();
+            transaction.executeUpdate(updateStatement2);
+          }
+          return null;
+        });
   }
   // [END spanner_dml_getting_started_update]
 
@@ -1253,33 +1215,29 @@ public class SpannerSample {
   static void updateUsingBatchDml(DatabaseClient dbClient) {
     dbClient
         .readWriteTransaction()
-        .run(
-            new TransactionCallable<Void>() {
-              @Override
-              public Void run(TransactionContext transaction) throws Exception {
-                List<Statement> stmts = new ArrayList<Statement>();
-                String sql =
-                    "INSERT INTO Albums "
-                        + "(SingerId, AlbumId, AlbumTitle, MarketingBudget) "
-                        + "VALUES (1, 3, 'Test Album Title', 10000) ";
-                stmts.add(Statement.of(sql));
-                sql =
-                    "UPDATE Albums "
-                        + "SET MarketingBudget = MarketingBudget * 2 "
-                        + "WHERE SingerId = 1 and AlbumId = 3";
-                stmts.add(Statement.of(sql));
-                long[] rowCounts;
-                try {
-                  rowCounts = transaction.batchUpdate(stmts);
-                } catch (SpannerBatchUpdateException e) {
-                  rowCounts = e.getUpdateCounts();
-                }
-                for (int i = 0; i < rowCounts.length; i++) {
-                  System.out.printf("%d record updated by stmt %d.\n", rowCounts[i], i);
-                }
-                return null;
-              }
-            });
+        .run(transaction -> {
+          List<Statement> stmts = new ArrayList<Statement>();
+          String sql =
+              "INSERT INTO Albums "
+                  + "(SingerId, AlbumId, AlbumTitle, MarketingBudget) "
+                  + "VALUES (1, 3, 'Test Album Title', 10000) ";
+          stmts.add(Statement.of(sql));
+          sql =
+              "UPDATE Albums "
+                  + "SET MarketingBudget = MarketingBudget * 2 "
+                  + "WHERE SingerId = 1 and AlbumId = 3";
+          stmts.add(Statement.of(sql));
+          long[] rowCounts;
+          try {
+            rowCounts = transaction.batchUpdate(stmts);
+          } catch (SpannerBatchUpdateException e) {
+            rowCounts = e.getUpdateCounts();
+          }
+          for (int i = 0; i < rowCounts.length; i++) {
+            System.out.printf("%d record updated by stmt %d.\n", rowCounts[i], i);
+          }
+          return null;
+        });
   }
   // [END spanner_dml_batch_update]
 

--- a/samples/snippets/src/main/java/com/example/spanner/StatementTimeoutExample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/StatementTimeoutExample.java
@@ -24,8 +24,6 @@ import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.SpannerOptions.CallContextConfigurator;
 import com.google.cloud.spanner.Statement;
-import com.google.cloud.spanner.TransactionContext;
-import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import com.google.spanner.v1.SpannerGrpc;
 import io.grpc.CallOptions;
 import io.grpc.Context;
@@ -67,14 +65,12 @@ class StatementTimeoutExample {
     // Run the transaction in the custom context.
     context.run(new Runnable() {
       public void run() {
-        client.readWriteTransaction().run(new TransactionCallable<long[]>() {
-          public long[] run(TransactionContext transaction) throws Exception {
-            String sql = "INSERT Singers (SingerId, FirstName, LastName)\n"
-                + "VALUES (20, 'George', 'Washington')";
-            long rowCount = transaction.executeUpdate(Statement.of(sql));
-            System.out.printf("%d record inserted.%n", rowCount);
-            return null;
-          }
+        client.readWriteTransaction().<long[]>run(transaction -> {
+          String sql = "INSERT Singers (SingerId, FirstName, LastName)\n"
+              + "VALUES (20, 'George', 'Washington')";
+          long rowCount = transaction.executeUpdate(Statement.of(sql));
+          System.out.printf("%d record inserted.%n", rowCount);
+          return null;
         });
       }
     });


### PR DESCRIPTION
Makes the `TransactionCallable` a `@FunctionalInterface` so it can be used with lambdas.

This PR also modifies all of its usages to the lambda syntax. Only syntatic changes were made, no logic changes were made here.
