### PR TITLE
feat: async work as functional interface

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncRunner.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncRunner.java
@@ -27,6 +27,7 @@ public interface AsyncRunner {
    * Functional interface for executing a read/write transaction asynchronously that returns a
    * result of type R.
    */
+  @FunctionalInterface
   interface AsyncWork<R> {
     /**
      * Performs a single transaction attempt. All reads/writes should be performed using {@code

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClient.java
@@ -398,21 +398,18 @@ public interface DatabaseClient {
    * AsyncRunner runner = client.runAsync();
    * ApiFuture<Long> rowCount =
    *     runner.runAsync(
-   *         new AsyncWork<Long>() {
-   *           @Override
-   *           public ApiFuture<Long> doWorkAsync(TransactionContext txn) {
-   *             String column = "FirstName";
-   *             Struct row =
-   *                 txn.readRow("Singers", Key.of(singerId), Collections.singleton("Name"));
-   *             String name = row.getString("Name");
-   *             return txn.executeUpdateAsync(
-   *                 Statement.newBuilder("UPDATE Singers SET Name=@name WHERE SingerId=@id")
-   *                     .bind("id")
-   *                     .to(singerId)
-   *                     .bind("name")
-   *                     .to(name.toUpperCase())
-   *                     .build());
-   *           }
+   *         () -> {
+   *           String column = "FirstName";
+   *           Struct row =
+   *               txn.readRow("Singers", Key.of(singerId), Collections.singleton("Name"));
+   *           String name = row.getString("Name");
+   *           return txn.executeUpdateAsync(
+   *               Statement.newBuilder("UPDATE Singers SET Name=@name WHERE SingerId=@id")
+   *                   .bind("id")
+   *                   .to(singerId)
+   *                   .bind("name")
+   *                   .to(name.toUpperCase())
+   *                   .build());
    *         },
    *         executor);
    * </code></pre>

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -41,7 +41,6 @@ import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.AbstractResultSet.GrpcStreamIterator;
 import com.google.cloud.spanner.AsyncResultSet.CallbackResponse;
 import com.google.cloud.spanner.AsyncResultSet.ReadyCallback;
-import com.google.cloud.spanner.AsyncRunner.AsyncWork;
 import com.google.cloud.spanner.AsyncTransactionManager.AsyncTransactionFunction;
 import com.google.cloud.spanner.AsyncTransactionManager.TransactionContextFuture;
 import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
@@ -510,12 +509,9 @@ public class DatabaseClientImplTest {
     AsyncRunner runner = client.runAsync(Options.tag("app=spanner,env=test,action=runner"));
     get(
         runner.runAsync(
-            new AsyncWork<Void>() {
-              @Override
-              public ApiFuture<Void> doWorkAsync(TransactionContext txn) {
-                txn.buffer(Mutation.delete("TEST", KeySet.all()));
-                return ApiFutures.immediateFuture(null);
-              }
+            txn -> {
+              txn.buffer(Mutation.delete("TEST", KeySet.all()));
+              return ApiFutures.immediateFuture(null);
             },
             executor));
 
@@ -874,13 +870,7 @@ public class DatabaseClientImplTest {
     AsyncRunner runner = client.runAsync();
     ApiFuture<Long> result =
         runner.runAsync(
-            new AsyncWork<Long>() {
-              @Override
-              public ApiFuture<Long> doWorkAsync(TransactionContext txn) {
-                return ApiFutures.immediateFuture(txn.executeUpdate(UPDATE_STATEMENT));
-              }
-            },
-            executor);
+            txn -> ApiFutures.immediateFuture(txn.executeUpdate(UPDATE_STATEMENT)), executor);
     assertEquals(UPDATE_COUNT, result.get().longValue());
     assertNotNull(runner.getCommitTimestamp().get());
     executor.shutdown();
@@ -894,12 +884,9 @@ public class DatabaseClientImplTest {
     AsyncRunner runner = client.runAsync(Options.commitStats());
     ApiFuture<Void> result =
         runner.runAsync(
-            new AsyncWork<Void>() {
-              @Override
-              public ApiFuture<Void> doWorkAsync(TransactionContext txn) {
-                txn.buffer(Mutation.delete("FOO", Key.of("foo")));
-                return ApiFutures.<Void>immediateFuture(null);
-              }
+            txn -> {
+              txn.buffer(Mutation.delete("FOO", Key.of("foo")));
+              return ApiFutures.<Void>immediateFuture(null);
             },
             executor);
     assertNull(get(result));
@@ -919,13 +906,7 @@ public class DatabaseClientImplTest {
     AsyncRunner runner = client.runAsync();
     ApiFuture<Long> fut =
         runner.runAsync(
-            new AsyncWork<Long>() {
-              @Override
-              public ApiFuture<Long> doWorkAsync(TransactionContext txn) {
-                return ApiFutures.immediateFuture(txn.executeUpdate(UPDATE_STATEMENT));
-              }
-            },
-            executor);
+            txn -> ApiFutures.immediateFuture(txn.executeUpdate(UPDATE_STATEMENT)), executor);
     mockSpanner.unfreeze();
     assertThat(fut.get()).isEqualTo(UPDATE_COUNT);
     executor.shutdown();
@@ -939,12 +920,7 @@ public class DatabaseClientImplTest {
     AsyncRunner runner = client.runAsync();
     ApiFuture<Long> fut =
         runner.runAsync(
-            new AsyncWork<Long>() {
-              @Override
-              public ApiFuture<Long> doWorkAsync(TransactionContext txn) {
-                return ApiFutures.immediateFuture(txn.executeUpdate(INVALID_UPDATE_STATEMENT));
-              }
-            },
+            txn -> ApiFutures.immediateFuture(txn.executeUpdate(INVALID_UPDATE_STATEMENT)),
             executor);
     try {
       fut.get();
@@ -2182,12 +2158,9 @@ public class DatabaseClientImplTest {
     AsyncRunner runner = client.runAsync(Options.priority(RpcPriority.HIGH));
     get(
         runner.runAsync(
-            new AsyncWork<Void>() {
-              @Override
-              public ApiFuture<Void> doWorkAsync(TransactionContext txn) {
-                txn.buffer(Mutation.delete("TEST", KeySet.all()));
-                return ApiFutures.immediateFuture(null);
-              }
+            txn -> {
+              txn.buffer(Mutation.delete("TEST", KeySet.all()));
+              return ApiFutures.immediateFuture(null);
             },
             executor));
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RetryOnInvalidatedSessionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RetryOnInvalidatedSessionTest.java
@@ -33,7 +33,6 @@ import com.google.cloud.NoCredentials;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.AsyncResultSet.CallbackResponse;
 import com.google.cloud.spanner.AsyncResultSet.ReadyCallback;
-import com.google.cloud.spanner.AsyncRunner.AsyncWork;
 import com.google.cloud.spanner.AsyncTransactionManager.AsyncTransactionFunction;
 import com.google.cloud.spanner.AsyncTransactionManager.AsyncTransactionStep;
 import com.google.cloud.spanner.AsyncTransactionManager.CommitTimestampFuture;
@@ -1513,39 +1512,36 @@ public class RetryOnInvalidatedSessionTest {
       final AtomicLong counter = new AtomicLong();
       ApiFuture<Long> count =
           runner.runAsync(
-              new AsyncWork<Long>() {
-                @Override
-                public ApiFuture<Long> doWorkAsync(TransactionContext txn) {
-                  AsyncResultSet rs = readFunction.apply(txn);
-                  ApiFuture<Void> fut =
-                      rs.setCallback(
-                          queryExecutor,
-                          new ReadyCallback() {
-                            @Override
-                            public CallbackResponse cursorReady(AsyncResultSet resultSet) {
-                              while (true) {
-                                switch (resultSet.tryNext()) {
-                                  case OK:
-                                    counter.incrementAndGet();
-                                    break;
-                                  case DONE:
-                                    return CallbackResponse.DONE;
-                                  case NOT_READY:
-                                    return CallbackResponse.CONTINUE;
-                                }
+              txn -> {
+                AsyncResultSet rs = readFunction.apply(txn);
+                ApiFuture<Void> fut =
+                    rs.setCallback(
+                        queryExecutor,
+                        new ReadyCallback() {
+                          @Override
+                          public CallbackResponse cursorReady(AsyncResultSet resultSet) {
+                            while (true) {
+                              switch (resultSet.tryNext()) {
+                                case OK:
+                                  counter.incrementAndGet();
+                                  break;
+                                case DONE:
+                                  return CallbackResponse.DONE;
+                                case NOT_READY:
+                                  return CallbackResponse.CONTINUE;
                               }
                             }
-                          });
-                  return ApiFutures.transform(
-                      fut,
-                      new ApiFunction<Void, Long>() {
-                        @Override
-                        public Long apply(Void input) {
-                          return counter.get();
-                        }
-                      },
-                      MoreExecutors.directExecutor());
-                }
+                          }
+                        });
+                return ApiFutures.transform(
+                    fut,
+                    new ApiFunction<Void, Long>() {
+                      @Override
+                      public Long apply(Void input) {
+                        return counter.get();
+                      }
+                    },
+                    MoreExecutors.directExecutor());
               },
               executor);
       assertThat(get(count)).isEqualTo(2);
@@ -1563,14 +1559,7 @@ public class RetryOnInvalidatedSessionTest {
     try {
       AsyncRunner runner = client.runAsync();
       ApiFuture<Struct> row =
-          runner.runAsync(
-              new AsyncWork<Struct>() {
-                @Override
-                public ApiFuture<Struct> doWorkAsync(TransactionContext txn) {
-                  return txn.readRowAsync("FOO", Key.of(), Arrays.asList("BAR"));
-                }
-              },
-              executor);
+          runner.runAsync(txn -> txn.readRowAsync("FOO", Key.of(), Arrays.asList("BAR")), executor);
       assertThat(get(row).getLong(0)).isEqualTo(1L);
       assertThat(failOnInvalidatedSession).isFalse();
     } catch (SessionNotFoundException e) {
@@ -1585,12 +1574,7 @@ public class RetryOnInvalidatedSessionTest {
       AsyncRunner runner = client.runAsync();
       ApiFuture<Struct> row =
           runner.runAsync(
-              new AsyncWork<Struct>() {
-                @Override
-                public ApiFuture<Struct> doWorkAsync(TransactionContext txn) {
-                  return txn.readRowUsingIndexAsync("FOO", "IDX", Key.of(), Arrays.asList("BAR"));
-                }
-              },
+              txn -> txn.readRowUsingIndexAsync("FOO", "IDX", Key.of(), Arrays.asList("BAR")),
               executor);
       assertThat(get(row).getLong(0)).isEqualTo(1L);
       assertThat(failOnInvalidatedSession).isFalse();
@@ -1605,14 +1589,7 @@ public class RetryOnInvalidatedSessionTest {
     try {
       AsyncRunner runner = client.runAsync();
       ApiFuture<Long> count =
-          runner.runAsync(
-              new AsyncWork<Long>() {
-                @Override
-                public ApiFuture<Long> doWorkAsync(TransactionContext txn) {
-                  return txn.executeUpdateAsync(UPDATE_STATEMENT);
-                }
-              },
-              executor);
+          runner.runAsync(txn -> txn.executeUpdateAsync(UPDATE_STATEMENT), executor);
       assertThat(get(count)).isEqualTo(UPDATE_COUNT);
       assertThat(failOnInvalidatedSession).isFalse();
     } catch (SessionNotFoundException e) {
@@ -1627,12 +1604,7 @@ public class RetryOnInvalidatedSessionTest {
       AsyncRunner runner = client.runAsync();
       ApiFuture<long[]> count =
           runner.runAsync(
-              new AsyncWork<long[]>() {
-                @Override
-                public ApiFuture<long[]> doWorkAsync(TransactionContext txn) {
-                  return txn.batchUpdateAsync(Arrays.asList(UPDATE_STATEMENT, UPDATE_STATEMENT));
-                }
-              },
+              txn -> txn.batchUpdateAsync(Arrays.asList(UPDATE_STATEMENT, UPDATE_STATEMENT)),
               executor);
       assertThat(get(count)).hasLength(2);
       assertThat(get(count)).asList().containsExactly(UPDATE_COUNT, UPDATE_COUNT);
@@ -1649,12 +1621,9 @@ public class RetryOnInvalidatedSessionTest {
       AsyncRunner runner = client.runAsync();
       ApiFuture<Void> res =
           runner.runAsync(
-              new AsyncWork<Void>() {
-                @Override
-                public ApiFuture<Void> doWorkAsync(TransactionContext txn) {
-                  txn.buffer(Mutation.newInsertBuilder("FOO").set("BAR").to(1L).build());
-                  return ApiFutures.immediateFuture(null);
-                }
+              txn -> {
+                txn.buffer(Mutation.newInsertBuilder("FOO").set("BAR").to(1L).build());
+                return ApiFutures.immediateFuture(null);
               },
               executor);
       assertThat(get(res)).isNull();

--- a/samples/snippets/src/main/java/com/example/spanner/AsyncDmlExample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/AsyncDmlExample.java
@@ -54,17 +54,14 @@ class AsyncDmlExample {
     AsyncRunner runner = client.runAsync();
     ApiFuture<Long> rowCount =
         runner.runAsync(
-            new AsyncWork<Long>() {
-              @Override
-              public ApiFuture<Long> doWorkAsync(TransactionContext txn) {
-                String sql =
-                    "INSERT INTO Singers (SingerId, FirstName, LastName) VALUES "
-                        + "(12, 'Melissa', 'Garcia'), "
-                        + "(13, 'Russell', 'Morales'), "
-                        + "(14, 'Jacqueline', 'Long'), "
-                        + "(15, 'Dylan', 'Shaw')";
-                return txn.executeUpdateAsync(Statement.of(sql));
-              }
+            txn -> {
+              String sql =
+                  "INSERT INTO Singers (SingerId, FirstName, LastName) VALUES "
+                      + "(12, 'Melissa', 'Garcia'), "
+                      + "(13, 'Russell', 'Morales'), "
+                      + "(14, 'Jacqueline', 'Long'), "
+                      + "(15, 'Dylan', 'Shaw')";
+              return txn.executeUpdateAsync(Statement.of(sql));
             },
             executor);
     System.out.printf("%d records inserted.%n", rowCount.get());

--- a/samples/snippets/src/main/java/com/example/spanner/AsyncRunnerExample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/AsyncRunnerExample.java
@@ -68,53 +68,50 @@ class AsyncRunnerExample {
     // longs.
     ApiFuture<long[]> rowCounts =
         runner.runAsync(
-            new AsyncWork<long[]>() {
-              @Override
-              public ApiFuture<long[]> doWorkAsync(TransactionContext txn) {
-                // Transfer marketing budget from one album to another. We do it in a
-                // transaction to ensure that the transfer is atomic.
-                ApiFuture<Struct> album1BudgetFut =
-                    txn.readRowAsync("Albums", Key.of(1, 1), ImmutableList.of("MarketingBudget"));
-                ApiFuture<Struct> album2BudgetFut =
-                    txn.readRowAsync("Albums", Key.of(2, 2), ImmutableList.of("MarketingBudget"));
+            txn -> {
+              // Transfer marketing budget from one album to another. We do it in a
+              // transaction to ensure that the transfer is atomic.
+              ApiFuture<Struct> album1BudgetFut =
+                  txn.readRowAsync("Albums", Key.of(1, 1), ImmutableList.of("MarketingBudget"));
+              ApiFuture<Struct> album2BudgetFut =
+                  txn.readRowAsync("Albums", Key.of(2, 2), ImmutableList.of("MarketingBudget"));
 
-                try {
-                  // Transaction will only be committed if this condition still holds at the
-                  // time of commit. Otherwise it will be aborted and the AsyncWork will be
-                  // rerun by the client library.
-                  long transfer = 200_000;
-                  if (album2BudgetFut.get().getLong(0) >= transfer) {
-                    long album1Budget = album1BudgetFut.get().getLong(0);
-                    long album2Budget = album2BudgetFut.get().getLong(0);
+              try {
+                // Transaction will only be committed if this condition still holds at the
+                // time of commit. Otherwise it will be aborted and the AsyncWork will be
+                // rerun by the client library.
+                long transfer = 200_000;
+                if (album2BudgetFut.get().getLong(0) >= transfer) {
+                  long album1Budget = album1BudgetFut.get().getLong(0);
+                  long album2Budget = album2BudgetFut.get().getLong(0);
 
-                    album1Budget += transfer;
-                    album2Budget -= transfer;
-                    Statement updateStatement1 =
-                        Statement.newBuilder(
-                                "UPDATE Albums "
-                                    + "SET MarketingBudget = @AlbumBudget "
-                                    + "WHERE SingerId = 1 and AlbumId = 1")
-                            .bind("AlbumBudget")
-                            .to(album1Budget)
-                            .build();
-                    Statement updateStatement2 =
-                        Statement.newBuilder(
-                                "UPDATE Albums "
-                                    + "SET MarketingBudget = @AlbumBudget "
-                                    + "WHERE SingerId = 2 and AlbumId = 2")
-                            .bind("AlbumBudget")
-                            .to(album2Budget)
-                            .build();
-                    return txn.batchUpdateAsync(
-                        ImmutableList.of(updateStatement1, updateStatement2));
-                  } else {
-                    return ApiFutures.immediateFuture(new long[] {0L, 0L});
-                  }
-                } catch (ExecutionException e) {
-                  throw SpannerExceptionFactory.newSpannerException(e.getCause());
-                } catch (InterruptedException e) {
-                  throw SpannerExceptionFactory.propagateInterrupt(e);
+                  album1Budget += transfer;
+                  album2Budget -= transfer;
+                  Statement updateStatement1 =
+                      Statement.newBuilder(
+                              "UPDATE Albums "
+                                  + "SET MarketingBudget = @AlbumBudget "
+                                  + "WHERE SingerId = 1 and AlbumId = 1")
+                          .bind("AlbumBudget")
+                          .to(album1Budget)
+                          .build();
+                  Statement updateStatement2 =
+                      Statement.newBuilder(
+                              "UPDATE Albums "
+                                  + "SET MarketingBudget = @AlbumBudget "
+                                  + "WHERE SingerId = 2 and AlbumId = 2")
+                          .bind("AlbumBudget")
+                          .to(album2Budget)
+                          .build();
+                  return txn.batchUpdateAsync(
+                      ImmutableList.of(updateStatement1, updateStatement2));
+                } else {
+                  return ApiFutures.immediateFuture(new long[] {0L, 0L});
                 }
+              } catch (ExecutionException e) {
+                throw SpannerExceptionFactory.newSpannerException(e.getCause());
+              } catch (InterruptedException e) {
+                throw SpannerExceptionFactory.propagateInterrupt(e);
               }
             },
             executor);


### PR DESCRIPTION
Marks the async work interface as a functional interface.

This PR also modifies all of its usages to the lambda syntax. Only syntatic changes were made, no logic changes were made here.