### PR TITLE
docs: fix javadoc for Date type

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Type.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Type.java
@@ -109,7 +109,7 @@ public final class Type implements Serializable {
 
   /**
    * Returns the descriptor for the {@code DATE} type: a timezone independent date in the range
-   * [1678-01-01, 2262-01-01).
+   * [0001-01-01, 9999-12-31).
    */
   public static Type date() {
     return TYPE_DATE;


### PR DESCRIPTION
Fix wrong Java docs for `Date` type.

Source: https://cloud.google.com/spanner/docs/data-definition-language#date