### PR TITLE
chore: uses lambda syntax for Runnables and Callables

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncRunnerImpl.java
@@ -43,16 +43,13 @@ class AsyncRunnerImpl implements AsyncRunner {
     commitResponse = SettableApiFuture.create();
     final SettableApiFuture<R> res = SettableApiFuture.create();
     executor.execute(
-        new Runnable() {
-          @Override
-          public void run() {
-            try {
-              res.set(runTransaction(work));
-            } catch (Throwable t) {
-              res.setException(t);
-            } finally {
-              setCommitResponse();
-            }
+        () -> {
+          try {
+            res.set(runTransaction(work));
+          } catch (Throwable t) {
+            res.setException(t);
+          } finally {
+            setCommitResponse();
           }
         });
     return res;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Operation.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Operation.java
@@ -28,7 +28,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.longrunning.Operation.ResultCase;
 import com.google.protobuf.Any;
 import com.google.rpc.Status;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
@@ -143,12 +142,7 @@ public class Operation<R, M> {
     try {
       com.google.longrunning.Operation proto =
           RetryHelper.poll(
-              new Callable<com.google.longrunning.Operation>() {
-                @Override
-                public com.google.longrunning.Operation call() throws Exception {
-                  return rpc.getOperation(name);
-                }
-              },
+              () -> rpc.getOperation(name),
               waitSettings,
               new BasicResultRetryAlgorithm<com.google.longrunning.Operation>() {
                 @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -322,29 +322,26 @@ class SessionImpl implements Session {
     requestFuture.addListener(
         tracer.withSpan(
             span,
-            new Runnable() {
-              @Override
-              public void run() {
-                try {
-                  Transaction txn = requestFuture.get();
-                  if (txn.getId().isEmpty()) {
-                    throw newSpannerException(
-                        ErrorCode.INTERNAL, "Missing id in transaction\n" + getName());
-                  }
-                  span.end(TraceUtil.END_SPAN_OPTIONS);
-                  res.set(txn.getId());
-                } catch (ExecutionException e) {
-                  TraceUtil.endSpanWithFailure(span, e);
-                  res.setException(
-                      SpannerExceptionFactory.newSpannerException(
-                          e.getCause() == null ? e : e.getCause()));
-                } catch (InterruptedException e) {
-                  TraceUtil.endSpanWithFailure(span, e);
-                  res.setException(SpannerExceptionFactory.propagateInterrupt(e));
-                } catch (Exception e) {
-                  TraceUtil.endSpanWithFailure(span, e);
-                  res.setException(e);
+            () -> {
+              try {
+                Transaction txn = requestFuture.get();
+                if (txn.getId().isEmpty()) {
+                  throw newSpannerException(
+                      ErrorCode.INTERNAL, "Missing id in transaction\n" + getName());
                 }
+                span.end(TraceUtil.END_SPAN_OPTIONS);
+                res.set(txn.getId());
+              } catch (ExecutionException e) {
+                TraceUtil.endSpanWithFailure(span, e);
+                res.setException(
+                    SpannerExceptionFactory.newSpannerException(
+                        e.getCause() == null ? e : e.getCause()));
+              } catch (InterruptedException e) {
+                TraceUtil.endSpanWithFailure(span, e);
+                res.setException(SpannerExceptionFactory.propagateInterrupt(e));
+              } catch (Exception e) {
+                TraceUtil.endSpanWithFailure(span, e);
+                res.setException(e);
               }
             }),
         MoreExecutors.directExecutor());

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -162,25 +162,23 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
    * Context context =
    *     Context.current().withValue(SpannerOptions.CALL_CONTEXT_CONFIGURATOR_KEY, configurator);
    * context.run(
-   *     new Runnable() {
-   *       public void run() {
-   *         try {
-   *           client
-   *               .readWriteTransaction()
-   *               .run(
-   *                   new TransactionCallable<long[]>() {
-   *                     public long[] run(TransactionContext transaction) throws Exception {
-   *                       return transaction.batchUpdate(
-   *                           ImmutableList.of(statement1, statement2));
-   *                     }
-   *                   });
-   *         } catch (SpannerException e) {
-   *           if (e.getErrorCode() == ErrorCode.DEADLINE_EXCEEDED) {
-   *             // handle timeout exception.
-   *           }
+   *     () -> {
+   *       try {
+   *         client
+   *             .readWriteTransaction()
+   *             .run(
+   *                 new TransactionCallable<long[]>() {
+   *                   public long[] run(TransactionContext transaction) throws Exception {
+   *                     return transaction.batchUpdate(
+   *                         ImmutableList.of(statement1, statement2));
+   *                   }
+   *                 });
+   *       } catch (SpannerException e) {
+   *         if (e.getErrorCode() == ErrorCode.DEADLINE_EXCEEDED) {
+   *           // handle timeout exception.
    *         }
    *       }
-   *     });
+   *     }
    * }</pre>
    */
   public static interface CallContextConfigurator {
@@ -285,24 +283,22 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
    *             SpannerCallContextTimeoutConfigurator.create()
    *                 .withExecuteQueryTimeout(Duration.ofSeconds(10L)));
    * context.run(
-   *     new Runnable() {
-   *       public void run() {
-   *         try (ResultSet rs =
-   *             client
-   *                 .singleUse()
-   *                 .executeQuery(
-   *                     Statement.of(
-   *                         "SELECT SingerId, FirstName, LastName FROM Singers ORDER BY LastName"))) {
-   *           while (rs.next()) {
-   *             System.out.printf("%d %s %s%n", rs.getLong(0), rs.getString(1), rs.getString(2));
-   *           }
-   *         } catch (SpannerException e) {
-   *           if (e.getErrorCode() == ErrorCode.DEADLINE_EXCEEDED) {
-   *             // Handle timeout.
-   *           }
+   *     () -> {
+   *       try (ResultSet rs =
+   *           client
+   *               .singleUse()
+   *               .executeQuery(
+   *                   Statement.of(
+   *                       "SELECT SingerId, FirstName, LastName FROM Singers ORDER BY LastName"))) {
+   *         while (rs.next()) {
+   *           System.out.printf("%d %s %s%n", rs.getLong(0), rs.getString(1), rs.getString(2));
+   *         }
+   *       } catch (SpannerException e) {
+   *         if (e.getErrorCode() == ErrorCode.DEADLINE_EXCEEDED) {
+   *           // Handle timeout.
    *         }
    *       }
-   *     });
+   *     }
    * }</pre>
    */
   public static class SpannerCallContextTimeoutConfigurator implements CallContextConfigurator {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContextFutureImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContextFutureImpl.java
@@ -197,31 +197,28 @@ class TransactionContextFutureImpl extends ForwardingApiFuture<TransactionContex
     } else {
       final SettableApiFuture<O> res = SettableApiFuture.create();
       executor.execute(
-          new Runnable() {
-            @Override
-            public void run() {
-              try {
-                ApiFuture<O> functionResult =
-                    Preconditions.checkNotNull(
-                        function.apply(txn, input),
-                        "AsyncTransactionFunction returned <null>. Did you mean to return ApiFutures.immediateFuture(null)?");
-                ApiFutures.addCallback(
-                    functionResult,
-                    new ApiFutureCallback<O>() {
-                      @Override
-                      public void onFailure(Throwable t) {
-                        res.setException(t);
-                      }
+          () -> {
+            try {
+              ApiFuture<O> functionResult =
+                  Preconditions.checkNotNull(
+                      function.apply(txn, input),
+                      "AsyncTransactionFunction returned <null>. Did you mean to return ApiFutures.immediateFuture(null)?");
+              ApiFutures.addCallback(
+                  functionResult,
+                  new ApiFutureCallback<O>() {
+                    @Override
+                    public void onFailure(Throwable t) {
+                      res.setException(t);
+                    }
 
-                      @Override
-                      public void onSuccess(O result) {
-                        res.set(result);
-                      }
-                    },
-                    MoreExecutors.directExecutor());
-              } catch (Throwable t) {
-                res.setException(t);
-              }
+                    @Override
+                    public void onSuccess(O result) {
+                      res.set(result);
+                    }
+                  },
+                  MoreExecutors.directExecutor());
+            } catch (Throwable t) {
+              res.setException(t);
             }
           });
       return res;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractMultiUseTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractMultiUseTransaction.java
@@ -26,7 +26,6 @@ import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.connection.StatementParser.ParsedStatement;
 import com.google.common.base.Preconditions;
 import com.google.spanner.v1.SpannerGrpc;
-import java.util.concurrent.Callable;
 
 /**
  * Base class for {@link Connection}-based transactions that can be used for multiple read and
@@ -67,13 +66,10 @@ abstract class AbstractMultiUseTransaction extends AbstractBaseUnitOfWork {
     checkValidTransaction();
     return executeStatementAsync(
         statement,
-        new Callable<ResultSet>() {
-          @Override
-          public ResultSet call() throws Exception {
-            checkAborted();
-            return DirectExecuteResultSet.ofResultSet(
-                internalExecuteQuery(statement, analyzeMode, options));
-          }
+        () -> {
+          checkAborted();
+          return DirectExecuteResultSet.ofResultSet(
+              internalExecuteQuery(statement, analyzeMode, options));
         },
         SpannerGrpc.getExecuteStreamingSqlMethod());
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
@@ -51,7 +51,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Stack;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -283,14 +282,7 @@ class ConnectionImpl implements Connection {
       // Add a no-op statement to the execute. Once this has been executed, we know that all
       // preceeding statements have also been executed, as the executor is single-threaded and
       // executes all statements in order of submitting.
-      futures.add(
-          statementExecutor.submit(
-              new Callable<Void>() {
-                @Override
-                public Void call() throws Exception {
-                  return null;
-                }
-              }));
+      futures.add(statementExecutor.submit(() -> null));
       statementExecutor.shutdown();
       leakedException = null;
       spannerPool.removeConnection(options, this);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DdlBatch.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DdlBatch.java
@@ -130,13 +130,9 @@ class DdlBatch extends AbstractBaseUnitOfWork {
           temp.remove(i);
           final QueryOption[] internalOptions = temp.toArray(new QueryOption[0]);
           Callable<ResultSet> callable =
-              new Callable<ResultSet>() {
-                @Override
-                public ResultSet call() throws Exception {
-                  return DirectExecuteResultSet.ofResultSet(
+              () ->
+                  DirectExecuteResultSet.ofResultSet(
                       dbClient.singleUse().executeQuery(statement.getStatement(), internalOptions));
-                }
-              };
           return executeStatementAsync(
               statement, callable, SpannerGrpc.getExecuteStreamingSqlMethod());
         }
@@ -231,28 +227,25 @@ class DdlBatch extends AbstractBaseUnitOfWork {
     }
     // create a statement that can be passed in to the execute method
     Callable<long[]> callable =
-        new Callable<long[]>() {
-          @Override
-          public long[] call() throws Exception {
+        () -> {
+          try {
+            OperationFuture<Void, UpdateDatabaseDdlMetadata> operation =
+                ddlClient.executeDdl(statements);
             try {
-              OperationFuture<Void, UpdateDatabaseDdlMetadata> operation =
-                  ddlClient.executeDdl(statements);
-              try {
-                // Wait until the operation has finished.
-                getWithStatementTimeout(operation, RUN_BATCH);
-                long[] updateCounts = new long[statements.size()];
-                Arrays.fill(updateCounts, 1L);
-                state = UnitOfWorkState.RAN;
-                return updateCounts;
-              } catch (SpannerException e) {
-                long[] updateCounts = extractUpdateCounts(operation);
-                throw SpannerExceptionFactory.newSpannerBatchUpdateException(
-                    e.getErrorCode(), e.getMessage(), updateCounts);
-              }
-            } catch (Throwable t) {
-              state = UnitOfWorkState.RUN_FAILED;
-              throw t;
+              // Wait until the operation has finished.
+              getWithStatementTimeout(operation, RUN_BATCH);
+              long[] updateCounts = new long[statements.size()];
+              Arrays.fill(updateCounts, 1L);
+              state = UnitOfWorkState.RAN;
+              return updateCounts;
+            } catch (SpannerException e) {
+              long[] updateCounts = extractUpdateCounts(operation);
+              throw SpannerExceptionFactory.newSpannerBatchUpdateException(
+                  e.getErrorCode(), e.getMessage(), updateCounts);
             }
+          } catch (Throwable t) {
+            state = UnitOfWorkState.RUN_FAILED;
+            throw t;
           }
         };
     this.state = UnitOfWorkState.RUNNING;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplStressTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplStressTest.java
@@ -369,13 +369,10 @@ public class AsyncResultSetImplStressTest {
       final AtomicBoolean finished = new AtomicBoolean(false);
       ExecutorService resumeService = createExecService();
       resumeService.execute(
-          new Runnable() {
-            @Override
-            public void run() {
-              while (!finished.get()) {
-                // Randomly resume result sets.
-                resultSets.get(random.nextInt(resultSets.size())).resume();
-              }
+          () -> {
+            while (!finished.get()) {
+              // Randomly resume result sets.
+              resultSets.get(random.nextInt(resultSets.size())).resume();
             }
           });
       List<ImmutableList<Row>> lists = ApiFutures.allAsList(futures).get();
@@ -441,30 +438,24 @@ public class AsyncResultSetImplStressTest {
       // Both resume and cancel resultsets randomly.
       ExecutorService resumeService = createExecService();
       resumeService.execute(
-          new Runnable() {
-            @Override
-            public void run() {
-              while (!finished.get()) {
-                // Randomly resume result sets.
-                resultSets.get(random.nextInt(resultSets.size())).resume();
-              }
-              // Make sure all result sets finish.
-              for (AsyncResultSet rs : resultSets) {
-                rs.resume();
-              }
+          () -> {
+            while (!finished.get()) {
+              // Randomly resume result sets.
+              resultSets.get(random.nextInt(resultSets.size())).resume();
+            }
+            // Make sure all result sets finish.
+            for (AsyncResultSet rs : resultSets) {
+              rs.resume();
             }
           });
       ExecutorService cancelService = createExecService();
       cancelService.execute(
-          new Runnable() {
-            @Override
-            public void run() {
-              while (!finished.get()) {
-                // Randomly cancel result sets.
-                int index = random.nextInt(resultSets.size());
-                resultSets.get(index).cancel();
-                cancelledIndexes.add(index);
-              }
+          () -> {
+            while (!finished.get()) {
+              // Randomly cancel result sets.
+              int index = random.nextInt(resultSets.size());
+              resultSets.get(index).cancel();
+              cancelledIndexes.add(index);
             }
           });
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -1890,27 +1890,24 @@ public class DatabaseClientImplTest {
             SpannerCallContextTimeoutConfigurator.create()
                 .withExecuteQueryTimeout(Duration.ofNanos(1L)))
         .run(
-            new Runnable() {
-              @Override
-              public void run() {
-                // Query should fail with a timeout.
-                try (ResultSet rs = client.singleUse().executeQuery(SELECT1)) {
-                  rs.next();
-                  fail("missing expected DEADLINE_EXCEEDED exception");
-                } catch (SpannerException e) {
-                  assertThat(e.getErrorCode()).isEqualTo(ErrorCode.DEADLINE_EXCEEDED);
-                }
-                // Update should succeed.
-                client
-                    .readWriteTransaction()
-                    .run(
-                        new TransactionCallable<Long>() {
-                          @Override
-                          public Long run(TransactionContext transaction) throws Exception {
-                            return transaction.executeUpdate(UPDATE_STATEMENT);
-                          }
-                        });
+            () -> {
+              // Query should fail with a timeout.
+              try (ResultSet rs = client.singleUse().executeQuery(SELECT1)) {
+                rs.next();
+                fail("missing expected DEADLINE_EXCEEDED exception");
+              } catch (SpannerException e) {
+                assertThat(e.getErrorCode()).isEqualTo(ErrorCode.DEADLINE_EXCEEDED);
               }
+              // Update should succeed.
+              client
+                  .readWriteTransaction()
+                  .run(
+                      new TransactionCallable<Long>() {
+                        @Override
+                        public Long run(TransactionContext transaction) throws Exception {
+                          return transaction.executeUpdate(UPDATE_STATEMENT);
+                        }
+                      });
             });
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ITSessionPoolIntegrationTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ITSessionPoolIntegrationTest.java
@@ -115,12 +115,9 @@ public class ITSessionPoolIntegrationTest {
     Session session2 = pool.getSession().get();
     final CountDownLatch latch = new CountDownLatch(1);
     new Thread(
-            new Runnable() {
-              @Override
-              public void run() {
-                try (Session session3 = pool.getSession().get()) {
-                  latch.countDown();
-                }
+            () -> {
+              try (Session session3 = pool.getSession().get()) {
+                latch.countDown();
               }
             })
         .start();
@@ -138,12 +135,9 @@ public class ITSessionPoolIntegrationTest {
     final CountDownLatch latch = new CountDownLatch(numSessions);
     for (int i = 0; i < numSessions; i++) {
       new Thread(
-              new Runnable() {
-                @Override
-                public void run() {
-                  try (Session session = pool.getSession().get()) {
-                    latch.countDown();
-                  }
+              () -> {
+                try (Session session = pool.getSession().get()) {
+                  latch.countDown();
                 }
               })
           .start();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginBenchmark.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginBenchmark.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -156,17 +155,14 @@ public class InlineBeginBenchmark {
     for (int i = 0; i < totalQueries; i++) {
       futures.add(
           service.submit(
-              new Callable<Void>() {
-                @Override
-                public Void call() throws Exception {
-                  Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
-                  try (ResultSet rs =
-                      server.client.singleUse().executeQuery(StandardBenchmarkMockServer.SELECT1)) {
-                    while (rs.next()) {
-                      Thread.sleep(RND.nextInt(HOLD_SESSION_TIME));
-                    }
-                    return null;
+              () -> {
+                Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
+                try (ResultSet rs =
+                    server.client.singleUse().executeQuery(StandardBenchmarkMockServer.SELECT1)) {
+                  while (rs.next()) {
+                    Thread.sleep(RND.nextInt(HOLD_SESSION_TIME));
                   }
+                  return null;
                 }
               }));
     }
@@ -189,20 +185,17 @@ public class InlineBeginBenchmark {
     for (int i = 0; i < totalWrites; i++) {
       futures.add(
           service.submit(
-              new Callable<Long>() {
-                @Override
-                public Long call() throws Exception {
-                  Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
-                  TransactionRunner runner = server.client.readWriteTransaction();
-                  return runner.run(
-                      new TransactionCallable<Long>() {
-                        @Override
-                        public Long run(TransactionContext transaction) throws Exception {
-                          return transaction.executeUpdate(
-                              StandardBenchmarkMockServer.UPDATE_STATEMENT);
-                        }
-                      });
-                }
+              () -> {
+                Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
+                TransactionRunner runner = server.client.readWriteTransaction();
+                return runner.run(
+                    new TransactionCallable<Long>() {
+                      @Override
+                      public Long run(TransactionContext transaction) throws Exception {
+                        return transaction.executeUpdate(
+                            StandardBenchmarkMockServer.UPDATE_STATEMENT);
+                      }
+                    });
               }));
     }
     Futures.allAsList(futures).get();
@@ -225,36 +218,30 @@ public class InlineBeginBenchmark {
     for (int i = 0; i < totalWrites; i++) {
       futures.add(
           service.submit(
-              new Callable<Long>() {
-                @Override
-                public Long call() throws Exception {
-                  Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
-                  TransactionRunner runner = server.client.readWriteTransaction();
-                  return runner.run(
-                      new TransactionCallable<Long>() {
-                        @Override
-                        public Long run(TransactionContext transaction) throws Exception {
-                          return transaction.executeUpdate(
-                              StandardBenchmarkMockServer.UPDATE_STATEMENT);
-                        }
-                      });
-                }
+              () -> {
+                Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
+                TransactionRunner runner = server.client.readWriteTransaction();
+                return runner.run(
+                    new TransactionCallable<Long>() {
+                      @Override
+                      public Long run(TransactionContext transaction) throws Exception {
+                        return transaction.executeUpdate(
+                            StandardBenchmarkMockServer.UPDATE_STATEMENT);
+                      }
+                    });
               }));
     }
     for (int i = 0; i < totalReads; i++) {
       futures.add(
           service.submit(
-              new Callable<Void>() {
-                @Override
-                public Void call() throws Exception {
-                  Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
-                  try (ResultSet rs =
-                      server.client.singleUse().executeQuery(StandardBenchmarkMockServer.SELECT1)) {
-                    while (rs.next()) {
-                      Thread.sleep(RND.nextInt(HOLD_SESSION_TIME));
-                    }
-                    return null;
+              () -> {
+                Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
+                try (ResultSet rs =
+                    server.client.singleUse().executeQuery(StandardBenchmarkMockServer.SELECT1)) {
+                  while (rs.next()) {
+                    Thread.sleep(RND.nextInt(HOLD_SESSION_TIME));
                   }
+                  return null;
                 }
               }));
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
@@ -60,7 +60,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -1069,16 +1068,13 @@ public class InlineBeginTransactionTest {
                       for (int i = 0; i < numQueries; i++) {
                         futures.add(
                             executor.submit(
-                                new Callable<Long>() {
-                                  @Override
-                                  public Long call() throws Exception {
-                                    try (ResultSet rs = transaction.executeQuery(SELECT1)) {
-                                      while (rs.next()) {
-                                        return rs.getLong(0);
-                                      }
+                                () -> {
+                                  try (ResultSet rs = transaction.executeQuery(SELECT1)) {
+                                    while (rs.next()) {
+                                      return rs.getLong(0);
                                     }
-                                    return 0L;
                                   }
+                                  return 0L;
                                 }));
                       }
                       Long res = 0L;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/LazySpannerInitializerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/LazySpannerInitializerTest.java
@@ -27,7 +27,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
@@ -100,13 +99,10 @@ public class LazySpannerInitializerTest {
     for (int i = 0; i < threads; i++) {
       futures.add(
           executor.submit(
-              new Callable<Spanner>() {
-                @Override
-                public Spanner call() throws Exception {
-                  latch.countDown();
-                  latch.await(10L, TimeUnit.SECONDS);
-                  return initializer.get();
-                }
+              () -> {
+                latch.countDown();
+                latch.await(10L, TimeUnit.SECONDS);
+                return initializer.get();
               }));
     }
     assertThat(Futures.allAsList(futures).get()).hasSize(threads);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SelectRandomBenchmark.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SelectRandomBenchmark.java
@@ -27,7 +27,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.AuxCounters;
@@ -129,18 +128,15 @@ public class SelectRandomBenchmark {
     for (int i = 0; i < totalQueries; i++) {
       futures.add(
           service.submit(
-              new Callable<Void>() {
-                @Override
-                public Void call() throws Exception {
-                  Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
-                  try (ResultSet rs =
-                      client.singleUse().executeQuery(StandardBenchmarkMockServer.SELECT_RANDOM)) {
-                    while (rs.next()) {
-                      // Get the entire current row and convert to String.
-                      rs.getCurrentRowAsStruct().toString();
-                    }
-                    return null;
+              () -> {
+                Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
+                try (ResultSet rs =
+                    client.singleUse().executeQuery(StandardBenchmarkMockServer.SELECT_RANDOM)) {
+                  while (rs.next()) {
+                    // Get the entire current row and convert to String.
+                    rs.getCurrentRowAsStruct().toString();
                   }
+                  return null;
                 }
               }));
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolBenchmark.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolBenchmark.java
@@ -29,7 +29,6 @@ import com.google.spanner.v1.BatchCreateSessionsRequest;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.AuxCounters;
@@ -159,17 +158,14 @@ public class SessionPoolBenchmark {
     for (int i = 0; i < totalQueries; i++) {
       futures.add(
           service.submit(
-              new Callable<Void>() {
-                @Override
-                public Void call() throws Exception {
-                  Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
-                  try (ResultSet rs =
-                      client.singleUse().executeQuery(StandardBenchmarkMockServer.SELECT1)) {
-                    while (rs.next()) {
-                      Thread.sleep(RND.nextInt(HOLD_SESSION_TIME));
-                    }
-                    return null;
+              () -> {
+                Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
+                try (ResultSet rs =
+                    client.singleUse().executeQuery(StandardBenchmarkMockServer.SELECT1)) {
+                  while (rs.next()) {
+                    Thread.sleep(RND.nextInt(HOLD_SESSION_TIME));
                   }
+                  return null;
                 }
               }));
     }
@@ -193,20 +189,17 @@ public class SessionPoolBenchmark {
     for (int i = 0; i < totalWrites; i++) {
       futures.add(
           service.submit(
-              new Callable<Long>() {
-                @Override
-                public Long call() throws Exception {
-                  Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
-                  TransactionRunner runner = client.readWriteTransaction();
-                  return runner.run(
-                      new TransactionCallable<Long>() {
-                        @Override
-                        public Long run(TransactionContext transaction) throws Exception {
-                          return transaction.executeUpdate(
-                              StandardBenchmarkMockServer.UPDATE_STATEMENT);
-                        }
-                      });
-                }
+              () -> {
+                Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
+                TransactionRunner runner = client.readWriteTransaction();
+                return runner.run(
+                    new TransactionCallable<Long>() {
+                      @Override
+                      public Long run(TransactionContext transaction) throws Exception {
+                        return transaction.executeUpdate(
+                            StandardBenchmarkMockServer.UPDATE_STATEMENT);
+                      }
+                    });
               }));
     }
     Futures.allAsList(futures).get();
@@ -230,36 +223,30 @@ public class SessionPoolBenchmark {
     for (int i = 0; i < totalWrites; i++) {
       futures.add(
           service.submit(
-              new Callable<Long>() {
-                @Override
-                public Long call() throws Exception {
-                  Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
-                  TransactionRunner runner = client.readWriteTransaction();
-                  return runner.run(
-                      new TransactionCallable<Long>() {
-                        @Override
-                        public Long run(TransactionContext transaction) throws Exception {
-                          return transaction.executeUpdate(
-                              StandardBenchmarkMockServer.UPDATE_STATEMENT);
-                        }
-                      });
-                }
+              () -> {
+                Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
+                TransactionRunner runner = client.readWriteTransaction();
+                return runner.run(
+                    new TransactionCallable<Long>() {
+                      @Override
+                      public Long run(TransactionContext transaction) throws Exception {
+                        return transaction.executeUpdate(
+                            StandardBenchmarkMockServer.UPDATE_STATEMENT);
+                      }
+                    });
               }));
     }
     for (int i = 0; i < totalReads; i++) {
       futures.add(
           service.submit(
-              new Callable<Void>() {
-                @Override
-                public Void call() throws Exception {
-                  Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
-                  try (ResultSet rs =
-                      client.singleUse().executeQuery(StandardBenchmarkMockServer.SELECT1)) {
-                    while (rs.next()) {
-                      Thread.sleep(RND.nextInt(HOLD_SESSION_TIME));
-                    }
-                    return null;
+              () -> {
+                Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
+                try (ResultSet rs =
+                    client.singleUse().executeQuery(StandardBenchmarkMockServer.SELECT1)) {
+                  while (rs.next()) {
+                    Thread.sleep(RND.nextInt(HOLD_SESSION_TIME));
                   }
+                  return null;
                 }
               }));
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolLeakTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolLeakTest.java
@@ -97,26 +97,18 @@ public class SessionPoolLeakTest {
   @Test
   public void testReadWriteTransactionExceptionOnCreateSession() {
     readWriteTransactionTest(
-        new Runnable() {
-          @Override
-          public void run() {
+        () ->
             mockSpanner.setBatchCreateSessionsExecutionTime(
-                SimulatedExecutionTime.ofException(FAILED_PRECONDITION));
-          }
-        },
+                SimulatedExecutionTime.ofException(FAILED_PRECONDITION)),
         0);
   }
 
   @Test
   public void testReadWriteTransactionExceptionOnBegin() {
     readWriteTransactionTest(
-        new Runnable() {
-          @Override
-          public void run() {
+        () ->
             mockSpanner.setBeginTransactionExecutionTime(
-                SimulatedExecutionTime.ofException(FAILED_PRECONDITION));
-          }
-        },
+                SimulatedExecutionTime.ofException(FAILED_PRECONDITION)),
         1);
   }
 
@@ -145,13 +137,9 @@ public class SessionPoolLeakTest {
   @Test
   public void testTansactionManagerExceptionOnCreateSession() {
     transactionManagerTest(
-        new Runnable() {
-          @Override
-          public void run() {
+        () ->
             mockSpanner.setBatchCreateSessionsExecutionTime(
-                SimulatedExecutionTime.ofException(FAILED_PRECONDITION));
-          }
-        },
+                SimulatedExecutionTime.ofException(FAILED_PRECONDITION)),
         0);
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerBenchmark.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerBenchmark.java
@@ -31,7 +31,6 @@ import com.google.spanner.v1.DeleteSessionRequest;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.AuxCounters;
@@ -154,17 +153,14 @@ public class SessionPoolMaintainerBenchmark {
     for (int i = 0; i < totalQueries; i++) {
       futures.add(
           service.submit(
-              new Callable<Void>() {
-                @Override
-                public Void call() throws Exception {
-                  Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
-                  try (ResultSet rs =
-                      client.singleUse().executeQuery(StandardBenchmarkMockServer.SELECT1)) {
-                    while (rs.next()) {
-                      Thread.sleep(RND.nextInt(HOLD_SESSION_TIME));
-                    }
-                    return null;
+              () -> {
+                Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
+                try (ResultSet rs =
+                    client.singleUse().executeQuery(StandardBenchmarkMockServer.SELECT1)) {
+                  while (rs.next()) {
+                    Thread.sleep(RND.nextInt(HOLD_SESSION_TIME));
                   }
+                  return null;
                 }
               }));
     }
@@ -190,20 +186,17 @@ public class SessionPoolMaintainerBenchmark {
     for (int i = 0; i < totalWrites; i++) {
       futures.add(
           service.submit(
-              new Callable<Long>() {
-                @Override
-                public Long call() throws Exception {
-                  Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
-                  TransactionRunner runner = client.readWriteTransaction();
-                  return runner.run(
-                      new TransactionCallable<Long>() {
-                        @Override
-                        public Long run(TransactionContext transaction) throws Exception {
-                          return transaction.executeUpdate(
-                              StandardBenchmarkMockServer.UPDATE_STATEMENT);
-                        }
-                      });
-                }
+              () -> {
+                Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
+                TransactionRunner runner = client.readWriteTransaction();
+                return runner.run(
+                    new TransactionCallable<Long>() {
+                      @Override
+                      public Long run(TransactionContext transaction) throws Exception {
+                        return transaction.executeUpdate(
+                            StandardBenchmarkMockServer.UPDATE_STATEMENT);
+                      }
+                    });
               }));
     }
     Futures.allAsList(futures).get();
@@ -229,36 +222,30 @@ public class SessionPoolMaintainerBenchmark {
     for (int i = 0; i < totalWrites; i++) {
       futures.add(
           service.submit(
-              new Callable<Long>() {
-                @Override
-                public Long call() throws Exception {
-                  Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
-                  TransactionRunner runner = client.readWriteTransaction();
-                  return runner.run(
-                      new TransactionCallable<Long>() {
-                        @Override
-                        public Long run(TransactionContext transaction) throws Exception {
-                          return transaction.executeUpdate(
-                              StandardBenchmarkMockServer.UPDATE_STATEMENT);
-                        }
-                      });
-                }
+              () -> {
+                Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
+                TransactionRunner runner = client.readWriteTransaction();
+                return runner.run(
+                    new TransactionCallable<Long>() {
+                      @Override
+                      public Long run(TransactionContext transaction) throws Exception {
+                        return transaction.executeUpdate(
+                            StandardBenchmarkMockServer.UPDATE_STATEMENT);
+                      }
+                    });
               }));
     }
     for (int i = 0; i < totalReads; i++) {
       futures.add(
           service.submit(
-              new Callable<Void>() {
-                @Override
-                public Void call() throws Exception {
-                  Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
-                  try (ResultSet rs =
-                      client.singleUse().executeQuery(StandardBenchmarkMockServer.SELECT1)) {
-                    while (rs.next()) {
-                      Thread.sleep(RND.nextInt(HOLD_SESSION_TIME));
-                    }
-                    return null;
+              () -> {
+                Thread.sleep(RND.nextInt(RND_WAIT_TIME_BETWEEN_REQUESTS));
+                try (ResultSet rs =
+                    client.singleUse().executeQuery(StandardBenchmarkMockServer.SELECT1)) {
+                  while (rs.next()) {
+                    Thread.sleep(RND.nextInt(HOLD_SESSION_TIME));
                   }
+                  return null;
                 }
               }));
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerTest.java
@@ -81,15 +81,12 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        int sessionCount = invocation.getArgumentAt(0, Integer.class);
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        for (int i = 0; i < sessionCount; i++) {
-                          consumer.onSessionReady(setupMockSession(mockSession()));
-                        }
+                    () -> {
+                      int sessionCount = invocation.getArgumentAt(0, Integer.class);
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      for (int i = 0; i < sessionCount; i++) {
+                        consumer.onSessionReady(setupMockSession(mockSession()));
                       }
                     });
                 return null;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolStressTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolStressTest.java
@@ -102,24 +102,21 @@ public class SessionPoolStressTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 createExecutor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        int sessionCount = invocation.getArgumentAt(0, Integer.class);
-                        for (int s = 0; s < sessionCount; s++) {
-                          SessionImpl session;
-                          synchronized (lock) {
-                            session = mockSession();
-                            setupSession(session);
-                            sessions.put(session.getName(), false);
-                            if (sessions.size() > maxAliveSessions) {
-                              maxAliveSessions = sessions.size();
-                            }
+                    () -> {
+                      int sessionCount = invocation.getArgumentAt(0, Integer.class);
+                      for (int s = 0; s < sessionCount; s++) {
+                        SessionImpl session;
+                        synchronized (lock) {
+                          session = mockSession();
+                          setupSession(session);
+                          sessions.put(session.getName(), false);
+                          if (sessions.size() > maxAliveSessions) {
+                            maxAliveSessions = sessions.size();
                           }
-                          SessionConsumerImpl consumer =
-                              invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                          consumer.onSessionReady(session);
                         }
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionReady(session);
                       }
                     });
                 return null;
@@ -254,42 +251,33 @@ public class SessionPoolStressTest extends BaseSessionPoolTest {
         };
     for (int i = 0; i < concurrentThreads; i++) {
       new Thread(
-              new Runnable() {
-
-                @Override
-                public void run() {
-                  Uninterruptibles.awaitUninterruptibly(releaseThreads);
-                  for (int j = 0; j < numOperationsPerThread; j++) {
-                    try {
-                      PooledSessionFuture session = pool.getSession();
-                      session.get();
-                      Uninterruptibles.sleepUninterruptibly(
-                          random.nextInt(2), TimeUnit.MILLISECONDS);
-                      resetTransaction(session.get().delegate);
-                      session.close();
-                    } catch (SpannerException e) {
-                      if (e.getErrorCode() != ErrorCode.RESOURCE_EXHAUSTED || shouldBlock) {
-                        setFailed(e);
-                      }
-                    } catch (Exception e) {
+              () -> {
+                Uninterruptibles.awaitUninterruptibly(releaseThreads);
+                for (int j = 0; j < numOperationsPerThread; j++) {
+                  try {
+                    PooledSessionFuture session = pool.getSession();
+                    session.get();
+                    Uninterruptibles.sleepUninterruptibly(random.nextInt(2), TimeUnit.MILLISECONDS);
+                    resetTransaction(session.get().delegate);
+                    session.close();
+                  } catch (SpannerException e) {
+                    if (e.getErrorCode() != ErrorCode.RESOURCE_EXHAUSTED || shouldBlock) {
                       setFailed(e);
                     }
+                  } catch (Exception e) {
+                    setFailed(e);
                   }
-                  threadsDone.countDown();
                 }
+                threadsDone.countDown();
               })
           .start();
     }
     // Start maintenance threads in tight loop
     final AtomicBoolean stopMaintenance = new AtomicBoolean(false);
     new Thread(
-            new Runnable() {
-
-              @Override
-              public void run() {
-                while (!stopMaintenance.get()) {
-                  runMaintainanceLoop(clock, pool, 1);
-                }
+            () -> {
+              while (!stopMaintenance.get()) {
+                runMaintainanceLoop(clock, pool, 1);
               }
             })
         .start();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -154,15 +154,12 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        int sessionCount = invocation.getArgumentAt(0, Integer.class);
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        for (int i = 0; i < sessionCount; i++) {
-                          consumer.onSessionReady(mockSession());
-                        }
+                    () -> {
+                      int sessionCount = invocation.getArgumentAt(0, Integer.class);
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      for (int i = 0; i < sessionCount; i++) {
+                        consumer.onSessionReady(mockSession());
                       }
                     });
                 return null;
@@ -238,13 +235,10 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(sessions.pop());
-                      }
+                    () -> {
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      consumer.onSessionReady(sessions.pop());
                     });
                 return null;
               }
@@ -270,14 +264,10 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     pool = createPool(clock);
     final AtomicBoolean stop = new AtomicBoolean(false);
     new Thread(
-            new Runnable() {
-
-              @Override
-              public void run() {
-                // Run in a tight loop.
-                while (!stop.get()) {
-                  runMaintainanceLoop(clock, pool, 1);
-                }
+            () -> {
+              // Run in a tight loop.
+              while (!stop.get()) {
+                runMaintainanceLoop(clock, pool, 1);
               }
             })
         .start();
@@ -296,13 +286,10 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(session1);
-                      }
+                    () -> {
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      consumer.onSessionReady(session1);
                     });
                 return null;
               }
@@ -354,13 +341,10 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(session1);
-                      }
+                    () -> {
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      consumer.onSessionReady(session1);
                     });
                 return null;
               }
@@ -446,13 +430,10 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(session);
-                      }
+                    () -> {
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      consumer.onSessionReady(session);
                     });
                 return null;
               }
@@ -533,13 +514,10 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(mockSession());
-                      }
+                    () -> {
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      consumer.onSessionReady(mockSession());
                     });
                 return null;
               }
@@ -579,13 +557,10 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(sessions.pop());
-                      }
+                    () -> {
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      consumer.onSessionReady(sessions.pop());
                     });
                 return null;
               }
@@ -644,15 +619,12 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        int sessionCount = invocation.getArgumentAt(0, Integer.class);
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        for (int i = 0; i < sessionCount; i++) {
-                          consumer.onSessionReady(session);
-                        }
+                    () -> {
+                      int sessionCount = invocation.getArgumentAt(0, Integer.class);
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      for (int i = 0; i < sessionCount; i++) {
+                        consumer.onSessionReady(session);
                       }
                     });
                 return null;
@@ -758,13 +730,10 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(closedSession);
-                      }
+                    () -> {
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      consumer.onSessionReady(closedSession);
                     });
                 return null;
               }
@@ -774,13 +743,10 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(openSession);
-                      }
+                    () -> {
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      consumer.onSessionReady(openSession);
                     });
                 return null;
               }
@@ -814,13 +780,10 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(closedSession);
-                      }
+                    () -> {
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      consumer.onSessionReady(closedSession);
                     });
                 return null;
               }
@@ -830,13 +793,10 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(openSession);
-                      }
+                    () -> {
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      consumer.onSessionReady(openSession);
                     });
                 return null;
               }
@@ -937,13 +897,10 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                 @Override
                 public Void answer(final InvocationOnMock invocation) {
                   executor.submit(
-                      new Runnable() {
-                        @Override
-                        public void run() {
-                          SessionConsumerImpl consumer =
-                              invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                          consumer.onSessionReady(closedSession);
-                        }
+                      () -> {
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionReady(closedSession);
                       });
                   return null;
                 }
@@ -953,13 +910,10 @@ public class SessionPoolTest extends BaseSessionPoolTest {
                 @Override
                 public Void answer(final InvocationOnMock invocation) {
                   executor.submit(
-                      new Runnable() {
-                        @Override
-                        public void run() {
-                          SessionConsumerImpl consumer =
-                              invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                          consumer.onSessionReady(openSession);
-                        }
+                      () -> {
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionReady(openSession);
                       });
                   return null;
                 }
@@ -1057,13 +1011,10 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(closedSession);
-                      }
+                    () -> {
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      consumer.onSessionReady(closedSession);
                     });
                 return null;
               }
@@ -1073,13 +1024,10 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(openSession);
-                      }
+                    () -> {
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      consumer.onSessionReady(openSession);
                     });
                 return null;
               }
@@ -1112,13 +1060,10 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(closedSession);
-                      }
+                    () -> {
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      consumer.onSessionReady(closedSession);
                     });
                 return null;
               }
@@ -1128,13 +1073,10 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(openSession);
-                      }
+                    () -> {
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      consumer.onSessionReady(openSession);
                     });
                 return null;
               }
@@ -1163,13 +1105,10 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(closedSession);
-                      }
+                    () -> {
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      consumer.onSessionReady(closedSession);
                     });
                 return null;
               }
@@ -1179,13 +1118,10 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(openSession);
-                      }
+                    () -> {
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      consumer.onSessionReady(openSession);
                     });
                 return null;
               }
@@ -1355,18 +1291,15 @@ public class SessionPoolTest extends BaseSessionPoolTest {
 
   private void getSessionAsync(final CountDownLatch latch, final AtomicBoolean failed) {
     new Thread(
-            new Runnable() {
-              @Override
-              public void run() {
-                try (PooledSessionFuture future = pool.getSession()) {
-                  PooledSession session = future.get();
-                  failed.compareAndSet(false, session == null);
-                  Uninterruptibles.sleepUninterruptibly(10, TimeUnit.MILLISECONDS);
-                } catch (Throwable e) {
-                  failed.compareAndSet(false, true);
-                } finally {
-                  latch.countDown();
-                }
+            () -> {
+              try (PooledSessionFuture future = pool.getSession()) {
+                PooledSession session = future.get();
+                failed.compareAndSet(false, session == null);
+                Uninterruptibles.sleepUninterruptibly(10, TimeUnit.MILLISECONDS);
+              } catch (Throwable e) {
+                failed.compareAndSet(false, true);
+              } finally {
+                latch.countDown();
               }
             })
         .start();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -75,7 +75,6 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -299,16 +298,13 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Callable<Void>() {
-                      @Override
-                      public Void call() throws Exception {
-                        insideCreation.countDown();
-                        releaseCreation.await();
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(session2);
-                        return null;
-                      }
+                    () -> {
+                      insideCreation.countDown();
+                      releaseCreation.await();
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      consumer.onSessionReady(session2);
+                      return null;
                     });
                 return null;
               }
@@ -354,16 +350,13 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Callable<Void>() {
-                      @Override
-                      public Void call() throws Exception {
-                        insideCreation.countDown();
-                        releaseCreation.await();
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(session2);
-                        return null;
-                      }
+                    () -> {
+                      insideCreation.countDown();
+                      releaseCreation.await();
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      consumer.onSessionReady(session2);
+                      return null;
                     });
                 return null;
               }
@@ -394,17 +387,14 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Callable<Void>() {
-                      @Override
-                      public Void call() throws Exception {
-                        insideCreation.countDown();
-                        releaseCreation.await();
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionCreateFailure(
-                            SpannerExceptionFactory.newSpannerException(new RuntimeException()), 1);
-                        return null;
-                      }
+                    () -> {
+                      insideCreation.countDown();
+                      releaseCreation.await();
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      consumer.onSessionCreateFailure(
+                          SpannerExceptionFactory.newSpannerException(new RuntimeException()), 1);
+                      return null;
                     });
                 return null;
               }
@@ -477,15 +467,12 @@ public class SessionPoolTest extends BaseSessionPoolTest {
               @Override
               public Void answer(final InvocationOnMock invocation) {
                 executor.submit(
-                    new Callable<Void>() {
-                      @Override
-                      public Void call() {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionCreateFailure(
-                            SpannerExceptionFactory.newSpannerException(ErrorCode.INTERNAL, ""), 1);
-                        return null;
-                      }
+                    () -> {
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      consumer.onSessionCreateFailure(
+                          SpannerExceptionFactory.newSpannerException(ErrorCode.INTERNAL, ""), 1);
+                      return null;
                     });
                 return null;
               }
@@ -676,14 +663,11 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     // Then try asynchronously to take another session. This attempt should time out.
     Future<Void> fut =
         executor.submit(
-            new Callable<Void>() {
-              @Override
-              public Void call() {
-                latch.countDown();
-                PooledSessionFuture session = pool.getSession();
-                session.close();
-                return null;
-              }
+            () -> {
+              latch.countDown();
+              PooledSessionFuture session = pool.getSession();
+              session.close();
+              return null;
             });
     // Wait until the background thread is actually waiting for a session.
     latch.await();
@@ -1232,14 +1216,11 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     // Try asynchronously to take another session. This attempt should time out.
     Future<Void> fut =
         executor.submit(
-            new Callable<Void>() {
-              @Override
-              public Void call() {
-                latch.countDown();
-                Session session = pool.getSession();
-                session.close();
-                return null;
-              }
+            () -> {
+              latch.countDown();
+              Session session = pool.getSession();
+              session.close();
+              return null;
             });
     // Wait until the background thread is actually waiting for a session.
     latch.await();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerRetryHelperTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerRetryHelperTest.java
@@ -63,15 +63,12 @@ public class SpannerRetryHelperTest {
     final FakeClock clock = new FakeClock();
     final AtomicInteger attempts = new AtomicInteger();
     Callable<Integer> callable =
-        new Callable<Integer>() {
-          @Override
-          public Integer call() {
-            if (attempts.getAndIncrement() == 0) {
-              clock.currentTime += TimeUnit.MILLISECONDS.convert(10L, TimeUnit.MINUTES);
-              throw SpannerExceptionFactory.newSpannerException(ErrorCode.ABORTED, "test");
-            }
-            return 1 + 1;
+        () -> {
+          if (attempts.getAndIncrement() == 0) {
+            clock.currentTime += TimeUnit.MILLISECONDS.convert(10L, TimeUnit.MINUTES);
+            throw SpannerExceptionFactory.newSpannerException(ErrorCode.ABORTED, "test");
           }
+          return 1 + 1;
         };
     assertEquals(
         2,
@@ -85,15 +82,12 @@ public class SpannerRetryHelperTest {
     final FakeClock clock = new FakeClock();
     final AtomicInteger attempts = new AtomicInteger();
     Callable<Integer> callable =
-        new Callable<Integer>() {
-          @Override
-          public Integer call() {
-            if (attempts.getAndIncrement() == 0) {
-              clock.currentTime += TimeUnit.MILLISECONDS.convert(25L, TimeUnit.HOURS);
-              throw SpannerExceptionFactory.newSpannerException(ErrorCode.ABORTED, "test");
-            }
-            return 1 + 1;
+        () -> {
+          if (attempts.getAndIncrement() == 0) {
+            clock.currentTime += TimeUnit.MILLISECONDS.convert(25L, TimeUnit.HOURS);
+            throw SpannerExceptionFactory.newSpannerException(ErrorCode.ABORTED, "test");
           }
+          return 1 + 1;
         };
     try {
       SpannerRetryHelper.runTxWithRetriesOnAborted(
@@ -110,22 +104,16 @@ public class SpannerRetryHelperTest {
     final CancellableContext withCancellation = Context.current().withCancellation();
     final CountDownLatch latch = new CountDownLatch(1);
     final Callable<Integer> callable =
-        new Callable<Integer>() {
-          @Override
-          public Integer call() {
-            latch.countDown();
-            throw SpannerExceptionFactory.newSpannerException(ErrorCode.ABORTED, "test");
-          }
+        () -> {
+          latch.countDown();
+          throw SpannerExceptionFactory.newSpannerException(ErrorCode.ABORTED, "test");
         };
     ScheduledExecutorService service = Executors.newScheduledThreadPool(1);
     service.submit(
-        new Callable<Void>() {
-          @Override
-          public Void call() throws Exception {
-            latch.await();
-            withCancellation.cancel(new InterruptedException());
-            return null;
-          }
+        () -> {
+          latch.await();
+          withCancellation.cancel(new InterruptedException());
+          return null;
         });
     try {
       withCancellation.run(() -> SpannerRetryHelper.runTxWithRetriesOnAborted(callable));
@@ -144,11 +132,8 @@ public class SpannerRetryHelperTest {
   public void testTimedoutContext() {
     ScheduledExecutorService service = Executors.newScheduledThreadPool(1);
     final Callable<Integer> callable =
-        new Callable<Integer>() {
-          @Override
-          public Integer call() {
-            throw SpannerExceptionFactory.newSpannerException(ErrorCode.ABORTED, "test");
-          }
+        () -> {
+          throw SpannerExceptionFactory.newSpannerException(ErrorCode.ABORTED, "test");
         };
     try {
       final CancellableContext withDeadline =
@@ -167,24 +152,15 @@ public class SpannerRetryHelperTest {
 
   @Test
   public void noException() {
-    Callable<Integer> callable =
-        new Callable<Integer>() {
-          @Override
-          public Integer call() {
-            return 1 + 1;
-          }
-        };
+    Callable<Integer> callable = () -> 1 + 1;
     assertThat(SpannerRetryHelper.runTxWithRetriesOnAborted(callable)).isEqualTo(2);
   }
 
   @Test(expected = IllegalStateException.class)
   public void propagateUncheckedException() {
     Callable<Integer> callable =
-        new Callable<Integer>() {
-          @Override
-          public Integer call() {
-            throw new IllegalStateException("test");
-          }
+        () -> {
+          throw new IllegalStateException("test");
         };
     SpannerRetryHelper.runTxWithRetriesOnAborted(callable);
   }
@@ -193,14 +169,11 @@ public class SpannerRetryHelperTest {
   public void retryOnAborted() {
     final AtomicInteger attempts = new AtomicInteger();
     Callable<Integer> callable =
-        new Callable<Integer>() {
-          @Override
-          public Integer call() {
-            if (attempts.getAndIncrement() == 0) {
-              throw abortedWithRetryInfo((int) TimeUnit.MILLISECONDS.toNanos(1L));
-            }
-            return 1 + 1;
+        () -> {
+          if (attempts.getAndIncrement() == 0) {
+            throw abortedWithRetryInfo((int) TimeUnit.MILLISECONDS.toNanos(1L));
           }
+          return 1 + 1;
         };
     assertThat(SpannerRetryHelper.runTxWithRetriesOnAborted(callable)).isEqualTo(2);
   }
@@ -209,14 +182,11 @@ public class SpannerRetryHelperTest {
   public void retryMultipleTimesOnAborted() {
     final AtomicInteger attempts = new AtomicInteger();
     Callable<Integer> callable =
-        new Callable<Integer>() {
-          @Override
-          public Integer call() {
-            if (attempts.getAndIncrement() < 2) {
-              throw abortedWithRetryInfo((int) TimeUnit.MILLISECONDS.toNanos(1));
-            }
-            return 1 + 1;
+        () -> {
+          if (attempts.getAndIncrement() < 2) {
+            throw abortedWithRetryInfo((int) TimeUnit.MILLISECONDS.toNanos(1));
           }
+          return 1 + 1;
         };
     assertThat(SpannerRetryHelper.runTxWithRetriesOnAborted(callable)).isEqualTo(2);
   }
@@ -225,14 +195,11 @@ public class SpannerRetryHelperTest {
   public void retryOnAbortedAndThenPropagateUnchecked() {
     final AtomicInteger attempts = new AtomicInteger();
     Callable<Integer> callable =
-        new Callable<Integer>() {
-          @Override
-          public Integer call() {
-            if (attempts.getAndIncrement() == 0) {
-              throw abortedWithRetryInfo((int) TimeUnit.MILLISECONDS.toNanos(1L));
-            }
-            throw new IllegalStateException("test");
+        () -> {
+          if (attempts.getAndIncrement() == 0) {
+            throw abortedWithRetryInfo((int) TimeUnit.MILLISECONDS.toNanos(1L));
           }
+          throw new IllegalStateException("test");
         };
     SpannerRetryHelper.runTxWithRetriesOnAborted(callable);
   }
@@ -272,14 +239,11 @@ public class SpannerRetryHelperTest {
         SpannerExceptionFactory.newSpannerException(new StatusRuntimeException(status, trailers));
     final AtomicInteger attempts = new AtomicInteger();
     Callable<Integer> callable =
-        new Callable<Integer>() {
-          @Override
-          public Integer call() {
-            if (attempts.getAndIncrement() == 0) {
-              throw e;
-            }
-            return 1 + 1;
+        () -> {
+          if (attempts.getAndIncrement() == 0) {
+            throw e;
           }
+          return 1 + 1;
         };
     // The following call should take at least 100ms, as that is the retry delay specified in the
     // retry info of the exception.

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerRetryHelperTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerRetryHelperTest.java
@@ -128,13 +128,7 @@ public class SpannerRetryHelperTest {
           }
         });
     try {
-      withCancellation.run(
-          new Runnable() {
-            @Override
-            public void run() {
-              SpannerRetryHelper.runTxWithRetriesOnAborted(callable);
-            }
-          });
+      withCancellation.run(() -> SpannerRetryHelper.runTxWithRetriesOnAborted(callable));
       fail("missing expected exception");
     } catch (SpannerException e) {
       if (e.getErrorCode() != ErrorCode.CANCELLED) {
@@ -159,13 +153,7 @@ public class SpannerRetryHelperTest {
     try {
       final CancellableContext withDeadline =
           Context.current().withDeadline(Deadline.after(1L, TimeUnit.MILLISECONDS), service);
-      withDeadline.run(
-          new Runnable() {
-            @Override
-            public void run() {
-              SpannerRetryHelper.runTxWithRetriesOnAborted(callable);
-            }
-          });
+      withDeadline.run(() -> SpannerRetryHelper.runTxWithRetriesOnAborted(callable));
       fail("missing expected exception");
     } catch (SpannerException e) {
       if (e.getErrorCode() != ErrorCode.DEADLINE_EXCEEDED) {
@@ -258,14 +246,11 @@ public class SpannerRetryHelperTest {
         .setDaemon(true)
         .build()
         .newThread(
-            new Runnable() {
-              @Override
-              public void run() {
-                while (true) {
-                  try {
-                    Thread.sleep(Long.MAX_VALUE);
-                  } catch (InterruptedException e) {
-                  }
+            () -> {
+              while (true) {
+                try {
+                  Thread.sleep(Long.MAX_VALUE);
+                } catch (InterruptedException e) {
                 }
               }
             });

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionAsyncApiAbortedTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionAsyncApiAbortedTest.java
@@ -291,14 +291,7 @@ public class ConnectionAsyncApiAbortedTest extends AbstractMockServerTest {
       // Wait until the query has actually executed.
       queryLatch.await(10L, TimeUnit.SECONDS);
       ApiFuture<Long> updateCount = connection.executeUpdateAsync(INSERT_STATEMENT);
-      updateCount.addListener(
-          new Runnable() {
-            @Override
-            public void run() {
-              updateLatch.countDown();
-            }
-          },
-          MoreExecutors.directExecutor());
+      updateCount.addListener(() -> updateLatch.countDown(), MoreExecutors.directExecutor());
 
       // We should not commit before the AsyncResultSet has finished.
       assertThat(get(finished)).isNull();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DdlBatchTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DdlBatchTest.java
@@ -538,15 +538,7 @@ public class DdlBatchTest {
     final DdlBatch batch = createSubject(client);
     batch.executeDdlAsync(statement);
     Executors.newSingleThreadScheduledExecutor()
-        .schedule(
-            new Runnable() {
-              @Override
-              public void run() {
-                batch.cancel();
-              }
-            },
-            100,
-            TimeUnit.MILLISECONDS);
+        .schedule(batch::cancel, 100, TimeUnit.MILLISECONDS);
     try {
       get(batch.runBatchAsync());
       fail("expected CANCELLED");

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementTimeoutTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementTimeoutTest.java
@@ -635,12 +635,9 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
       connection.setAutocommit(true);
       connection.setReadOnly(true);
       executor.execute(
-          new Runnable() {
-            @Override
-            public void run() {
-              waitForRequestsToContain(ExecuteSqlRequest.class);
-              connection.cancel();
-            }
+          () -> {
+            waitForRequestsToContain(ExecuteSqlRequest.class);
+            connection.cancel();
           });
       try {
         connection.executeQuery(SELECT_RANDOM_STATEMENT);
@@ -663,12 +660,9 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
       connection.setAutocommit(true);
       connection.setReadOnly(true);
       executor.execute(
-          new Runnable() {
-            @Override
-            public void run() {
-              waitForRequestsToContain(ExecuteSqlRequest.class);
-              connection.cancel();
-            }
+          () -> {
+            waitForRequestsToContain(ExecuteSqlRequest.class);
+            connection.cancel();
           });
 
       try (ResultSet rs = connection.executeQuery(SELECT_RANDOM_STATEMENT)) {
@@ -697,12 +691,9 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
       connection.setReadOnly(true);
       connection.setAutocommit(false);
       executor.execute(
-          new Runnable() {
-            @Override
-            public void run() {
-              waitForRequestsToContain(ExecuteSqlRequest.class);
-              connection.cancel();
-            }
+          () -> {
+            waitForRequestsToContain(ExecuteSqlRequest.class);
+            connection.cancel();
           });
       try {
         connection.executeQuery(SELECT_RANDOM_STATEMENT);
@@ -725,12 +716,9 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
       connection.setReadOnly(true);
       connection.setAutocommit(false);
       executor.execute(
-          new Runnable() {
-            @Override
-            public void run() {
-              waitForRequestsToContain(ExecuteSqlRequest.class);
-              connection.cancel();
-            }
+          () -> {
+            waitForRequestsToContain(ExecuteSqlRequest.class);
+            connection.cancel();
           });
       try {
         connection.executeQuery(Statement.of(SLOW_SELECT));
@@ -764,12 +752,9 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
     try (Connection connection = createConnection()) {
       connection.setAutocommit(true);
       executor.execute(
-          new Runnable() {
-            @Override
-            public void run() {
-              waitForRequestsToContain(ExecuteSqlRequest.class);
-              connection.cancel();
-            }
+          () -> {
+            waitForRequestsToContain(ExecuteSqlRequest.class);
+            connection.cancel();
           });
       try {
         connection.executeQuery(SELECT_RANDOM_STATEMENT);
@@ -791,12 +776,9 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
     try (Connection connection = createConnection()) {
       connection.setAutocommit(true);
       executor.execute(
-          new Runnable() {
-            @Override
-            public void run() {
-              waitForRequestsToContain(ExecuteSqlRequest.class);
-              connection.cancel();
-            }
+          () -> {
+            waitForRequestsToContain(ExecuteSqlRequest.class);
+            connection.cancel();
           });
       try {
         connection.executeQuery(SELECT_RANDOM_STATEMENT);
@@ -825,12 +807,9 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
     try (Connection connection = createConnection()) {
       connection.setAutocommit(true);
       executor.execute(
-          new Runnable() {
-            @Override
-            public void run() {
-              waitForRequestsToContain(ExecuteSqlRequest.class);
-              connection.cancel();
-            }
+          () -> {
+            waitForRequestsToContain(ExecuteSqlRequest.class);
+            connection.cancel();
           });
       try {
         connection.execute(INSERT_STATEMENT);
@@ -852,12 +831,9 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
     try (Connection connection = createConnection()) {
       connection.setAutocommit(true);
       executor.execute(
-          new Runnable() {
-            @Override
-            public void run() {
-              waitForRequestsToContain(CommitRequest.class);
-              connection.cancel();
-            }
+          () -> {
+            waitForRequestsToContain(CommitRequest.class);
+            connection.cancel();
           });
       connection.execute(INSERT_STATEMENT);
       fail("Missing expected exception");
@@ -877,12 +853,9 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
     try (Connection connection = createConnection()) {
       connection.setAutocommit(false);
       executor.execute(
-          new Runnable() {
-            @Override
-            public void run() {
-              waitForRequestsToContain(ExecuteSqlRequest.class);
-              connection.cancel();
-            }
+          () -> {
+            waitForRequestsToContain(ExecuteSqlRequest.class);
+            connection.cancel();
           });
       connection.executeQuery(SELECT_RANDOM_STATEMENT);
       fail("Missing expected exception");
@@ -902,12 +875,9 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
     try (Connection connection = createConnection()) {
       connection.setAutocommit(false);
       executor.execute(
-          new Runnable() {
-            @Override
-            public void run() {
-              waitForRequestsToContain(ExecuteSqlRequest.class);
-              connection.cancel();
-            }
+          () -> {
+            waitForRequestsToContain(ExecuteSqlRequest.class);
+            connection.cancel();
           });
       try {
         connection.executeQuery(SELECT_RANDOM_STATEMENT);
@@ -972,12 +942,9 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
       connection.startBatchDdl();
       connection.execute(Statement.of(SLOW_DDL));
       executor.execute(
-          new Runnable() {
-            @Override
-            public void run() {
-              Uninterruptibles.sleepUninterruptibly(100L, TimeUnit.MILLISECONDS);
-              connection.cancel();
-            }
+          () -> {
+            Uninterruptibles.sleepUninterruptibly(100L, TimeUnit.MILLISECONDS);
+            connection.cancel();
           });
       connection.runBatch();
       fail("Missing expected exception");
@@ -996,12 +963,9 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
     try (Connection connection = createConnection()) {
       connection.setAutocommit(true);
       executor.execute(
-          new Runnable() {
-            @Override
-            public void run() {
-              Uninterruptibles.sleepUninterruptibly(100L, TimeUnit.MILLISECONDS);
-              connection.cancel();
-            }
+          () -> {
+            Uninterruptibles.sleepUninterruptibly(100L, TimeUnit.MILLISECONDS);
+            connection.cancel();
           });
       connection.execute(Statement.of(SLOW_DDL));
       fail("Missing expected exception");

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/it/ITBulkConnectionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/it/ITBulkConnectionTest.java
@@ -26,7 +26,6 @@ import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.connection.ITAbstractSpannerTest;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -70,17 +69,14 @@ public class ITBulkConnectionTest extends ITAbstractSpannerTest {
     ExecutorService executor = Executors.newFixedThreadPool(50);
     for (int i = 0; i < NUMBER_OF_TEST_CONNECTIONS; i++) {
       executor.submit(
-          new Callable<Void>() {
-            @Override
-            public Void call() {
-              try (ITConnection connection = createConnection()) {
-                try (ResultSet rs = connection.executeQuery(Statement.of("select 1"))) {
-                  assertThat(rs.next(), is(true));
-                  assertThat(connection.getReadTimestamp(), is(notNullValue()));
-                }
+          () -> {
+            try (ITConnection connection = createConnection()) {
+              try (ResultSet rs = connection.executeQuery(Statement.of("select 1"))) {
+                assertThat(rs.next(), is(true));
+                assertThat(connection.getReadTimestamp(), is(notNullValue()));
               }
-              return null;
             }
+            return null;
           });
     }
     executor.shutdown();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/it/ITReadOnlySpannerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/it/ITReadOnlySpannerTest.java
@@ -200,18 +200,12 @@ public class ITReadOnlySpannerTest extends ITAbstractSpannerTest {
       final ResultSet rs2 = connection.executeQuery(Statement.of("SELECT * FROM NUMBERS"));
       ExecutorService exec = Executors.newFixedThreadPool(2);
       exec.submit(
-          new Runnable() {
-            @Override
-            public void run() {
-              while (rs1.next()) {}
-            }
+          () -> {
+            while (rs1.next()) {}
           });
       exec.submit(
-          new Runnable() {
-            @Override
-            public void run() {
-              while (rs2.next()) {}
-            }
+          () -> {
+            while (rs2.next()) {}
           });
       exec.shutdown();
       exec.awaitTermination(1000L, TimeUnit.SECONDS);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITReadTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITReadTest.java
@@ -346,13 +346,10 @@ public class ITReadTest {
     Context.CancellableContext context = Context.current().withCancellation();
     Runnable work =
         context.wrap(
-            new Runnable() {
-              @Override
-              public void run() {
-                client
-                    .singleUse(TimestampBound.strong())
-                    .readRow(TABLE_NAME, Key.of("k1"), ALL_COLUMNS);
-              }
+            () -> {
+              client
+                  .singleUse(TimestampBound.strong())
+                  .readRow(TABLE_NAME, Key.of("k1"), ALL_COLUMNS);
             });
     context.cancel(new RuntimeException("Cancelled by test"));
 
@@ -371,13 +368,10 @@ public class ITReadTest {
         Context.current().withDeadlineAfter(10, TimeUnit.NANOSECONDS, executor);
     Runnable work =
         context.wrap(
-            new Runnable() {
-              @Override
-              public void run() {
-                client
-                    .singleUse(TimestampBound.strong())
-                    .readRow(TABLE_NAME, Key.of("k1"), ALL_COLUMNS);
-              }
+            () -> {
+              client
+                  .singleUse(TimestampBound.strong())
+                  .readRow(TABLE_NAME, Key.of("k1"), ALL_COLUMNS);
             });
 
     try {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITWriteTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITWriteTest.java
@@ -764,11 +764,8 @@ public class ITWriteTest {
     context.cancel(new RuntimeException("Cancelled by test"));
     Runnable work =
         context.wrap(
-            new Runnable() {
-              @Override
-              public void run() {
-                write(baseInsert().set("BoolValue").to(true).build());
-              }
+            () -> {
+              write(baseInsert().set("BoolValue").to(true).build());
             });
 
     try {
@@ -786,11 +783,8 @@ public class ITWriteTest {
         Context.current().withDeadlineAfter(10, TimeUnit.NANOSECONDS, executor);
     Runnable work =
         context.wrap(
-            new Runnable() {
-              @Override
-              public void run() {
-                write(baseInsert().set("BoolValue").to(true).build());
-              }
+            () -> {
+              write(baseInsert().set("BoolValue").to(true).build());
             });
 
     try {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
@@ -428,13 +428,28 @@ public class GapicSpannerRpcTest {
       Context context =
           Context.current().withValue(SpannerOptions.CALL_CONTEXT_CONFIGURATOR_KEY, configurator);
       context.run(
-          new Runnable() {
-            @Override
-            public void run() {
-              try {
-                // First try with a 1ns timeout. This should always cause a DEADLINE_EXCEEDED
-                // exception.
-                timeoutHolder.timeout = Duration.ofNanos(1L);
+          () -> {
+            try {
+              // First try with a 1ns timeout. This should always cause a DEADLINE_EXCEEDED
+              // exception.
+              timeoutHolder.timeout = Duration.ofNanos(1L);
+              client
+                  .readWriteTransaction()
+                  .run(
+                      new TransactionCallable<Long>() {
+                        @Override
+                        public Long run(TransactionContext transaction) throws Exception {
+                          return transaction.executeUpdate(UPDATE_FOO_STATEMENT);
+                        }
+                      });
+              fail("missing expected timeout exception");
+            } catch (SpannerException e) {
+              assertThat(e.getErrorCode()).isEqualTo(ErrorCode.DEADLINE_EXCEEDED);
+            }
+
+            // Then try with a longer timeout. This should now succeed.
+            timeoutHolder.timeout = Duration.ofMinutes(1L);
+            Long updateCount =
                 client
                     .readWriteTransaction()
                     .run(
@@ -444,25 +459,7 @@ public class GapicSpannerRpcTest {
                             return transaction.executeUpdate(UPDATE_FOO_STATEMENT);
                           }
                         });
-                fail("missing expected timeout exception");
-              } catch (SpannerException e) {
-                assertThat(e.getErrorCode()).isEqualTo(ErrorCode.DEADLINE_EXCEEDED);
-              }
-
-              // Then try with a longer timeout. This should now succeed.
-              timeoutHolder.timeout = Duration.ofMinutes(1L);
-              Long updateCount =
-                  client
-                      .readWriteTransaction()
-                      .run(
-                          new TransactionCallable<Long>() {
-                            @Override
-                            public Long run(TransactionContext transaction) throws Exception {
-                              return transaction.executeUpdate(UPDATE_FOO_STATEMENT);
-                            }
-                          });
-              assertThat(updateCount).isEqualTo(1L);
-            }
+            assertThat(updateCount).isEqualTo(1L);
           });
     }
   }

--- a/samples/snippets/src/main/java/com/example/spanner/StatementTimeoutExample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/StatementTimeoutExample.java
@@ -65,18 +65,14 @@ class StatementTimeoutExample {
     Context context =
         Context.current().withValue(SpannerOptions.CALL_CONTEXT_CONFIGURATOR_KEY, configurator);
     // Run the transaction in the custom context.
-    context.run(new Runnable() {
-      public void run() {
-        client.readWriteTransaction().run(new TransactionCallable<long[]>() {
-          public long[] run(TransactionContext transaction) throws Exception {
-            String sql = "INSERT Singers (SingerId, FirstName, LastName)\n"
-                + "VALUES (20, 'George', 'Washington')";
-            long rowCount = transaction.executeUpdate(Statement.of(sql));
-            System.out.printf("%d record inserted.%n", rowCount);
-            return null;
-          }
-        });
+    context.run(() -> client.readWriteTransaction().run(new TransactionCallable<long[]>() {
+      public long[] run(TransactionContext transaction) throws Exception {
+        String sql = "INSERT Singers (SingerId, FirstName, LastName)\n"
+            + "VALUES (20, 'George', 'Washington')";
+        long rowCount = transaction.executeUpdate(Statement.of(sql));
+        System.out.printf("%d record inserted.%n", rowCount);
+        return null;
       }
-    });
+    }));
   }
 }

--- a/samples/snippets/src/test/java/com/example/spanner/SpannerSampleIT.java
+++ b/samples/snippets/src/test/java/com/example/spanner/SpannerSampleIT.java
@@ -400,18 +400,14 @@ public class SpannerSampleIT {
   public void testCreateInstanceSample() {
     String instanceId = formatForTest("sample-inst");
     String out =
-        runSampleRunnable(
-            new Runnable() {
-              @Override
-              public void run() {
-                try {
-                  CreateInstanceExample.createInstance(
-                      dbId.getInstanceId().getProject(), instanceId);
-                } finally {
-                  spanner.getInstanceAdminClient().deleteInstance(instanceId);
-                }
-              }
-            });
+        runSampleRunnable(() -> {
+          try {
+            CreateInstanceExample.createInstance(
+                dbId.getInstanceId().getProject(), instanceId);
+          } finally {
+            spanner.getInstanceAdminClient().deleteInstance(instanceId);
+          }
+        });
     assertThat(out)
         .contains(
             String.format(


### PR DESCRIPTION
Uses Java 8 lambda syntax for Runnables and Callables.

No logic change has been made, this is purely a syntatic change.
