### PR TITLE
fix: allow using case-insensitive user-agent key

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -166,6 +166,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
@@ -493,7 +494,14 @@ public class GapicSpannerRpc implements SpannerRpc {
 
   private static HeaderProvider headerProviderWithUserAgentFrom(HeaderProvider headerProvider) {
     final Map<String, String> headersWithUserAgent = new HashMap<>(headerProvider.getHeaders());
-    final String userAgent = headersWithUserAgent.get(USER_AGENT_KEY);
+    String userAgent = null;
+    for (Entry<String, String> entry : headersWithUserAgent.entrySet()) {
+      if (entry.getKey().equalsIgnoreCase(USER_AGENT_KEY)) {
+        userAgent = entry.getValue();
+        headersWithUserAgent.remove(entry.getKey());
+        break;
+      }
+    }
     headersWithUserAgent.put(
         USER_AGENT_KEY,
         userAgent == null ? DEFAULT_USER_AGENT : userAgent + " " + DEFAULT_USER_AGENT);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
@@ -509,27 +509,29 @@ public class GapicSpannerRpcTest {
 
   @Test
   public void testCustomUserAgent() {
-    final HeaderProvider userAgentHeaderProvider =
-        new HeaderProvider() {
-          @Override
-          public Map<String, String> getHeaders() {
-            final Map<String, String> headers = new HashMap<>();
-            headers.put("user-agent", "test-agent");
-            return headers;
-          }
-        };
-    final SpannerOptions options =
-        createSpannerOptions().toBuilder().setHeaderProvider(userAgentHeaderProvider).build();
-    try (Spanner spanner = options.getService()) {
-      final DatabaseClient databaseClient =
-          spanner.getDatabaseClient(DatabaseId.of("[PROJECT]", "[INSTANCE]", "[DATABASE]"));
+    for (String headerId : new String[] {"user-agent", "User-Agent", "USER-AGENT"}) {
+      final HeaderProvider userAgentHeaderProvider =
+          new HeaderProvider() {
+            @Override
+            public Map<String, String> getHeaders() {
+              final Map<String, String> headers = new HashMap<>();
+              headers.put(headerId, "test-agent");
+              return headers;
+            }
+          };
+      final SpannerOptions options =
+          createSpannerOptions().toBuilder().setHeaderProvider(userAgentHeaderProvider).build();
+      try (Spanner spanner = options.getService()) {
+        final DatabaseClient databaseClient =
+            spanner.getDatabaseClient(DatabaseId.of("[PROJECT]", "[INSTANCE]", "[DATABASE]"));
 
-      try (final ResultSet rs = databaseClient.singleUse().executeQuery(SELECT1AND2)) {
-        rs.next();
+        try (final ResultSet rs = databaseClient.singleUse().executeQuery(SELECT1AND2)) {
+          rs.next();
+        }
+
+        assertThat(seenHeaders.get(Key.of("user-agent", Metadata.ASCII_STRING_MARSHALLER)))
+            .contains("test-agent " + defaultUserAgent);
       }
-
-      assertThat(seenHeaders.get(Key.of("user-agent", Metadata.ASCII_STRING_MARSHALLER)))
-          .contains("test-agent " + defaultUserAgent);
     }
   }
 


### PR DESCRIPTION
Adding a custom user-agent was only possible by using an all lower-case key. A header key should however be case-insensitive. This PR changes the merging of a custom user-agent value with the default user-agent to use a case-insensitive comparison.