### PR TITLE
refactor: fixes various code analyser issues

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
@@ -224,7 +224,7 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
                   + newValue.getKindCase());
         }
         if (kind == KindCase.STRING_VALUE) {
-          merged = (String) merged + newValue.getStringValue();
+          merged = merged + newValue.getStringValue();
         } else {
           concatLists(
               (List<com.google.protobuf.Value>) merged, newValue.getListValue().getValuesList());

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
@@ -318,7 +318,7 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
         KindCase lastKind = last.getKindCase();
         KindCase firstKind = first.getKindCase();
         if (isMergeable(lastKind) && lastKind == firstKind) {
-          com.google.protobuf.Value merged = null;
+          com.google.protobuf.Value merged;
           if (lastKind == KindCase.STRING_VALUE) {
             String lastStr = last.getStringValue();
             String firstStr = first.getStringValue();

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
@@ -536,7 +536,7 @@ class AsyncResultSetImpl extends ForwardingStructReader implements ListenableAsy
           finished,
           new ApiAsyncFunction<Void, List<T>>() {
             @Override
-            public ApiFuture<List<T>> apply(Void input) throws Exception {
+            public ApiFuture<List<T>> apply(Void input) {
               return res;
             }
           },

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.spanner;
 
-import com.google.api.core.ApiAsyncFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.core.ListenableFutureToApiFuture;
@@ -532,15 +531,7 @@ class AsyncResultSetImpl extends ForwardingStructReader implements ListenableAsy
       final SettableApiFuture<List<T>> res = SettableApiFuture.<List<T>>create();
       CreateListCallback<T> callback = new CreateListCallback<>(res, transformer);
       ApiFuture<Void> finished = setCallback(executor, callback);
-      return ApiFutures.transformAsync(
-          finished,
-          new ApiAsyncFunction<Void, List<T>>() {
-            @Override
-            public ApiFuture<List<T>> apply(Void input) {
-              return res;
-            }
-          },
-          MoreExecutors.directExecutor());
+      return ApiFutures.transformAsync(finished, ignored -> res, MoreExecutors.directExecutor());
     }
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
@@ -528,7 +528,7 @@ class AsyncResultSetImpl extends ForwardingStructReader implements ListenableAsy
       Preconditions.checkState(!closed, "This AsyncResultSet has been closed");
       Preconditions.checkState(
           this.state == State.INITIALIZED, "This AsyncResultSet has already been used.");
-      final SettableApiFuture<List<T>> res = SettableApiFuture.<List<T>>create();
+      final SettableApiFuture<List<T>> res = SettableApiFuture.create();
       CreateListCallback<T> callback = new CreateListCallback<>(res, transformer);
       ApiFuture<Void> finished = setCallback(executor, callback);
       return ApiFutures.transformAsync(finished, ignored -> res, MoreExecutors.directExecutor());

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncRunnerImpl.java
@@ -18,7 +18,6 @@ package com.google.cloud.spanner;
 
 import static com.google.common.base.Preconditions.checkState;
 
-import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.core.SettableApiFuture;
@@ -79,14 +78,7 @@ class AsyncRunnerImpl implements AsyncRunner {
   public ApiFuture<Timestamp> getCommitTimestamp() {
     checkState(commitResponse != null, "runAsync() has not yet been called");
     return ApiFutures.transform(
-        commitResponse,
-        new ApiFunction<CommitResponse, Timestamp>() {
-          @Override
-          public Timestamp apply(CommitResponse input) {
-            return input.getCommitTimestamp();
-          }
-        },
-        MoreExecutors.directExecutor());
+        commitResponse, CommitResponse::getCommitTimestamp, MoreExecutors.directExecutor());
   }
 
   public ApiFuture<CommitResponse> getCommitResponse() {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncTransactionManagerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncTransactionManagerImpl.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.spanner;
 
-import com.google.api.core.ApiAsyncFunction;
-import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
@@ -30,7 +28,6 @@ import com.google.cloud.spanner.TransactionManager.TransactionState;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.protobuf.Empty;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
@@ -154,14 +151,7 @@ final class AsyncTransactionManagerImpl
         },
         MoreExecutors.directExecutor());
     return ApiFutures.transform(
-        commitResponseFuture,
-        new ApiFunction<CommitResponse, Timestamp>() {
-          @Override
-          public Timestamp apply(CommitResponse input) {
-            return input.getCommitTimestamp();
-          }
-        },
-        MoreExecutors.directExecutor());
+        commitResponseFuture, CommitResponse::getCommitTimestamp, MoreExecutors.directExecutor());
   }
 
   @Override
@@ -172,12 +162,7 @@ final class AsyncTransactionManagerImpl
     try {
       return ApiFutures.transformAsync(
           txn.rollbackAsync(),
-          new ApiAsyncFunction<Empty, Void>() {
-            @Override
-            public ApiFuture<Void> apply(Empty input) {
-              return ApiFutures.immediateFuture(null);
-            }
-          },
+          ignored -> ApiFutures.immediateFuture(null),
           MoreExecutors.directExecutor());
     } finally {
       txnState = TransactionState.ROLLED_BACK;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncTransactionManagerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncTransactionManagerImpl.java
@@ -70,7 +70,7 @@ final class AsyncTransactionManagerImpl
     if (txn != null) {
       txn.close();
     }
-    return MoreObjects.firstNonNull(res, ApiFutures.<Void>immediateFuture(null));
+    return MoreObjects.firstNonNull(res, ApiFutures.immediateFuture(null));
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncTransactionManagerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncTransactionManagerImpl.java
@@ -174,7 +174,7 @@ final class AsyncTransactionManagerImpl
           txn.rollbackAsync(),
           new ApiAsyncFunction<Empty, Void>() {
             @Override
-            public ApiFuture<Void> apply(Empty input) throws Exception {
+            public ApiFuture<Void> apply(Empty input) {
               return ApiFutures.immediateFuture(null);
             }
           },

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseAdminClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseAdminClientImpl.java
@@ -16,11 +16,9 @@
 
 package com.google.cloud.spanner;
 
-import com.google.api.core.ApiFunction;
 import com.google.api.gax.grpc.ProtoOperationTransformers;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.api.gax.longrunning.OperationFutureImpl;
-import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.paging.Page;
 import com.google.cloud.Policy;
 import com.google.cloud.Policy.DefaultMarshaller;
@@ -108,22 +106,15 @@ class DatabaseAdminClientImpl implements DatabaseAdminClient {
     return new OperationFutureImpl<>(
         rawOperationFuture.getPollingFuture(),
         rawOperationFuture.getInitialFuture(),
-        new ApiFunction<OperationSnapshot, Database>() {
-          @Override
-          public Database apply(OperationSnapshot snapshot) {
-            return Database.fromProto(
+        snapshot ->
+            Database.fromProto(
                 ProtoOperationTransformers.ResponseTransformer.create(
                         com.google.spanner.admin.database.v1.Database.class)
                     .apply(snapshot),
-                DatabaseAdminClientImpl.this);
-          }
-        },
+                DatabaseAdminClientImpl.this),
         ProtoOperationTransformers.MetadataTransformer.create(RestoreDatabaseMetadata.class),
-        new ApiFunction<Exception, Database>() {
-          @Override
-          public Database apply(Exception e) {
-            throw SpannerExceptionFactory.newSpannerException(e);
-          }
+        e -> {
+          throw SpannerExceptionFactory.newSpannerException(e);
         });
   }
 
@@ -154,30 +145,24 @@ class DatabaseAdminClientImpl implements DatabaseAdminClient {
     return new OperationFutureImpl<>(
         rawOperationFuture.getPollingFuture(),
         rawOperationFuture.getInitialFuture(),
-        new ApiFunction<OperationSnapshot, Backup>() {
-          @Override
-          public Backup apply(OperationSnapshot snapshot) {
-            com.google.spanner.admin.database.v1.Backup proto =
-                ProtoOperationTransformers.ResponseTransformer.create(
-                        com.google.spanner.admin.database.v1.Backup.class)
-                    .apply(snapshot);
-            return Backup.fromProto(
-                com.google.spanner.admin.database.v1.Backup.newBuilder(proto)
-                    .setName(proto.getName())
-                    .setExpireTime(proto.getExpireTime())
-                    .setVersionTime(proto.getVersionTime())
-                    .setState(proto.getState())
-                    .setEncryptionInfo(proto.getEncryptionInfo())
-                    .build(),
-                DatabaseAdminClientImpl.this);
-          }
+        snapshot -> {
+          com.google.spanner.admin.database.v1.Backup proto =
+              ProtoOperationTransformers.ResponseTransformer.create(
+                      com.google.spanner.admin.database.v1.Backup.class)
+                  .apply(snapshot);
+          return Backup.fromProto(
+              com.google.spanner.admin.database.v1.Backup.newBuilder(proto)
+                  .setName(proto.getName())
+                  .setExpireTime(proto.getExpireTime())
+                  .setVersionTime(proto.getVersionTime())
+                  .setState(proto.getState())
+                  .setEncryptionInfo(proto.getEncryptionInfo())
+                  .build(),
+              DatabaseAdminClientImpl.this);
         },
         ProtoOperationTransformers.MetadataTransformer.create(CreateBackupMetadata.class),
-        new ApiFunction<Exception, Backup>() {
-          @Override
-          public Backup apply(Exception e) {
-            throw SpannerExceptionFactory.newSpannerException(e);
-          }
+        e -> {
+          throw SpannerExceptionFactory.newSpannerException(e);
         });
   }
 
@@ -311,22 +296,15 @@ class DatabaseAdminClientImpl implements DatabaseAdminClient {
     return new OperationFutureImpl<>(
         rawOperationFuture.getPollingFuture(),
         rawOperationFuture.getInitialFuture(),
-        new ApiFunction<OperationSnapshot, Database>() {
-          @Override
-          public Database apply(OperationSnapshot snapshot) {
-            return Database.fromProto(
+        snapshot ->
+            Database.fromProto(
                 ProtoOperationTransformers.ResponseTransformer.create(
                         com.google.spanner.admin.database.v1.Database.class)
                     .apply(snapshot),
-                DatabaseAdminClientImpl.this);
-          }
-        },
+                DatabaseAdminClientImpl.this),
         ProtoOperationTransformers.MetadataTransformer.create(CreateDatabaseMetadata.class),
-        new ApiFunction<Exception, Database>() {
-          @Override
-          public Database apply(Exception e) {
-            throw SpannerExceptionFactory.newSpannerException(e);
-          }
+        e -> {
+          throw SpannerExceptionFactory.newSpannerException(e);
         });
   }
 
@@ -350,19 +328,13 @@ class DatabaseAdminClientImpl implements DatabaseAdminClient {
     return new OperationFutureImpl<>(
         rawOperationFuture.getPollingFuture(),
         rawOperationFuture.getInitialFuture(),
-        new ApiFunction<OperationSnapshot, Void>() {
-          @Override
-          public Void apply(OperationSnapshot snapshot) {
-            ProtoOperationTransformers.ResponseTransformer.create(Empty.class).apply(snapshot);
-            return null;
-          }
+        snapshot -> {
+          ProtoOperationTransformers.ResponseTransformer.create(Empty.class).apply(snapshot);
+          return null;
         },
         ProtoOperationTransformers.MetadataTransformer.create(UpdateDatabaseDdlMetadata.class),
-        new ApiFunction<Exception, Void>() {
-          @Override
-          public Void apply(Exception e) {
-            throw SpannerExceptionFactory.newSpannerException(e);
-          }
+        e -> {
+          throw SpannerExceptionFactory.newSpannerException(e);
         });
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
@@ -64,13 +64,7 @@ class DatabaseClientImpl implements DatabaseClient {
       throws SpannerException {
     Span span = tracer.spanBuilder(READ_WRITE_TRANSACTION).startSpan();
     try (Scope s = tracer.withSpan(span)) {
-      return runWithSessionRetry(
-          new Function<Session, CommitResponse>() {
-            @Override
-            public CommitResponse apply(Session session) {
-              return session.writeWithOptions(mutations, options);
-            }
-          });
+      return runWithSessionRetry(session -> session.writeWithOptions(mutations, options));
     } catch (RuntimeException e) {
       TraceUtil.setWithFailure(span, e);
       throw e;
@@ -91,12 +85,7 @@ class DatabaseClientImpl implements DatabaseClient {
     Span span = tracer.spanBuilder(READ_WRITE_TRANSACTION).startSpan();
     try (Scope s = tracer.withSpan(span)) {
       return runWithSessionRetry(
-          new Function<Session, CommitResponse>() {
-            @Override
-            public CommitResponse apply(Session session) {
-              return session.writeAtLeastOnceWithOptions(mutations, options);
-            }
-          });
+          session -> session.writeAtLeastOnceWithOptions(mutations, options));
     } catch (RuntimeException e) {
       TraceUtil.setWithFailure(span, e);
       throw e;
@@ -221,13 +210,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public long executePartitionedUpdate(final Statement stmt, final UpdateOption... options) {
     Span span = tracer.spanBuilder(PARTITION_DML_TRANSACTION).startSpan();
     try (Scope s = tracer.withSpan(span)) {
-      return runWithSessionRetry(
-          new Function<Session, Long>() {
-            @Override
-            public Long apply(Session session) {
-              return session.executePartitionedUpdate(stmt, options);
-            }
-          });
+      return runWithSessionRetry(session -> session.executePartitionedUpdate(stmt, options));
     } catch (RuntimeException e) {
       TraceUtil.endSpanWithFailure(span, e);
       throw e;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceAdminClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceAdminClientImpl.java
@@ -16,11 +16,9 @@
 
 package com.google.cloud.spanner;
 
-import com.google.api.core.ApiFunction;
 import com.google.api.gax.grpc.ProtoOperationTransformers;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.api.gax.longrunning.OperationFutureImpl;
-import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.paging.Page;
 import com.google.api.pathtemplate.PathTemplate;
 import com.google.cloud.Policy;
@@ -106,23 +104,16 @@ class InstanceAdminClientImpl implements InstanceAdminClient {
     return new OperationFutureImpl<>(
         rawOperationFuture.getPollingFuture(),
         rawOperationFuture.getInitialFuture(),
-        new ApiFunction<OperationSnapshot, Instance>() {
-          @Override
-          public Instance apply(OperationSnapshot snapshot) {
-            return Instance.fromProto(
+        snapshot ->
+            Instance.fromProto(
                 ProtoOperationTransformers.ResponseTransformer.create(
                         com.google.spanner.admin.instance.v1.Instance.class)
                     .apply(snapshot),
                 InstanceAdminClientImpl.this,
-                dbClient);
-          }
-        },
+                dbClient),
         ProtoOperationTransformers.MetadataTransformer.create(CreateInstanceMetadata.class),
-        new ApiFunction<Exception, Instance>() {
-          @Override
-          public Instance apply(Exception e) {
-            throw SpannerExceptionFactory.newSpannerException(e);
-          }
+        e -> {
+          throw SpannerExceptionFactory.newSpannerException(e);
         });
   }
 
@@ -175,23 +166,16 @@ class InstanceAdminClientImpl implements InstanceAdminClient {
     return new OperationFutureImpl<>(
         rawOperationFuture.getPollingFuture(),
         rawOperationFuture.getInitialFuture(),
-        new ApiFunction<OperationSnapshot, Instance>() {
-          @Override
-          public Instance apply(OperationSnapshot snapshot) {
-            return Instance.fromProto(
+        snapshot ->
+            Instance.fromProto(
                 ProtoOperationTransformers.ResponseTransformer.create(
                         com.google.spanner.admin.instance.v1.Instance.class)
                     .apply(snapshot),
                 InstanceAdminClientImpl.this,
-                dbClient);
-          }
-        },
+                dbClient),
         ProtoOperationTransformers.MetadataTransformer.create(UpdateInstanceMetadata.class),
-        new ApiFunction<Exception, Instance>() {
-          @Override
-          public Instance apply(Exception e) {
-            throw SpannerExceptionFactory.newSpannerException(e);
-          }
+        e -> {
+          throw SpannerExceptionFactory.newSpannerException(e);
         });
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/KeySet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/KeySet.java
@@ -47,7 +47,7 @@ public final class KeySet implements Serializable {
    * as there are columns in the primary or index key with this this key set is used.
    */
   public static KeySet singleKey(Key key) {
-    return new KeySet(false, ImmutableList.of(key), ImmutableList.<KeyRange>of());
+    return new KeySet(false, ImmutableList.of(key), ImmutableList.of());
   }
 
   /**
@@ -55,7 +55,7 @@ public final class KeySet implements Serializable {
    * ranges.
    */
   public static KeySet range(KeyRange range) {
-    return new KeySet(false, ImmutableList.<Key>of(), ImmutableList.of(range));
+    return new KeySet(false, ImmutableList.of(), ImmutableList.of(range));
   }
 
   /**
@@ -68,7 +68,7 @@ public final class KeySet implements Serializable {
 
   /** Creates a key set that will retrieve all rows of a table or index. */
   public static KeySet all() {
-    return new KeySet(true, ImmutableList.<Key>of(), ImmutableList.<KeyRange>of());
+    return new KeySet(true, ImmutableList.of(), ImmutableList.of());
   }
 
   /** Returns a new builder that can be used to construct a key set. */
@@ -124,8 +124,8 @@ public final class KeySet implements Serializable {
     public KeySet build() {
       return new KeySet(
           all,
-          keys != null ? keys.build() : ImmutableList.<Key>of(),
-          ranges != null ? ranges.build() : ImmutableList.<KeyRange>of());
+          keys != null ? keys.build() : ImmutableList.of(),
+          ranges != null ? ranges.build() : ImmutableList.of());
     }
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Operation.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Operation.java
@@ -100,7 +100,7 @@ public class Operation<R, M> {
 
   static <R, M> Operation<R, M> create(
       SpannerRpc rpc, com.google.longrunning.Operation proto, Parser<R, M> parser) {
-    return Operation.<R, M>create(rpc, proto, parser, CurrentMillisClock.getDefaultClock());
+    return Operation.create(rpc, proto, parser, CurrentMillisClock.getDefaultClock());
   }
 
   static <R, M> Operation<R, M> create(
@@ -109,13 +109,13 @@ public class Operation<R, M> {
     String name = proto.getName();
     if (proto.getDone()) {
       if (proto.getResultCase() == ResultCase.ERROR) {
-        return Operation.<R, M>failed(rpc, name, proto.getError(), metadata, parser, clock);
+        return Operation.failed(rpc, name, proto.getError(), metadata, parser, clock);
       } else {
-        return Operation.<R, M>successful(
+        return Operation.successful(
             rpc, name, metadata, parser.parseResult(proto.getResponse()), parser, clock);
       }
     } else {
-      return Operation.<R, M>pending(rpc, name, metadata, parser, clock);
+      return Operation.pending(rpc, name, metadata, parser, clock);
     }
   }
 
@@ -125,7 +125,7 @@ public class Operation<R, M> {
       return this;
     }
     com.google.longrunning.Operation proto = rpc.getOperation(name);
-    return Operation.<R, M>create(rpc, proto, parser);
+    return Operation.create(rpc, proto, parser);
   }
 
   /**

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionClient.java
@@ -125,7 +125,7 @@ class SessionClient implements AutoCloseable {
 
     @Override
     public void run() {
-      List<SessionImpl> sessions = null;
+      List<SessionImpl> sessions;
       int remainingSessionsToCreate = sessionCount;
       Span span = SpannerImpl.tracer.spanBuilder(SpannerImpl.BATCH_CREATE_SESSIONS).startSpan();
       try (Scope s = SpannerImpl.tracer.withSpan(span)) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -59,13 +59,7 @@ class SessionImpl implements Session {
   private static final Tracer tracer = Tracing.getTracer();
 
   /** Keep track of running transactions on this session per thread. */
-  static final ThreadLocal<Boolean> hasPendingTransaction =
-      new ThreadLocal<Boolean>() {
-        @Override
-        protected Boolean initialValue() {
-          return false;
-        }
-      };
+  static final ThreadLocal<Boolean> hasPendingTransaction = ThreadLocal.withInitial(() -> false);
 
   static void throwIfTransactionsPending() {
     if (hasPendingTransaction.get() == Boolean.TRUE) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -39,7 +39,6 @@ import static com.google.cloud.spanner.MetricRegistryConstants.SPANNER_LABEL_KEY
 import static com.google.cloud.spanner.SpannerExceptionFactory.newSpannerException;
 import static com.google.common.base.Preconditions.checkState;
 
-import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.core.SettableApiFuture;
@@ -69,7 +68,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.protobuf.Empty;
 import io.opencensus.common.Scope;
-import io.opencensus.common.ToLongFunction;
 import io.opencensus.metrics.DerivedLongCumulative;
 import io.opencensus.metrics.DerivedLongGauge;
 import io.opencensus.metrics.LabelValue;
@@ -579,14 +577,11 @@ class SessionPool {
     public ApiFuture<Void> setCallback(Executor executor, final ReadyCallback callback) {
       return super.setCallback(
           executor,
-          new ReadyCallback() {
-            @Override
-            public CallbackResponse cursorReady(AsyncResultSet resultSet) {
-              try {
-                return callback.cursorReady(resultSet);
-              } catch (SessionNotFoundException e) {
-                throw handler.handleSessionNotFound(e);
-              }
+          resultSet -> {
+            try {
+              return callback.cursorReady(resultSet);
+            } catch (SessionNotFoundException e) {
+              throw handler.handleSessionNotFound(e);
             }
           });
     }
@@ -668,11 +663,8 @@ class SessionPool {
         return ApiFutures.catching(
             AbstractReadContext.consumeSingleRowAsync(rs),
             SessionNotFoundException.class,
-            new ApiFunction<SessionNotFoundException, Struct>() {
-              @Override
-              public Struct apply(SessionNotFoundException input) {
-                throw handler.handleSessionNotFound(input);
-              }
+            input -> {
+              throw handler.handleSessionNotFound(input);
             },
             MoreExecutors.directExecutor());
       }
@@ -699,11 +691,8 @@ class SessionPool {
         return ApiFutures.catching(
             AbstractReadContext.consumeSingleRowAsync(rs),
             SessionNotFoundException.class,
-            new ApiFunction<SessionNotFoundException, Struct>() {
-              @Override
-              public Struct apply(SessionNotFoundException input) {
-                throw handler.handleSessionNotFound(input);
-              }
+            input -> {
+              throw handler.handleSessionNotFound(input);
             },
             MoreExecutors.directExecutor());
       }
@@ -728,11 +717,8 @@ class SessionPool {
       return ApiFutures.catching(
           delegate.executeUpdateAsync(statement, options),
           SessionNotFoundException.class,
-          new ApiFunction<SessionNotFoundException, Long>() {
-            @Override
-            public Long apply(SessionNotFoundException input) {
-              throw handler.handleSessionNotFound(input);
-            }
+          input -> {
+            throw handler.handleSessionNotFound(input);
           },
           MoreExecutors.directExecutor());
     }
@@ -752,11 +738,8 @@ class SessionPool {
       return ApiFutures.catching(
           delegate.batchUpdateAsync(statements, options),
           SessionNotFoundException.class,
-          new ApiFunction<SessionNotFoundException, long[]>() {
-            @Override
-            public long[] apply(SessionNotFoundException input) {
-              throw handler.handleSessionNotFound(input);
-            }
+          input -> {
+            throw handler.handleSessionNotFound(input);
           },
           MoreExecutors.directExecutor());
     }
@@ -1047,14 +1030,7 @@ class SessionPool {
     public ApiFuture<Timestamp> getCommitTimestamp() {
       checkState(commitResponse != null, "runAsync() has not yet been called");
       return ApiFutures.transform(
-          commitResponse,
-          new ApiFunction<CommitResponse, Timestamp>() {
-            @Override
-            public Timestamp apply(CommitResponse input) {
-              return input.getCommitTimestamp();
-            }
-          },
-          MoreExecutors.directExecutor());
+          commitResponse, input -> input.getCommitTimestamp(), MoreExecutors.directExecutor());
     }
 
     @Override
@@ -1141,12 +1117,9 @@ class SessionPool {
     public ReadContext singleUse() {
       try {
         return new AutoClosingReadContext<>(
-            new Function<PooledSessionFuture, ReadContext>() {
-              @Override
-              public ReadContext apply(PooledSessionFuture session) {
-                PooledSession ps = session.get();
-                return ps.delegate.singleUse();
-              }
+            session -> {
+              PooledSession ps = session.get();
+              return ps.delegate.singleUse();
             },
             SessionPool.this,
             this,
@@ -1161,12 +1134,9 @@ class SessionPool {
     public ReadContext singleUse(final TimestampBound bound) {
       try {
         return new AutoClosingReadContext<>(
-            new Function<PooledSessionFuture, ReadContext>() {
-              @Override
-              public ReadContext apply(PooledSessionFuture session) {
-                PooledSession ps = session.get();
-                return ps.delegate.singleUse(bound);
-              }
+            session -> {
+              PooledSession ps = session.get();
+              return ps.delegate.singleUse(bound);
             },
             SessionPool.this,
             this,
@@ -1180,12 +1150,9 @@ class SessionPool {
     @Override
     public ReadOnlyTransaction singleUseReadOnlyTransaction() {
       return internalReadOnlyTransaction(
-          new Function<PooledSessionFuture, ReadOnlyTransaction>() {
-            @Override
-            public ReadOnlyTransaction apply(PooledSessionFuture session) {
-              PooledSession ps = session.get();
-              return ps.delegate.singleUseReadOnlyTransaction();
-            }
+          session -> {
+            PooledSession ps = session.get();
+            return ps.delegate.singleUseReadOnlyTransaction();
           },
           true);
     }
@@ -1193,12 +1160,9 @@ class SessionPool {
     @Override
     public ReadOnlyTransaction singleUseReadOnlyTransaction(final TimestampBound bound) {
       return internalReadOnlyTransaction(
-          new Function<PooledSessionFuture, ReadOnlyTransaction>() {
-            @Override
-            public ReadOnlyTransaction apply(PooledSessionFuture session) {
-              PooledSession ps = session.get();
-              return ps.delegate.singleUseReadOnlyTransaction(bound);
-            }
+          session -> {
+            PooledSession ps = session.get();
+            return ps.delegate.singleUseReadOnlyTransaction(bound);
           },
           true);
     }
@@ -1206,12 +1170,9 @@ class SessionPool {
     @Override
     public ReadOnlyTransaction readOnlyTransaction() {
       return internalReadOnlyTransaction(
-          new Function<PooledSessionFuture, ReadOnlyTransaction>() {
-            @Override
-            public ReadOnlyTransaction apply(PooledSessionFuture session) {
-              PooledSession ps = session.get();
-              return ps.delegate.readOnlyTransaction();
-            }
+          session -> {
+            PooledSession ps = session.get();
+            return ps.delegate.readOnlyTransaction();
           },
           false);
     }
@@ -1219,12 +1180,9 @@ class SessionPool {
     @Override
     public ReadOnlyTransaction readOnlyTransaction(final TimestampBound bound) {
       return internalReadOnlyTransaction(
-          new Function<PooledSessionFuture, ReadOnlyTransaction>() {
-            @Override
-            public ReadOnlyTransaction apply(PooledSessionFuture session) {
-              PooledSession ps = session.get();
-              return ps.delegate.readOnlyTransaction(bound);
-            }
+          session -> {
+            PooledSession ps = session.get();
+            return ps.delegate.readOnlyTransaction(bound);
           },
           false);
     }
@@ -2409,62 +2367,26 @@ class SessionPool {
     // invoked whenever metrics are collected.
     maxInUseSessionsMetric.removeTimeSeries(labelValues);
     maxInUseSessionsMetric.createTimeSeries(
-        labelValues,
-        this,
-        new ToLongFunction<SessionPool>() {
-          @Override
-          public long applyAsLong(SessionPool sessionPool) {
-            return sessionPool.maxSessionsInUse;
-          }
-        });
+        labelValues, this, sessionPool -> sessionPool.maxSessionsInUse);
 
     // The value of a maxSessions is observed from a callback function. This function is invoked
     // whenever metrics are collected.
     maxAllowedSessionsMetric.removeTimeSeries(labelValues);
     maxAllowedSessionsMetric.createTimeSeries(
-        labelValues,
-        options,
-        new ToLongFunction<SessionPoolOptions>() {
-          @Override
-          public long applyAsLong(SessionPoolOptions options) {
-            return options.getMaxSessions();
-          }
-        });
+        labelValues, options, SessionPoolOptions::getMaxSessions);
 
     // The value of a numWaiterTimeouts is observed from a callback function. This function is
     // invoked whenever metrics are collected.
     sessionsTimeouts.removeTimeSeries(labelValues);
-    sessionsTimeouts.createTimeSeries(
-        labelValues,
-        this,
-        new ToLongFunction<SessionPool>() {
-          @Override
-          public long applyAsLong(SessionPool sessionPool) {
-            return sessionPool.getNumWaiterTimeouts();
-          }
-        });
+    sessionsTimeouts.createTimeSeries(labelValues, this, SessionPool::getNumWaiterTimeouts);
 
     numAcquiredSessionsMetric.removeTimeSeries(labelValues);
     numAcquiredSessionsMetric.createTimeSeries(
-        labelValues,
-        this,
-        new ToLongFunction<SessionPool>() {
-          @Override
-          public long applyAsLong(SessionPool sessionPool) {
-            return sessionPool.numSessionsAcquired;
-          }
-        });
+        labelValues, this, sessionPool -> sessionPool.numSessionsAcquired);
 
     numReleasedSessionsMetric.removeTimeSeries(labelValues);
     numReleasedSessionsMetric.createTimeSeries(
-        labelValues,
-        this,
-        new ToLongFunction<SessionPool>() {
-          @Override
-          public long applyAsLong(SessionPool sessionPool) {
-            return sessionPool.numSessionsReleased;
-          }
-        });
+        labelValues, this, sessionPool -> sessionPool.numSessionsReleased);
 
     List<LabelValue> labelValuesWithBeingPreparedType = new ArrayList<>(labelValues);
     labelValuesWithBeingPreparedType.add(NUM_SESSIONS_BEING_PREPARED);
@@ -2472,39 +2394,22 @@ class SessionPool {
     numSessionsInPoolMetric.createTimeSeries(
         labelValuesWithBeingPreparedType,
         this,
-        new ToLongFunction<SessionPool>() {
-          @Override
-          public long applyAsLong(SessionPool sessionPool) {
-            // TODO: Remove metric.
-            return 0L;
-          }
+        sessionPool -> {
+          // TODO: Remove metric.
+          return 0L;
         });
 
     List<LabelValue> labelValuesWithInUseType = new ArrayList<>(labelValues);
     labelValuesWithInUseType.add(NUM_IN_USE_SESSIONS);
     numSessionsInPoolMetric.removeTimeSeries(labelValuesWithInUseType);
     numSessionsInPoolMetric.createTimeSeries(
-        labelValuesWithInUseType,
-        this,
-        new ToLongFunction<SessionPool>() {
-          @Override
-          public long applyAsLong(SessionPool sessionPool) {
-            return sessionPool.numSessionsInUse;
-          }
-        });
+        labelValuesWithInUseType, this, sessionPool -> sessionPool.numSessionsInUse);
 
     List<LabelValue> labelValuesWithReadType = new ArrayList<>(labelValues);
     labelValuesWithReadType.add(NUM_READ_SESSIONS);
     numSessionsInPoolMetric.removeTimeSeries(labelValuesWithReadType);
     numSessionsInPoolMetric.createTimeSeries(
-        labelValuesWithReadType,
-        this,
-        new ToLongFunction<SessionPool>() {
-          @Override
-          public long applyAsLong(SessionPool sessionPool) {
-            return sessionPool.sessions.size();
-          }
-        });
+        labelValuesWithReadType, this, sessionPool -> sessionPool.sessions.size());
 
     List<LabelValue> labelValuesWithWriteType = new ArrayList<>(labelValues);
     labelValuesWithWriteType.add(NUM_WRITE_SESSIONS);
@@ -2512,12 +2417,9 @@ class SessionPool {
     numSessionsInPoolMetric.createTimeSeries(
         labelValuesWithWriteType,
         this,
-        new ToLongFunction<SessionPool>() {
-          @Override
-          public long applyAsLong(SessionPool sessionPool) {
-            // TODO: Remove metric.
-            return 0L;
-          }
+        sessionPool -> {
+          // TODO: Remove metric.
+          return 0L;
         });
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -1030,7 +1030,7 @@ class SessionPool {
     public ApiFuture<Timestamp> getCommitTimestamp() {
       checkState(commitResponse != null, "runAsync() has not yet been called");
       return ApiFutures.transform(
-          commitResponse, input -> input.getCommitTimestamp(), MoreExecutors.directExecutor());
+          commitResponse, CommitResponse::getCommitTimestamp, MoreExecutors.directExecutor());
     }
 
     @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -2394,10 +2394,8 @@ class SessionPool {
     numSessionsInPoolMetric.createTimeSeries(
         labelValuesWithBeingPreparedType,
         this,
-        sessionPool -> {
-          // TODO: Remove metric.
-          return 0L;
-        });
+        // TODO: Remove metric.
+        ignored -> 0L);
 
     List<LabelValue> labelValuesWithInUseType = new ArrayList<>(labelValues);
     labelValuesWithInUseType.add(NUM_IN_USE_SESSIONS);
@@ -2417,9 +2415,7 @@ class SessionPool {
     numSessionsInPoolMetric.createTimeSeries(
         labelValuesWithWriteType,
         this,
-        sessionPool -> {
-          // TODO: Remove metric.
-          return 0L;
-        });
+        // TODO: Remove metric.
+        ignored -> 0L);
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolAsyncTransactionManager.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolAsyncTransactionManager.java
@@ -187,7 +187,7 @@ class SessionPoolAsyncTransactionManager
         delegate,
         new ApiAsyncFunction<AsyncTransactionManagerImpl, Timestamp>() {
           @Override
-          public ApiFuture<Timestamp> apply(AsyncTransactionManagerImpl input) throws Exception {
+          public ApiFuture<Timestamp> apply(AsyncTransactionManagerImpl input) {
             final SettableApiFuture<Timestamp> res = SettableApiFuture.create();
             ApiFutures.addCallback(
                 input.commitAsync(),
@@ -229,7 +229,7 @@ class SessionPoolAsyncTransactionManager
         delegate,
         new ApiAsyncFunction<AsyncTransactionManagerImpl, Void>() {
           @Override
-          public ApiFuture<Void> apply(AsyncTransactionManagerImpl input) throws Exception {
+          public ApiFuture<Void> apply(AsyncTransactionManagerImpl input) {
             ApiFuture<Void> res = input.rollbackAsync();
             res.addListener(() -> session.close(), MoreExecutors.directExecutor());
             return res;
@@ -253,8 +253,7 @@ class SessionPoolAsyncTransactionManager
                 delegate,
                 new ApiAsyncFunction<AsyncTransactionManagerImpl, TransactionContext>() {
                   @Override
-                  public ApiFuture<TransactionContext> apply(AsyncTransactionManagerImpl input)
-                      throws Exception {
+                  public ApiFuture<TransactionContext> apply(AsyncTransactionManagerImpl input) {
                     if (restartedAfterSessionNotFound) {
                       restartedAfterSessionNotFound = false;
                       return input.beginAsync();
@@ -291,8 +290,7 @@ class SessionPoolAsyncTransactionManager
         delegate,
         new ApiAsyncFunction<AsyncTransactionManagerImpl, CommitResponse>() {
           @Override
-          public ApiFuture<CommitResponse> apply(AsyncTransactionManagerImpl input)
-              throws Exception {
+          public ApiFuture<CommitResponse> apply(AsyncTransactionManagerImpl input) {
             return input.getCommitResponse();
           }
         },

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolAsyncTransactionManager.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolAsyncTransactionManager.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.spanner;
 
-import com.google.api.core.ApiAsyncFunction;
-import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
@@ -185,34 +183,31 @@ class SessionPoolAsyncTransactionManager
     }
     return ApiFutures.transformAsync(
         delegate,
-        new ApiAsyncFunction<AsyncTransactionManagerImpl, Timestamp>() {
-          @Override
-          public ApiFuture<Timestamp> apply(AsyncTransactionManagerImpl input) {
-            final SettableApiFuture<Timestamp> res = SettableApiFuture.create();
-            ApiFutures.addCallback(
-                input.commitAsync(),
-                new ApiFutureCallback<Timestamp>() {
-                  @Override
-                  public void onFailure(Throwable t) {
-                    synchronized (lock) {
-                      if (t instanceof AbortedException) {
-                        txnState = TransactionState.ABORTED;
-                        abortedException = (AbortedException) t;
-                      } else {
-                        txnState = TransactionState.COMMIT_FAILED;
-                      }
+        input -> {
+          final SettableApiFuture<Timestamp> res = SettableApiFuture.create();
+          ApiFutures.addCallback(
+              input.commitAsync(),
+              new ApiFutureCallback<Timestamp>() {
+                @Override
+                public void onFailure(Throwable t) {
+                  synchronized (lock) {
+                    if (t instanceof AbortedException) {
+                      txnState = TransactionState.ABORTED;
+                      abortedException = (AbortedException) t;
+                    } else {
+                      txnState = TransactionState.COMMIT_FAILED;
                     }
-                    res.setException(t);
                   }
+                  res.setException(t);
+                }
 
-                  @Override
-                  public void onSuccess(Timestamp result) {
-                    res.set(result);
-                  }
-                },
-                MoreExecutors.directExecutor());
-            return res;
-          }
+                @Override
+                public void onSuccess(Timestamp result) {
+                  res.set(result);
+                }
+              },
+              MoreExecutors.directExecutor());
+          return res;
         },
         MoreExecutors.directExecutor());
   }
@@ -227,13 +222,10 @@ class SessionPoolAsyncTransactionManager
     }
     return ApiFutures.transformAsync(
         delegate,
-        new ApiAsyncFunction<AsyncTransactionManagerImpl, Void>() {
-          @Override
-          public ApiFuture<Void> apply(AsyncTransactionManagerImpl input) {
-            ApiFuture<Void> res = input.rollbackAsync();
-            res.addListener(() -> session.close(), MoreExecutors.directExecutor());
-            return res;
-          }
+        input -> {
+          ApiFuture<Void> res = input.rollbackAsync();
+          res.addListener(() -> session.close(), MoreExecutors.directExecutor());
+          return res;
         },
         MoreExecutors.directExecutor());
   }
@@ -251,25 +243,17 @@ class SessionPoolAsyncTransactionManager
         ApiFutures.transform(
             ApiFutures.transformAsync(
                 delegate,
-                new ApiAsyncFunction<AsyncTransactionManagerImpl, TransactionContext>() {
-                  @Override
-                  public ApiFuture<TransactionContext> apply(AsyncTransactionManagerImpl input) {
-                    if (restartedAfterSessionNotFound) {
-                      restartedAfterSessionNotFound = false;
-                      return input.beginAsync();
-                    }
-                    return input.resetForRetryAsync();
+                input -> {
+                  if (restartedAfterSessionNotFound) {
+                    restartedAfterSessionNotFound = false;
+                    return input.beginAsync();
                   }
+                  return input.resetForRetryAsync();
                 },
                 MoreExecutors.directExecutor()),
-            new ApiFunction<TransactionContext, TransactionContext>() {
-
-              @Override
-              public TransactionContext apply(TransactionContext input) {
-                return new SessionPool.SessionPoolTransactionContext(
-                    SessionPoolAsyncTransactionManager.this, input);
-              }
-            },
+            input ->
+                new SessionPool.SessionPoolTransactionContext(
+                    SessionPoolAsyncTransactionManager.this, input),
             MoreExecutors.directExecutor()));
   }
 
@@ -287,13 +271,6 @@ class SessionPoolAsyncTransactionManager
           "commit can only be invoked if the transaction was successfully committed");
     }
     return ApiFutures.transformAsync(
-        delegate,
-        new ApiAsyncFunction<AsyncTransactionManagerImpl, CommitResponse>() {
-          @Override
-          public ApiFuture<CommitResponse> apply(AsyncTransactionManagerImpl input) {
-            return input.getCommitResponse();
-          }
-        },
-        MoreExecutors.directExecutor());
+        delegate, AsyncTransactionManagerImpl::getCommitResponse, MoreExecutors.directExecutor());
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
@@ -244,7 +244,7 @@ class SpannerImpl extends BaseService<SpannerOptions> implements Spanner {
   }
 
   void close(long timeout, TimeUnit unit) {
-    List<ListenableFuture<Void>> closureFutures = null;
+    List<ListenableFuture<Void>> closureFutures;
     synchronized (this) {
       checkClosed();
       closedException = new ClosedException();

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -1015,13 +1015,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
         this.setHost(emulatorHost);
         // Channels are secure by default (via SSL/TLS). For the example we disable TLS to avoid
         // needing certificates.
-        this.setChannelConfigurator(
-            new ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder>() {
-              @Override
-              public ManagedChannelBuilder apply(ManagedChannelBuilder builder) {
-                return builder.usePlaintext();
-              }
-            });
+        this.setChannelConfigurator(ManagedChannelBuilder::usePlaintext);
         // As we are using plain text, we should never send any credentials.
         this.setCredentials(NoCredentials.getInstance());
       }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -1004,7 +1004,6 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
       return this;
     }
 
-    @SuppressWarnings("rawtypes")
     @Override
     public SpannerOptions build() {
       // Set the host of emulator has been set.

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContextFutureImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContextFutureImpl.java
@@ -91,7 +91,7 @@ class TransactionContextFutureImpl extends ForwardingApiFuture<TransactionContex
         ApiFuture<I> input,
         final AsyncTransactionFunction<I, O> function,
         Executor executor) {
-      this(SettableApiFuture.<O>create(), txnFuture, input, function, executor);
+      this(SettableApiFuture.create(), txnFuture, input, function, executor);
     }
 
     AsyncTransactionStatementImpl(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -573,7 +573,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
       if (exceptionToThrow.getErrorCode() == ErrorCode.ABORTED) {
         long delay = -1L;
         if (exceptionToThrow instanceof AbortedException) {
-          delay = ((AbortedException) exceptionToThrow).getRetryDelayInMillis();
+          delay = exceptionToThrow.getRetryDelayInMillis();
         }
         if (delay == -1L) {
           txnLogger.log(
@@ -918,7 +918,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
                       "Attempt", AttributeValue.longAttributeValue(attempt.longValue())));
               shouldRollback = false;
               if (e instanceof AbortedException) {
-                throw (AbortedException) e;
+                throw e;
               }
               throw SpannerExceptionFactory.newSpannerException(
                   ErrorCode.ABORTED, e.getMessage(), e);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -21,7 +21,6 @@ import static com.google.cloud.spanner.SpannerExceptionFactory.newSpannerExcepti
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
-import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.core.SettableApiFuture;
@@ -44,7 +43,6 @@ import com.google.spanner.v1.ExecuteBatchDmlResponse;
 import com.google.spanner.v1.ExecuteSqlRequest;
 import com.google.spanner.v1.ExecuteSqlRequest.QueryMode;
 import com.google.spanner.v1.RequestOptions;
-import com.google.spanner.v1.ResultSet;
 import com.google.spanner.v1.RollbackRequest;
 import com.google.spanner.v1.Transaction;
 import com.google.spanner.v1.TransactionOptions;
@@ -671,35 +669,29 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
       ApiFuture<Long> updateCount =
           ApiFutures.transform(
               resultSet,
-              new ApiFunction<com.google.spanner.v1.ResultSet, Long>() {
-                @Override
-                public Long apply(ResultSet input) {
-                  if (!input.hasStats()) {
-                    throw SpannerExceptionFactory.newSpannerException(
-                        ErrorCode.INVALID_ARGUMENT,
-                        "DML response missing stats possibly due to non-DML statement as input");
-                  }
-                  if (builder.getTransaction().hasBegin()
-                      && !(input.getMetadata().hasTransaction()
-                          && input.getMetadata().getTransaction().getId() != ByteString.EMPTY)) {
-                    throw SpannerExceptionFactory.newSpannerException(
-                        ErrorCode.FAILED_PRECONDITION, NO_TRANSACTION_RETURNED_MSG);
-                  }
-                  // For standard DML, using the exact row count.
-                  return input.getStats().getRowCountExact();
+              input -> {
+                if (!input.hasStats()) {
+                  throw SpannerExceptionFactory.newSpannerException(
+                      ErrorCode.INVALID_ARGUMENT,
+                      "DML response missing stats possibly due to non-DML statement as input");
                 }
+                if (builder.getTransaction().hasBegin()
+                    && !(input.getMetadata().hasTransaction()
+                        && input.getMetadata().getTransaction().getId() != ByteString.EMPTY)) {
+                  throw SpannerExceptionFactory.newSpannerException(
+                      ErrorCode.FAILED_PRECONDITION, NO_TRANSACTION_RETURNED_MSG);
+                }
+                // For standard DML, using the exact row count.
+                return input.getStats().getRowCountExact();
               },
               MoreExecutors.directExecutor());
       updateCount =
           ApiFutures.catching(
               updateCount,
               Throwable.class,
-              new ApiFunction<Throwable, Long>() {
-                @Override
-                public Long apply(Throwable input) {
-                  SpannerException e = SpannerExceptionFactory.asSpannerException(input);
-                  throw onError(e, builder.getTransaction().hasBegin());
-                }
+              input -> {
+                SpannerException e = SpannerExceptionFactory.asSpannerException(input);
+                throw onError(e, builder.getTransaction().hasBegin());
               },
               MoreExecutors.directExecutor());
       updateCount.addListener(
@@ -787,42 +779,36 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
       ApiFuture<long[]> updateCounts =
           ApiFutures.transform(
               response,
-              new ApiFunction<ExecuteBatchDmlResponse, long[]>() {
-                @Override
-                public long[] apply(ExecuteBatchDmlResponse batchDmlResponse) {
-                  long[] results = new long[batchDmlResponse.getResultSetsCount()];
-                  for (int i = 0; i < batchDmlResponse.getResultSetsCount(); ++i) {
-                    results[i] = batchDmlResponse.getResultSets(i).getStats().getRowCountExact();
-                    if (batchDmlResponse.getResultSets(i).getMetadata().hasTransaction()) {
-                      onTransactionMetadata(
-                          batchDmlResponse.getResultSets(i).getMetadata().getTransaction(),
-                          builder.getTransaction().hasBegin());
-                    }
+              batchDmlResponse -> {
+                long[] results = new long[batchDmlResponse.getResultSetsCount()];
+                for (int i = 0; i < batchDmlResponse.getResultSetsCount(); ++i) {
+                  results[i] = batchDmlResponse.getResultSets(i).getStats().getRowCountExact();
+                  if (batchDmlResponse.getResultSets(i).getMetadata().hasTransaction()) {
+                    onTransactionMetadata(
+                        batchDmlResponse.getResultSets(i).getMetadata().getTransaction(),
+                        builder.getTransaction().hasBegin());
                   }
-                  // If one of the DML statements was aborted, we should throw an aborted exception.
-                  // In all other cases, we should throw a BatchUpdateException.
-                  if (batchDmlResponse.getStatus().getCode() == Code.ABORTED_VALUE) {
-                    throw createAbortedExceptionForBatchDml(batchDmlResponse);
-                  } else if (batchDmlResponse.getStatus().getCode() != 0) {
-                    throw newSpannerBatchUpdateException(
-                        ErrorCode.fromRpcStatus(batchDmlResponse.getStatus()),
-                        batchDmlResponse.getStatus().getMessage(),
-                        results);
-                  }
-                  return results;
                 }
+                // If one of the DML statements was aborted, we should throw an aborted exception.
+                // In all other cases, we should throw a BatchUpdateException.
+                if (batchDmlResponse.getStatus().getCode() == Code.ABORTED_VALUE) {
+                  throw createAbortedExceptionForBatchDml(batchDmlResponse);
+                } else if (batchDmlResponse.getStatus().getCode() != 0) {
+                  throw newSpannerBatchUpdateException(
+                      ErrorCode.fromRpcStatus(batchDmlResponse.getStatus()),
+                      batchDmlResponse.getStatus().getMessage(),
+                      results);
+                }
+                return results;
               },
               MoreExecutors.directExecutor());
       updateCounts =
           ApiFutures.catching(
               updateCounts,
               Throwable.class,
-              new ApiFunction<Throwable, long[]>() {
-                @Override
-                public long[] apply(Throwable input) {
-                  SpannerException e = SpannerExceptionFactory.asSpannerException(input);
-                  throw onError(e, builder.getTransaction().hasBegin());
-                }
+              input -> {
+                SpannerException e = SpannerExceptionFactory.asSpannerException(input);
+                throw onError(e, builder.getTransaction().hasBegin());
               },
               MoreExecutors.directExecutor());
       updateCounts.addListener(this::decreaseAsyncOperations, MoreExecutors.directExecutor());

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractBaseUnitOfWork.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractBaseUnitOfWork.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.spanner.connection;
 
-import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.gax.grpc.GrpcCallContext;
@@ -228,12 +227,9 @@ abstract class AbstractBaseUnitOfWork implements UnitOfWork {
         ApiFutures.catching(
             f,
             Throwable.class,
-            new ApiFunction<Throwable, T>() {
-              @Override
-              public T apply(Throwable input) {
-                input.addSuppressed(caller);
-                throw SpannerExceptionFactory.asSpannerException(input);
-              }
+            input -> {
+              input.addSuppressed(caller);
+              throw SpannerExceptionFactory.asSpannerException(input);
             },
             MoreExecutors.directExecutor());
     synchronized (this) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractBaseUnitOfWork.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractBaseUnitOfWork.java
@@ -139,8 +139,8 @@ abstract class AbstractBaseUnitOfWork implements UnitOfWork {
         callable,
         InterceptorsUsage.INVOKE_INTERCEPTORS,
         applyStatementTimeoutToMethod == null
-            ? Collections.<MethodDescriptor<?, ?>>emptySet()
-            : ImmutableList.<MethodDescriptor<?, ?>>of(applyStatementTimeoutToMethod));
+            ? Collections.emptySet()
+            : ImmutableList.of(applyStatementTimeoutToMethod));
   }
 
   <T> ApiFuture<T> executeStatementAsync(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AsyncStatementResultImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AsyncStatementResultImpl.java
@@ -46,8 +46,7 @@ class AsyncStatementResultImpl implements AsyncStatementResult {
           clientSideStatementResult.getClientSideStatementType());
     } else {
       return new AsyncStatementResultImpl(
-          clientSideStatementResult.getClientSideStatementType(),
-          ApiFutures.<Void>immediateFuture(null));
+          clientSideStatementResult.getClientSideStatementType(), ApiFutures.immediateFuture(null));
     }
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ChecksumResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ChecksumResultSet.java
@@ -93,7 +93,7 @@ class ChecksumResultSet extends ReplaceableForwardingResultSet implements Retria
   /** Simple {@link Callable} for calling {@link ResultSet#next()} */
   private final class NextCallable implements Callable<Boolean> {
     @Override
-    public Boolean call() throws Exception {
+    public Boolean call() {
       transaction
           .getStatementExecutor()
           .invokeInterceptors(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ChecksumResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ChecksumResultSet.java
@@ -342,7 +342,7 @@ class ChecksumResultSet extends ReplaceableForwardingResultSet implements Retria
             into.putDouble((Double) value);
             break;
           case NUMERIC:
-            String stringRepresentation = ((BigDecimal) value).toString();
+            String stringRepresentation = value.toString();
             into.putInt(stringRepresentation.length());
             into.putUnencodedChars(stringRepresentation);
             break;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ClientSideStatementValueConverters.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ClientSideStatementValueConverters.java
@@ -38,14 +38,7 @@ class ClientSideStatementValueConverters {
 
     /** Create an map using the name of the enum elements as keys. */
     private CaseInsensitiveEnumMap(Class<E> elementType) {
-      this(
-          elementType,
-          new Function<E, String>() {
-            @Override
-            public String apply(E input) {
-              return input.name();
-            }
-          });
+      this(elementType, Enum::name);
     }
 
     /** Create a map using the specific function to get the key per enum value. */
@@ -231,14 +224,7 @@ class ClientSideStatementValueConverters {
   static class TransactionModeConverter
       implements ClientSideStatementValueConverter<TransactionMode> {
     private final CaseInsensitiveEnumMap<TransactionMode> values =
-        new CaseInsensitiveEnumMap<>(
-            TransactionMode.class,
-            new Function<TransactionMode, String>() {
-              @Override
-              public String apply(TransactionMode input) {
-                return input.getStatementString();
-              }
-            });
+        new CaseInsensitiveEnumMap<>(TransactionMode.class, TransactionMode::getStatementString);
 
     public TransactionModeConverter(String allowedValues) {}
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
@@ -18,7 +18,6 @@ package com.google.cloud.spanner.connection;
 
 import static com.google.cloud.spanner.SpannerApiFutures.get;
 
-import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.cloud.Timestamp;
@@ -287,14 +286,7 @@ class ConnectionImpl implements Connection {
       leakedException = null;
       spannerPool.removeConnection(options, this);
       return ApiFutures.transform(
-          ApiFutures.allAsList(futures),
-          new ApiFunction<List<Void>, Void>() {
-            @Override
-            public Void apply(List<Void> input) {
-              return null;
-            }
-          },
-          MoreExecutors.directExecutor());
+          ApiFutures.allAsList(futures), ignored -> null, MoreExecutors.directExecutor());
     }
     return ApiFutures.immediateFuture(null);
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
@@ -237,8 +237,7 @@ class ConnectionImpl implements Connection {
     Preconditions.checkNotNull(spannerPool);
     Preconditions.checkNotNull(ddlClient);
     Preconditions.checkNotNull(dbClient);
-    this.statementExecutor =
-        new StatementExecutor(Collections.<StatementExecutionInterceptor>emptyList());
+    this.statementExecutor = new StatementExecutor(Collections.emptyList());
     this.spannerPool = spannerPool;
     this.options = options;
     this.spanner = spannerPool.getSpanner(options, this);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
@@ -710,14 +710,13 @@ public class ConnectionOptions {
       }
     }
     if (lenient) {
-      return String.format(
-          "Invalid properties found in connection URI: %s", invalidProperties.toString());
+      return String.format("Invalid properties found in connection URI: %s", invalidProperties);
     } else {
       Preconditions.checkArgument(
           invalidProperties.isEmpty(),
           String.format(
               "Invalid properties found in connection URI. Add lenient=true to the connection string to ignore unknown properties. Invalid properties: %s",
-              invalidProperties.toString()));
+              invalidProperties));
       return null;
     }
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
@@ -246,7 +246,7 @@ public class ConnectionOptions {
   private static final Set<ConnectionProperty> INTERNAL_PROPERTIES =
       Collections.unmodifiableSet(
           new HashSet<>(
-              Arrays.asList(
+              Collections.singletonList(
                   ConnectionProperty.createStringProperty(USER_AGENT_PROPERTY_NAME, ""))));
   private static final Set<ConnectionProperty> INTERNAL_VALID_PROPERTIES =
       Sets.union(VALID_PROPERTIES, INTERNAL_PROPERTIES);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
@@ -671,12 +671,12 @@ public class ConnectionOptions {
   @VisibleForTesting
   static boolean parseReturnCommitStats(String uri) {
     String value = parseUriProperty(uri, "returnCommitStats");
-    return value != null ? Boolean.parseBoolean(value) : false;
+    return Boolean.parseBoolean(value);
   }
 
   static boolean parseAutoConfigEmulator(String uri) {
     String value = parseUriProperty(uri, "autoConfigEmulator");
-    return value != null ? Boolean.parseBoolean(value) : false;
+    return Boolean.parseBoolean(value);
   }
 
   @VisibleForTesting

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DdlClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DdlClient.java
@@ -21,7 +21,7 @@ import com.google.cloud.spanner.DatabaseAdminClient;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -81,7 +81,7 @@ class DdlClient {
 
   /** Execute a single DDL statement. */
   OperationFuture<Void, UpdateDatabaseDdlMetadata> executeDdl(String ddl) {
-    return executeDdl(Arrays.asList(ddl));
+    return executeDdl(Collections.singletonList(ddl));
   }
 
   /** Execute a list of DDL statements as one operation. */

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/EmulatorUtil.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/EmulatorUtil.java
@@ -71,7 +71,7 @@ class EmulatorUtil {
           .createDatabase(
               databaseId.getInstanceId().getInstance(),
               databaseId.getDatabase(),
-              ImmutableList.<String>of())
+              ImmutableList.of())
           .get();
     } catch (ExecutionException executionException) {
       SpannerException spannerException = (SpannerException) executionException.getCause();

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ReadWriteTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ReadWriteTransaction.java
@@ -45,7 +45,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.spanner.v1.SpannerGrpc;
-import io.grpc.MethodDescriptor;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -342,7 +341,7 @@ class ReadWriteTransaction extends AbstractMultiUseTransaction {
               },
               // ignore interceptors here as they are invoked in the Callable.
               InterceptorsUsage.IGNORE_INTERCEPTORS,
-              ImmutableList.<MethodDescriptor<?, ?>>of(SpannerGrpc.getExecuteStreamingSqlMethod()));
+              ImmutableList.of(SpannerGrpc.getExecuteStreamingSqlMethod()));
     } else {
       res = super.executeQueryAsync(statement, analyzeMode, options);
     }
@@ -397,7 +396,7 @@ class ReadWriteTransaction extends AbstractMultiUseTransaction {
               },
               // ignore interceptors here as they are invoked in the Callable.
               InterceptorsUsage.IGNORE_INTERCEPTORS,
-              ImmutableList.<MethodDescriptor<?, ?>>of(SpannerGrpc.getExecuteSqlMethod()));
+              ImmutableList.of(SpannerGrpc.getExecuteSqlMethod()));
     } else {
       res =
           executeStatementAsync(
@@ -480,7 +479,7 @@ class ReadWriteTransaction extends AbstractMultiUseTransaction {
               },
               // ignore interceptors here as they are invoked in the Callable.
               InterceptorsUsage.IGNORE_INTERCEPTORS,
-              ImmutableList.<MethodDescriptor<?, ?>>of(SpannerGrpc.getExecuteBatchDmlMethod()));
+              ImmutableList.of(SpannerGrpc.getExecuteBatchDmlMethod()));
     } else {
       res =
           executeStatementAsync(
@@ -579,7 +578,7 @@ class ReadWriteTransaction extends AbstractMultiUseTransaction {
                 }
               },
               InterceptorsUsage.IGNORE_INTERCEPTORS,
-              ImmutableList.<MethodDescriptor<?, ?>>of(SpannerGrpc.getCommitMethod()));
+              ImmutableList.of(SpannerGrpc.getCommitMethod()));
     } else {
       res =
           executeStatementAsync(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ReadWriteTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ReadWriteTransaction.java
@@ -535,7 +535,7 @@ class ReadWriteTransaction extends AbstractMultiUseTransaction {
   private final Callable<Void> commitCallable =
       new Callable<Void>() {
         @Override
-        public Void call() throws Exception {
+        public Void call() {
           checkAborted();
           get(txContextFuture).buffer(mutations);
           txManager.commit();
@@ -837,7 +837,7 @@ class ReadWriteTransaction extends AbstractMultiUseTransaction {
   private final Callable<Void> rollbackCallable =
       new Callable<Void>() {
         @Override
-        public Void call() throws Exception {
+        public Void call() {
           try {
             if (state != UnitOfWorkState.ABORTED) {
               // Make sure the transaction has actually started before we try to rollback.

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/RetriableBatchUpdate.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/RetriableBatchUpdate.java
@@ -44,7 +44,7 @@ final class RetriableBatchUpdate implements RetriableStatement {
 
   @Override
   public void retry(AbortedException aborted) throws AbortedException {
-    long[] newCount = null;
+    long[] newCount;
     try {
       transaction
           .getStatementExecutor()

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SingleUseTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SingleUseTransaction.java
@@ -37,7 +37,6 @@ import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.TransactionRunner;
 import com.google.cloud.spanner.connection.StatementParser.ParsedStatement;
 import com.google.cloud.spanner.connection.StatementParser.StatementType;
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -385,14 +384,7 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
                 try {
                   long[] res =
                       transaction.batchUpdate(
-                          Iterables.transform(
-                              updates,
-                              new Function<ParsedStatement, Statement>() {
-                                @Override
-                                public Statement apply(ParsedStatement input) {
-                                  return input.getStatement();
-                                }
-                              }));
+                          Iterables.transform(updates, ParsedStatement::getStatement));
                   state = UnitOfWorkState.COMMITTED;
                   return res;
                 } catch (Throwable t) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SingleUseTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SingleUseTransaction.java
@@ -43,7 +43,6 @@ import com.google.common.collect.Iterables;
 import com.google.spanner.admin.database.v1.DatabaseAdminGrpc;
 import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
 import com.google.spanner.v1.SpannerGrpc;
-import io.grpc.MethodDescriptor;
 import java.util.concurrent.Callable;
 
 /**
@@ -355,8 +354,7 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
     return executeStatementAsync(
         update,
         callable,
-        ImmutableList.<MethodDescriptor<?, ?>>of(
-            SpannerGrpc.getExecuteSqlMethod(), SpannerGrpc.getCommitMethod()));
+        ImmutableList.of(SpannerGrpc.getExecuteSqlMethod(), SpannerGrpc.getCommitMethod()));
   }
 
   private ApiFuture<Long> executePartitionedUpdateAsync(final ParsedStatement update) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
@@ -30,6 +30,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
 import com.google.common.base.Ticker;
 import com.google.common.collect.Iterables;
+import io.grpc.ManagedChannelBuilder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -329,11 +330,7 @@ public class SpannerPool {
       // Credentials may not be sent over a plain text channel.
       builder.setCredentials(NoCredentials.getInstance());
       // Set a custom channel configurator to allow http instead of https.
-      builder.setChannelConfigurator(
-          input -> {
-            input.usePlaintext();
-            return input;
-          });
+      builder.setChannelConfigurator(ManagedChannelBuilder::usePlaintext);
     }
     if (options.getConfigurator() != null) {
       options.getConfigurator().configure(builder);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
@@ -313,7 +313,6 @@ public class SpannerPool {
     initialized = true;
   }
 
-  @SuppressWarnings("rawtypes")
   @VisibleForTesting
   Spanner createSpanner(SpannerPoolKey key, ConnectionOptions options) {
     SpannerOptions.Builder builder = SpannerOptions.newBuilder();

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/StatementResultImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/StatementResultImpl.java
@@ -24,7 +24,7 @@ import com.google.cloud.spanner.ResultSets;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.StructField;
-import java.util.Arrays;
+import java.util.Collections;
 
 /** Implementation of {@link StatementResult} */
 class StatementResultImpl implements StatementResult {
@@ -77,7 +77,7 @@ class StatementResultImpl implements StatementResult {
     return of(
         ResultSets.forRows(
             Type.struct(StructField.of(name, Type.bool())),
-            Arrays.asList(Struct.newBuilder().set(name).to(value).build())),
+            Collections.singletonList(Struct.newBuilder().set(name).to(value).build())),
         clientSideStatementType);
   }
 
@@ -90,7 +90,7 @@ class StatementResultImpl implements StatementResult {
     return of(
         ResultSets.forRows(
             Type.struct(StructField.of(name, Type.int64())),
-            Arrays.asList(Struct.newBuilder().set(name).to(value).build())),
+            Collections.singletonList(Struct.newBuilder().set(name).to(value).build())),
         clientSideStatementType);
   }
 
@@ -103,7 +103,7 @@ class StatementResultImpl implements StatementResult {
     return of(
         ResultSets.forRows(
             Type.struct(StructField.of(name, Type.array(Type.int64()))),
-            Arrays.asList(Struct.newBuilder().set(name).toInt64Array(values).build())),
+            Collections.singletonList(Struct.newBuilder().set(name).toInt64Array(values).build())),
         clientSideStatementType);
   }
 
@@ -116,7 +116,7 @@ class StatementResultImpl implements StatementResult {
     return of(
         ResultSets.forRows(
             Type.struct(StructField.of(name, Type.string())),
-            Arrays.asList(Struct.newBuilder().set(name).to(value).build())),
+            Collections.singletonList(Struct.newBuilder().set(name).to(value).build())),
         clientSideStatementType);
   }
 
@@ -130,7 +130,7 @@ class StatementResultImpl implements StatementResult {
     return of(
         ResultSets.forRows(
             Type.struct(StructField.of(name, Type.string())),
-            Arrays.asList(Struct.newBuilder().set(name).to(value.toString()).build())),
+            Collections.singletonList(Struct.newBuilder().set(name).to(value.toString()).build())),
         clientSideStatementType);
   }
 
@@ -143,7 +143,7 @@ class StatementResultImpl implements StatementResult {
     return of(
         ResultSets.forRows(
             Type.struct(StructField.of(name, Type.timestamp())),
-            Arrays.asList(Struct.newBuilder().set(name).to(value).build())),
+            Collections.singletonList(Struct.newBuilder().set(name).to(value).build())),
         clientSideStatementType);
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -658,7 +658,7 @@ public class GapicSpannerRpc implements SpannerRpc {
     }
 
     @Override
-    public OperationFuture<ResponseT, MetadataT> call() throws Exception {
+    public OperationFuture<ResponseT, MetadataT> call() {
       acquireAdministrativeRequestsRateLimiter();
 
       return runWithRetryOnAdministrativeRequestsExceeded(
@@ -701,8 +701,7 @@ public class GapicSpannerRpc implements SpannerRpc {
   private Operation mostRecentOperation(
       OperationsLister lister,
       Function<Operation, Timestamp> getStartTimeFunction,
-      Timestamp initialCallTime)
-      throws InvalidProtocolBufferException {
+      Timestamp initialCallTime) {
     Operation res = null;
     Timestamp currMaxStartTime = null;
     String nextPageToken = null;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -980,38 +980,30 @@ public class GapicSpannerRpc implements SpannerRpc {
             request,
             DatabaseAdminGrpc.getCreateDatabaseMethod(),
             instanceName,
-            new OperationsLister() {
-              @Override
-              public Paginated<Operation> listOperations(String nextPageToken) {
-                return listDatabaseOperations(
+            nextPageToken ->
+                listDatabaseOperations(
                     instanceName,
                     0,
                     String.format(
                         "(metadata.@type:type.googleapis.com/%s) AND (name:%s/operations/)",
                         CreateDatabaseMetadata.getDescriptor().getFullName(),
                         String.format("%s/databases/%s", instanceName, databaseId)),
-                    nextPageToken);
-              }
-            },
-            new Function<Operation, Timestamp>() {
-              @Override
-              public Timestamp apply(Operation input) {
-                if (input.getDone() && input.hasResponse()) {
-                  try {
-                    Timestamp createTime =
-                        input.getResponse().unpack(Database.class).getCreateTime();
-                    if (Timestamp.getDefaultInstance().equals(createTime)) {
-                      // Create time was not returned by the server (proto objects never return
-                      // null, instead they return the default instance). Return null from this
-                      // method to indicate that there is no known create time.
-                      return null;
-                    }
-                  } catch (InvalidProtocolBufferException e) {
+                    nextPageToken),
+            input -> {
+              if (input.getDone() && input.hasResponse()) {
+                try {
+                  Timestamp createTime = input.getResponse().unpack(Database.class).getCreateTime();
+                  if (Timestamp.getDefaultInstance().equals(createTime)) {
+                    // Create time was not returned by the server (proto objects never return
+                    // null, instead they return the default instance). Return null from this
+                    // method to indicate that there is no known create time.
                     return null;
                   }
+                } catch (InvalidProtocolBufferException e) {
+                  return null;
                 }
-                return null;
               }
+              return null;
             });
     return RetryHelper.runWithRetries(
         callable,
@@ -1151,31 +1143,24 @@ public class GapicSpannerRpc implements SpannerRpc {
             request,
             DatabaseAdminGrpc.getCreateBackupMethod(),
             instanceName,
-            new OperationsLister() {
-              @Override
-              public Paginated<Operation> listOperations(String nextPageToken) {
-                return listBackupOperations(
+            nextPageToken ->
+                listBackupOperations(
                     instanceName,
                     0,
                     String.format(
                         "(metadata.@type:type.googleapis.com/%s) AND (metadata.name:%s)",
                         CreateBackupMetadata.getDescriptor().getFullName(),
                         String.format("%s/backups/%s", instanceName, backupId)),
-                    nextPageToken);
-              }
-            },
-            new Function<Operation, Timestamp>() {
-              @Override
-              public Timestamp apply(Operation input) {
-                try {
-                  return input
-                      .getMetadata()
-                      .unpack(CreateBackupMetadata.class)
-                      .getProgress()
-                      .getStartTime();
-                } catch (InvalidProtocolBufferException e) {
-                  return null;
-                }
+                    nextPageToken),
+            input -> {
+              try {
+                return input
+                    .getMetadata()
+                    .unpack(CreateBackupMetadata.class)
+                    .getProgress()
+                    .getStartTime();
+              } catch (InvalidProtocolBufferException e) {
+                return null;
               }
             });
     return RetryHelper.runWithRetries(
@@ -1210,31 +1195,24 @@ public class GapicSpannerRpc implements SpannerRpc {
                 requestBuilder.build(),
                 DatabaseAdminGrpc.getRestoreDatabaseMethod(),
                 databaseInstanceName,
-                new OperationsLister() {
-                  @Override
-                  public Paginated<Operation> listOperations(String nextPageToken) {
-                    return listDatabaseOperations(
+                nextPageToken ->
+                    listDatabaseOperations(
                         databaseInstanceName,
                         0,
                         String.format(
                             "(metadata.@type:type.googleapis.com/%s) AND (metadata.name:%s)",
                             RestoreDatabaseMetadata.getDescriptor().getFullName(),
                             String.format("%s/databases/%s", databaseInstanceName, databaseId)),
-                        nextPageToken);
-                  }
-                },
-                new Function<Operation, Timestamp>() {
-                  @Override
-                  public Timestamp apply(Operation input) {
-                    try {
-                      return input
-                          .getMetadata()
-                          .unpack(RestoreDatabaseMetadata.class)
-                          .getProgress()
-                          .getStartTime();
-                    } catch (InvalidProtocolBufferException e) {
-                      return null;
-                    }
+                        nextPageToken),
+                input -> {
+                  try {
+                    return input
+                        .getMetadata()
+                        .unpack(RestoreDatabaseMetadata.class)
+                        .getProgress()
+                        .getStartTime();
+                  } catch (InvalidProtocolBufferException e) {
+                    return null;
                   }
                 });
     return RetryHelper.runWithRetries(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerMetadataProvider.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerMetadataProvider.java
@@ -18,7 +18,7 @@ package com.google.cloud.spanner.spi.v1;
 import com.google.common.collect.ImmutableMap;
 import io.grpc.Metadata;
 import io.grpc.Metadata.Key;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -61,7 +61,8 @@ class SpannerMetadataProvider {
     return ImmutableMap.<String, List<String>>builder()
         .put(
             resourceHeaderKey,
-            Arrays.asList(getResourceHeaderValue(resourceTokenTemplate, defaultResourceToken)))
+            Collections.singletonList(
+                getResourceHeaderValue(resourceTokenTemplate, defaultResourceToken)))
         .build();
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerRpc.java
@@ -123,7 +123,7 @@ public interface SpannerRpc extends ServiceRpc {
     public Paginated(@Nullable Iterable<T> results, @Nullable String nextPageToken) {
       // The generated HTTP client has null members when no results are present, rather than an
       // empty list.  Implicitly convert to an empty list to minimize the risk of NPEs.
-      this.results = (results == null) ? ImmutableList.<T>of() : results;
+      this.results = (results == null) ? ImmutableList.of() : results;
       this.nextPageToken =
           (nextPageToken == null || nextPageToken.isEmpty()) ? null : nextPageToken;
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractAsyncTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractAsyncTransactionTest.java
@@ -32,6 +32,7 @@ import static com.google.cloud.spanner.MockSpannerTestUtil.UPDATE_STATEMENT;
 
 import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import io.grpc.ManagedChannelBuilder;
 import io.grpc.Server;
 import io.grpc.Status;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
@@ -92,11 +93,7 @@ public abstract class AbstractAsyncTransactionTest {
     spanner =
         SpannerOptions.newBuilder()
             .setProjectId(TEST_PROJECT)
-            .setChannelConfigurator(
-                input -> {
-                  input.usePlaintext();
-                  return input;
-                })
+            .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
             .setHost("http://" + endpoint)
             .setCredentials(NoCredentials.getInstance())
             .setSessionPoolOption(SessionPoolOptions.newBuilder().setFailOnSessionLeak().build())

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractAsyncTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractAsyncTransactionTest.java
@@ -30,10 +30,8 @@ import static com.google.cloud.spanner.MockSpannerTestUtil.UPDATE_ABORTED_STATEM
 import static com.google.cloud.spanner.MockSpannerTestUtil.UPDATE_COUNT;
 import static com.google.cloud.spanner.MockSpannerTestUtil.UPDATE_STATEMENT;
 
-import com.google.api.core.ApiFunction;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.Server;
 import io.grpc.Status;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
@@ -95,12 +93,9 @@ public abstract class AbstractAsyncTransactionTest {
         SpannerOptions.newBuilder()
             .setProjectId(TEST_PROJECT)
             .setChannelConfigurator(
-                new ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder>() {
-                  @Override
-                  public ManagedChannelBuilder apply(ManagedChannelBuilder input) {
-                    input.usePlaintext();
-                    return input;
-                  }
+                input -> {
+                  input.usePlaintext();
+                  return input;
                 })
             .setHost("http://" + endpoint)
             .setCredentials(NoCredentials.getInstance())

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractAsyncTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractAsyncTransactionTest.java
@@ -89,7 +89,7 @@ public abstract class AbstractAsyncTransactionTest {
   }
 
   @Before
-  public void before() throws Exception {
+  public void before() {
     String endpoint = address.getHostString() + ":" + server.getPort();
     spanner =
         SpannerOptions.newBuilder()
@@ -122,7 +122,7 @@ public abstract class AbstractAsyncTransactionTest {
   }
 
   @After
-  public void after() throws Exception {
+  public void after() {
     spanner.close();
     spannerWithEmptySessionPool.close();
     mockSpanner.removeAllExecutionTimes();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplStressTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplStressTest.java
@@ -170,7 +170,7 @@ public class AsyncResultSetImplStressTest {
   }
 
   @Test
-  public void toList() throws Exception {
+  public void toList() {
     ExecutorProvider executorProvider = SpannerOptions.createDefaultAsyncExecutorProvider();
     for (int bufferSize = 1; bufferSize < resultSetSize * 2; bufferSize *= 2) {
       for (int i = 0; i < TEST_RUNS; i++) {
@@ -191,7 +191,7 @@ public class AsyncResultSetImplStressTest {
   }
 
   @Test
-  public void toListWithErrors() throws Exception {
+  public void toListWithErrors() {
     ExecutorProvider executorProvider = SpannerOptions.createDefaultAsyncExecutorProvider();
     for (int bufferSize = 1; bufferSize < resultSetSize * 2; bufferSize *= 2) {
       for (int i = 0; i < TEST_RUNS; i++) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplStressTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplStressTest.java
@@ -232,7 +232,7 @@ public class AsyncResultSetImplStressTest {
           final SettableApiFuture<ImmutableList<Row>> future = SettableApiFuture.create();
           try (AsyncResultSetImpl impl =
               new AsyncResultSetImpl(executorProvider, createResultSet(), bufferSize)) {
-            final ImmutableList.Builder<Row> builder = ImmutableList.<Row>builder();
+            final ImmutableList.Builder<Row> builder = ImmutableList.builder();
             impl.setCallback(
                 executor,
                 resultSet -> {
@@ -312,7 +312,7 @@ public class AsyncResultSetImplStressTest {
           try (AsyncResultSetImpl impl =
               new AsyncResultSetImpl(executorProvider, createResultSet(), bufferSize)) {
             resultSets.add(impl);
-            final ImmutableList.Builder<Row> builder = ImmutableList.<Row>builder();
+            final ImmutableList.Builder<Row> builder = ImmutableList.builder();
             impl.setCallback(
                 executor,
                 resultSet -> {
@@ -371,7 +371,7 @@ public class AsyncResultSetImplStressTest {
           try (AsyncResultSetImpl impl =
               new AsyncResultSetImpl(executorProvider, createResultSet(), bufferSize)) {
             resultSets.add(impl);
-            final ImmutableList.Builder<Row> builder = ImmutableList.<Row>builder();
+            final ImmutableList.Builder<Row> builder = ImmutableList.builder();
             impl.setCallback(
                 executor,
                 resultSet -> {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplTest.java
@@ -407,11 +407,9 @@ public class AsyncResultSetImplTest {
         new AsyncResultSetImpl(simpleProvider, delegate, AsyncResultSetImpl.DEFAULT_BUFFER_SIZE)) {
       rs.setCallback(
           executor,
-          resultSet -> {
-            // Not calling resultSet.tryNext() means that it will also never return DONE.
-            // Instead the callback indicates that it does not want any more rows.
-            return CallbackResponse.DONE;
-          });
+          // Not calling resultSet.tryNext() means that it will also never return DONE.
+          // Instead the callback indicates that it does not want any more rows.
+          ignored -> CallbackResponse.DONE);
       rs.getResult().get(10L, TimeUnit.SECONDS);
     }
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplTest.java
@@ -72,16 +72,19 @@ public class AsyncResultSetImplTest {
       rs.setCallback(mock(Executor.class), mock(ReadyCallback.class));
       fail("missing expected exception");
     } catch (IllegalStateException e) {
+      // Expected exception
     }
     try {
       rs.toList(mock(Function.class));
       fail("missing expected exception");
     } catch (IllegalStateException e) {
+      // Expected exception
     }
     try {
       rs.toListAsync(mock(Function.class), mock(Executor.class));
       fail("missing expected exception");
     } catch (IllegalStateException e) {
+      // Expected exception
     }
 
     // The following methods are allowed on a closed result set.

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerImplTest.java
@@ -40,7 +40,7 @@ public class AsyncTransactionManagerImplTest {
         new AsyncTransactionManagerImpl(session, mock(Span.class), Options.commitStats())) {
       when(session.newTransaction(Options.fromTransactionOptions(Options.commitStats())))
           .thenReturn(transaction);
-      when(transaction.ensureTxnAsync()).thenReturn(ApiFutures.<Void>immediateFuture(null));
+      when(transaction.ensureTxnAsync()).thenReturn(ApiFutures.immediateFuture(null));
       Timestamp commitTimestamp = Timestamp.ofTimeMicroseconds(1);
       CommitResponse response = mock(CommitResponse.class);
       when(response.getCommitTimestamp()).thenReturn(commitTimestamp);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerTest.java
@@ -843,13 +843,11 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
                           mockSpanner.abortNextStatement();
                         }
                         // This update statement will be aborted, but the error will not propagated
-                        // to
-                        // the transaction manager and cause the transaction to retry. Instead, the
-                        // commit call will do that. Depending on the timing, that will happen
+                        // to the transaction manager and cause the transaction to retry. Instead,
+                        // the commit call will do that. Depending on the timing, that will happen
                         // directly in the transaction manager if the ABORTED error has already been
                         // returned by the batch update call before the commit call starts.
-                        // Otherwise,
-                        // the backend will return an ABORTED error for the commit call.
+                        // Otherwise, the backend will return an ABORTED error for the commit call.
                         transaction.batchUpdateAsync(
                             ImmutableList.of(UPDATE_STATEMENT, UPDATE_STATEMENT));
                         return ApiFutures.immediateFuture(null);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerTest.java
@@ -99,7 +99,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
         final ReadOption... options) {
       return new AsyncTransactionFunction<I, AsyncResultSet>() {
         @Override
-        public ApiFuture<AsyncResultSet> apply(TransactionContext txn, I input) throws Exception {
+        public ApiFuture<AsyncResultSet> apply(TransactionContext txn, I input) {
           return ApiFutures.immediateFuture(txn.readAsync(table, keys, columns, options));
         }
       };
@@ -109,7 +109,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
         final String table, final Key key, final Iterable<String> columns) {
       return new AsyncTransactionFunction<I, Struct>() {
         @Override
-        public ApiFuture<Struct> apply(TransactionContext txn, I input) throws Exception {
+        public ApiFuture<Struct> apply(TransactionContext txn, I input) {
           return txn.readRowAsync(table, key, columns);
         }
       };
@@ -122,7 +122,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
     public static <I> AsyncTransactionFunction<I, Void> buffer(final Iterable<Mutation> mutations) {
       return new AsyncTransactionFunction<I, Void>() {
         @Override
-        public ApiFuture<Void> apply(TransactionContext txn, I input) throws Exception {
+        public ApiFuture<Void> apply(TransactionContext txn, I input) {
           txn.buffer(mutations);
           return ApiFutures.immediateFuture(null);
         }
@@ -137,7 +137,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
         final SettableApiFuture<Long> result, final Statement statement) {
       return new AsyncTransactionFunction<I, Long>() {
         @Override
-        public ApiFuture<Long> apply(TransactionContext txn, I input) throws Exception {
+        public ApiFuture<Long> apply(TransactionContext txn, I input) {
           ApiFuture<Long> updateCount = txn.executeUpdateAsync(statement);
           ApiFutures.addCallback(
               updateCount,
@@ -167,7 +167,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
         final SettableApiFuture<long[]> result, final Statement... statements) {
       return new AsyncTransactionFunction<I, long[]>() {
         @Override
-        public ApiFuture<long[]> apply(TransactionContext txn, I input) throws Exception {
+        public ApiFuture<long[]> apply(TransactionContext txn, I input) {
           ApiFuture<long[]> updateCounts = txn.batchUpdateAsync(Arrays.asList(statements));
           ApiFutures.addCallback(
               updateCounts,
@@ -336,8 +336,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
                   .then(
                       new AsyncTransactionFunction<Long, Void>() {
                         @Override
-                        public ApiFuture<Void> apply(TransactionContext txn, Long input)
-                            throws Exception {
+                        public ApiFuture<Void> apply(TransactionContext txn, Long input) {
                           if (attempt.get() == 1) {
                             mockSpanner.abortTransaction(txn);
                           }
@@ -369,8 +368,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
               txn.then(
                       new AsyncTransactionFunction<Void, Long>() {
                         @Override
-                        public ApiFuture<Long> apply(TransactionContext txn, Void input)
-                            throws Exception {
+                        public ApiFuture<Long> apply(TransactionContext txn, Void input) {
                           // This fire-and-forget update statement should not fail the transaction.
                           // The exception will however cause the transaction to be retried, as the
                           // statement will not return a transaction id.
@@ -433,8 +431,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
                   .then(
                       new AsyncTransactionFunction<Struct, String>() {
                         @Override
-                        public ApiFuture<String> apply(TransactionContext txn, Struct input)
-                            throws Exception {
+                        public ApiFuture<String> apply(TransactionContext txn, Struct input) {
                           return ApiFutures.immediateFuture(input.getString("Value"));
                         }
                       },
@@ -442,8 +439,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
                   .then(
                       new AsyncTransactionFunction<String, Void>() {
                         @Override
-                        public ApiFuture<Void> apply(TransactionContext txn, String input)
-                            throws Exception {
+                        public ApiFuture<Void> apply(TransactionContext txn, String input) {
                           assertThat(input).isEqualTo("v1");
                           return ApiFutures.immediateFuture(null);
                         }
@@ -473,8 +469,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
                   .then(
                       new AsyncTransactionFunction<Long, Void>() {
                         @Override
-                        public ApiFuture<Void> apply(TransactionContext txn, Long input)
-                            throws Exception {
+                        public ApiFuture<Void> apply(TransactionContext txn, Long input) {
                           throw new IllegalStateException("this should not be executed");
                         }
                       },
@@ -509,8 +504,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
               txn.then(
                       new AsyncTransactionFunction<Void, Void>() {
                         @Override
-                        public ApiFuture<Void> apply(TransactionContext txn, Void input)
-                            throws Exception {
+                        public ApiFuture<Void> apply(TransactionContext txn, Void input) {
                           if (attempt.incrementAndGet() == 1) {
                             // Abort the first attempt.
                             mockSpanner.abortNextStatement();
@@ -550,8 +544,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
               txn.then(
                       new AsyncTransactionFunction<Void, Void>() {
                         @Override
-                        public ApiFuture<Void> apply(TransactionContext txn, Void input)
-                            throws Exception {
+                        public ApiFuture<Void> apply(TransactionContext txn, Void input) {
                           if (attempt.incrementAndGet() == 1) {
                             mockSpanner.abortNextStatement();
                           }
@@ -627,8 +620,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
           txn.then(
                   new AsyncTransactionFunction<Void, Void>() {
                     @Override
-                    public ApiFuture<Void> apply(TransactionContext txn, Void input)
-                        throws Exception {
+                    public ApiFuture<Void> apply(TransactionContext txn, Void input) {
                       // Shoot-and-forget update. The commit will still wait for this request to
                       // finish.
                       txn.executeUpdateAsync(UPDATE_STATEMENT);
@@ -732,8 +724,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
           txn.then(
                   new AsyncTransactionFunction<Void, Void>() {
                     @Override
-                    public ApiFuture<Void> apply(TransactionContext txn, Void input)
-                        throws Exception {
+                    public ApiFuture<Void> apply(TransactionContext txn, Void input) {
                       txn.batchUpdateAsync(
                           ImmutableList.of(UPDATE_STATEMENT, INVALID_UPDATE_STATEMENT));
                       return ApiFutures.immediateFuture(null);
@@ -771,8 +762,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
           txn.then(
                   new AsyncTransactionFunction<Void, long[]>() {
                     @Override
-                    public ApiFuture<long[]> apply(TransactionContext txn, Void input)
-                        throws Exception {
+                    public ApiFuture<long[]> apply(TransactionContext txn, Void input) {
                       if (attempt.incrementAndGet() == 1) {
                         return txn.batchUpdateAsync(
                             ImmutableList.of(UPDATE_STATEMENT, UPDATE_ABORTED_STATEMENT));
@@ -813,8 +803,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
           txn.then(
                   new AsyncTransactionFunction<Void, long[]>() {
                     @Override
-                    public ApiFuture<long[]> apply(TransactionContext txn, Void input)
-                        throws Exception {
+                    public ApiFuture<long[]> apply(TransactionContext txn, Void input) {
                       if (attempt.incrementAndGet() == 1) {
                         mockSpanner.abortNextStatement();
                       }
@@ -856,8 +845,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
           txn.then(
                   new AsyncTransactionFunction<Void, Void>() {
                     @Override
-                    public ApiFuture<Void> apply(TransactionContext txn, Void input)
-                        throws Exception {
+                    public ApiFuture<Void> apply(TransactionContext txn, Void input) {
                       if (attempt.get() > 0) {
                         // Set the result of the update statement back to 1 row.
                         mockSpanner.putStatementResult(
@@ -874,8 +862,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
               .then(
                   new AsyncTransactionFunction<long[], Void>() {
                     @Override
-                    public ApiFuture<Void> apply(TransactionContext txn, long[] input)
-                        throws Exception {
+                    public ApiFuture<Void> apply(TransactionContext txn, long[] input) {
                       if (attempt.incrementAndGet() == 1) {
                         mockSpanner.abortTransaction(txn);
                       }
@@ -915,8 +902,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
           txn.then(
                   new AsyncTransactionFunction<Void, Void>() {
                     @Override
-                    public ApiFuture<Void> apply(TransactionContext txn, Void input)
-                        throws Exception {
+                    public ApiFuture<Void> apply(TransactionContext txn, Void input) {
                       if (attempt.incrementAndGet() == 1) {
                         mockSpanner.abortNextStatement();
                       }
@@ -1006,8 +992,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
           txn.then(
                   new AsyncTransactionFunction<Void, Void>() {
                     @Override
-                    public ApiFuture<Void> apply(TransactionContext txn, Void input)
-                        throws Exception {
+                    public ApiFuture<Void> apply(TransactionContext txn, Void input) {
                       txn.batchUpdateAsync(ImmutableList.of(UPDATE_STATEMENT));
                       return ApiFutures.immediateFuture(null);
                     }
@@ -1043,8 +1028,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
                       .then(
                           new AsyncTransactionFunction<Struct, String>() {
                             @Override
-                            public ApiFuture<String> apply(TransactionContext txn, Struct input)
-                                throws Exception {
+                            public ApiFuture<String> apply(TransactionContext txn, Struct input) {
                               return ApiFutures.immediateFuture(input.getString("Value"));
                             }
                           },
@@ -1070,8 +1054,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
               txn.then(
                   new AsyncTransactionFunction<Void, List<String>>() {
                     @Override
-                    public ApiFuture<List<String>> apply(TransactionContext txn, Void input)
-                        throws Exception {
+                    public ApiFuture<List<String>> apply(TransactionContext txn, Void input) {
                       return txn.readAsync(READ_TABLE_NAME, KeySet.all(), READ_COLUMN_NAMES)
                           .toListAsync(
                               new Function<StructReader, String>() {
@@ -1110,8 +1093,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
             txn.then(
                     new AsyncTransactionFunction<Void, Struct>() {
                       @Override
-                      public ApiFuture<Struct> apply(TransactionContext txn, Void input)
-                          throws Exception {
+                      public ApiFuture<Struct> apply(TransactionContext txn, Void input) {
                         return txn.readRowAsync(
                             "Singers", Key.of(singerId), Collections.singleton(column));
                       }
@@ -1120,8 +1102,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
                 .then(
                     new AsyncTransactionFunction<Struct, Void>() {
                       @Override
-                      public ApiFuture<Void> apply(TransactionContext txn, Struct input)
-                          throws Exception {
+                      public ApiFuture<Void> apply(TransactionContext txn, Struct input) {
                         String name = input.getString(column);
                         txn.buffer(
                             Mutation.newUpdateBuilder("Singers")
@@ -1154,7 +1135,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
           txnContextFuture.then(
               new AsyncTransactionFunction<Void, Long>() {
                 @Override
-                public ApiFuture<Long> apply(TransactionContext txn, Void input) throws Exception {
+                public ApiFuture<Long> apply(TransactionContext txn, Void input) {
                   return txn.executeUpdateAsync(INVALID_UPDATE_STATEMENT);
                 }
               },

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerTest.java
@@ -116,7 +116,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
     }
 
     public static <I> AsyncTransactionFunction<I, Long> executeUpdateAsync(Statement statement) {
-      return executeUpdateAsync(SettableApiFuture.<Long>create(), statement);
+      return executeUpdateAsync(SettableApiFuture.create(), statement);
     }
 
     public static <I> AsyncTransactionFunction<I, Long> executeUpdateAsync(
@@ -143,7 +143,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
 
     public static <I> AsyncTransactionFunction<I, long[]> batchUpdateAsync(
         final Statement... statements) {
-      return batchUpdateAsync(SettableApiFuture.<long[]>create(), statements);
+      return batchUpdateAsync(SettableApiFuture.create(), statements);
     }
 
     public static <I> AsyncTransactionFunction<I, long[]> batchUpdateAsync(
@@ -202,8 +202,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
           CommitTimestampFuture commitTimestamp =
               transaction
                   .then(
-                      AsyncTransactionManagerHelper.<Void>buffer(
-                          Mutation.delete("FOO", Key.of("foo"))),
+                      AsyncTransactionManagerHelper.buffer(Mutation.delete("FOO", Key.of("foo"))),
                       executor)
                   .commitAsync();
           assertNotNull(commitTimestamp.get());
@@ -228,7 +227,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
         try {
           CommitTimestampFuture commitTimestamp =
               txn.then(
-                      AsyncTransactionManagerHelper.<Void>executeUpdateAsync(
+                      AsyncTransactionManagerHelper.executeUpdateAsync(
                           updateCount, UPDATE_STATEMENT),
                       executor)
                   .commitAsync();
@@ -253,7 +252,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
         try {
           CommitTimestampFuture commitTimestamp =
               txn.then(
-                      AsyncTransactionManagerHelper.<Void>executeUpdateAsync(
+                      AsyncTransactionManagerHelper.executeUpdateAsync(
                           updateCount, UPDATE_STATEMENT),
                       executor)
                   .commitAsync();
@@ -276,8 +275,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
         try {
           CommitTimestampFuture commitTimestamp =
               txn.then(
-                      AsyncTransactionManagerHelper.<Void>executeUpdateAsync(
-                          INVALID_UPDATE_STATEMENT),
+                      AsyncTransactionManagerHelper.executeUpdateAsync(INVALID_UPDATE_STATEMENT),
                       executor)
                   .commitAsync();
           commitTimestamp.get();
@@ -307,7 +305,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
           attempt.incrementAndGet();
           CommitTimestampFuture commitTimestamp =
               txn.then(
-                      AsyncTransactionManagerHelper.<Void>executeUpdateAsync(
+                      AsyncTransactionManagerHelper.executeUpdateAsync(
                           updateCount, UPDATE_STATEMENT),
                       executor)
                   .then(
@@ -393,11 +391,9 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
       while (true) {
         try {
           CommitTimestampFuture ts =
-              txn.then(
-                      AsyncTransactionManagerHelper.<Void>executeUpdateAsync(UPDATE_STATEMENT),
-                      executor)
+              txn.then(AsyncTransactionManagerHelper.executeUpdateAsync(UPDATE_STATEMENT), executor)
                   .then(
-                      AsyncTransactionManagerHelper.<Long>readRowAsync(
+                      AsyncTransactionManagerHelper.readRowAsync(
                           READ_TABLE_NAME, Key.of(1L), READ_COLUMN_NAMES),
                       executor)
                   .then(
@@ -428,8 +424,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
         try {
           CommitTimestampFuture ts =
               txn.then(
-                      AsyncTransactionManagerHelper.<Void>executeUpdateAsync(
-                          INVALID_UPDATE_STATEMENT),
+                      AsyncTransactionManagerHelper.executeUpdateAsync(INVALID_UPDATE_STATEMENT),
                       executor)
                   .then(
                       (AsyncTransactionFunction<Long, Void>)
@@ -479,8 +474,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
                           },
                       executor)
                   .then(
-                      AsyncTransactionManagerHelper.<Void>executeUpdateAsync(UPDATE_STATEMENT),
-                      executor)
+                      AsyncTransactionManagerHelper.executeUpdateAsync(UPDATE_STATEMENT), executor)
                   .commitAsync();
           assertThat(ts.get()).isNotNull();
           break;
@@ -551,9 +545,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
       TransactionContextFuture txn = mgr.beginAsync();
       while (true) {
         try {
-          txn.then(
-                  AsyncTransactionManagerHelper.<Void>executeUpdateAsync(UPDATE_STATEMENT),
-                  executor)
+          txn.then(AsyncTransactionManagerHelper.executeUpdateAsync(UPDATE_STATEMENT), executor)
               .commitAsync()
               .get();
           fail("missing expected exception");
@@ -606,7 +598,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
       while (true) {
         try {
           txn.then(
-                  AsyncTransactionManagerHelper.<Void>batchUpdateAsync(
+                  AsyncTransactionManagerHelper.batchUpdateAsync(
                       result, UPDATE_STATEMENT, UPDATE_STATEMENT),
                   executor)
               .commitAsync()
@@ -630,7 +622,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
         try {
           CommitTimestampFuture ts =
               txn.then(
-                      AsyncTransactionManagerHelper.<Void>batchUpdateAsync(res, UPDATE_STATEMENT),
+                      AsyncTransactionManagerHelper.batchUpdateAsync(res, UPDATE_STATEMENT),
                       executor)
                   .commitAsync();
           mockSpanner.unfreeze();
@@ -652,7 +644,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
       while (true) {
         try {
           txn.then(
-                  AsyncTransactionManagerHelper.<Void>batchUpdateAsync(
+                  AsyncTransactionManagerHelper.batchUpdateAsync(
                       result, UPDATE_STATEMENT, INVALID_UPDATE_STATEMENT),
                   executor)
               .commitAsync()
@@ -687,7 +679,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
                       },
                   executor)
               .then(
-                  AsyncTransactionManagerHelper.<Void>batchUpdateAsync(
+                  AsyncTransactionManagerHelper.batchUpdateAsync(
                       result, UPDATE_STATEMENT, UPDATE_STATEMENT),
                   executor)
               .commitAsync()
@@ -803,7 +795,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
                       },
                   executor)
               .then(
-                  AsyncTransactionManagerHelper.<Void>batchUpdateAsync(
+                  AsyncTransactionManagerHelper.batchUpdateAsync(
                       result, UPDATE_STATEMENT, UPDATE_STATEMENT),
                   executor)
               .then(
@@ -907,7 +899,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
       while (true) {
         try {
           txn.then(
-                  AsyncTransactionManagerHelper.<Void>batchUpdateAsync(
+                  AsyncTransactionManagerHelper.batchUpdateAsync(
                       UPDATE_STATEMENT, UPDATE_STATEMENT),
                   executor)
               .commitAsync()
@@ -966,7 +958,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
           val =
               step =
                   txn.then(
-                          AsyncTransactionManagerHelper.<Void>readRowAsync(
+                          AsyncTransactionManagerHelper.readRowAsync(
                               READ_TABLE_NAME, Key.of(1L), READ_COLUMN_NAMES),
                           executor)
                       .then(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BackupTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BackupTest.java
@@ -34,7 +34,7 @@ import com.google.cloud.spanner.BackupInfo.State;
 import com.google.cloud.spanner.encryption.EncryptionInfo;
 import com.google.rpc.Code;
 import com.google.rpc.Status;
-import java.util.Arrays;
+import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -283,7 +283,7 @@ public class BackupTest {
         dbClient
             .newBackupBuilder(BackupId.of("test-project", "test-instance", "test-backup"))
             .build();
-    Iterable<String> permissions = Arrays.asList("read");
+    Iterable<String> permissions = Collections.singletonList("read");
     backup.testIAMPermissions(permissions);
     verify(dbClient).testBackupIAMPermissions("test-instance", "test-backup", permissions);
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BackupTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BackupTest.java
@@ -41,7 +41,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 @RunWith(JUnit4.class)
@@ -68,12 +67,8 @@ public class BackupTest {
     initMocks(this);
     when(dbClient.newBackupBuilder(Mockito.any(BackupId.class)))
         .thenAnswer(
-            new Answer<Backup.Builder>() {
-              @Override
-              public Builder answer(InvocationOnMock invocation) {
-                return new Backup.Builder(dbClient, (BackupId) invocation.getArguments()[0]);
-              }
-            });
+            (Answer<Builder>)
+                invocation -> new Builder(dbClient, (BackupId) invocation.getArguments()[0]));
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BackupTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BackupTest.java
@@ -41,7 +41,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.stubbing.Answer;
 
 @RunWith(JUnit4.class)
 public class BackupTest {
@@ -66,9 +65,7 @@ public class BackupTest {
   public void setUp() {
     initMocks(this);
     when(dbClient.newBackupBuilder(Mockito.any(BackupId.class)))
-        .thenAnswer(
-            (Answer<Builder>)
-                invocation -> new Builder(dbClient, (BackupId) invocation.getArguments()[0]));
+        .thenAnswer(invocation -> new Builder(dbClient, (BackupId) invocation.getArguments()[0]));
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BatchClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BatchClientImplTest.java
@@ -31,7 +31,6 @@ import com.google.cloud.grpc.GrpcTransportOptions.ExecutorFactory;
 import com.google.cloud.spanner.spi.v1.SpannerRpc;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.util.Timestamps;
-import com.google.spanner.v1.BeginTransactionRequest;
 import com.google.spanner.v1.Session;
 import com.google.spanner.v1.Transaction;
 import java.util.Collections;
@@ -71,7 +70,7 @@ public final class BatchClientImplTest {
     when(spannerOptions.getRetrySettings()).thenReturn(RetrySettings.newBuilder().build());
     when(spannerOptions.getClock()).thenReturn(NanoClock.getDefaultClock());
     when(spannerOptions.getSpannerRpcV1()).thenReturn(gapicRpc);
-    when(spannerOptions.getSessionLabels()).thenReturn(Collections.<String, String>emptyMap());
+    when(spannerOptions.getSessionLabels()).thenReturn(Collections.emptyMap());
     GrpcTransportOptions transportOptions = mock(GrpcTransportOptions.class);
     when(transportOptions.getExecutorFactory()).thenReturn(mock(ExecutorFactory.class));
     when(spannerOptions.getTransportOptions()).thenReturn(transportOptions);
@@ -89,8 +88,7 @@ public final class BatchClientImplTest {
     com.google.protobuf.Timestamp timestamp = Timestamps.parse(TIMESTAMP);
     Transaction txnMetadata =
         Transaction.newBuilder().setId(TXN_ID).setReadTimestamp(timestamp).build();
-    when(gapicRpc.beginTransaction(Mockito.<BeginTransactionRequest>any(), optionsCaptor.capture()))
-        .thenReturn(txnMetadata);
+    when(gapicRpc.beginTransaction(Mockito.any(), optionsCaptor.capture())).thenReturn(txnMetadata);
 
     BatchReadOnlyTransaction batchTxn = client.batchReadOnlyTransaction(TimestampBound.strong());
     assertThat(batchTxn.getBatchTransactionId().getSessionId()).isEqualTo(SESSION_NAME);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BatchCreateSessionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BatchCreateSessionsTest.java
@@ -140,7 +140,7 @@ public class BatchCreateSessionsTest {
   public void testClosePoolWhileInitializing() throws InterruptedException {
     int minSessions = 10_000;
     int maxSessions = 10_000;
-    DatabaseClientImpl client = null;
+    DatabaseClientImpl client;
     // Freeze the server to prevent it from creating sessions before we want to.
     mockSpanner.freeze();
     try (Spanner spanner = createSpanner(minSessions, maxSessions)) {
@@ -175,7 +175,7 @@ public class BatchCreateSessionsTest {
     // After this the server will return an error when batchCreateSessions is called.
     // This error is not propagated to the client.
     int maxServerSessions = 550;
-    DatabaseClientImpl client = null;
+    DatabaseClientImpl client;
     mockSpanner.setMaxTotalSessions(maxServerSessions);
     try (Spanner spanner = createSpanner(minSessions, maxSessions)) {
       // Create a database client which will create a session pool.
@@ -210,8 +210,8 @@ public class BatchCreateSessionsTest {
   public void testSpannerReturnsResourceExhausted() throws InterruptedException {
     int minSessions = 100;
     int maxSessions = 1000;
-    int expectedSessions = minSessions;
-    DatabaseClientImpl client = null;
+    int expectedSessions;
+    DatabaseClientImpl client;
     // Make the first BatchCreateSessions return an error.
     mockSpanner.addException(Status.RESOURCE_EXHAUSTED.asRuntimeException());
     try (Spanner spanner = createSpanner(minSessions, maxSessions)) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminClientImplTest.java
@@ -160,12 +160,12 @@ public class DatabaseAdminClientImplTest {
     when(rpc.createDatabase(
             INSTANCE_NAME,
             "CREATE DATABASE `" + DB_ID + "`",
-            Collections.<String>emptyList(),
+            Collections.emptyList(),
             new com.google.cloud.spanner.Database(
                 DatabaseId.of(DB_NAME), State.UNSPECIFIED, client)))
         .thenReturn(rawOperationFuture);
     OperationFuture<com.google.cloud.spanner.Database, CreateDatabaseMetadata> op =
-        client.createDatabase(INSTANCE_ID, DB_ID, Collections.<String>emptyList());
+        client.createDatabase(INSTANCE_ID, DB_ID, Collections.emptyList());
     assertThat(op.isDone()).isTrue();
     assertThat(op.get().getId().getName()).isEqualTo(DB_NAME);
   }
@@ -184,13 +184,10 @@ public class DatabaseAdminClientImplTest {
             getEncryptedDatabaseProto(),
             CreateDatabaseMetadata.getDefaultInstance());
     when(rpc.createDatabase(
-            INSTANCE_NAME,
-            "CREATE DATABASE `" + DB_ID + "`",
-            Collections.<String>emptyList(),
-            database))
+            INSTANCE_NAME, "CREATE DATABASE `" + DB_ID + "`", Collections.emptyList(), database))
         .thenReturn(rawOperationFuture);
     OperationFuture<com.google.cloud.spanner.Database, CreateDatabaseMetadata> op =
-        client.createDatabase(database, Collections.<String>emptyList());
+        client.createDatabase(database, Collections.emptyList());
     assertThat(op.isDone()).isTrue();
     assertThat(op.get().getId().getName()).isEqualTo(DB_NAME);
   }
@@ -244,9 +241,9 @@ public class DatabaseAdminClientImplTest {
   public void listDatabases() {
     String pageToken = "token";
     when(rpc.listDatabases(INSTANCE_NAME, 1, null))
-        .thenReturn(new Paginated<>(ImmutableList.<Database>of(getDatabaseProto()), pageToken));
+        .thenReturn(new Paginated<>(ImmutableList.of(getDatabaseProto()), pageToken));
     when(rpc.listDatabases(INSTANCE_NAME, 1, pageToken))
-        .thenReturn(new Paginated<>(ImmutableList.<Database>of(getAnotherDatabaseProto()), ""));
+        .thenReturn(new Paginated<>(ImmutableList.of(getAnotherDatabaseProto()), ""));
     List<com.google.cloud.spanner.Database> dbs =
         Lists.newArrayList(client.listDatabases(INSTANCE_ID, Options.pageSize(1)).iterateAll());
     assertThat(dbs.get(0).getId().getName()).isEqualTo(DB_NAME);
@@ -273,7 +270,7 @@ public class DatabaseAdminClientImplTest {
   public void listDatabaseErrorWithToken() {
     String pageToken = "token";
     when(rpc.listDatabases(INSTANCE_NAME, 1, null))
-        .thenReturn(new Paginated<>(ImmutableList.<Database>of(getDatabaseProto()), pageToken));
+        .thenReturn(new Paginated<>(ImmutableList.of(getDatabaseProto()), pageToken));
     when(rpc.listDatabases(INSTANCE_NAME, 1, pageToken))
         .thenThrow(
             SpannerExceptionFactory.newSpannerException(ErrorCode.INVALID_ARGUMENT, "Test error"));
@@ -469,9 +466,9 @@ public class DatabaseAdminClientImplTest {
   public void listBackups() {
     String pageToken = "token";
     when(rpc.listBackups(INSTANCE_NAME, 1, null, null))
-        .thenReturn(new Paginated<>(ImmutableList.<Backup>of(getBackupProto()), pageToken));
+        .thenReturn(new Paginated<>(ImmutableList.of(getBackupProto()), pageToken));
     when(rpc.listBackups(INSTANCE_NAME, 1, null, pageToken))
-        .thenReturn(new Paginated<>(ImmutableList.<Backup>of(getAnotherBackupProto()), ""));
+        .thenReturn(new Paginated<>(ImmutableList.of(getAnotherBackupProto()), ""));
     List<com.google.cloud.spanner.Backup> backups =
         Lists.newArrayList(client.listBackups(INSTANCE_ID, Options.pageSize(1)).iterateAll());
     assertThat(backups.get(0).getId().getName()).isEqualTo(BK_NAME);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminClientTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminClientTest.java
@@ -20,7 +20,6 @@ import static com.google.cloud.spanner.testing.TimestampHelper.afterDays;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
-import com.google.api.core.ApiFunction;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.longrunning.OperationTimedPollAlgorithm;
@@ -196,13 +195,7 @@ public class DatabaseAdminClientTest {
     spanner =
         builder
             .setHost("http://localhost:" + server.getPort())
-            .setChannelConfigurator(
-                new ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder>() {
-                  @Override
-                  public ManagedChannelBuilder apply(ManagedChannelBuilder input) {
-                    return input.usePlaintext();
-                  }
-                })
+            .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
             .setCredentials(NoCredentials.getInstance())
             .setProjectId(PROJECT_ID)
             .build()

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminClientTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminClientTest.java
@@ -706,7 +706,7 @@ public class DatabaseAdminClientTest {
     assertThat(database.listDatabaseOperations().iterateAll()).hasSize(1);
     // Update the database DDL. This should create an operation for this database.
     OperationFuture<Void, UpdateDatabaseDdlMetadata> op =
-        database.updateDdl(Arrays.asList("DROP TABLE FOO"), null);
+        database.updateDdl(Collections.singletonList("DROP TABLE FOO"), null);
     mockDatabaseAdmin.addFilterMatches("name:databases/" + DB_ID, op.getName());
     assertThat(database.listDatabaseOperations().iterateAll()).hasSize(2);
   }
@@ -801,7 +801,7 @@ public class DatabaseAdminClientTest {
   public void testDatabaseIAMPermissions() {
     Iterable<String> permissions =
         client.testDatabaseIAMPermissions(
-            INSTANCE_ID, DB_ID, Arrays.asList("spanner.databases.select"));
+            INSTANCE_ID, DB_ID, Collections.singletonList("spanner.databases.select"));
     assertThat(permissions).containsExactly("spanner.databases.select");
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminClientTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminClientTest.java
@@ -640,7 +640,7 @@ public class DatabaseAdminClientTest {
     // + restores a database --> 2 operations.
     assertThat(client.listDatabaseOperations(INSTANCE_ID).iterateAll()).hasSize(3);
     // Create another database which should also create another operation.
-    client.createDatabase(INSTANCE_ID, "other-database", Collections.<String>emptyList()).get();
+    client.createDatabase(INSTANCE_ID, "other-database", Collections.emptyList()).get();
     assertThat(client.listDatabaseOperations(INSTANCE_ID).iterateAll()).hasSize(4);
     // Restore a backup. This should create 2 database operations: One to restore the database and
     // one to optimize it.
@@ -657,7 +657,7 @@ public class DatabaseAdminClientTest {
             .newInstanceBuilder(InstanceId.of(PROJECT_ID, INSTANCE_ID))
             .build();
     assertThat(instance.listDatabaseOperations().iterateAll()).hasSize(3);
-    instance.createDatabase("other-database", Collections.<String>emptyList()).get();
+    instance.createDatabase("other-database", Collections.emptyList()).get();
     assertThat(instance.listDatabaseOperations().iterateAll()).hasSize(4);
     client
         .newBackupBuilder(BackupId.of(PROJECT_ID, INSTANCE_ID, BCK_ID))
@@ -702,7 +702,7 @@ public class DatabaseAdminClientTest {
     assertThat(database.listDatabaseOperations().iterateAll()).hasSize(1);
     // Create another database which should also create another operation, but for a different
     // database.
-    client.createDatabase(INSTANCE_ID, "other-database", Collections.<String>emptyList()).get();
+    client.createDatabase(INSTANCE_ID, "other-database", Collections.emptyList()).get();
     assertThat(database.listDatabaseOperations().iterateAll()).hasSize(1);
     // Update the database DDL. This should create an operation for this database.
     OperationFuture<Void, UpdateDatabaseDdlMetadata> op =
@@ -883,7 +883,7 @@ public class DatabaseAdminClientTest {
         SimulatedExecutionTime.ofException(Status.DEADLINE_EXCEEDED.asRuntimeException()));
     final String databaseId = "other-database-id";
     OperationFuture<Database, CreateDatabaseMetadata> op =
-        client.createDatabase(INSTANCE_ID, databaseId, Collections.<String>emptyList());
+        client.createDatabase(INSTANCE_ID, databaseId, Collections.emptyList());
     Database database = op.get();
     assertThat(database.getId().getName())
         .isEqualTo(
@@ -901,7 +901,7 @@ public class DatabaseAdminClientTest {
         SimulatedExecutionTime.ofException(Status.DEADLINE_EXCEEDED.asRuntimeException()));
     final String databaseId = "other-database-id";
     OperationFuture<Database, CreateDatabaseMetadata> op =
-        client.createDatabase(INSTANCE_ID, databaseId, Collections.<String>emptyList());
+        client.createDatabase(INSTANCE_ID, databaseId, Collections.emptyList());
     Database database = op.get();
     assertThat(database.getId().getName())
         .isEqualTo(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminClientTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminClientTest.java
@@ -107,7 +107,6 @@ public class DatabaseAdminClientTest {
     server.awaitTermination();
   }
 
-  @SuppressWarnings("rawtypes")
   @Before
   public void setUp() {
     mockDatabaseAdmin.reset();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminClientTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminClientTest.java
@@ -582,7 +582,7 @@ public class DatabaseAdminClientTest {
         .containsExactly(backupWithLargestSize);
     // All backups with a create time after a certain timestamp and that are also ready.
     ts = backup2.getProto().getCreateTime().toString();
-    filter = String.format("create_time >= \"%s\" AND state:READY", ts.toString());
+    filter = String.format("create_time >= \"%s\" AND state:READY", ts);
     mockDatabaseAdmin.addFilterMatches(filter, backup2.getId().getName());
     assertThat(instance.listBackups(Options.filter(filter)).iterateAll()).containsExactly(backup2);
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminGaxTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminGaxTest.java
@@ -16,13 +16,10 @@
 
 package com.google.cloud.spanner;
 
-import com.google.api.core.ApiFunction;
 import com.google.api.gax.grpc.testing.LocalChannelProvider;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.api.gax.paging.Page;
 import com.google.api.gax.retrying.RetrySettings;
-import com.google.api.gax.rpc.UnaryCallSettings;
-import com.google.api.gax.rpc.UnaryCallSettings.Builder;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.admin.database.v1.MockDatabaseAdminImpl;
 import com.google.common.base.Throwables;
@@ -246,12 +243,9 @@ public class DatabaseAdminGaxTest {
     builder
         .getDatabaseAdminStubSettingsBuilder()
         .applyToAllUnaryMethods(
-            new ApiFunction<UnaryCallSettings.Builder<?, ?>, Void>() {
-              @Override
-              public Void apply(Builder<?, ?> input) {
-                input.setRetrySettings(retrySettingsToUse);
-                return null;
-              }
+            input -> {
+              input.setRetrySettings(retrySettingsToUse);
+              return null;
             });
     if (!builder
         .getDatabaseAdminStubSettingsBuilder()

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminGaxTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminGaxTest.java
@@ -38,8 +38,8 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.inprocess.InProcessServerBuilder;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -317,7 +317,8 @@ public class DatabaseAdminGaxTest {
     }
     for (int i = 0; i < 2; i++) {
       ListDatabasesResponse.Builder builder =
-          ListDatabasesResponse.newBuilder().addAllDatabases(Arrays.asList(databases.get(i)));
+          ListDatabasesResponse.newBuilder()
+              .addAllDatabases(Collections.singletonList(databases.get(i)));
       if (i < (databases.size() - 1)) {
         builder.setNextPageToken(String.format(nextPageToken, i));
       }
@@ -387,7 +388,10 @@ public class DatabaseAdminGaxTest {
     for (int i = 0; i < 2; i++) {
       OperationFuture<Void, UpdateDatabaseDdlMetadata> actualResponse =
           client.updateDatabaseDdl(
-              INSTANCE, "DATABASE", Arrays.asList("CREATE TABLE FOO"), "updateDatabaseDdlTest");
+              INSTANCE,
+              "DATABASE",
+              Collections.singletonList("CREATE TABLE FOO"),
+              "updateDatabaseDdlTest");
       try {
         actualResponse.get();
       } catch (ExecutionException e) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -849,7 +849,7 @@ public class DatabaseClientImplTest {
         runner.runAsync(
             txn -> {
               txn.buffer(Mutation.delete("FOO", Key.of("foo")));
-              return ApiFutures.<Void>immediateFuture(null);
+              return ApiFutures.immediateFuture(null);
             },
             executor);
     assertNull(get(result));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -67,7 +67,7 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.inprocess.InProcessServerBuilder;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -176,7 +176,7 @@ public class DatabaseClientImplTest {
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
     Timestamp timestamp =
         client.write(
-            Arrays.asList(
+            Collections.singletonList(
                 Mutation.newInsertBuilder("FOO").set("ID").to(1L).set("NAME").to("Bar").build()));
     assertNotNull(timestamp);
 
@@ -192,7 +192,7 @@ public class DatabaseClientImplTest {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
     client.writeWithOptions(
-        Arrays.asList(
+        Collections.singletonList(
             Mutation.newInsertBuilder("FOO").set("ID").to(1L).set("NAME").to("Bar").build()),
         Options.priority(RpcPriority.HIGH));
 
@@ -209,7 +209,7 @@ public class DatabaseClientImplTest {
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
     CommitResponse response =
         client.writeWithOptions(
-            Arrays.asList(
+            Collections.singletonList(
                 Mutation.newInsertBuilder("FOO").set("ID").to(1L).set("NAME").to("Bar").build()),
             Options.commitStats());
     assertNotNull(response);
@@ -223,7 +223,7 @@ public class DatabaseClientImplTest {
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
     Timestamp timestamp =
         client.writeAtLeastOnce(
-            Arrays.asList(
+            Collections.singletonList(
                 Mutation.newInsertBuilder("FOO").set("ID").to(1L).set("NAME").to("Bar").build()));
     assertNotNull(timestamp);
   }
@@ -234,7 +234,7 @@ public class DatabaseClientImplTest {
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
     CommitResponse response =
         client.writeAtLeastOnceWithOptions(
-            Arrays.asList(
+            Collections.singletonList(
                 Mutation.newInsertBuilder("FOO").set("ID").to(1L).set("NAME").to("Bar").build()),
             Options.commitStats());
     assertNotNull(response);
@@ -255,7 +255,7 @@ public class DatabaseClientImplTest {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
     client.writeAtLeastOnceWithOptions(
-        Arrays.asList(
+        Collections.singletonList(
             Mutation.newInsertBuilder("FOO").set("ID").to(1L).set("NAME").to("Bar").build()),
         Options.priority(RpcPriority.LOW));
 
@@ -273,7 +273,7 @@ public class DatabaseClientImplTest {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
     client.writeAtLeastOnceWithOptions(
-        Arrays.asList(
+        Collections.singletonList(
             Mutation.newInsertBuilder("FOO").set("ID").to(1L).set("NAME").to("Bar").build()),
         Options.tag("app=spanner,env=test"));
 
@@ -413,7 +413,8 @@ public class DatabaseClientImplTest {
     runner.run(
         transaction ->
             transaction.batchUpdate(
-                Arrays.asList(UPDATE_STATEMENT), Options.tag("app=spanner,env=test,action=batch")));
+                Collections.singletonList(UPDATE_STATEMENT),
+                Options.tag("app=spanner,env=test,action=batch")));
 
     List<ExecuteBatchDmlRequest> requests =
         mockSpanner.getRequestsOfType(ExecuteBatchDmlRequest.class);
@@ -1724,7 +1725,7 @@ public class DatabaseClientImplTest {
             assertThat(client.clientId).isEqualTo(prevClientId);
           }
           prevClientId = client.clientId;
-          client.singleUse().readRow("MyTable", Key.of(0), Arrays.asList("MyColumn"));
+          client.singleUse().readRow("MyTable", Key.of(0), Collections.singletonList("MyColumn"));
         } catch (Exception e) {
           // ignore
         }
@@ -2029,7 +2030,7 @@ public class DatabaseClientImplTest {
     runner.run(
         transaction ->
             transaction.batchUpdate(
-                Arrays.asList(UPDATE_STATEMENT), Options.priority(RpcPriority.HIGH)));
+                Collections.singletonList(UPDATE_STATEMENT), Options.priority(RpcPriority.HIGH)));
 
     List<ExecuteBatchDmlRequest> requests =
         mockSpanner.getRequestsOfType(ExecuteBatchDmlRequest.class);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -40,7 +40,6 @@ import com.google.cloud.NoCredentials;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.AbstractResultSet.GrpcStreamIterator;
 import com.google.cloud.spanner.AsyncResultSet.CallbackResponse;
-import com.google.cloud.spanner.AsyncTransactionManager.AsyncTransactionFunction;
 import com.google.cloud.spanner.AsyncTransactionManager.TransactionContextFuture;
 import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
@@ -515,11 +514,10 @@ public class DatabaseClientImplTest {
       get(
           transaction
               .then(
-                  (AsyncTransactionFunction<Void, Void>)
-                      (txn, input) -> {
-                        txn.buffer(Mutation.delete("TEST", KeySet.all()));
-                        return ApiFutures.immediateFuture(null);
-                      },
+                  (txn, input) -> {
+                    txn.buffer(Mutation.delete("TEST", KeySet.all()));
+                    return ApiFutures.immediateFuture(null);
+                  },
                   executor)
               .commitAsync());
     }
@@ -2117,11 +2115,10 @@ public class DatabaseClientImplTest {
       get(
           transaction
               .then(
-                  (AsyncTransactionFunction<Void, Void>)
-                      (txn, input) -> {
-                        txn.buffer(Mutation.delete("TEST", KeySet.all()));
-                        return ApiFutures.immediateFuture(null);
-                      },
+                  (txn, input) -> {
+                    txn.buffer(Mutation.delete("TEST", KeySet.all()));
+                    return ApiFutures.immediateFuture(null);
+                  },
                   executor)
               .commitAsync());
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -517,8 +517,7 @@ public class DatabaseClientImplTest {
               .then(
                   new AsyncTransactionFunction<Void, Void>() {
                     @Override
-                    public ApiFuture<Void> apply(TransactionContext txn, Void input)
-                        throws Exception {
+                    public ApiFuture<Void> apply(TransactionContext txn, Void input) {
                       txn.buffer(Mutation.delete("TEST", KeySet.all()));
                       return ApiFutures.immediateFuture(null);
                     }
@@ -596,7 +595,7 @@ public class DatabaseClientImplTest {
   }
 
   @Test
-  public void singleUseAsyncWithoutCallback() throws Exception {
+  public void singleUseAsyncWithoutCallback() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
     int rowCount = 0;
@@ -906,7 +905,7 @@ public class DatabaseClientImplTest {
   }
 
   @Test
-  public void testTransactionManager() throws Exception {
+  public void testTransactionManager() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
     try (TransactionManager manager = client.transactionManager()) {
@@ -925,7 +924,7 @@ public class DatabaseClientImplTest {
   }
 
   @Test
-  public void testTransactionManager_returnsCommitStats() throws InterruptedException {
+  public void testTransactionManager_returnsCommitStats() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
     try (TransactionManager manager = client.transactionManager(Options.commitStats())) {
@@ -2130,8 +2129,7 @@ public class DatabaseClientImplTest {
               .then(
                   new AsyncTransactionFunction<Void, Void>() {
                     @Override
-                    public ApiFuture<Void> apply(TransactionContext txn, Void input)
-                        throws Exception {
+                    public ApiFuture<Void> apply(TransactionContext txn, Void input) {
                       txn.buffer(Mutation.delete("TEST", KeySet.all()));
                       return ApiFutures.immediateFuture(null);
                     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -909,7 +909,7 @@ public class DatabaseClientImplTest {
           assertNotNull(manager.getCommitTimestamp());
           break;
         } catch (AbortedException e) {
-          transaction = manager.resetForRetry();
+          manager.resetForRetry();
         }
       }
     }
@@ -930,7 +930,7 @@ public class DatabaseClientImplTest {
           assertEquals(1L, manager.getCommitResponse().getCommitStats().getMutationCount());
           break;
         } catch (AbortedException e) {
-          transaction = manager.resetForRetry();
+          manager.resetForRetry();
         }
       }
     }
@@ -952,7 +952,7 @@ public class DatabaseClientImplTest {
           break;
         } catch (AbortedException e) {
           Thread.sleep(e.getRetryDelayInMillis());
-          tx = txManager.resetForRetry();
+          txManager.resetForRetry();
         }
       }
     }
@@ -992,7 +992,7 @@ public class DatabaseClientImplTest {
           break;
         } catch (AbortedException e) {
           Thread.sleep(e.getRetryDelayInMillis());
-          tx = txManager.resetForRetry();
+          txManager.resetForRetry();
         }
       }
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -1372,11 +1372,13 @@ public class DatabaseClientImplTest {
           while (rs.next()) {}
           fail("missing expected exception");
         } catch (DatabaseNotFoundException | InstanceNotFoundException e) {
+          // Expected exception
         }
         try {
           dbClient.readWriteTransaction().run(transaction -> null);
           fail("missing expected exception");
         } catch (DatabaseNotFoundException | InstanceNotFoundException e) {
+          // Expected exception
         }
 
         // Now simulate that the database has been re-created. The database client should still
@@ -1389,11 +1391,13 @@ public class DatabaseClientImplTest {
           while (rs.next()) {}
           fail("missing expected exception");
         } catch (DatabaseNotFoundException | InstanceNotFoundException e) {
+          // Expected exception
         }
         try {
           dbClient.readWriteTransaction().run(transaction -> null);
           fail("missing expected exception");
         } catch (DatabaseNotFoundException | InstanceNotFoundException e) {
+          // Expected exception
         }
         assertThat(mockSpanner.getRequests()).isEmpty();
         // Now get a new database client. Normally multiple calls to Spanner#getDatabaseClient will

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseTest.java
@@ -39,7 +39,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.stubbing.Answer;
 
 /** Unit tests for {@link com.google.cloud.spanner.Database}. */
 @RunWith(JUnit4.class)
@@ -70,14 +69,11 @@ public class DatabaseTest {
     initMocks(this);
     when(dbClient.newBackupBuilder(Mockito.any(BackupId.class)))
         .thenAnswer(
-            (Answer<Backup.Builder>)
-                invocation ->
-                    new Backup.Builder(dbClient, (BackupId) invocation.getArguments()[0]));
+            invocation -> new Backup.Builder(dbClient, (BackupId) invocation.getArguments()[0]));
     when(dbClient.newDatabaseBuilder(Mockito.any(DatabaseId.class)))
         .thenAnswer(
-            (Answer<Database.Builder>)
-                invocation ->
-                    new Database.Builder(dbClient, (DatabaseId) invocation.getArguments()[0]));
+            invocation ->
+                new Database.Builder(dbClient, (DatabaseId) invocation.getArguments()[0]));
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseTest.java
@@ -82,7 +82,7 @@ public class DatabaseTest {
         .thenAnswer(
             new Answer<Database.Builder>() {
               @Override
-              public Database.Builder answer(InvocationOnMock invocation) throws Throwable {
+              public Database.Builder answer(InvocationOnMock invocation) {
                 return new Database.Builder(dbClient, (DatabaseId) invocation.getArguments()[0]);
               }
             });

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseTest.java
@@ -31,7 +31,6 @@ import com.google.cloud.spanner.encryption.EncryptionConfigs;
 import com.google.rpc.Code;
 import com.google.rpc.Status;
 import com.google.spanner.admin.database.v1.EncryptionInfo;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
@@ -168,7 +167,7 @@ public class DatabaseTest {
     Database database =
         new Database(
             DatabaseId.of("test-project", "test-instance", "test-database"), State.READY, dbClient);
-    Iterable<String> permissions = Arrays.asList("read");
+    Iterable<String> permissions = Collections.singletonList("read");
     database.testIAMPermissions(permissions);
     verify(dbClient).testDatabaseIAMPermissions("test-instance", "test-database", permissions);
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseTest.java
@@ -40,7 +40,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 /** Unit tests for {@link com.google.cloud.spanner.Database}. */
@@ -72,20 +71,14 @@ public class DatabaseTest {
     initMocks(this);
     when(dbClient.newBackupBuilder(Mockito.any(BackupId.class)))
         .thenAnswer(
-            new Answer<Backup.Builder>() {
-              @Override
-              public Backup.Builder answer(InvocationOnMock invocation) {
-                return new Backup.Builder(dbClient, (BackupId) invocation.getArguments()[0]);
-              }
-            });
+            (Answer<Backup.Builder>)
+                invocation ->
+                    new Backup.Builder(dbClient, (BackupId) invocation.getArguments()[0]));
     when(dbClient.newDatabaseBuilder(Mockito.any(DatabaseId.class)))
         .thenAnswer(
-            new Answer<Database.Builder>() {
-              @Override
-              public Database.Builder answer(InvocationOnMock invocation) {
-                return new Database.Builder(dbClient, (DatabaseId) invocation.getArguments()[0]);
-              }
-            });
+            (Answer<Database.Builder>)
+                invocation ->
+                    new Database.Builder(dbClient, (DatabaseId) invocation.getArguments()[0]));
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GrpcResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GrpcResultSetTest.java
@@ -285,18 +285,8 @@ public class GrpcResultSetTest {
         chunkedValue,
         afterValue,
         Type.bool(),
-        new Function<List<Boolean>, com.google.protobuf.Value>() {
-          @Override
-          public com.google.protobuf.Value apply(List<Boolean> input) {
-            return Value.boolArray(input).toProto();
-          }
-        },
-        new Function<StructReader, List<Boolean>>() {
-          @Override
-          public List<Boolean> apply(StructReader input) {
-            return input.getBooleanList(0);
-          }
-        });
+        input -> Value.boolArray(input).toProto(),
+        input -> input.getBooleanList(0));
   }
 
   @Test
@@ -309,18 +299,8 @@ public class GrpcResultSetTest {
         chunkedValue,
         afterValue,
         Type.int64(),
-        new Function<List<Long>, com.google.protobuf.Value>() {
-          @Override
-          public com.google.protobuf.Value apply(List<Long> input) {
-            return Value.int64Array(input).toProto();
-          }
-        },
-        new Function<StructReader, List<Long>>() {
-          @Override
-          public List<Long> apply(StructReader input) {
-            return input.getLongList(0);
-          }
-        });
+        input -> Value.int64Array(input).toProto(),
+        input -> input.getLongList(0));
   }
 
   @Test
@@ -333,18 +313,8 @@ public class GrpcResultSetTest {
         chunkedValue,
         afterValue,
         Type.float64(),
-        new Function<List<Double>, com.google.protobuf.Value>() {
-          @Override
-          public com.google.protobuf.Value apply(List<Double> input) {
-            return Value.float64Array(input).toProto();
-          }
-        },
-        new Function<StructReader, List<Double>>() {
-          @Override
-          public List<Double> apply(StructReader input) {
-            return input.getDoubleList(0);
-          }
-        });
+        input -> Value.float64Array(input).toProto(),
+        input -> input.getDoubleList(0));
   }
 
   @Test
@@ -357,18 +327,8 @@ public class GrpcResultSetTest {
         chunkedValue,
         afterValue,
         Type.string(),
-        new Function<List<String>, com.google.protobuf.Value>() {
-          @Override
-          public com.google.protobuf.Value apply(List<String> input) {
-            return Value.stringArray(input).toProto();
-          }
-        },
-        new Function<StructReader, List<String>>() {
-          @Override
-          public List<String> apply(StructReader input) {
-            return input.getStringList(0);
-          }
-        });
+        input -> Value.stringArray(input).toProto(),
+        input -> input.getStringList(0));
   }
 
   private static ByteArray b(String data) {
@@ -386,18 +346,8 @@ public class GrpcResultSetTest {
         chunkedValue,
         afterValue,
         Type.bytes(),
-        new Function<List<ByteArray>, com.google.protobuf.Value>() {
-          @Override
-          public com.google.protobuf.Value apply(List<ByteArray> input) {
-            return Value.bytesArray(input).toProto();
-          }
-        },
-        new Function<StructReader, List<ByteArray>>() {
-          @Override
-          public List<ByteArray> apply(StructReader input) {
-            return input.getBytesList(0);
-          }
-        });
+        input -> Value.bytesArray(input).toProto(),
+        input -> input.getBytesList(0));
   }
 
   private static Struct s(String a, long b) {
@@ -419,18 +369,8 @@ public class GrpcResultSetTest {
         chunkedValue,
         afterValue,
         elementType,
-        new Function<List<Struct>, com.google.protobuf.Value>() {
-          @Override
-          public com.google.protobuf.Value apply(List<Struct> input) {
-            return Value.structArray(elementType, input).toProto();
-          }
-        },
-        new Function<StructReader, List<Struct>>() {
-          @Override
-          public List<Struct> apply(StructReader input) {
-            return input.getStructList(0);
-          }
-        });
+        input -> Value.structArray(elementType, input).toProto(),
+        input -> input.getStructList(0));
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GrpcResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GrpcResultSetTest.java
@@ -38,6 +38,7 @@ import com.google.spanner.v1.Transaction;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -277,9 +278,9 @@ public class GrpcResultSetTest {
 
   @Test
   public void multiResponseChunkingBoolArray() {
-    List<Boolean> beforeValue = Arrays.asList(true);
+    List<Boolean> beforeValue = Collections.singletonList(true);
     List<Boolean> chunkedValue = Arrays.asList(false, null, true, true, true, null, null, false);
-    List<Boolean> afterValue = Arrays.asList(true);
+    List<Boolean> afterValue = Collections.singletonList(true);
     doArrayTest(
         beforeValue,
         chunkedValue,
@@ -291,9 +292,9 @@ public class GrpcResultSetTest {
 
   @Test
   public void multiResponseChunkingInt64Array() {
-    List<Long> beforeValue = Arrays.asList(10L);
+    List<Long> beforeValue = Collections.singletonList(10L);
     List<Long> chunkedValue = Arrays.asList(1L, 2L, null, null, 5L, null, 7L, 8L);
-    List<Long> afterValue = Arrays.asList(20L);
+    List<Long> afterValue = Collections.singletonList(20L);
     doArrayTest(
         beforeValue,
         chunkedValue,
@@ -305,9 +306,9 @@ public class GrpcResultSetTest {
 
   @Test
   public void multiResponseChunkingFloat64Array() {
-    List<Double> beforeValue = Arrays.asList(10.0);
+    List<Double> beforeValue = Collections.singletonList(10.0);
     List<Double> chunkedValue = Arrays.asList(null, 2.0, 3.0, 4.0, null, 6.0, 7.0, null);
-    List<Double> afterValue = Arrays.asList(20.0);
+    List<Double> afterValue = Collections.singletonList(20.0);
     doArrayTest(
         beforeValue,
         chunkedValue,
@@ -319,9 +320,9 @@ public class GrpcResultSetTest {
 
   @Test
   public void multiResponseChunkingStringArray() {
-    List<String> beforeValue = Arrays.asList("before");
+    List<String> beforeValue = Collections.singletonList("before");
     List<String> chunkedValue = Arrays.asList("a", "b", null, "d", null, "f", null, "h");
-    List<String> afterValue = Arrays.asList("after");
+    List<String> afterValue = Collections.singletonList("after");
     doArrayTest(
         beforeValue,
         chunkedValue,
@@ -337,10 +338,10 @@ public class GrpcResultSetTest {
 
   @Test
   public void multiResponseChunkingBytesArray() {
-    List<ByteArray> beforeValue = Arrays.asList(b("before"));
+    List<ByteArray> beforeValue = Collections.singletonList(b("before"));
     List<ByteArray> chunkedValue =
         Arrays.asList(b("a"), b("b"), null, b("d"), null, b("f"), null, b("h"));
-    List<ByteArray> afterValue = Arrays.asList(b("after"));
+    List<ByteArray> afterValue = Collections.singletonList(b("after"));
     doArrayTest(
         beforeValue,
         chunkedValue,
@@ -359,11 +360,11 @@ public class GrpcResultSetTest {
     final Type elementType =
         Type.struct(
             Type.StructField.of("a", Type.string()), Type.StructField.of("b", Type.int64()));
-    List<Struct> beforeValue = Arrays.asList(s("before", 10));
+    List<Struct> beforeValue = Collections.singletonList(s("before", 10));
     List<Struct> chunkedValue =
         Arrays.asList(
             s("a", 1), s("b", 2), s("c", 3), null, s(null, 5), null, s("g", 7), s("h", 8));
-    List<Struct> afterValue = Arrays.asList(s("after", 20));
+    List<Struct> afterValue = Collections.singletonList(s("after", 20));
     doArrayTest(
         beforeValue,
         chunkedValue,
@@ -546,7 +547,7 @@ public class GrpcResultSetTest {
         Value.struct(s(null, 30)),
         Value.struct(structType, null),
         Value.structArray(structType, Arrays.asList(s("def", 10), null)),
-        Value.structArray(structType, Arrays.asList((Struct) null)),
+        Value.structArray(structType, Collections.singletonList((Struct) null)),
         Value.structArray(structType, null));
   }
 
@@ -558,7 +559,7 @@ public class GrpcResultSetTest {
                 Type.StructField.of("a", Type.string()), Type.StructField.of("b", Type.int64())));
 
     Struct nestedStruct = s("1", 2L);
-    Value struct = Value.structArray(structType, Arrays.asList(nestedStruct));
+    Value struct = Value.structArray(structType, Collections.singletonList(nestedStruct));
     verifySerialization(
         new Function<Value, com.google.protobuf.Value>() {
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GrpcResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GrpcResultSetTest.java
@@ -547,7 +547,7 @@ public class GrpcResultSetTest {
         Value.struct(s(null, 30)),
         Value.struct(structType, null),
         Value.structArray(structType, Arrays.asList(s("def", 10), null)),
-        Value.structArray(structType, Collections.singletonList((Struct) null)),
+        Value.structArray(structType, Collections.singletonList(null)),
         Value.structArray(structType, null));
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginBenchmark.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginBenchmark.java
@@ -25,7 +25,6 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -123,7 +122,7 @@ public class InlineBeginBenchmark {
           .build();
     }
 
-    SpannerOptions createRealServerOptions() throws IOException {
+    SpannerOptions createRealServerOptions() {
       return SpannerOptions.newBuilder()
           .setSessionPoolOption(
               SessionPoolOptions.newBuilder().setWriteSessionsFraction(writeFraction).build())

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
@@ -56,6 +56,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -614,7 +615,7 @@ public class InlineBeginTransactionTest {
                   transaction -> {
                     // The first attempt will return UNAVAILABLE and retry internally.
                     try (ResultSet rs =
-                        transaction.read("FOO", KeySet.all(), Arrays.asList("ID"))) {
+                        transaction.read("FOO", KeySet.all(), Collections.singletonList("ID"))) {
                       while (rs.next()) {
                         return rs.getLong(0);
                       }
@@ -659,7 +660,7 @@ public class InlineBeginTransactionTest {
               .run(
                   transaction -> {
                     try (ResultSet rs =
-                        transaction.read("FOO", KeySet.all(), Arrays.asList("ID"))) {
+                        transaction.read("FOO", KeySet.all(), Collections.singletonList("ID"))) {
                       while (rs.next()) {
                         return rs.getLong(0);
                       }
@@ -1210,7 +1211,7 @@ public class InlineBeginTransactionTest {
                   .readWriteTransaction()
                   .<Long>run(
                       transaction -> {
-                        transaction.read("FOO", KeySet.all(), Arrays.asList("ID"));
+                        transaction.read("FOO", KeySet.all(), Collections.singletonList("ID"));
                         return transaction.executeUpdate(UPDATE_STATEMENT);
                       }))
           .isEqualTo(UPDATE_COUNT);
@@ -1228,7 +1229,7 @@ public class InlineBeginTransactionTest {
                   .readWriteTransaction()
                   .<Long>run(
                       transaction -> {
-                        transaction.readAsync("FOO", KeySet.all(), Arrays.asList("ID"));
+                        transaction.readAsync("FOO", KeySet.all(), Collections.singletonList("ID"));
                         return transaction.executeUpdate(UPDATE_STATEMENT);
                       }))
           .isEqualTo(UPDATE_COUNT);
@@ -1384,7 +1385,7 @@ public class InlineBeginTransactionTest {
             .readWriteTransaction()
             .run(
                 transaction -> {
-                  transaction.readRow("FOO", Key.of(1L), Arrays.asList("BAR"));
+                  transaction.readRow("FOO", Key.of(1L), Collections.singletonList("BAR"));
                   return null;
                 });
         fail("missing expected exception");
@@ -1432,7 +1433,7 @@ public class InlineBeginTransactionTest {
             .readWriteTransaction()
             .run(
                 transaction -> {
-                  transaction.batchUpdate(Arrays.asList(UPDATE_STATEMENT));
+                  transaction.batchUpdate(Collections.singletonList(UPDATE_STATEMENT));
                   return null;
                 });
         fail("missing expected exception");
@@ -1524,7 +1525,7 @@ public class InlineBeginTransactionTest {
             .run(
                 transaction ->
                     SpannerApiFutures.get(
-                        transaction.batchUpdateAsync(Arrays.asList(UPDATE_STATEMENT))));
+                        transaction.batchUpdateAsync(Collections.singletonList(UPDATE_STATEMENT))));
         fail("missing expected exception");
       } catch (SpannerException e) {
         assertThat(e.getErrorCode()).isEqualTo(ErrorCode.FAILED_PRECONDITION);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
@@ -1262,10 +1262,9 @@ public class InlineBeginTransactionTest {
       assertThat(countTransactionsStarted()).isEqualTo(1);
       List<ExecuteSqlRequest> requests = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class);
       assertThat(requests.get(0)).isInstanceOf(ExecuteSqlRequest.class);
-      assertThat(((ExecuteSqlRequest) requests.get(0)).getSql())
-          .isEqualTo(UPDATE_STATEMENT.getSql());
+      assertThat(requests.get(0).getSql()).isEqualTo(UPDATE_STATEMENT.getSql());
       assertThat(requests.get(1)).isInstanceOf(ExecuteSqlRequest.class);
-      assertThat(((ExecuteSqlRequest) requests.get(1)).getSql()).isEqualTo(SELECT1.getSql());
+      assertThat(requests.get(1).getSql()).isEqualTo(SELECT1.getSql());
     }
 
     @Test
@@ -1290,14 +1289,14 @@ public class InlineBeginTransactionTest {
 
       List<ExecuteSqlRequest> requests = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class);
       assertThat(requests.get(0)).isInstanceOf(ExecuteSqlRequest.class);
-      ExecuteSqlRequest request1 = (ExecuteSqlRequest) requests.get(0);
+      ExecuteSqlRequest request1 = requests.get(0);
       assertThat(request1.getSql()).isEqualTo(SELECT1_UNION_ALL_SELECT2.getSql());
       assertThat(request1.getTransaction().getBegin().hasReadWrite()).isTrue();
       assertThat(request1.getTransaction().getId()).isEqualTo(ByteString.EMPTY);
       assertThat(request1.getResumeToken()).isEqualTo(ByteString.EMPTY);
 
       assertThat(requests.get(1)).isInstanceOf(ExecuteSqlRequest.class);
-      ExecuteSqlRequest request2 = (ExecuteSqlRequest) requests.get(1);
+      ExecuteSqlRequest request2 = requests.get(1);
       assertThat(request2.getSql()).isEqualTo(SELECT1_UNION_ALL_SELECT2.getSql());
       assertThat(request2.getTransaction().hasBegin()).isFalse();
       assertThat(request2.getTransaction().getId()).isNotEqualTo(ByteString.EMPTY);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
@@ -26,7 +26,6 @@ import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.grpc.testing.LocalChannelProvider;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.AsyncResultSet.CallbackResponse;
-import com.google.cloud.spanner.AsyncTransactionManager.AsyncTransactionFunction;
 import com.google.cloud.spanner.AsyncTransactionManager.AsyncTransactionStep;
 import com.google.cloud.spanner.AsyncTransactionManager.CommitTimestampFuture;
 import com.google.cloud.spanner.AsyncTransactionManager.TransactionContextFuture;
@@ -383,11 +382,10 @@ public class InlineBeginTransactionTest {
               // Abort the transaction after the statement has been executed to ensure that the
               // transaction has actually been started before the test tries to abort it.
               updateCount.then(
-                  (AsyncTransactionFunction<Long, Void>)
-                      (ignored1, ignored2) -> {
-                        mockSpanner.abortAllTransactions();
-                        return ApiFutures.immediateFuture(null);
-                      },
+                  (ignored1, ignored2) -> {
+                    mockSpanner.abortAllTransactions();
+                    return ApiFutures.immediateFuture(null);
+                  },
                   MoreExecutors.directExecutor());
               first = false;
             }
@@ -414,12 +412,10 @@ public class InlineBeginTransactionTest {
         while (true) {
           try {
             txn.then(
-                    (AsyncTransactionFunction<Void, Void>)
-                        (transaction, ignored) -> {
-                          transaction.buffer(
-                              Mutation.newInsertBuilder("FOO").set("ID").to(1L).build());
-                          return ApiFutures.immediateFuture(null);
-                        },
+                    (transaction, ignored) -> {
+                      transaction.buffer(Mutation.newInsertBuilder("FOO").set("ID").to(1L).build());
+                      return ApiFutures.immediateFuture(null);
+                    },
                     executor)
                 .commitAsync()
                 .get();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
@@ -66,7 +66,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -175,7 +174,7 @@ public class InlineBeginTransactionTest {
   }
 
   @Before
-  public void setUp() throws IOException {
+  public void setUp() {
     mockSpanner.reset();
     mockSpanner.removeAllExecutionTimes();
     // Create a Spanner instance that will inline BeginTransaction calls. It also has no prepared
@@ -191,7 +190,7 @@ public class InlineBeginTransactionTest {
   }
 
   @After
-  public void tearDown() throws Exception {
+  public void tearDown() {
     spanner.close();
     mockSpanner.reset();
     mockSpanner.clearRequests();
@@ -356,8 +355,7 @@ public class InlineBeginTransactionTest {
               txn.then(
                   new AsyncTransactionFunction<Void, Long>() {
                     @Override
-                    public ApiFuture<Long> apply(TransactionContext txn, Void input)
-                        throws Exception {
+                    public ApiFuture<Long> apply(TransactionContext txn, Void input) {
                       return txn.executeUpdateAsync(UPDATE_STATEMENT);
                     }
                   },
@@ -390,8 +388,7 @@ public class InlineBeginTransactionTest {
                 txn.then(
                     new AsyncTransactionFunction<Void, Long>() {
                       @Override
-                      public ApiFuture<Long> apply(TransactionContext txn, Void input)
-                          throws Exception {
+                      public ApiFuture<Long> apply(TransactionContext txn, Void input) {
                         return txn.executeUpdateAsync(UPDATE_STATEMENT);
                       }
                     },
@@ -402,8 +399,7 @@ public class InlineBeginTransactionTest {
               updateCount.then(
                   new AsyncTransactionFunction<Long, Void>() {
                     @Override
-                    public ApiFuture<Void> apply(TransactionContext txn, Long input)
-                        throws Exception {
+                    public ApiFuture<Void> apply(TransactionContext txn, Long input) {
                       mockSpanner.abortAllTransactions();
                       return ApiFutures.immediateFuture(null);
                     }
@@ -436,8 +432,7 @@ public class InlineBeginTransactionTest {
             txn.then(
                     new AsyncTransactionFunction<Void, Void>() {
                       @Override
-                      public ApiFuture<Void> apply(TransactionContext txn, Void input)
-                          throws Exception {
+                      public ApiFuture<Void> apply(TransactionContext txn, Void input) {
                         txn.buffer(Mutation.newInsertBuilder("FOO").set("ID").to(1L).build());
                         return ApiFutures.immediateFuture(null);
                       }
@@ -457,8 +452,7 @@ public class InlineBeginTransactionTest {
     }
 
     @Test
-    public void testAsyncTransactionManagerInlinedBeginTxWithError()
-        throws InterruptedException, ExecutionException {
+    public void testAsyncTransactionManagerInlinedBeginTxWithError() throws InterruptedException {
       DatabaseClient client =
           spanner.getDatabaseClient(DatabaseId.of("[PROJECT]", "[INSTANCE]", "[DATABASE]"));
       try (AsyncTransactionManager txMgr = client.transactionManagerAsync()) {
@@ -469,8 +463,7 @@ public class InlineBeginTransactionTest {
                 txn.then(
                         new AsyncTransactionFunction<Void, Long>() {
                           @Override
-                          public ApiFuture<Long> apply(TransactionContext txn, Void input)
-                              throws Exception {
+                          public ApiFuture<Long> apply(TransactionContext txn, Void input) {
                             return txn.executeUpdateAsync(INVALID_UPDATE_STATEMENT);
                           }
                         },
@@ -478,8 +471,7 @@ public class InlineBeginTransactionTest {
                     .then(
                         new AsyncTransactionFunction<Long, Long>() {
                           @Override
-                          public ApiFuture<Long> apply(TransactionContext txn, Long input)
-                              throws Exception {
+                          public ApiFuture<Long> apply(TransactionContext txn, Long input) {
                             return txn.executeUpdateAsync(UPDATE_STATEMENT);
                           }
                         },
@@ -555,7 +547,7 @@ public class InlineBeginTransactionTest {
                     boolean firstAttempt = true;
 
                     @Override
-                    public Long run(TransactionContext transaction) throws Exception {
+                    public Long run(TransactionContext transaction) {
                       if (firstAttempt) {
                         firstAttempt = false;
                         mockSpanner.putStatementResult(
@@ -587,7 +579,7 @@ public class InlineBeginTransactionTest {
                     boolean firstAttempt = true;
 
                     @Override
-                    public Long run(TransactionContext transaction) throws Exception {
+                    public Long run(TransactionContext transaction) {
                       if (firstAttempt) {
                         firstAttempt = false;
                         mockSpanner.putStatementResult(
@@ -1191,7 +1183,7 @@ public class InlineBeginTransactionTest {
                         ApiFutures.allAsList(futures),
                         new ApiAsyncFunction<List<Long>, Long>() {
                           @Override
-                          public ApiFuture<Long> apply(List<Long> input) throws Exception {
+                          public ApiFuture<Long> apply(List<Long> input) {
                             long sum = 0L;
                             for (Long l : input) {
                               sum += l;
@@ -1280,8 +1272,7 @@ public class InlineBeginTransactionTest {
     }
 
     @Test
-    public void query_ThenUpdate_ThenConsumeResultSet()
-        throws InterruptedException, TimeoutException {
+    public void query_ThenUpdate_ThenConsumeResultSet() {
       DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
       assertThat(
               client
@@ -1355,7 +1346,7 @@ public class InlineBeginTransactionTest {
                 int attempt = 0;
 
                 @Override
-                public Void run(TransactionContext transaction) throws Exception {
+                public Void run(TransactionContext transaction) {
                   attempt++;
                   TransactionContextImpl impl = (TransactionContextImpl) transaction;
                   if (attempt == 1) {
@@ -1601,7 +1592,7 @@ public class InlineBeginTransactionTest {
                     int attempt = 0;
 
                     @Override
-                    public Long run(TransactionContext transaction) throws Exception {
+                    public Long run(TransactionContext transaction) {
                       if (attempt > 0) {
                         mockSpanner.putStatementResult(StatementResult.update(statement, 1L));
                       }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceAdminClientTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceAdminClientTest.java
@@ -19,13 +19,12 @@ package com.google.cloud.spanner;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.gax.grpc.testing.LocalChannelProvider;
-import com.google.api.gax.grpc.testing.MockGrpcService;
 import com.google.api.gax.grpc.testing.MockServiceHelper;
 import com.google.cloud.Identity;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.Policy;
 import com.google.cloud.Role;
-import java.util.Arrays;
+import java.util.Collections;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -49,7 +48,7 @@ public class InstanceAdminClientTest {
   public static void startStaticServer() {
     mockInstanceAdmin = new MockInstanceAdminServiceImpl();
     serviceHelper =
-        new MockServiceHelper("in-process-1", Arrays.<MockGrpcService>asList(mockInstanceAdmin));
+        new MockServiceHelper("in-process-1", Collections.singletonList(mockInstanceAdmin));
     serviceHelper.start();
   }
 
@@ -91,7 +90,8 @@ public class InstanceAdminClientTest {
   @Test
   public void testIAMPermissions() {
     Iterable<String> permissions =
-        client.testInstanceIAMPermissions(INSTANCE_ID, Arrays.asList("spanner.instances.list"));
+        client.testInstanceIAMPermissions(
+            INSTANCE_ID, Collections.singletonList("spanner.instances.list"));
     assertThat(permissions).containsExactly("spanner.instances.list");
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceAdminGaxTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceAdminGaxTest.java
@@ -18,13 +18,10 @@ package com.google.cloud.spanner;
 
 import static org.junit.Assert.fail;
 
-import com.google.api.core.ApiFunction;
 import com.google.api.gax.grpc.testing.LocalChannelProvider;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.api.gax.paging.Page;
 import com.google.api.gax.retrying.RetrySettings;
-import com.google.api.gax.rpc.UnaryCallSettings;
-import com.google.api.gax.rpc.UnaryCallSettings.Builder;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.admin.instance.v1.MockInstanceAdminImpl;
 import com.google.common.base.Throwables;
@@ -253,12 +250,9 @@ public class InstanceAdminGaxTest {
     builder
         .getInstanceAdminStubSettingsBuilder()
         .applyToAllUnaryMethods(
-            new ApiFunction<UnaryCallSettings.Builder<?, ?>, Void>() {
-              @Override
-              public Void apply(Builder<?, ?> input) {
-                input.setRetrySettings(retrySettingsToUse);
-                return null;
-              }
+            input -> {
+              input.setRetrySettings(retrySettingsToUse);
+              return null;
             });
     if (!builder
         .getInstanceAdminStubSettingsBuilder()

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceAdminGaxTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceAdminGaxTest.java
@@ -45,8 +45,8 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.inprocess.InProcessServerBuilder;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -325,7 +325,7 @@ public class InstanceAdminGaxTest {
     for (int i = 0; i < 2; i++) {
       ListInstanceConfigsResponse.Builder builder =
           ListInstanceConfigsResponse.newBuilder()
-              .addAllInstanceConfigs(Arrays.asList(configs.get(i)));
+              .addAllInstanceConfigs(Collections.singletonList(configs.get(i)));
       if (i < (configs.size() - 1)) {
         builder.setNextPageToken(String.format(nextPageToken, i));
       }
@@ -391,7 +391,8 @@ public class InstanceAdminGaxTest {
     }
     for (int i = 0; i < 2; i++) {
       ListInstancesResponse.Builder builder =
-          ListInstancesResponse.newBuilder().addAllInstances(Arrays.asList(instances.get(i)));
+          ListInstancesResponse.newBuilder()
+              .addAllInstances(Collections.singletonList(instances.get(i)));
       if (i < (instances.size() - 1)) {
         builder.setNextPageToken(String.format(nextPageToken, i));
       }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceTest.java
@@ -24,7 +24,7 @@ import com.google.cloud.Identity;
 import com.google.cloud.Policy;
 import com.google.cloud.Role;
 import com.google.common.testing.EqualsTester;
-import java.util.Arrays;
+import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -163,7 +163,7 @@ public class InstanceTest {
   public void testIAMPermissions() {
     InstanceId id = new InstanceId("test-project", "test-instance");
     Instance instance = new Instance.Builder(instanceClient, dbClient, id).build();
-    Iterable<String> permissions = Arrays.asList("read");
+    Iterable<String> permissions = Collections.singletonList("read");
     instance.testIAMPermissions(permissions);
     verify(instanceClient).testInstanceIAMPermissions("test-instance", permissions);
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestWithClosedSessionsEnv.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestWithClosedSessionsEnv.java
@@ -34,8 +34,7 @@ public class IntegrationTestWithClosedSessionsEnv extends IntegrationTestEnv {
   }
 
   @Override
-  RemoteSpannerHelper createTestHelper(SpannerOptions options, InstanceId instanceId)
-      throws Throwable {
+  RemoteSpannerHelper createTestHelper(SpannerOptions options, InstanceId instanceId) {
     SpannerWithClosedSessionsImpl spanner = new SpannerWithClosedSessionsImpl(options);
     return new RemoteSpannerHelperWithClosedSessions(options, instanceId, spanner);
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IsRetryableInternalErrorTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IsRetryableInternalErrorTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-@SuppressWarnings("unchecked")
 @RunWith(JUnit4.class)
 public class IsRetryableInternalErrorTest {
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IsSslHandshakeExceptionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IsSslHandshakeExceptionTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-@SuppressWarnings("unchecked")
 @RunWith(JUnit4.class)
 public class IsSslHandshakeExceptionTest {
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MetricRegistryTestUtils.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MetricRegistryTestUtils.java
@@ -95,7 +95,7 @@ class MetricRegistryTestUtils {
       this.record
           .metrics
           .get(this.name)
-          .add(new PointWithFunction(t, toLongFunction, labelKeys, labelValues));
+          .add(new PointWithFunction<>(t, toLongFunction, labelKeys, labelValues));
     }
 
     @Override
@@ -126,7 +126,7 @@ class MetricRegistryTestUtils {
       this.record
           .metrics
           .get(this.name)
-          .add(new PointWithFunction(t, toLongFunction, labelKeys, labelValues));
+          .add(new PointWithFunction<>(t, toLongFunction, labelKeys, labelValues));
     }
 
     @Override

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockDatabaseAdminServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockDatabaseAdminServiceImpl.java
@@ -18,7 +18,6 @@ package com.google.cloud.spanner;
 
 import com.google.api.gax.grpc.testing.MockGrpcService;
 import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
-import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
 import com.google.common.collect.Collections2;
 import com.google.iam.v1.GetIamPolicyRequest;
@@ -914,15 +913,7 @@ public class MockDatabaseAdminServiceImpl extends DatabaseAdminImplBase implemen
   }
 
   public int countRequestsOfType(final Class<? extends AbstractMessage> type) {
-    return Collections2.filter(
-            getRequests(),
-            new Predicate<AbstractMessage>() {
-              @Override
-              public boolean apply(AbstractMessage input) {
-                return input.getClass().equals(type);
-              }
-            })
-        .size();
+    return Collections2.filter(getRequests(), input -> input.getClass().equals(type)).size();
   }
 
   @Override

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockDatabaseAdminServiceImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockDatabaseAdminServiceImplTest.java
@@ -21,7 +21,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.grpc.testing.LocalChannelProvider;
-import com.google.api.gax.grpc.testing.MockGrpcService;
 import com.google.api.gax.grpc.testing.MockServiceHelper;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.api.gax.longrunning.OperationTimedPollAlgorithm;
@@ -129,8 +128,7 @@ public class MockDatabaseAdminServiceImplTest {
     mockOperations = new MockOperationsServiceImpl();
     mockDatabaseAdmin = new MockDatabaseAdminServiceImpl(mockOperations);
     serviceHelper =
-        new MockServiceHelper(
-            "in-process-1", Arrays.<MockGrpcService>asList(mockOperations, mockDatabaseAdmin));
+        new MockServiceHelper("in-process-1", Arrays.asList(mockOperations, mockDatabaseAdmin));
     serviceHelper.start();
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -83,6 +83,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -879,8 +880,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
               session.toBuilder().setApproximateLastUseTime(getCurrentGoogleTimestamp()).build());
         }
       }
-      Collections.sort(
-          res, (session1, session2) -> session1.getName().compareTo(session2.getName()));
+      res.sort(Comparator.comparing(Session::getName));
       responseObserver.onNext(ListSessionsResponse.newBuilder().addAllSessions(res).build());
       responseObserver.onCompleted();
     } catch (StatusRuntimeException e) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -432,17 +432,17 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
 
     public static SimulatedExecutionTime ofException(Exception exception) {
       return new SimulatedExecutionTime(
-          0, 0, Arrays.asList(exception), false, Collections.<Long>emptySet());
+          0, 0, Collections.singletonList(exception), false, Collections.<Long>emptySet());
     }
 
     public static SimulatedExecutionTime ofStickyException(Exception exception) {
       return new SimulatedExecutionTime(
-          0, 0, Arrays.asList(exception), true, Collections.<Long>emptySet());
+          0, 0, Collections.singletonList(exception), true, Collections.<Long>emptySet());
     }
 
     public static SimulatedExecutionTime ofStreamException(Exception exception, long streamIndex) {
       return new SimulatedExecutionTime(
-          0, 0, Arrays.asList(exception), false, Collections.singleton(streamIndex));
+          0, 0, Collections.singletonList(exception), false, Collections.singleton(streamIndex));
     }
 
     public static SimulatedExecutionTime stickyDatabaseNotFoundException(String name) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -432,12 +432,12 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
 
     public static SimulatedExecutionTime ofException(Exception exception) {
       return new SimulatedExecutionTime(
-          0, 0, Collections.singletonList(exception), false, Collections.<Long>emptySet());
+          0, 0, Collections.singletonList(exception), false, Collections.emptySet());
     }
 
     public static SimulatedExecutionTime ofStickyException(Exception exception) {
       return new SimulatedExecutionTime(
-          0, 0, Collections.singletonList(exception), true, Collections.<Long>emptySet());
+          0, 0, Collections.singletonList(exception), true, Collections.emptySet());
     }
 
     public static SimulatedExecutionTime ofStreamException(Exception exception, long streamIndex) {
@@ -451,7 +451,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
     }
 
     public static SimulatedExecutionTime ofExceptions(Collection<? extends Exception> exceptions) {
-      return new SimulatedExecutionTime(0, 0, exceptions, false, Collections.<Long>emptySet());
+      return new SimulatedExecutionTime(0, 0, exceptions, false, Collections.emptySet());
     }
 
     public static SimulatedExecutionTime ofMinimumAndRandomTimeAndExceptions(
@@ -459,16 +459,11 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
         int randomExecutionTime,
         Collection<? extends Exception> exceptions) {
       return new SimulatedExecutionTime(
-          minimumExecutionTime,
-          randomExecutionTime,
-          exceptions,
-          false,
-          Collections.<Long>emptySet());
+          minimumExecutionTime, randomExecutionTime, exceptions, false, Collections.emptySet());
     }
 
     private SimulatedExecutionTime(int minimum, int random) {
-      this(
-          minimum, random, Collections.<Exception>emptyList(), false, Collections.<Long>emptySet());
+      this(minimum, random, Collections.emptyList(), false, Collections.emptySet());
     }
 
     private SimulatedExecutionTime(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -83,7 +83,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -881,13 +880,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
         }
       }
       Collections.sort(
-          res,
-          new Comparator<Session>() {
-            @Override
-            public int compare(Session o1, Session o2) {
-              return o1.getName().compareTo(o2.getName());
-            }
-          });
+          res, (session1, session2) -> session1.getName().compareTo(session2.getName()));
       responseObserver.onNext(ListSessionsResponse.newBuilder().addAllSessions(res).build());
       responseObserver.onCompleted();
     } catch (StatusRuntimeException e) {
@@ -1420,13 +1413,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
       // Get or start transaction
       ByteString transactionId = getTransactionId(session, request.getTransaction());
       simulateAbort(session, transactionId);
-      Iterable<String> cols =
-          new Iterable<String>() {
-            @Override
-            public Iterator<String> iterator() {
-              return request.getColumnsList().iterator();
-            }
-          };
+      Iterable<String> cols = () -> request.getColumnsList().iterator();
       Statement statement =
           StatementResult.createReadStatement(
               request.getTable(),
@@ -1472,13 +1459,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
         }
       }
       simulateAbort(session, transactionId);
-      Iterable<String> cols =
-          new Iterable<String>() {
-            @Override
-            public Iterator<String> iterator() {
-              return request.getColumnsList().iterator();
-            }
-          };
+      Iterable<String> cols = () -> request.getColumnsList().iterator();
       Statement statement =
           StatementResult.createReadStatement(
               request.getTable(),

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OperationFutureUtil.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OperationFutureUtil.java
@@ -184,7 +184,7 @@ class OperationFutureUtil {
 
   public static <ResponseT> RetryingFuture<ResponseT> immediateRetryingFuture(
       final ResponseT response) {
-    return new ImmediateRetryingFuture(response);
+    return new ImmediateRetryingFuture<>(response);
   }
 
   public static <ResponseT extends Message, MetadataT extends Message>

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OperationFutureUtil.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OperationFutureUtil.java
@@ -79,7 +79,7 @@ class OperationFutureUtil {
     }
   }
 
-  public static final <ResponseT extends Message, MetadataT extends Message>
+  public static <ResponseT extends Message, MetadataT extends Message>
       OperationSnapshot completedSnapshot(
           final String name, final ResponseT response, final MetadataT metadata) {
     return new OperationSnapshot() {
@@ -182,12 +182,12 @@ class OperationFutureUtil {
     }
   }
 
-  public static final <ResponseT> RetryingFuture<ResponseT> immediateRetryingFuture(
+  public static <ResponseT> RetryingFuture<ResponseT> immediateRetryingFuture(
       final ResponseT response) {
     return new ImmediateRetryingFuture(response);
   }
 
-  public static final <ResponseT extends Message, MetadataT extends Message>
+  public static <ResponseT extends Message, MetadataT extends Message>
       OperationFuture<ResponseT, MetadataT> immediateOperationFuture(
           final String name, final ResponseT response, final MetadataT metadata) {
     return immediateOperationFuture(completedSnapshot(name, response, metadata));
@@ -201,7 +201,7 @@ class OperationFutureUtil {
    * respectively.
    */
   @SuppressWarnings("unchecked")
-  public static final <ResponseT, MetadataT>
+  public static <ResponseT, MetadataT>
       OperationFuture<ResponseT, MetadataT> immediateOperationFuture(
           final OperationSnapshot completedSnapshot) {
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OperationFutureUtil.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OperationFutureUtil.java
@@ -29,7 +29,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 // TODO(hzyi): add a public FakeOperationSnapshot in gax to support testing
 class OperationFutureUtil {
@@ -131,8 +130,7 @@ class OperationFutureUtil {
     }
 
     @Override
-    public V get(long time, TimeUnit unit)
-        throws ExecutionException, InterruptedException, TimeoutException {
+    public V get(long time, TimeUnit unit) throws ExecutionException, InterruptedException {
       return get();
     }
 
@@ -247,7 +245,7 @@ class OperationFutureUtil {
 
       @Override
       public ResponseT get(long time, TimeUnit unit)
-          throws ExecutionException, InterruptedException, TimeoutException {
+          throws ExecutionException, InterruptedException {
         return get();
       }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/PartitionedDmlTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/PartitionedDmlTransactionTest.java
@@ -288,7 +288,7 @@ public class PartitionedDmlTransactionTest {
               long ticks = 0L;
 
               @Override
-              public Long answer(InvocationOnMock invocation) throws Throwable {
+              public Long answer(InvocationOnMock invocation) {
                 return TimeUnit.NANOSECONDS.convert(++ticks, TimeUnit.MINUTES);
               }
             });

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RandomResultSetGenerator.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RandomResultSetGenerator.java
@@ -71,7 +71,7 @@ public class RandomResultSetGenerator {
             .build(),
       };
 
-  private static final ResultSetMetadata generateMetadata() {
+  private static ResultSetMetadata generateMetadata() {
     StructType.Builder rowTypeBuilder = StructType.newBuilder();
     for (int col = 0; col < TYPES.length; col++) {
       rowTypeBuilder.addFields(Field.newBuilder().setName("COL" + col).setType(TYPES[col])).build();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadAsyncTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadAsyncTest.java
@@ -372,8 +372,7 @@ public class ReadAsyncTest {
                 resultSet -> {
                   try {
                     // Make sure the uneven result set has returned the first before we start the
-                    // even
-                    // results.
+                    // even results.
                     unevenReturnedFirstRow.await();
                     while (true) {
                       switch (resultSet.tryNext()) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadAsyncTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadAsyncTest.java
@@ -36,6 +36,7 @@ import io.grpc.Status;
 import io.grpc.inprocess.InProcessServerBuilder;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
@@ -319,11 +320,8 @@ public class ReadAsyncTest {
             input ->
                 Iterables.mergeSorted(
                     input,
-                    (o1, o2) -> {
-                      // Return in numerical order (i.e. without the preceding 'v').
-                      return Integer.valueOf(o1.substring(1))
-                          .compareTo(Integer.valueOf(o2.substring(1)));
-                    }),
+                    // Return in numerical order (i.e. without the preceding 'v').
+                    Comparator.comparing(o -> Integer.valueOf(o.substring(1)))),
             executor);
     assertThat(allValues.get()).containsExactly("v1", "v2", "v3", "v10", "v11", "v12");
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadFormatTestRunner.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadFormatTestRunner.java
@@ -181,7 +181,7 @@ public class ReadFormatTestRunner extends ParentRunner<JSONObject> {
       }
     }
 
-    private List<?> getRawList(Struct actualRow, int index, Type elementType) throws Exception {
+    private List<?> getRawList(Struct actualRow, int index, Type elementType) {
       List<?> rawList = null;
       switch (elementType.getCode()) {
         case BOOL:

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadFormatTestRunner.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadFormatTestRunner.java
@@ -101,7 +101,7 @@ public class ReadFormatTestRunner extends ParentRunner<JSONObject> {
     }
   }
 
-  private class TestCaseRunner {
+  private static class TestCaseRunner {
     private AbstractResultSet.GrpcResultSet resultSet;
     private SpannerRpc.ResultStreamConsumer consumer;
     private AbstractResultSet.GrpcStreamIterator stream;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadWriteTransactionWithInlineBeginTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadWriteTransactionWithInlineBeginTest.java
@@ -120,7 +120,7 @@ public class ReadWriteTransactionWithInlineBeginTest {
   }
 
   @Before
-  public void setUp() throws IOException {
+  public void setUp() {
     mockSpanner.reset();
     mockSpanner.removeAllExecutionTimes();
     spanner =
@@ -134,7 +134,7 @@ public class ReadWriteTransactionWithInlineBeginTest {
   }
 
   @After
-  public void tearDown() throws Exception {
+  public void tearDown() {
     spanner.close();
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ResultSetsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ResultSetsTest.java
@@ -27,7 +27,6 @@ import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.AsyncResultSet.CallbackResponse;
-import com.google.cloud.spanner.AsyncResultSet.ReadyCallback;
 import com.google.common.primitives.Booleans;
 import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Longs;
@@ -412,19 +411,16 @@ public class ResultSetsTest {
     ApiFuture<Void> fut =
         rs.setCallback(
             MoreExecutors.directExecutor(),
-            new ReadyCallback() {
-              @Override
-              public CallbackResponse cursorReady(AsyncResultSet resultSet) {
-                while (true) {
-                  switch (resultSet.tryNext()) {
-                    case DONE:
-                      return CallbackResponse.DONE;
-                    case NOT_READY:
-                      return CallbackResponse.CONTINUE;
-                    case OK:
-                      count.incrementAndGet();
-                      assertThat(resultSet.getString("f1")).isEqualTo("x");
-                  }
+            resultSet -> {
+              while (true) {
+                switch (resultSet.tryNext()) {
+                  case DONE:
+                    return CallbackResponse.DONE;
+                  case NOT_READY:
+                    return CallbackResponse.CONTINUE;
+                  case OK:
+                    count.incrementAndGet();
+                    assertThat(resultSet.getString("f1")).isEqualTo("x");
                 }
               }
             });
@@ -458,19 +454,16 @@ public class ResultSetsTest {
     ApiFuture<Void> fut =
         rs.setCallback(
             MoreExecutors.directExecutor(),
-            new ReadyCallback() {
-              @Override
-              public CallbackResponse cursorReady(AsyncResultSet resultSet) {
-                while (true) {
-                  switch (resultSet.tryNext()) {
-                    case DONE:
-                      return CallbackResponse.DONE;
-                    case NOT_READY:
-                      return CallbackResponse.CONTINUE;
-                    case OK:
-                      count.incrementAndGet();
-                      assertThat(resultSet.getString("f1")).isEqualTo("x");
-                  }
+            resultSet -> {
+              while (true) {
+                switch (resultSet.tryNext()) {
+                  case DONE:
+                    return CallbackResponse.DONE;
+                  case NOT_READY:
+                    return CallbackResponse.CONTINUE;
+                  case OK:
+                    count.incrementAndGet();
+                    assertThat(resultSet.getString("f1")).isEqualTo("x");
                 }
               }
             });
@@ -506,19 +499,16 @@ public class ResultSetsTest {
     ApiFuture<Void> fut =
         rs.setCallback(
             MoreExecutors.directExecutor(),
-            new ReadyCallback() {
-              @Override
-              public CallbackResponse cursorReady(AsyncResultSet resultSet) {
-                while (true) {
-                  switch (resultSet.tryNext()) {
-                    case DONE:
-                      return CallbackResponse.DONE;
-                    case NOT_READY:
-                      return CallbackResponse.CONTINUE;
-                    case OK:
-                      count.incrementAndGet();
-                      assertThat(resultSet.getString("f1")).isEqualTo("x");
-                  }
+            resultSet -> {
+              while (true) {
+                switch (resultSet.tryNext()) {
+                  case DONE:
+                    return CallbackResponse.DONE;
+                  case NOT_READY:
+                    return CallbackResponse.CONTINUE;
+                  case OK:
+                    count.incrementAndGet();
+                    assertThat(resultSet.getString("f1")).isEqualTo("x");
                 }
               }
             });

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ResultSetsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ResultSetsTest.java
@@ -375,7 +375,7 @@ public class ResultSetsTest {
     ResultSet rs =
         ResultSets.forRows(
             Type.struct(Type.StructField.of("f1", Type.string())),
-            Arrays.asList(Struct.newBuilder().set("f1").to("x").build()));
+            Collections.singletonList(Struct.newBuilder().set("f1").to("x").build()));
     rs.close();
     try {
       rs.getCurrentRowAsStruct();
@@ -390,7 +390,7 @@ public class ResultSetsTest {
     ResultSet rs =
         ResultSets.forRows(
             Type.struct(Type.StructField.of("f1", Type.string())),
-            Arrays.asList(Struct.newBuilder().set("f1").to("x").build()));
+            Collections.singletonList(Struct.newBuilder().set("f1").to("x").build()));
     try {
       rs.getCurrentRowAsStruct();
       fail("Expected exception");
@@ -404,7 +404,7 @@ public class ResultSetsTest {
     ResultSet delegate =
         ResultSets.forRows(
             Type.struct(Type.StructField.of("f1", Type.string())),
-            Arrays.asList(Struct.newBuilder().set("f1").to("x").build()));
+            Collections.singletonList(Struct.newBuilder().set("f1").to("x").build()));
 
     final AtomicInteger count = new AtomicInteger();
     AsyncResultSet rs = ResultSets.toAsyncResultSet(delegate);
@@ -433,7 +433,7 @@ public class ResultSetsTest {
     ResultSet delegate =
         ResultSets.forRows(
             Type.struct(Type.StructField.of("f1", Type.string())),
-            Arrays.asList(Struct.newBuilder().set("f1").to("x").build()));
+            Collections.singletonList(Struct.newBuilder().set("f1").to("x").build()));
 
     ExecutorProvider provider =
         new ExecutorProvider() {
@@ -478,7 +478,7 @@ public class ResultSetsTest {
         ApiFutures.immediateFuture(
             ResultSets.forRows(
                 Type.struct(Type.StructField.of("f1", Type.string())),
-                Arrays.asList(Struct.newBuilder().set("f1").to("x").build())));
+                Collections.singletonList(Struct.newBuilder().set("f1").to("x").build())));
 
     ExecutorProvider provider =
         new ExecutorProvider() {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RetryOnInvalidatedSessionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RetryOnInvalidatedSessionTest.java
@@ -1640,8 +1640,7 @@ public class RetryOnInvalidatedSessionTest {
               context.then(
                   new AsyncTransactionFunction<Void, Long>() {
                     @Override
-                    public ApiFuture<Long> apply(TransactionContext txn, Void input)
-                        throws Exception {
+                    public ApiFuture<Long> apply(TransactionContext txn, Void input) {
                       AsyncResultSet rs = fn.apply(txn);
                       ApiFuture<Void> fut =
                           rs.setCallback(
@@ -1735,8 +1734,7 @@ public class RetryOnInvalidatedSessionTest {
               context.then(
                   new AsyncTransactionFunction<Void, Long>() {
                     @Override
-                    public ApiFuture<Long> apply(TransactionContext txn, Void input)
-                        throws Exception {
+                    public ApiFuture<Long> apply(TransactionContext txn, Void input) {
                       long counter = 0L;
                       try (ResultSet rs = fn.apply(txn)) {
                         while (rs.next()) {
@@ -1821,8 +1819,7 @@ public class RetryOnInvalidatedSessionTest {
               context.then(
                   new AsyncTransactionFunction<Void, Struct>() {
                     @Override
-                    public ApiFuture<Struct> apply(TransactionContext txn, Void input)
-                        throws Exception {
+                    public ApiFuture<Struct> apply(TransactionContext txn, Void input) {
                       return fn.apply(txn);
                     }
                   },
@@ -1903,7 +1900,7 @@ public class RetryOnInvalidatedSessionTest {
               transaction.then(
                   new AsyncTransactionFunction<Void, T>() {
                     @Override
-                    public ApiFuture<T> apply(TransactionContext txn, Void input) throws Exception {
+                    public ApiFuture<T> apply(TransactionContext txn, Void input) {
                       return fn.apply(txn);
                     }
                   },

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RetryOnInvalidatedSessionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RetryOnInvalidatedSessionTest.java
@@ -53,6 +53,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -169,10 +170,14 @@ public class RetryOnInvalidatedSessionTest {
     mockSpanner = new MockSpannerServiceImpl();
     mockSpanner.setAbortProbability(0.0D); // We don't want any unpredictable aborted transactions.
     mockSpanner.putStatementResult(
-        StatementResult.read("FOO", KeySet.all(), Arrays.asList("BAR"), READ_RESULTSET));
+        StatementResult.read(
+            "FOO", KeySet.all(), Collections.singletonList("BAR"), READ_RESULTSET));
     mockSpanner.putStatementResult(
         StatementResult.read(
-            "FOO", KeySet.singleKey(Key.of()), Arrays.asList("BAR"), READ_ROW_RESULTSET));
+            "FOO",
+            KeySet.singleKey(Key.of()),
+            Collections.singletonList("BAR"),
+            READ_ROW_RESULTSET));
     mockSpanner.putStatementResult(StatementResult.query(SELECT1AND2, SELECT1_RESULTSET));
     mockSpanner.putStatementResult(StatementResult.update(UPDATE_STATEMENT, UPDATE_COUNT));
 
@@ -287,7 +292,7 @@ public class RetryOnInvalidatedSessionTest {
     invalidateSessionPool();
     int count = 0;
     try (ReadContext context = client.singleUse()) {
-      try (ResultSet rs = context.read("FOO", KeySet.all(), Arrays.asList("BAR"))) {
+      try (ResultSet rs = context.read("FOO", KeySet.all(), Collections.singletonList("BAR"))) {
         while (rs.next()) {
           count++;
         }
@@ -305,7 +310,7 @@ public class RetryOnInvalidatedSessionTest {
     int count = 0;
     try (ReadContext context = client.singleUse()) {
       try (ResultSet rs =
-          context.readUsingIndex("FOO", "IDX", KeySet.all(), Arrays.asList("BAR"))) {
+          context.readUsingIndex("FOO", "IDX", KeySet.all(), Collections.singletonList("BAR"))) {
         while (rs.next()) {
           count++;
         }
@@ -321,7 +326,7 @@ public class RetryOnInvalidatedSessionTest {
   public void singleUseReadRow() throws InterruptedException {
     invalidateSessionPool();
     try (ReadContext context = client.singleUse()) {
-      Struct row = context.readRow("FOO", Key.of(), Arrays.asList("BAR"));
+      Struct row = context.readRow("FOO", Key.of(), Collections.singletonList("BAR"));
       assertThat(row.getLong(0)).isEqualTo(1L);
       assertThat(failOnInvalidatedSession).isFalse();
     } catch (SessionNotFoundException e) {
@@ -333,7 +338,8 @@ public class RetryOnInvalidatedSessionTest {
   public void singleUseReadRowUsingIndex() throws InterruptedException {
     invalidateSessionPool();
     try (ReadContext context = client.singleUse()) {
-      Struct row = context.readRowUsingIndex("FOO", "IDX", Key.of(), Arrays.asList("BAR"));
+      Struct row =
+          context.readRowUsingIndex("FOO", "IDX", Key.of(), Collections.singletonList("BAR"));
       assertThat(row.getLong(0)).isEqualTo(1L);
       assertThat(failOnInvalidatedSession).isFalse();
     } catch (SessionNotFoundException e) {
@@ -363,7 +369,7 @@ public class RetryOnInvalidatedSessionTest {
     invalidateSessionPool();
     int count = 0;
     try (ReadContext context = client.singleUseReadOnlyTransaction()) {
-      try (ResultSet rs = context.read("FOO", KeySet.all(), Arrays.asList("BAR"))) {
+      try (ResultSet rs = context.read("FOO", KeySet.all(), Collections.singletonList("BAR"))) {
         while (rs.next()) {
           count++;
         }
@@ -381,7 +387,7 @@ public class RetryOnInvalidatedSessionTest {
     int count = 0;
     try (ReadContext context = client.singleUseReadOnlyTransaction()) {
       try (ResultSet rs =
-          context.readUsingIndex("FOO", "IDX", KeySet.all(), Arrays.asList("BAR"))) {
+          context.readUsingIndex("FOO", "IDX", KeySet.all(), Collections.singletonList("BAR"))) {
         while (rs.next()) {
           count++;
         }
@@ -397,7 +403,7 @@ public class RetryOnInvalidatedSessionTest {
   public void singleUseReadOnlyTransactionReadRow() throws InterruptedException {
     invalidateSessionPool();
     try (ReadContext context = client.singleUseReadOnlyTransaction()) {
-      Struct row = context.readRow("FOO", Key.of(), Arrays.asList("BAR"));
+      Struct row = context.readRow("FOO", Key.of(), Collections.singletonList("BAR"));
       assertThat(row.getLong(0)).isEqualTo(1L);
       assertThat(failOnInvalidatedSession).isFalse();
     } catch (SessionNotFoundException e) {
@@ -409,7 +415,8 @@ public class RetryOnInvalidatedSessionTest {
   public void singleUseReadOnlyTransactionReadRowUsingIndex() throws InterruptedException {
     invalidateSessionPool();
     try (ReadContext context = client.singleUseReadOnlyTransaction()) {
-      Struct row = context.readRowUsingIndex("FOO", "IDX", Key.of(), Arrays.asList("BAR"));
+      Struct row =
+          context.readRowUsingIndex("FOO", "IDX", Key.of(), Collections.singletonList("BAR"));
       assertThat(row.getLong(0)).isEqualTo(1L);
       assertThat(failOnInvalidatedSession).isFalse();
     } catch (SessionNotFoundException e) {
@@ -439,7 +446,7 @@ public class RetryOnInvalidatedSessionTest {
     invalidateSessionPool();
     int count = 0;
     try (ReadContext context = client.readOnlyTransaction()) {
-      try (ResultSet rs = context.read("FOO", KeySet.all(), Arrays.asList("BAR"))) {
+      try (ResultSet rs = context.read("FOO", KeySet.all(), Collections.singletonList("BAR"))) {
         while (rs.next()) {
           count++;
         }
@@ -457,7 +464,7 @@ public class RetryOnInvalidatedSessionTest {
     int count = 0;
     try (ReadContext context = client.readOnlyTransaction()) {
       try (ResultSet rs =
-          context.readUsingIndex("FOO", "IDX", KeySet.all(), Arrays.asList("BAR"))) {
+          context.readUsingIndex("FOO", "IDX", KeySet.all(), Collections.singletonList("BAR"))) {
         while (rs.next()) {
           count++;
         }
@@ -473,7 +480,7 @@ public class RetryOnInvalidatedSessionTest {
   public void readOnlyTransactionReadRow() throws InterruptedException {
     invalidateSessionPool();
     try (ReadContext context = client.readOnlyTransaction()) {
-      Struct row = context.readRow("FOO", Key.of(), Arrays.asList("BAR"));
+      Struct row = context.readRow("FOO", Key.of(), Collections.singletonList("BAR"));
       assertThat(row.getLong(0)).isEqualTo(1L);
       assertThat(failOnInvalidatedSession).isFalse();
     } catch (SessionNotFoundException e) {
@@ -485,7 +492,8 @@ public class RetryOnInvalidatedSessionTest {
   public void readOnlyTransactionReadRowUsingIndex() throws InterruptedException {
     invalidateSessionPool();
     try (ReadContext context = client.readOnlyTransaction()) {
-      Struct row = context.readRowUsingIndex("FOO", "IDX", Key.of(), Arrays.asList("BAR"));
+      Struct row =
+          context.readRowUsingIndex("FOO", "IDX", Key.of(), Collections.singletonList("BAR"));
       assertThat(row.getLong(0)).isEqualTo(1L);
       assertThat(failOnInvalidatedSession).isFalse();
     } catch (SessionNotFoundException e) {
@@ -517,14 +525,14 @@ public class RetryOnInvalidatedSessionTest {
   public void readOnlyTransactionReadNonRecoverable() throws InterruptedException {
     int count = 0;
     try (ReadContext context = client.readOnlyTransaction()) {
-      try (ResultSet rs = context.read("FOO", KeySet.all(), Arrays.asList("BAR"))) {
+      try (ResultSet rs = context.read("FOO", KeySet.all(), Collections.singletonList("BAR"))) {
         while (rs.next()) {
           count++;
         }
       }
       assertThat(count).isEqualTo(2);
       invalidateSessionPool();
-      try (ResultSet rs = context.read("FOO", KeySet.all(), Arrays.asList("BAR"))) {
+      try (ResultSet rs = context.read("FOO", KeySet.all(), Collections.singletonList("BAR"))) {
         while (rs.next()) {
           count++;
         }
@@ -537,7 +545,7 @@ public class RetryOnInvalidatedSessionTest {
     int count = 0;
     try (ReadContext context = client.readOnlyTransaction()) {
       try (ResultSet rs =
-          context.readUsingIndex("FOO", "IDX", KeySet.all(), Arrays.asList("BAR"))) {
+          context.readUsingIndex("FOO", "IDX", KeySet.all(), Collections.singletonList("BAR"))) {
         while (rs.next()) {
           count++;
         }
@@ -545,7 +553,7 @@ public class RetryOnInvalidatedSessionTest {
       assertThat(count).isEqualTo(2);
       invalidateSessionPool();
       try (ResultSet rs =
-          context.readUsingIndex("FOO", "IDX", KeySet.all(), Arrays.asList("BAR"))) {
+          context.readUsingIndex("FOO", "IDX", KeySet.all(), Collections.singletonList("BAR"))) {
         while (rs.next()) {
           count++;
         }
@@ -556,20 +564,21 @@ public class RetryOnInvalidatedSessionTest {
   @Test(expected = SessionNotFoundException.class)
   public void readOnlyTransactionReadRowNonRecoverable() throws InterruptedException {
     try (ReadContext context = client.readOnlyTransaction()) {
-      Struct row = context.readRow("FOO", Key.of(), Arrays.asList("BAR"));
+      Struct row = context.readRow("FOO", Key.of(), Collections.singletonList("BAR"));
       assertThat(row.getLong(0)).isEqualTo(1L);
       invalidateSessionPool();
-      row = context.readRow("FOO", Key.of(), Arrays.asList("BAR"));
+      row = context.readRow("FOO", Key.of(), Collections.singletonList("BAR"));
     }
   }
 
   @Test(expected = SessionNotFoundException.class)
   public void readOnlyTransactionReadRowUsingIndexNonRecoverable() throws InterruptedException {
     try (ReadContext context = client.readOnlyTransaction()) {
-      Struct row = context.readRowUsingIndex("FOO", "IDX", Key.of(), Arrays.asList("BAR"));
+      Struct row =
+          context.readRowUsingIndex("FOO", "IDX", Key.of(), Collections.singletonList("BAR"));
       assertThat(row.getLong(0)).isEqualTo(1L);
       invalidateSessionPool();
-      row = context.readRowUsingIndex("FOO", "IDX", Key.of(), Arrays.asList("BAR"));
+      row = context.readRowUsingIndex("FOO", "IDX", Key.of(), Collections.singletonList("BAR"));
     }
   }
 
@@ -642,7 +651,8 @@ public class RetryOnInvalidatedSessionTest {
           runner.run(
               transaction -> {
                 int count1 = 0;
-                try (ResultSet rs = transaction.read("FOO", KeySet.all(), Arrays.asList("BAR"))) {
+                try (ResultSet rs =
+                    transaction.read("FOO", KeySet.all(), Collections.singletonList("BAR"))) {
                   while (rs.next()) {
                     count1++;
                   }
@@ -666,7 +676,8 @@ public class RetryOnInvalidatedSessionTest {
               transaction -> {
                 int count1 = 0;
                 try (ResultSet rs =
-                    transaction.readUsingIndex("FOO", "IDX", KeySet.all(), Arrays.asList("BAR"))) {
+                    transaction.readUsingIndex(
+                        "FOO", "IDX", KeySet.all(), Collections.singletonList("BAR"))) {
                   while (rs.next()) {
                     count1++;
                   }
@@ -686,7 +697,9 @@ public class RetryOnInvalidatedSessionTest {
     try {
       TransactionRunner runner = client.readWriteTransaction();
       Struct row =
-          runner.run(transaction -> transaction.readRow("FOO", Key.of(), Arrays.asList("BAR")));
+          runner.run(
+              transaction ->
+                  transaction.readRow("FOO", Key.of(), Collections.singletonList("BAR")));
       assertThat(row.getLong(0)).isEqualTo(1L);
       assertThat(failOnInvalidatedSession).isFalse();
     } catch (SessionNotFoundException e) {
@@ -702,7 +715,8 @@ public class RetryOnInvalidatedSessionTest {
       Struct row =
           runner.run(
               transaction ->
-                  transaction.readRowUsingIndex("FOO", "IDX", Key.of(), Arrays.asList("BAR")));
+                  transaction.readRowUsingIndex(
+                      "FOO", "IDX", Key.of(), Collections.singletonList("BAR")));
       assertThat(row.getLong(0)).isEqualTo(1L);
       assertThat(failOnInvalidatedSession).isFalse();
     } catch (SessionNotFoundException e) {
@@ -729,7 +743,8 @@ public class RetryOnInvalidatedSessionTest {
     try {
       TransactionRunner runner = client.readWriteTransaction();
       long[] count =
-          runner.run(transaction -> transaction.batchUpdate(Arrays.asList(UPDATE_STATEMENT)));
+          runner.run(
+              transaction -> transaction.batchUpdate(Collections.singletonList(UPDATE_STATEMENT)));
       assertThat(count.length).isEqualTo(1);
       assertThat(count[0]).isEqualTo(UPDATE_COUNT);
       assertThat(failOnInvalidatedSession).isFalse();
@@ -805,7 +820,8 @@ public class RetryOnInvalidatedSessionTest {
                 public Integer run(TransactionContext transaction) throws Exception {
                   attempt++;
                   int count = 0;
-                  try (ResultSet rs = transaction.read("FOO", KeySet.all(), Arrays.asList("BAR"))) {
+                  try (ResultSet rs =
+                      transaction.read("FOO", KeySet.all(), Collections.singletonList("BAR"))) {
                     while (rs.next()) {
                       count++;
                     }
@@ -814,7 +830,8 @@ public class RetryOnInvalidatedSessionTest {
                   if (attempt == 1) {
                     invalidateSessionPool();
                   }
-                  try (ResultSet rs = transaction.read("FOO", KeySet.all(), Arrays.asList("BAR"))) {
+                  try (ResultSet rs =
+                      transaction.read("FOO", KeySet.all(), Collections.singletonList("BAR"))) {
                     while (rs.next()) {
                       count++;
                     }
@@ -844,7 +861,7 @@ public class RetryOnInvalidatedSessionTest {
                   int count = 0;
                   try (ResultSet rs =
                       transaction.readUsingIndex(
-                          "FOO", "IDX", KeySet.all(), Arrays.asList("BAR"))) {
+                          "FOO", "IDX", KeySet.all(), Collections.singletonList("BAR"))) {
                     while (rs.next()) {
                       count++;
                     }
@@ -855,7 +872,7 @@ public class RetryOnInvalidatedSessionTest {
                   }
                   try (ResultSet rs =
                       transaction.readUsingIndex(
-                          "FOO", "IDX", KeySet.all(), Arrays.asList("BAR"))) {
+                          "FOO", "IDX", KeySet.all(), Collections.singletonList("BAR"))) {
                     while (rs.next()) {
                       count++;
                     }
@@ -882,12 +899,13 @@ public class RetryOnInvalidatedSessionTest {
                 @Override
                 public Integer run(TransactionContext transaction) throws Exception {
                   attempt++;
-                  Struct row = transaction.readRow("FOO", Key.of(), Arrays.asList("BAR"));
+                  Struct row =
+                      transaction.readRow("FOO", Key.of(), Collections.singletonList("BAR"));
                   assertThat(row.getLong(0)).isEqualTo(1L);
                   if (attempt == 1) {
                     invalidateSessionPool();
                   }
-                  row = transaction.readRow("FOO", Key.of(), Arrays.asList("BAR"));
+                  row = transaction.readRow("FOO", Key.of(), Collections.singletonList("BAR"));
                   return attempt;
                 }
               });
@@ -911,12 +929,15 @@ public class RetryOnInvalidatedSessionTest {
                 public Integer run(TransactionContext transaction) throws Exception {
                   attempt++;
                   Struct row =
-                      transaction.readRowUsingIndex("FOO", "IDX", Key.of(), Arrays.asList("BAR"));
+                      transaction.readRowUsingIndex(
+                          "FOO", "IDX", Key.of(), Collections.singletonList("BAR"));
                   assertThat(row.getLong(0)).isEqualTo(1L);
                   if (attempt == 1) {
                     invalidateSessionPool();
                   }
-                  row = transaction.readRowUsingIndex("FOO", "IDX", Key.of(), Arrays.asList("BAR"));
+                  row =
+                      transaction.readRowUsingIndex(
+                          "FOO", "IDX", Key.of(), Collections.singletonList("BAR"));
                   return attempt;
                 }
               });
@@ -1011,7 +1032,8 @@ public class RetryOnInvalidatedSessionTest {
       TransactionContext transaction = manager.begin();
       while (true) {
         try {
-          try (ResultSet rs = transaction.read("FOO", KeySet.all(), Arrays.asList("BAR"))) {
+          try (ResultSet rs =
+              transaction.read("FOO", KeySet.all(), Collections.singletonList("BAR"))) {
             while (rs.next()) {
               count++;
             }
@@ -1040,7 +1062,8 @@ public class RetryOnInvalidatedSessionTest {
       while (true) {
         try {
           try (ResultSet rs =
-              transaction.readUsingIndex("FOO", "IDX", KeySet.all(), Arrays.asList("BAR"))) {
+              transaction.readUsingIndex(
+                  "FOO", "IDX", KeySet.all(), Collections.singletonList("BAR"))) {
             while (rs.next()) {
               count++;
             }
@@ -1068,7 +1091,7 @@ public class RetryOnInvalidatedSessionTest {
       TransactionContext transaction = manager.begin();
       while (true) {
         try {
-          row = transaction.readRow("FOO", Key.of(), Arrays.asList("BAR"));
+          row = transaction.readRow("FOO", Key.of(), Collections.singletonList("BAR"));
           manager.commit();
           break;
         } catch (AbortedException e) {
@@ -1092,7 +1115,9 @@ public class RetryOnInvalidatedSessionTest {
       TransactionContext transaction = manager.begin();
       while (true) {
         try {
-          row = transaction.readRowUsingIndex("FOO", "IDX", Key.of(), Arrays.asList("BAR"));
+          row =
+              transaction.readRowUsingIndex(
+                  "FOO", "IDX", Key.of(), Collections.singletonList("BAR"));
           manager.commit();
           break;
         } catch (AbortedException e) {
@@ -1176,7 +1201,7 @@ public class RetryOnInvalidatedSessionTest {
       TransactionContext transaction = manager.begin();
       while (true) {
         try {
-          count = transaction.batchUpdate(Arrays.asList(UPDATE_STATEMENT));
+          count = transaction.batchUpdate(Collections.singletonList(UPDATE_STATEMENT));
           manager.commit();
           break;
         } catch (AbortedException e) {
@@ -1263,7 +1288,8 @@ public class RetryOnInvalidatedSessionTest {
         attempts++;
         int count = 0;
         try {
-          try (ResultSet rs = transaction.read("FOO", KeySet.all(), Arrays.asList("BAR"))) {
+          try (ResultSet rs =
+              transaction.read("FOO", KeySet.all(), Collections.singletonList("BAR"))) {
             while (rs.next()) {
               count++;
             }
@@ -1272,7 +1298,8 @@ public class RetryOnInvalidatedSessionTest {
           if (attempts == 1) {
             invalidateSessionPool();
           }
-          try (ResultSet rs = transaction.read("FOO", KeySet.all(), Arrays.asList("BAR"))) {
+          try (ResultSet rs =
+              transaction.read("FOO", KeySet.all(), Collections.singletonList("BAR"))) {
             while (rs.next()) {
               count++;
             }
@@ -1303,7 +1330,8 @@ public class RetryOnInvalidatedSessionTest {
         int count = 0;
         try {
           try (ResultSet rs =
-              transaction.readUsingIndex("FOO", "IDX", KeySet.all(), Arrays.asList("BAR"))) {
+              transaction.readUsingIndex(
+                  "FOO", "IDX", KeySet.all(), Collections.singletonList("BAR"))) {
             while (rs.next()) {
               count++;
             }
@@ -1313,7 +1341,8 @@ public class RetryOnInvalidatedSessionTest {
             invalidateSessionPool();
           }
           try (ResultSet rs =
-              transaction.readUsingIndex("FOO", "IDX", KeySet.all(), Arrays.asList("BAR"))) {
+              transaction.readUsingIndex(
+                  "FOO", "IDX", KeySet.all(), Collections.singletonList("BAR"))) {
             while (rs.next()) {
               count++;
             }
@@ -1341,12 +1370,12 @@ public class RetryOnInvalidatedSessionTest {
       while (true) {
         attempts++;
         try {
-          Struct row = transaction.readRow("FOO", Key.of(), Arrays.asList("BAR"));
+          Struct row = transaction.readRow("FOO", Key.of(), Collections.singletonList("BAR"));
           assertThat(row.getLong(0)).isEqualTo(1L);
           if (attempts == 1) {
             invalidateSessionPool();
           }
-          row = transaction.readRow("FOO", Key.of(), Arrays.asList("BAR"));
+          row = transaction.readRow("FOO", Key.of(), Collections.singletonList("BAR"));
           manager.commit();
           break;
         } catch (AbortedException e) {
@@ -1371,12 +1400,16 @@ public class RetryOnInvalidatedSessionTest {
       while (true) {
         attempts++;
         try {
-          Struct row = transaction.readRowUsingIndex("FOO", "IDX", Key.of(), Arrays.asList("BAR"));
+          Struct row =
+              transaction.readRowUsingIndex(
+                  "FOO", "IDX", Key.of(), Collections.singletonList("BAR"));
           assertThat(row.getLong(0)).isEqualTo(1L);
           if (attempts == 1) {
             invalidateSessionPool();
           }
-          row = transaction.readRowUsingIndex("FOO", "IDX", Key.of(), Arrays.asList("BAR"));
+          row =
+              transaction.readRowUsingIndex(
+                  "FOO", "IDX", Key.of(), Collections.singletonList("BAR"));
           manager.commit();
           break;
         } catch (AbortedException e) {
@@ -1406,7 +1439,8 @@ public class RetryOnInvalidatedSessionTest {
   public void write() throws InterruptedException {
     invalidateSessionPool();
     try {
-      Timestamp timestamp = client.write(Arrays.asList(Mutation.delete("FOO", KeySet.all())));
+      Timestamp timestamp =
+          client.write(Collections.singletonList(Mutation.delete("FOO", KeySet.all())));
       assertThat(timestamp).isNotNull();
       assertThat(failOnInvalidatedSession).isFalse();
     } catch (SessionNotFoundException e) {
@@ -1419,7 +1453,7 @@ public class RetryOnInvalidatedSessionTest {
     invalidateSessionPool();
     try {
       Timestamp timestamp =
-          client.writeAtLeastOnce(Arrays.asList(Mutation.delete("FOO", KeySet.all())));
+          client.writeAtLeastOnce(Collections.singletonList(Mutation.delete("FOO", KeySet.all())));
       assertThat(timestamp).isNotNull();
       assertThat(failOnInvalidatedSession).isFalse();
     } catch (SessionNotFoundException e) {
@@ -1435,13 +1469,15 @@ public class RetryOnInvalidatedSessionTest {
   @Test
   public void asyncRunnerRead() throws InterruptedException {
     asyncRunner_withReadFunction(
-        input -> input.readAsync("FOO", KeySet.all(), Arrays.asList("BAR")));
+        input -> input.readAsync("FOO", KeySet.all(), Collections.singletonList("BAR")));
   }
 
   @Test
   public void asyncRunnerReadUsingIndex() throws InterruptedException {
     asyncRunner_withReadFunction(
-        input -> input.readUsingIndexAsync("FOO", "IDX", KeySet.all(), Arrays.asList("BAR")));
+        input ->
+            input.readUsingIndexAsync(
+                "FOO", "IDX", KeySet.all(), Collections.singletonList("BAR")));
   }
 
   private void asyncRunner_withReadFunction(
@@ -1490,7 +1526,8 @@ public class RetryOnInvalidatedSessionTest {
     try {
       AsyncRunner runner = client.runAsync();
       ApiFuture<Struct> row =
-          runner.runAsync(txn -> txn.readRowAsync("FOO", Key.of(), Arrays.asList("BAR")), executor);
+          runner.runAsync(
+              txn -> txn.readRowAsync("FOO", Key.of(), Collections.singletonList("BAR")), executor);
       assertThat(get(row).getLong(0)).isEqualTo(1L);
       assertThat(failOnInvalidatedSession).isFalse();
     } catch (SessionNotFoundException e) {
@@ -1505,7 +1542,9 @@ public class RetryOnInvalidatedSessionTest {
       AsyncRunner runner = client.runAsync();
       ApiFuture<Struct> row =
           runner.runAsync(
-              txn -> txn.readRowUsingIndexAsync("FOO", "IDX", Key.of(), Arrays.asList("BAR")),
+              txn ->
+                  txn.readRowUsingIndexAsync(
+                      "FOO", "IDX", Key.of(), Collections.singletonList("BAR")),
               executor);
       assertThat(get(row).getLong(0)).isEqualTo(1L);
       assertThat(failOnInvalidatedSession).isFalse();
@@ -1573,13 +1612,15 @@ public class RetryOnInvalidatedSessionTest {
   @Test
   public void asyncTransactionManagerAsyncRead() throws InterruptedException {
     asyncTransactionManager_readAsync(
-        input -> input.readAsync("FOO", KeySet.all(), Arrays.asList("BAR")));
+        input -> input.readAsync("FOO", KeySet.all(), Collections.singletonList("BAR")));
   }
 
   @Test
   public void asyncTransactionManagerAsyncReadUsingIndex() throws InterruptedException {
     asyncTransactionManager_readAsync(
-        input -> input.readUsingIndexAsync("FOO", "idx", KeySet.all(), Arrays.asList("BAR")));
+        input ->
+            input.readUsingIndexAsync(
+                "FOO", "idx", KeySet.all(), Collections.singletonList("BAR")));
   }
 
   private void asyncTransactionManager_readAsync(
@@ -1639,13 +1680,14 @@ public class RetryOnInvalidatedSessionTest {
   @Test
   public void asyncTransactionManagerRead() throws InterruptedException {
     asyncTransactionManager_readSync(
-        input -> input.read("FOO", KeySet.all(), Arrays.asList("BAR")));
+        input -> input.read("FOO", KeySet.all(), Collections.singletonList("BAR")));
   }
 
   @Test
   public void asyncTransactionManagerReadUsingIndex() throws InterruptedException {
     asyncTransactionManager_readSync(
-        input -> input.readUsingIndex("FOO", "idx", KeySet.all(), Arrays.asList("BAR")));
+        input ->
+            input.readUsingIndex("FOO", "idx", KeySet.all(), Collections.singletonList("BAR")));
   }
 
   private void asyncTransactionManager_readSync(final Function<TransactionContext, ResultSet> fn)
@@ -1688,7 +1730,8 @@ public class RetryOnInvalidatedSessionTest {
   public void asyncTransactionManagerReadRow() throws InterruptedException {
     asyncTransactionManager_readRowFunction(
         input ->
-            ApiFutures.immediateFuture(input.readRow("FOO", Key.of("foo"), Arrays.asList("BAR"))));
+            ApiFutures.immediateFuture(
+                input.readRow("FOO", Key.of("foo"), Collections.singletonList("BAR"))));
   }
 
   @Test
@@ -1696,19 +1739,22 @@ public class RetryOnInvalidatedSessionTest {
     asyncTransactionManager_readRowFunction(
         input ->
             ApiFutures.immediateFuture(
-                input.readRowUsingIndex("FOO", "idx", Key.of("foo"), Arrays.asList("BAR"))));
+                input.readRowUsingIndex(
+                    "FOO", "idx", Key.of("foo"), Collections.singletonList("BAR"))));
   }
 
   @Test
   public void asyncTransactionManagerReadRowAsync() throws InterruptedException {
     asyncTransactionManager_readRowFunction(
-        input -> input.readRowAsync("FOO", Key.of("foo"), Arrays.asList("BAR")));
+        input -> input.readRowAsync("FOO", Key.of("foo"), Collections.singletonList("BAR")));
   }
 
   @Test
   public void asyncTransactionManagerReadRowUsingIndexAsync() throws InterruptedException {
     asyncTransactionManager_readRowFunction(
-        input -> input.readRowUsingIndexAsync("FOO", "idx", Key.of("foo"), Arrays.asList("BAR")));
+        input ->
+            input.readRowUsingIndexAsync(
+                "FOO", "idx", Key.of("foo"), Collections.singletonList("BAR")));
   }
 
   private void asyncTransactionManager_readRowFunction(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RetryOnInvalidatedSessionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RetryOnInvalidatedSessionTest.java
@@ -567,7 +567,7 @@ public class RetryOnInvalidatedSessionTest {
       Struct row = context.readRow("FOO", Key.of(), Collections.singletonList("BAR"));
       assertThat(row.getLong(0)).isEqualTo(1L);
       invalidateSessionPool();
-      row = context.readRow("FOO", Key.of(), Collections.singletonList("BAR"));
+      context.readRow("FOO", Key.of(), Collections.singletonList("BAR"));
     }
   }
 
@@ -578,7 +578,7 @@ public class RetryOnInvalidatedSessionTest {
           context.readRowUsingIndex("FOO", "IDX", Key.of(), Collections.singletonList("BAR"));
       assertThat(row.getLong(0)).isEqualTo(1L);
       invalidateSessionPool();
-      row = context.readRowUsingIndex("FOO", "IDX", Key.of(), Collections.singletonList("BAR"));
+      context.readRowUsingIndex("FOO", "IDX", Key.of(), Collections.singletonList("BAR"));
     }
   }
 
@@ -905,7 +905,7 @@ public class RetryOnInvalidatedSessionTest {
                   if (attempt == 1) {
                     invalidateSessionPool();
                   }
-                  row = transaction.readRow("FOO", Key.of(), Collections.singletonList("BAR"));
+                  transaction.readRow("FOO", Key.of(), Collections.singletonList("BAR"));
                   return attempt;
                 }
               });
@@ -935,9 +935,8 @@ public class RetryOnInvalidatedSessionTest {
                   if (attempt == 1) {
                     invalidateSessionPool();
                   }
-                  row =
-                      transaction.readRowUsingIndex(
-                          "FOO", "IDX", Key.of(), Collections.singletonList("BAR"));
+                  transaction.readRowUsingIndex(
+                      "FOO", "IDX", Key.of(), Collections.singletonList("BAR"));
                   return attempt;
                 }
               });
@@ -1375,7 +1374,7 @@ public class RetryOnInvalidatedSessionTest {
           if (attempts == 1) {
             invalidateSessionPool();
           }
-          row = transaction.readRow("FOO", Key.of(), Collections.singletonList("BAR"));
+          transaction.readRow("FOO", Key.of(), Collections.singletonList("BAR"));
           manager.commit();
           break;
         } catch (AbortedException e) {
@@ -1407,9 +1406,7 @@ public class RetryOnInvalidatedSessionTest {
           if (attempts == 1) {
             invalidateSessionPool();
           }
-          row =
-              transaction.readRowUsingIndex(
-                  "FOO", "IDX", Key.of(), Collections.singletonList("BAR"));
+          transaction.readRowUsingIndex("FOO", "IDX", Key.of(), Collections.singletonList("BAR"));
           manager.commit();
           break;
         } catch (AbortedException e) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionClientTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionClientTest.java
@@ -204,7 +204,7 @@ public class SessionClientTest {
   public void batchCreateSessionsDistributesMultipleRequestsOverChannels() {
     DatabaseId db = DatabaseId.of(dbName);
     final String sessionName = dbName + "/sessions/s%d";
-    final Map<String, String> labels = Collections.<String, String>emptyMap();
+    final Map<String, String> labels = Collections.emptyMap();
     when(spannerOptions.getSessionLabels()).thenReturn(labels);
     final Set<Long> usedChannelHints = Collections.synchronizedSet(new HashSet<>());
     when(rpc.batchCreateSessions(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionClientTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionClientTest.java
@@ -52,7 +52,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.mockito.stubbing.Answer;
 
 @RunWith(Parameterized.class)
 public class SessionClientTest {
@@ -149,22 +148,21 @@ public class SessionClientTest {
     when(rpc.batchCreateSessions(
             Mockito.eq(dbName), Mockito.anyInt(), Mockito.eq(labels), Mockito.anyMap()))
         .then(
-            (Answer<List<com.google.spanner.v1.Session>>)
-                invocation -> {
-                  Map<Option, Object> options = invocation.getArgumentAt(3, Map.class);
-                  Long channelHint = (Long) options.get(Option.CHANNEL_HINT);
-                  usedChannels.add(channelHint);
-                  int sessionCount = invocation.getArgumentAt(1, Integer.class);
-                  List<com.google.spanner.v1.Session> res = new ArrayList<>();
-                  for (int i = 1; i <= sessionCount; i++) {
-                    res.add(
-                        com.google.spanner.v1.Session.newBuilder()
-                            .setName(String.format(sessionName, i))
-                            .putAllLabels(labels)
-                            .build());
-                  }
-                  return res;
-                });
+            invocation -> {
+              Map<Option, Object> options = invocation.getArgumentAt(3, Map.class);
+              Long channelHint = (Long) options.get(Option.CHANNEL_HINT);
+              usedChannels.add(channelHint);
+              int sessionCount = invocation.getArgumentAt(1, Integer.class);
+              List<com.google.spanner.v1.Session> res = new ArrayList<>();
+              for (int i = 1; i <= sessionCount; i++) {
+                res.add(
+                    com.google.spanner.v1.Session.newBuilder()
+                        .setName(String.format(sessionName, i))
+                        .putAllLabels(labels)
+                        .build());
+              }
+              return res;
+            });
 
     final AtomicInteger returnedSessionCount = new AtomicInteger();
     SessionConsumer consumer =
@@ -210,22 +208,21 @@ public class SessionClientTest {
     when(rpc.batchCreateSessions(
             Mockito.eq(dbName), Mockito.anyInt(), Mockito.eq(labels), Mockito.anyMap()))
         .then(
-            (Answer<List<com.google.spanner.v1.Session>>)
-                invocation -> {
-                  Map<Option, Object> options = invocation.getArgumentAt(3, Map.class);
-                  Long channelHint = (Long) options.get(Option.CHANNEL_HINT);
-                  usedChannelHints.add(channelHint);
-                  int sessionCount = invocation.getArgumentAt(1, Integer.class);
-                  List<com.google.spanner.v1.Session> res = new ArrayList<>();
-                  for (int i = 1; i <= sessionCount; i++) {
-                    res.add(
-                        com.google.spanner.v1.Session.newBuilder()
-                            .setName(String.format(sessionName, i))
-                            .putAllLabels(labels)
-                            .build());
-                  }
-                  return res;
-                });
+            invocation -> {
+              Map<Option, Object> options = invocation.getArgumentAt(3, Map.class);
+              Long channelHint = (Long) options.get(Option.CHANNEL_HINT);
+              usedChannelHints.add(channelHint);
+              int sessionCount = invocation.getArgumentAt(1, Integer.class);
+              List<com.google.spanner.v1.Session> res = new ArrayList<>();
+              for (int i = 1; i <= sessionCount; i++) {
+                res.add(
+                    com.google.spanner.v1.Session.newBuilder()
+                        .setName(String.format(sessionName, i))
+                        .putAllLabels(labels)
+                        .build());
+              }
+              return res;
+            });
 
     final AtomicInteger returnedSessionCount = new AtomicInteger();
     SessionConsumer consumer =
@@ -292,25 +289,24 @@ public class SessionClientTest {
         when(rpc.batchCreateSessions(
                 Mockito.eq(dbName), Mockito.anyInt(), Mockito.anyMap(), Mockito.anyMap()))
             .then(
-                (Answer<List<com.google.spanner.v1.Session>>)
-                    invocation -> {
-                      Map<Option, Object> options = invocation.getArgumentAt(3, Map.class);
-                      Long channelHint = (Long) options.get(Option.CHANNEL_HINT);
-                      if (errorOnChannels.contains(channelHint)) {
-                        throw SpannerExceptionFactory.newSpannerException(
-                            ErrorCode.RESOURCE_EXHAUSTED, "could not create any more sessions");
-                      } else {
-                        int sessionCount = invocation.getArgumentAt(1, Integer.class);
-                        List<com.google.spanner.v1.Session> res = new ArrayList<>();
-                        for (int i = 1; i <= sessionCount; i++) {
-                          res.add(
-                              com.google.spanner.v1.Session.newBuilder()
-                                  .setName(String.format(sessionName, i))
-                                  .build());
-                        }
-                        return res;
-                      }
-                    });
+                invocation -> {
+                  Map<Option, Object> options = invocation.getArgumentAt(3, Map.class);
+                  Long channelHint = (Long) options.get(Option.CHANNEL_HINT);
+                  if (errorOnChannels.contains(channelHint)) {
+                    throw SpannerExceptionFactory.newSpannerException(
+                        ErrorCode.RESOURCE_EXHAUSTED, "could not create any more sessions");
+                  } else {
+                    int sessionCount = invocation.getArgumentAt(1, Integer.class);
+                    List<com.google.spanner.v1.Session> res = new ArrayList<>();
+                    for (int i = 1; i <= sessionCount; i++) {
+                      res.add(
+                          com.google.spanner.v1.Session.newBuilder()
+                              .setName(String.format(sessionName, i))
+                              .build());
+                    }
+                    return res;
+                  }
+                });
 
         final AtomicInteger errorForSessionsCount = new AtomicInteger();
         final AtomicInteger errorCount = new AtomicInteger();
@@ -357,18 +353,17 @@ public class SessionClientTest {
     when(rpc.batchCreateSessions(
             Mockito.eq(dbName), Mockito.anyInt(), Mockito.anyMap(), Mockito.anyMap()))
         .then(
-            (Answer<List<com.google.spanner.v1.Session>>)
-                invocation -> {
-                  int sessionCount = invocation.getArgumentAt(1, Integer.class);
-                  List<com.google.spanner.v1.Session> res = new ArrayList<>();
-                  for (int i = 1; i <= Math.min(MAX_SESSIONS_PER_BATCH, sessionCount); i++) {
-                    res.add(
-                        com.google.spanner.v1.Session.newBuilder()
-                            .setName(String.format(sessionName, i))
-                            .build());
-                  }
-                  return res;
-                });
+            invocation -> {
+              int sessionCount = invocation.getArgumentAt(1, Integer.class);
+              List<com.google.spanner.v1.Session> res = new ArrayList<>();
+              for (int i = 1; i <= Math.min(MAX_SESSIONS_PER_BATCH, sessionCount); i++) {
+                res.add(
+                    com.google.spanner.v1.Session.newBuilder()
+                        .setName(String.format(sessionName, i))
+                        .build());
+              }
+              return res;
+            });
 
     final AtomicInteger returnedSessionCount = new AtomicInteger();
     SessionConsumer consumer =

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionClientTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionClientTest.java
@@ -26,6 +26,7 @@ import com.google.cloud.grpc.GrpcTransportOptions;
 import com.google.cloud.grpc.GrpcTransportOptions.ExecutorFactory;
 import com.google.cloud.spanner.SessionClient.SessionConsumer;
 import com.google.cloud.spanner.spi.v1.SpannerRpc;
+import com.google.cloud.spanner.spi.v1.SpannerRpc.Option;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -51,7 +52,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 @RunWith(Parameterized.class)
@@ -149,24 +149,22 @@ public class SessionClientTest {
     when(rpc.batchCreateSessions(
             Mockito.eq(dbName), Mockito.anyInt(), Mockito.eq(labels), Mockito.anyMap()))
         .then(
-            new Answer<List<com.google.spanner.v1.Session>>() {
-              @Override
-              public List<com.google.spanner.v1.Session> answer(InvocationOnMock invocation) {
-                Map<SpannerRpc.Option, Object> options = invocation.getArgumentAt(3, Map.class);
-                Long channelHint = (Long) options.get(SpannerRpc.Option.CHANNEL_HINT);
-                usedChannels.add(channelHint);
-                int sessionCount = invocation.getArgumentAt(1, Integer.class);
-                List<com.google.spanner.v1.Session> res = new ArrayList<>();
-                for (int i = 1; i <= sessionCount; i++) {
-                  res.add(
-                      com.google.spanner.v1.Session.newBuilder()
-                          .setName(String.format(sessionName, i))
-                          .putAllLabels(labels)
-                          .build());
-                }
-                return res;
-              }
-            });
+            (Answer<List<com.google.spanner.v1.Session>>)
+                invocation -> {
+                  Map<Option, Object> options = invocation.getArgumentAt(3, Map.class);
+                  Long channelHint = (Long) options.get(Option.CHANNEL_HINT);
+                  usedChannels.add(channelHint);
+                  int sessionCount = invocation.getArgumentAt(1, Integer.class);
+                  List<com.google.spanner.v1.Session> res = new ArrayList<>();
+                  for (int i = 1; i <= sessionCount; i++) {
+                    res.add(
+                        com.google.spanner.v1.Session.newBuilder()
+                            .setName(String.format(sessionName, i))
+                            .putAllLabels(labels)
+                            .build());
+                  }
+                  return res;
+                });
 
     final AtomicInteger returnedSessionCount = new AtomicInteger();
     SessionConsumer consumer =
@@ -212,24 +210,22 @@ public class SessionClientTest {
     when(rpc.batchCreateSessions(
             Mockito.eq(dbName), Mockito.anyInt(), Mockito.eq(labels), Mockito.anyMap()))
         .then(
-            new Answer<List<com.google.spanner.v1.Session>>() {
-              @Override
-              public List<com.google.spanner.v1.Session> answer(InvocationOnMock invocation) {
-                Map<SpannerRpc.Option, Object> options = invocation.getArgumentAt(3, Map.class);
-                Long channelHint = (Long) options.get(SpannerRpc.Option.CHANNEL_HINT);
-                usedChannelHints.add(channelHint);
-                int sessionCount = invocation.getArgumentAt(1, Integer.class);
-                List<com.google.spanner.v1.Session> res = new ArrayList<>();
-                for (int i = 1; i <= sessionCount; i++) {
-                  res.add(
-                      com.google.spanner.v1.Session.newBuilder()
-                          .setName(String.format(sessionName, i))
-                          .putAllLabels(labels)
-                          .build());
-                }
-                return res;
-              }
-            });
+            (Answer<List<com.google.spanner.v1.Session>>)
+                invocation -> {
+                  Map<Option, Object> options = invocation.getArgumentAt(3, Map.class);
+                  Long channelHint = (Long) options.get(Option.CHANNEL_HINT);
+                  usedChannelHints.add(channelHint);
+                  int sessionCount = invocation.getArgumentAt(1, Integer.class);
+                  List<com.google.spanner.v1.Session> res = new ArrayList<>();
+                  for (int i = 1; i <= sessionCount; i++) {
+                    res.add(
+                        com.google.spanner.v1.Session.newBuilder()
+                            .setName(String.format(sessionName, i))
+                            .putAllLabels(labels)
+                            .build());
+                  }
+                  return res;
+                });
 
     final AtomicInteger returnedSessionCount = new AtomicInteger();
     SessionConsumer consumer =
@@ -296,27 +292,25 @@ public class SessionClientTest {
         when(rpc.batchCreateSessions(
                 Mockito.eq(dbName), Mockito.anyInt(), Mockito.anyMap(), Mockito.anyMap()))
             .then(
-                new Answer<List<com.google.spanner.v1.Session>>() {
-                  @Override
-                  public List<com.google.spanner.v1.Session> answer(InvocationOnMock invocation) {
-                    Map<SpannerRpc.Option, Object> options = invocation.getArgumentAt(3, Map.class);
-                    Long channelHint = (Long) options.get(SpannerRpc.Option.CHANNEL_HINT);
-                    if (errorOnChannels.contains(channelHint)) {
-                      throw SpannerExceptionFactory.newSpannerException(
-                          ErrorCode.RESOURCE_EXHAUSTED, "could not create any more sessions");
-                    } else {
-                      int sessionCount = invocation.getArgumentAt(1, Integer.class);
-                      List<com.google.spanner.v1.Session> res = new ArrayList<>();
-                      for (int i = 1; i <= sessionCount; i++) {
-                        res.add(
-                            com.google.spanner.v1.Session.newBuilder()
-                                .setName(String.format(sessionName, i))
-                                .build());
+                (Answer<List<com.google.spanner.v1.Session>>)
+                    invocation -> {
+                      Map<Option, Object> options = invocation.getArgumentAt(3, Map.class);
+                      Long channelHint = (Long) options.get(Option.CHANNEL_HINT);
+                      if (errorOnChannels.contains(channelHint)) {
+                        throw SpannerExceptionFactory.newSpannerException(
+                            ErrorCode.RESOURCE_EXHAUSTED, "could not create any more sessions");
+                      } else {
+                        int sessionCount = invocation.getArgumentAt(1, Integer.class);
+                        List<com.google.spanner.v1.Session> res = new ArrayList<>();
+                        for (int i = 1; i <= sessionCount; i++) {
+                          res.add(
+                              com.google.spanner.v1.Session.newBuilder()
+                                  .setName(String.format(sessionName, i))
+                                  .build());
+                        }
+                        return res;
                       }
-                      return res;
-                    }
-                  }
-                });
+                    });
 
         final AtomicInteger errorForSessionsCount = new AtomicInteger();
         final AtomicInteger errorCount = new AtomicInteger();
@@ -363,20 +357,18 @@ public class SessionClientTest {
     when(rpc.batchCreateSessions(
             Mockito.eq(dbName), Mockito.anyInt(), Mockito.anyMap(), Mockito.anyMap()))
         .then(
-            new Answer<List<com.google.spanner.v1.Session>>() {
-              @Override
-              public List<com.google.spanner.v1.Session> answer(InvocationOnMock invocation) {
-                int sessionCount = invocation.getArgumentAt(1, Integer.class);
-                List<com.google.spanner.v1.Session> res = new ArrayList<>();
-                for (int i = 1; i <= Math.min(MAX_SESSIONS_PER_BATCH, sessionCount); i++) {
-                  res.add(
-                      com.google.spanner.v1.Session.newBuilder()
-                          .setName(String.format(sessionName, i))
-                          .build());
-                }
-                return res;
-              }
-            });
+            (Answer<List<com.google.spanner.v1.Session>>)
+                invocation -> {
+                  int sessionCount = invocation.getArgumentAt(1, Integer.class);
+                  List<com.google.spanner.v1.Session> res = new ArrayList<>();
+                  for (int i = 1; i <= Math.min(MAX_SESSIONS_PER_BATCH, sessionCount); i++) {
+                    res.add(
+                        com.google.spanner.v1.Session.newBuilder()
+                            .setName(String.format(sessionName, i))
+                            .build());
+                  }
+                  return res;
+                });
 
     final AtomicInteger returnedSessionCount = new AtomicInteger();
     SessionConsumer consumer =

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
@@ -29,6 +29,7 @@ import com.google.cloud.Timestamp;
 import com.google.cloud.grpc.GrpcTransportOptions;
 import com.google.cloud.grpc.GrpcTransportOptions.ExecutorFactory;
 import com.google.cloud.spanner.spi.v1.SpannerRpc;
+import com.google.cloud.spanner.spi.v1.SpannerRpc.StreamingCall;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
 import com.google.protobuf.ListValue;
@@ -62,7 +63,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 /** Unit tests for {@link com.google.cloud.spanner.SessionImpl}. */
@@ -435,14 +435,12 @@ public class SessionImplTest {
         ArgumentCaptor.forClass(SpannerRpc.ResultStreamConsumer.class);
     Mockito.when(rpc.read(Mockito.<ReadRequest>any(), consumer.capture(), Mockito.eq(options)))
         .then(
-            new Answer<SpannerRpc.StreamingCall>() {
-              @Override
-              public SpannerRpc.StreamingCall answer(InvocationOnMock invocation) {
-                consumer.getValue().onPartialResultSet(myResultSet);
-                consumer.getValue().onCompleted();
-                return new NoOpStreamingCall();
-              }
-            });
+            (Answer<StreamingCall>)
+                invocation -> {
+                  consumer.getValue().onPartialResultSet(myResultSet);
+                  consumer.getValue().onCompleted();
+                  return new NoOpStreamingCall();
+                });
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
@@ -39,7 +39,6 @@ import com.google.spanner.v1.CommitRequest;
 import com.google.spanner.v1.CommitResponse;
 import com.google.spanner.v1.Mutation.Write;
 import com.google.spanner.v1.PartialResultSet;
-import com.google.spanner.v1.ReadRequest;
 import com.google.spanner.v1.ResultSetMetadata;
 import com.google.spanner.v1.RollbackRequest;
 import com.google.spanner.v1.Session;
@@ -81,7 +80,7 @@ public class SessionImplTest {
     when(spannerOptions.getPrefetchChunks()).thenReturn(1);
     when(spannerOptions.getRetrySettings()).thenReturn(RetrySettings.newBuilder().build());
     when(spannerOptions.getClock()).thenReturn(NanoClock.getDefaultClock());
-    when(spannerOptions.getSessionLabels()).thenReturn(Collections.<String, String>emptyMap());
+    when(spannerOptions.getSessionLabels()).thenReturn(Collections.emptyMap());
     GrpcTransportOptions transportOptions = mock(GrpcTransportOptions.class);
     when(transportOptions.getExecutorFactory()).thenReturn(mock(ExecutorFactory.class));
     when(spannerOptions.getTransportOptions()).thenReturn(transportOptions);
@@ -315,7 +314,7 @@ public class SessionImplTest {
   public void writeClosesOldSingleUseContext() throws ParseException {
     ReadContext ctx = session.singleUse(TimestampBound.strong());
 
-    Mockito.when(rpc.commit(Mockito.<CommitRequest>any(), Mockito.eq(options)))
+    Mockito.when(rpc.commit(Mockito.any(), Mockito.eq(options)))
         .thenReturn(
             CommitResponse.newBuilder()
                 .setCommitTimestamp(Timestamps.parse("2015-10-01T10:54:20.021Z"))
@@ -364,7 +363,7 @@ public class SessionImplTest {
   public void prepareClosesOldSingleUseContext() {
     ReadContext ctx = session.singleUse(TimestampBound.strong());
 
-    Mockito.when(rpc.beginTransaction(Mockito.<BeginTransactionRequest>any(), Mockito.eq(options)))
+    Mockito.when(rpc.beginTransaction(Mockito.any(), Mockito.eq(options)))
         .thenReturn(Transaction.newBuilder().setId(ByteString.copyFromUtf8("t1")).build());
     session.prepareReadWriteTransaction();
     try {
@@ -433,7 +432,7 @@ public class SessionImplTest {
   private void mockRead(final PartialResultSet myResultSet) {
     final ArgumentCaptor<SpannerRpc.ResultStreamConsumer> consumer =
         ArgumentCaptor.forClass(SpannerRpc.ResultStreamConsumer.class);
-    Mockito.when(rpc.read(Mockito.<ReadRequest>any(), consumer.capture(), Mockito.eq(options)))
+    Mockito.when(rpc.read(Mockito.any(), consumer.capture(), Mockito.eq(options)))
         .then(
             (Answer<StreamingCall>)
                 invocation -> {
@@ -450,8 +449,7 @@ public class SessionImplTest {
         PartialResultSet.newBuilder()
             .setMetadata(newMetadata(Type.struct(Type.StructField.of("C", Type.string()))))
             .build();
-    Mockito.when(rpc.beginTransaction(Mockito.<BeginTransactionRequest>any(), Mockito.eq(options)))
-        .thenReturn(txnMetadata);
+    Mockito.when(rpc.beginTransaction(Mockito.any(), Mockito.eq(options))).thenReturn(txnMetadata);
     mockRead(resultSet);
 
     ReadOnlyTransaction txn = session.readOnlyTransaction(TimestampBound.strong());
@@ -470,8 +468,7 @@ public class SessionImplTest {
         PartialResultSet.newBuilder()
             .setMetadata(newMetadata(Type.struct(Type.StructField.of("C", Type.string()))))
             .build();
-    Mockito.when(rpc.beginTransaction(Mockito.<BeginTransactionRequest>any(), Mockito.eq(options)))
-        .thenReturn(txnMetadata);
+    Mockito.when(rpc.beginTransaction(Mockito.any(), Mockito.eq(options))).thenReturn(txnMetadata);
     mockRead(resultSet);
 
     ReadOnlyTransaction txn = session.readOnlyTransaction(TimestampBound.strong());
@@ -491,8 +488,7 @@ public class SessionImplTest {
         PartialResultSet.newBuilder()
             .setMetadata(newMetadata(Type.struct(Type.StructField.of("C", Type.string()))))
             .build();
-    Mockito.when(rpc.beginTransaction(Mockito.<BeginTransactionRequest>any(), Mockito.eq(options)))
-        .thenReturn(txnMetadata);
+    Mockito.when(rpc.beginTransaction(Mockito.any(), Mockito.eq(options))).thenReturn(txnMetadata);
     mockRead(resultSet);
 
     ReadOnlyTransaction txn = session.readOnlyTransaction(TimestampBound.strong());

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
@@ -29,7 +29,6 @@ import com.google.cloud.Timestamp;
 import com.google.cloud.grpc.GrpcTransportOptions;
 import com.google.cloud.grpc.GrpcTransportOptions.ExecutorFactory;
 import com.google.cloud.spanner.spi.v1.SpannerRpc;
-import com.google.cloud.spanner.spi.v1.SpannerRpc.StreamingCall;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
 import com.google.protobuf.ListValue;
@@ -61,7 +60,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.mockito.stubbing.Answer;
 
 /** Unit tests for {@link com.google.cloud.spanner.SessionImpl}. */
 @RunWith(JUnit4.class)
@@ -434,12 +432,11 @@ public class SessionImplTest {
         ArgumentCaptor.forClass(SpannerRpc.ResultStreamConsumer.class);
     Mockito.when(rpc.read(Mockito.any(), consumer.capture(), Mockito.eq(options)))
         .then(
-            (Answer<StreamingCall>)
-                invocation -> {
-                  consumer.getValue().onPartialResultSet(myResultSet);
-                  consumer.getValue().onCompleted();
-                  return new NoOpStreamingCall();
-                });
+            invocation -> {
+              consumer.getValue().onPartialResultSet(myResultSet);
+              consumer.getValue().onCompleted();
+              return new NoOpStreamingCall();
+            });
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
@@ -319,7 +319,7 @@ public class SessionImplTest {
             CommitResponse.newBuilder()
                 .setCommitTimestamp(Timestamps.parse("2015-10-01T10:54:20.021Z"))
                 .build());
-    session.writeAtLeastOnce(Collections.<Mutation>emptyList());
+    session.writeAtLeastOnce(Collections.emptyList());
     try {
       ctx.read("Dummy", KeySet.all(), Collections.singletonList("C"));
       fail("Expected exception");

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolBenchmark.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolBenchmark.java
@@ -245,7 +245,7 @@ public class SessionPoolBenchmark {
 
   /** Measures the time needed to acquire MaxSessions session sequentially. */
   @Benchmark
-  public void steadyIncrease(BenchmarkState server) throws Exception {
+  public void steadyIncrease(BenchmarkState server) {
     final DatabaseClient client =
         server.spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
     SessionPool pool = ((DatabaseClientImpl) client).pool;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolStressTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolStressTest.java
@@ -25,10 +25,8 @@ import static org.mockito.Mockito.when;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.cloud.spanner.SessionClient.SessionConsumer;
-import com.google.cloud.spanner.SessionPool.PooledSession;
 import com.google.cloud.spanner.SessionPool.PooledSessionFuture;
 import com.google.cloud.spanner.SessionPool.SessionConsumerImpl;
-import com.google.common.base.Function;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
@@ -51,7 +49,6 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 /**
@@ -98,30 +95,28 @@ public class SessionPoolStressTest extends BaseSessionPoolTest {
     when(mockSpanner.getSessionClient(db)).thenReturn(sessionClient);
     when(mockSpanner.getOptions()).thenReturn(spannerOptions);
     doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                createExecutor.submit(
-                    () -> {
-                      int sessionCount = invocation.getArgumentAt(0, Integer.class);
-                      for (int s = 0; s < sessionCount; s++) {
-                        SessionImpl session;
-                        synchronized (lock) {
-                          session = mockSession();
-                          setupSession(session);
-                          sessions.put(session.getName(), false);
-                          if (sessions.size() > maxAliveSessions) {
-                            maxAliveSessions = sessions.size();
+            (Answer<Void>)
+                invocation -> {
+                  createExecutor.submit(
+                      () -> {
+                        int sessionCount = invocation.getArgumentAt(0, Integer.class);
+                        for (int s = 0; s < sessionCount; s++) {
+                          SessionImpl session;
+                          synchronized (lock) {
+                            session = mockSession();
+                            setupSession(session);
+                            sessions.put(session.getName(), false);
+                            if (sessions.size() > maxAliveSessions) {
+                              maxAliveSessions = sessions.size();
+                            }
                           }
+                          SessionConsumerImpl consumer =
+                              invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                          consumer.onSessionReady(session);
                         }
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(session);
-                      }
-                    });
-                return null;
-              }
-            })
+                      });
+                  return null;
+                })
         .when(sessionClient)
         .asyncBatchCreateSessions(
             Mockito.anyInt(), Mockito.anyBoolean(), Mockito.any(SessionConsumer.class));
@@ -133,57 +128,51 @@ public class SessionPoolStressTest extends BaseSessionPoolTest {
     when(session.singleUse(any(TimestampBound.class))).thenReturn(mockContext);
     when(mockContext.executeQuery(any(Statement.class)))
         .thenAnswer(
-            new Answer<ResultSet>() {
-
-              @Override
-              public ResultSet answer(InvocationOnMock invocation) {
-                resetTransaction(session);
-                return mockResult;
-              }
-            });
+            (Answer<ResultSet>)
+                invocation -> {
+                  resetTransaction(session);
+                  return mockResult;
+                });
     when(mockResult.next()).thenReturn(true);
     doAnswer(
-            new Answer<ApiFuture<Empty>>() {
-
-              @Override
-              public ApiFuture<Empty> answer(InvocationOnMock invocation) {
-                synchronized (lock) {
-                  if (expiredSessions.contains(session.getName())) {
-                    return ApiFutures.immediateFailedFuture(
-                        SpannerExceptionFactoryTest.newSessionNotFoundException(session.getName()));
+            (Answer<ApiFuture<Empty>>)
+                invocation -> {
+                  synchronized (lock) {
+                    if (expiredSessions.contains(session.getName())) {
+                      return ApiFutures.immediateFailedFuture(
+                          SpannerExceptionFactoryTest.newSessionNotFoundException(
+                              session.getName()));
+                    }
+                    if (sessions.remove(session.getName()) == null) {
+                      setFailed(closedSessions.get(session.getName()));
+                    }
+                    closedSessions.put(session.getName(), new Exception("Session closed at:"));
+                    if (sessions.size() < minSessionsWhenSessionClosed) {
+                      minSessionsWhenSessionClosed = sessions.size();
+                    }
                   }
-                  if (sessions.remove(session.getName()) == null) {
-                    setFailed(closedSessions.get(session.getName()));
-                  }
-                  closedSessions.put(session.getName(), new Exception("Session closed at:"));
-                  if (sessions.size() < minSessionsWhenSessionClosed) {
-                    minSessionsWhenSessionClosed = sessions.size();
-                  }
-                }
-                return ApiFutures.immediateFuture(Empty.getDefaultInstance());
-              }
-            })
+                  return ApiFutures.immediateFuture(Empty.getDefaultInstance());
+                })
         .when(session)
         .asyncClose();
 
     doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(InvocationOnMock invocation) {
-                if (random.nextInt(100) < 10) {
-                  expireSession(session);
-                  throw SpannerExceptionFactoryTest.newSessionNotFoundException(session.getName());
-                }
-                String name = session.getName();
-                synchronized (lock) {
-                  if (sessions.put(name, true)) {
-                    setFailed();
+            (Answer<Void>)
+                invocation -> {
+                  if (random.nextInt(100) < 10) {
+                    expireSession(session);
+                    throw SpannerExceptionFactoryTest.newSessionNotFoundException(
+                        session.getName());
                   }
-                  session.readyTransactionId = ByteString.copyFromUtf8("foo");
-                }
-                return null;
-              }
-            })
+                  String name = session.getName();
+                  synchronized (lock) {
+                    if (sessions.put(name, true)) {
+                      setFailed();
+                    }
+                    session.readyTransactionId = ByteString.copyFromUtf8("foo");
+                  }
+                  return null;
+                })
         .when(session)
         .prepareReadWriteTransaction();
     when(session.hasReadyTransaction()).thenCallRealMethod();
@@ -239,14 +228,11 @@ public class SessionPoolStressTest extends BaseSessionPoolTest {
         SessionPool.createPool(
             builder.build(), new TestExecutorFactory(), mockSpanner.getSessionClient(db), clock);
     pool.idleSessionRemovedListener =
-        new Function<PooledSession, Void>() {
-          @Override
-          public Void apply(PooledSession pooled) {
-            String name = pooled.getName();
-            synchronized (lock) {
-              sessions.remove(name);
-              return null;
-            }
+        pooled -> {
+          String name = pooled.getName();
+          synchronized (lock) {
+            sessions.remove(name);
+            return null;
           }
         };
     for (int i = 0; i < concurrentThreads; i++) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -90,7 +90,6 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.stubbing.Answer;
 
 /** Tests for SessionPool that mock out the underlying stub. */
 @RunWith(Parameterized.class)
@@ -149,19 +148,18 @@ public class SessionPoolTest extends BaseSessionPoolTest {
 
   private void setupMockSessionCreation() {
     doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  executor.submit(
-                      () -> {
-                        int sessionCount = invocation.getArgumentAt(0, Integer.class);
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        for (int i = 0; i < sessionCount; i++) {
-                          consumer.onSessionReady(mockSession());
-                        }
-                      });
-                  return null;
-                })
+            invocation -> {
+              executor.submit(
+                  () -> {
+                    int sessionCount = invocation.getArgumentAt(0, Integer.class);
+                    SessionConsumerImpl consumer =
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                    for (int i = 0; i < sessionCount; i++) {
+                      consumer.onSessionReady(mockSession());
+                    }
+                  });
+              return null;
+            })
         .when(sessionClient)
         .asyncBatchCreateSessions(
             Mockito.anyInt(), Mockito.anyBoolean(), any(SessionConsumer.class));
@@ -228,16 +226,15 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     final LinkedList<SessionImpl> sessions =
         new LinkedList<>(Arrays.asList(mockSession1, mockSession2));
     doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  executor.submit(
-                      () -> {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(sessions.pop());
-                      });
-                  return null;
-                })
+            invocation -> {
+              executor.submit(
+                  () -> {
+                    SessionConsumerImpl consumer =
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                    consumer.onSessionReady(sessions.pop());
+                  });
+              return null;
+            })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
@@ -277,30 +274,28 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     final SessionImpl session1 = mockSession();
     final SessionImpl session2 = mockSession();
     doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  executor.submit(
-                      () -> {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(session1);
-                      });
-                  return null;
-                })
+            invocation -> {
+              executor.submit(
+                  () -> {
+                    SessionConsumerImpl consumer =
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                    consumer.onSessionReady(session1);
+                  });
+              return null;
+            })
         .doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  executor.submit(
-                      () -> {
-                        insideCreation.countDown();
-                        releaseCreation.await();
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(session2);
-                        return null;
-                      });
-                  return null;
-                })
+            invocation -> {
+              executor.submit(
+                  () -> {
+                    insideCreation.countDown();
+                    releaseCreation.await();
+                    SessionConsumerImpl consumer =
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                    consumer.onSessionReady(session2);
+                    return null;
+                  });
+              return null;
+            })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
 
@@ -325,30 +320,28 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     final SessionImpl session1 = mockSession();
     final SessionImpl session2 = mockSession();
     doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  executor.submit(
-                      () -> {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(session1);
-                      });
-                  return null;
-                })
+            invocation -> {
+              executor.submit(
+                  () -> {
+                    SessionConsumerImpl consumer =
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                    consumer.onSessionReady(session1);
+                  });
+              return null;
+            })
         .doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  executor.submit(
-                      () -> {
-                        insideCreation.countDown();
-                        releaseCreation.await();
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(session2);
-                        return null;
-                      });
-                  return null;
-                })
+            invocation -> {
+              executor.submit(
+                  () -> {
+                    insideCreation.countDown();
+                    releaseCreation.await();
+                    SessionConsumerImpl consumer =
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                    consumer.onSessionReady(session2);
+                    return null;
+                  });
+              return null;
+            })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
 
@@ -371,20 +364,19 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     final CountDownLatch insideCreation = new CountDownLatch(1);
     final CountDownLatch releaseCreation = new CountDownLatch(1);
     doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  executor.submit(
-                      () -> {
-                        insideCreation.countDown();
-                        releaseCreation.await();
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionCreateFailure(
-                            SpannerExceptionFactory.newSpannerException(new RuntimeException()), 1);
-                        return null;
-                      });
-                  return null;
-                })
+            invocation -> {
+              executor.submit(
+                  () -> {
+                    insideCreation.countDown();
+                    releaseCreation.await();
+                    SessionConsumerImpl consumer =
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                    consumer.onSessionCreateFailure(
+                        SpannerExceptionFactory.newSpannerException(new RuntimeException()), 1);
+                    return null;
+                  });
+              return null;
+            })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
@@ -402,16 +394,15 @@ public class SessionPoolTest extends BaseSessionPoolTest {
   public void poolClosureFailsNewRequests() {
     final SessionImpl session = mockSession();
     doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  executor.submit(
-                      () -> {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(session);
-                      });
-                  return null;
-                })
+            invocation -> {
+              executor.submit(
+                  () -> {
+                    SessionConsumerImpl consumer =
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                    consumer.onSessionReady(session);
+                  });
+              return null;
+            })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
@@ -447,18 +438,17 @@ public class SessionPoolTest extends BaseSessionPoolTest {
   @Test
   public void creationExceptionPropagatesToReadSession() {
     doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  executor.submit(
-                      () -> {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionCreateFailure(
-                            SpannerExceptionFactory.newSpannerException(ErrorCode.INTERNAL, ""), 1);
-                        return null;
-                      });
-                  return null;
-                })
+            invocation -> {
+              executor.submit(
+                  () -> {
+                    SessionConsumerImpl consumer =
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                    consumer.onSessionCreateFailure(
+                        SpannerExceptionFactory.newSpannerException(ErrorCode.INTERNAL, ""), 1);
+                    return null;
+                  });
+              return null;
+            })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
@@ -479,16 +469,15 @@ public class SessionPoolTest extends BaseSessionPoolTest {
             .setFailIfPoolExhausted()
             .build();
     doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  executor.submit(
-                      () -> {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(mockSession());
-                      });
-                  return null;
-                })
+            invocation -> {
+              executor.submit(
+                  () -> {
+                    SessionConsumerImpl consumer =
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                    consumer.onSessionReady(mockSession());
+                  });
+              return null;
+            })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
@@ -520,16 +509,15 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     final LinkedList<SessionImpl> sessions =
         new LinkedList<>(Arrays.asList(session1, session2, session3));
     doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  executor.submit(
-                      () -> {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(sessions.pop());
-                      });
-                  return null;
-                })
+            invocation -> {
+              executor.submit(
+                  () -> {
+                    SessionConsumerImpl consumer =
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                    consumer.onSessionReady(sessions.pop());
+                  });
+              return null;
+            })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     for (SessionImpl session : sessions) {
@@ -580,19 +568,18 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     // This is cheating as we are returning the same session each but it makes the verification
     // easier.
     doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  executor.submit(
-                      () -> {
-                        int sessionCount = invocation.getArgumentAt(0, Integer.class);
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        for (int i = 0; i < sessionCount; i++) {
-                          consumer.onSessionReady(session);
-                        }
-                      });
-                  return null;
-                })
+            invocation -> {
+              executor.submit(
+                  () -> {
+                    int sessionCount = invocation.getArgumentAt(0, Integer.class);
+                    SessionConsumerImpl consumer =
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                    for (int i = 0; i < sessionCount; i++) {
+                      consumer.onSessionReady(session);
+                    }
+                  });
+              return null;
+            })
         .when(sessionClient)
         .asyncBatchCreateSessions(anyInt(), Mockito.anyBoolean(), any(SessionConsumer.class));
     FakeClock clock = new FakeClock();
@@ -686,27 +673,25 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     when(openSession.singleUse()).thenReturn(openContext);
 
     doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  executor.submit(
-                      () -> {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(closedSession);
-                      });
-                  return null;
-                })
+            invocation -> {
+              executor.submit(
+                  () -> {
+                    SessionConsumerImpl consumer =
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                    consumer.onSessionReady(closedSession);
+                  });
+              return null;
+            })
         .doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  executor.submit(
-                      () -> {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(openSession);
-                      });
-                  return null;
-                })
+            invocation -> {
+              executor.submit(
+                  () -> {
+                    SessionConsumerImpl consumer =
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                    consumer.onSessionReady(openSession);
+                  });
+              return null;
+            })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     FakeClock clock = new FakeClock();
@@ -732,27 +717,25 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     when(openSession.readOnlyTransaction()).thenReturn(openTransaction);
 
     doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  executor.submit(
-                      () -> {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(closedSession);
-                      });
-                  return null;
-                })
+            invocation -> {
+              executor.submit(
+                  () -> {
+                    SessionConsumerImpl consumer =
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                    consumer.onSessionReady(closedSession);
+                  });
+              return null;
+            })
         .doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  executor.submit(
-                      () -> {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(openSession);
-                      });
-                  return null;
-                })
+            invocation -> {
+              executor.submit(
+                  () -> {
+                    SessionConsumerImpl consumer =
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                    consumer.onSessionReady(openSession);
+                  });
+              return null;
+            })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     FakeClock clock = new FakeClock();
@@ -845,27 +828,25 @@ public class SessionPoolTest extends BaseSessionPoolTest {
       when(spanner.getSessionClient(db)).thenReturn(sessionClient);
 
       doAnswer(
-              (Answer<Void>)
-                  invocation -> {
-                    executor.submit(
-                        () -> {
-                          SessionConsumerImpl consumer =
-                              invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                          consumer.onSessionReady(closedSession);
-                        });
-                    return null;
-                  })
+              invocation -> {
+                executor.submit(
+                    () -> {
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      consumer.onSessionReady(closedSession);
+                    });
+                return null;
+              })
           .doAnswer(
-              (Answer<Void>)
-                  invocation -> {
-                    executor.submit(
-                        () -> {
-                          SessionConsumerImpl consumer =
-                              invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                          consumer.onSessionReady(openSession);
-                        });
-                    return null;
-                  })
+              invocation -> {
+                executor.submit(
+                    () -> {
+                      SessionConsumerImpl consumer =
+                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                      consumer.onSessionReady(openSession);
+                    });
+                return null;
+              })
           .when(sessionClient)
           .asyncBatchCreateSessions(
               Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
@@ -955,27 +936,25 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     when(response.getCommitTimestamp()).thenReturn(Timestamp.now());
     when(openSession.writeWithOptions(mutations)).thenReturn(response);
     doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  executor.submit(
-                      () -> {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(closedSession);
-                      });
-                  return null;
-                })
+            invocation -> {
+              executor.submit(
+                  () -> {
+                    SessionConsumerImpl consumer =
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                    consumer.onSessionReady(closedSession);
+                  });
+              return null;
+            })
         .doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  executor.submit(
-                      () -> {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(openSession);
-                      });
-                  return null;
-                })
+            invocation -> {
+              executor.submit(
+                  () -> {
+                    SessionConsumerImpl consumer =
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                    consumer.onSessionReady(openSession);
+                  });
+              return null;
+            })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
 
@@ -1000,27 +979,25 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     when(response.getCommitTimestamp()).thenReturn(Timestamp.now());
     when(openSession.writeAtLeastOnceWithOptions(mutations)).thenReturn(response);
     doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  executor.submit(
-                      () -> {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(closedSession);
-                      });
-                  return null;
-                })
+            invocation -> {
+              executor.submit(
+                  () -> {
+                    SessionConsumerImpl consumer =
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                    consumer.onSessionReady(closedSession);
+                  });
+              return null;
+            })
         .doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  executor.submit(
-                      () -> {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(openSession);
-                      });
-                  return null;
-                })
+            invocation -> {
+              executor.submit(
+                  () -> {
+                    SessionConsumerImpl consumer =
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                    consumer.onSessionReady(openSession);
+                  });
+              return null;
+            })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     FakeClock clock = new FakeClock();
@@ -1041,27 +1018,25 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     final SessionImpl openSession = mockSession();
     when(openSession.executePartitionedUpdate(statement)).thenReturn(1L);
     doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  executor.submit(
-                      () -> {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(closedSession);
-                      });
-                  return null;
-                })
+            invocation -> {
+              executor.submit(
+                  () -> {
+                    SessionConsumerImpl consumer =
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                    consumer.onSessionReady(closedSession);
+                  });
+              return null;
+            })
         .doAnswer(
-            (Answer<Void>)
-                invocation -> {
-                  executor.submit(
-                      () -> {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(openSession);
-                      });
-                  return null;
-                })
+            invocation -> {
+              executor.submit(
+                  () -> {
+                    SessionConsumerImpl consumer =
+                        invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                    consumer.onSessionReady(openSession);
+                  });
+              return null;
+            })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     FakeClock clock = new FakeClock();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -89,7 +89,6 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 /** Tests for SessionPool that mock out the underlying stub. */
@@ -149,21 +148,19 @@ public class SessionPoolTest extends BaseSessionPoolTest {
 
   private void setupMockSessionCreation() {
     doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    () -> {
-                      int sessionCount = invocation.getArgumentAt(0, Integer.class);
-                      SessionConsumerImpl consumer =
-                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                      for (int i = 0; i < sessionCount; i++) {
-                        consumer.onSessionReady(mockSession());
-                      }
-                    });
-                return null;
-              }
-            })
+            (Answer<Void>)
+                invocation -> {
+                  executor.submit(
+                      () -> {
+                        int sessionCount = invocation.getArgumentAt(0, Integer.class);
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        for (int i = 0; i < sessionCount; i++) {
+                          consumer.onSessionReady(mockSession());
+                        }
+                      });
+                  return null;
+                })
         .when(sessionClient)
         .asyncBatchCreateSessions(
             Mockito.anyInt(), Mockito.anyBoolean(), any(SessionConsumer.class));
@@ -230,18 +227,16 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     final LinkedList<SessionImpl> sessions =
         new LinkedList<>(Arrays.asList(mockSession1, mockSession2));
     doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    () -> {
-                      SessionConsumerImpl consumer =
-                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                      consumer.onSessionReady(sessions.pop());
-                    });
-                return null;
-              }
-            })
+            (Answer<Void>)
+                invocation -> {
+                  executor.submit(
+                      () -> {
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionReady(sessions.pop());
+                      });
+                  return null;
+                })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
@@ -281,34 +276,30 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     final SessionImpl session1 = mockSession();
     final SessionImpl session2 = mockSession();
     doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    () -> {
-                      SessionConsumerImpl consumer =
-                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                      consumer.onSessionReady(session1);
-                    });
-                return null;
-              }
-            })
+            (Answer<Void>)
+                invocation -> {
+                  executor.submit(
+                      () -> {
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionReady(session1);
+                      });
+                  return null;
+                })
         .doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    () -> {
-                      insideCreation.countDown();
-                      releaseCreation.await();
-                      SessionConsumerImpl consumer =
-                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                      consumer.onSessionReady(session2);
-                      return null;
-                    });
-                return null;
-              }
-            })
+            (Answer<Void>)
+                invocation -> {
+                  executor.submit(
+                      () -> {
+                        insideCreation.countDown();
+                        releaseCreation.await();
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionReady(session2);
+                        return null;
+                      });
+                  return null;
+                })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
 
@@ -333,34 +324,30 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     final SessionImpl session1 = mockSession();
     final SessionImpl session2 = mockSession();
     doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    () -> {
-                      SessionConsumerImpl consumer =
-                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                      consumer.onSessionReady(session1);
-                    });
-                return null;
-              }
-            })
+            (Answer<Void>)
+                invocation -> {
+                  executor.submit(
+                      () -> {
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionReady(session1);
+                      });
+                  return null;
+                })
         .doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    () -> {
-                      insideCreation.countDown();
-                      releaseCreation.await();
-                      SessionConsumerImpl consumer =
-                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                      consumer.onSessionReady(session2);
-                      return null;
-                    });
-                return null;
-              }
-            })
+            (Answer<Void>)
+                invocation -> {
+                  executor.submit(
+                      () -> {
+                        insideCreation.countDown();
+                        releaseCreation.await();
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionReady(session2);
+                        return null;
+                      });
+                  return null;
+                })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
 
@@ -383,22 +370,20 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     final CountDownLatch insideCreation = new CountDownLatch(1);
     final CountDownLatch releaseCreation = new CountDownLatch(1);
     doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    () -> {
-                      insideCreation.countDown();
-                      releaseCreation.await();
-                      SessionConsumerImpl consumer =
-                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                      consumer.onSessionCreateFailure(
-                          SpannerExceptionFactory.newSpannerException(new RuntimeException()), 1);
-                      return null;
-                    });
-                return null;
-              }
-            })
+            (Answer<Void>)
+                invocation -> {
+                  executor.submit(
+                      () -> {
+                        insideCreation.countDown();
+                        releaseCreation.await();
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionCreateFailure(
+                            SpannerExceptionFactory.newSpannerException(new RuntimeException()), 1);
+                        return null;
+                      });
+                  return null;
+                })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
@@ -416,18 +401,16 @@ public class SessionPoolTest extends BaseSessionPoolTest {
   public void poolClosureFailsNewRequests() {
     final SessionImpl session = mockSession();
     doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    () -> {
-                      SessionConsumerImpl consumer =
-                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                      consumer.onSessionReady(session);
-                    });
-                return null;
-              }
-            })
+            (Answer<Void>)
+                invocation -> {
+                  executor.submit(
+                      () -> {
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionReady(session);
+                      });
+                  return null;
+                })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
@@ -463,20 +446,18 @@ public class SessionPoolTest extends BaseSessionPoolTest {
   @Test
   public void creationExceptionPropagatesToReadSession() {
     doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    () -> {
-                      SessionConsumerImpl consumer =
-                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                      consumer.onSessionCreateFailure(
-                          SpannerExceptionFactory.newSpannerException(ErrorCode.INTERNAL, ""), 1);
-                      return null;
-                    });
-                return null;
-              }
-            })
+            (Answer<Void>)
+                invocation -> {
+                  executor.submit(
+                      () -> {
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionCreateFailure(
+                            SpannerExceptionFactory.newSpannerException(ErrorCode.INTERNAL, ""), 1);
+                        return null;
+                      });
+                  return null;
+                })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
@@ -497,18 +478,16 @@ public class SessionPoolTest extends BaseSessionPoolTest {
             .setFailIfPoolExhausted()
             .build();
     doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    () -> {
-                      SessionConsumerImpl consumer =
-                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                      consumer.onSessionReady(mockSession());
-                    });
-                return null;
-              }
-            })
+            (Answer<Void>)
+                invocation -> {
+                  executor.submit(
+                      () -> {
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionReady(mockSession());
+                      });
+                  return null;
+                })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     pool = createPool();
@@ -540,18 +519,16 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     final LinkedList<SessionImpl> sessions =
         new LinkedList<>(Arrays.asList(session1, session2, session3));
     doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    () -> {
-                      SessionConsumerImpl consumer =
-                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                      consumer.onSessionReady(sessions.pop());
-                    });
-                return null;
-              }
-            })
+            (Answer<Void>)
+                invocation -> {
+                  executor.submit(
+                      () -> {
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionReady(sessions.pop());
+                      });
+                  return null;
+                })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     for (SessionImpl session : sessions) {
@@ -602,21 +579,19 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     // This is cheating as we are returning the same session each but it makes the verification
     // easier.
     doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    () -> {
-                      int sessionCount = invocation.getArgumentAt(0, Integer.class);
-                      SessionConsumerImpl consumer =
-                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                      for (int i = 0; i < sessionCount; i++) {
-                        consumer.onSessionReady(session);
-                      }
-                    });
-                return null;
-              }
-            })
+            (Answer<Void>)
+                invocation -> {
+                  executor.submit(
+                      () -> {
+                        int sessionCount = invocation.getArgumentAt(0, Integer.class);
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        for (int i = 0; i < sessionCount; i++) {
+                          consumer.onSessionReady(session);
+                        }
+                      });
+                  return null;
+                })
         .when(sessionClient)
         .asyncBatchCreateSessions(anyInt(), Mockito.anyBoolean(), any(SessionConsumer.class));
     FakeClock clock = new FakeClock();
@@ -710,31 +685,27 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     when(openSession.singleUse()).thenReturn(openContext);
 
     doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    () -> {
-                      SessionConsumerImpl consumer =
-                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                      consumer.onSessionReady(closedSession);
-                    });
-                return null;
-              }
-            })
+            (Answer<Void>)
+                invocation -> {
+                  executor.submit(
+                      () -> {
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionReady(closedSession);
+                      });
+                  return null;
+                })
         .doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    () -> {
-                      SessionConsumerImpl consumer =
-                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                      consumer.onSessionReady(openSession);
-                    });
-                return null;
-              }
-            })
+            (Answer<Void>)
+                invocation -> {
+                  executor.submit(
+                      () -> {
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionReady(openSession);
+                      });
+                  return null;
+                })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     FakeClock clock = new FakeClock();
@@ -760,31 +731,27 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     when(openSession.readOnlyTransaction()).thenReturn(openTransaction);
 
     doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    () -> {
-                      SessionConsumerImpl consumer =
-                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                      consumer.onSessionReady(closedSession);
-                    });
-                return null;
-              }
-            })
+            (Answer<Void>)
+                invocation -> {
+                  executor.submit(
+                      () -> {
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionReady(closedSession);
+                      });
+                  return null;
+                })
         .doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    () -> {
-                      SessionConsumerImpl consumer =
-                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                      consumer.onSessionReady(openSession);
-                    });
-                return null;
-              }
-            })
+            (Answer<Void>)
+                invocation -> {
+                  executor.submit(
+                      () -> {
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionReady(openSession);
+                      });
+                  return null;
+                })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     FakeClock clock = new FakeClock();
@@ -877,31 +844,27 @@ public class SessionPoolTest extends BaseSessionPoolTest {
       when(spanner.getSessionClient(db)).thenReturn(sessionClient);
 
       doAnswer(
-              new Answer<Void>() {
-                @Override
-                public Void answer(final InvocationOnMock invocation) {
-                  executor.submit(
-                      () -> {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(closedSession);
-                      });
-                  return null;
-                }
-              })
+              (Answer<Void>)
+                  invocation -> {
+                    executor.submit(
+                        () -> {
+                          SessionConsumerImpl consumer =
+                              invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                          consumer.onSessionReady(closedSession);
+                        });
+                    return null;
+                  })
           .doAnswer(
-              new Answer<Void>() {
-                @Override
-                public Void answer(final InvocationOnMock invocation) {
-                  executor.submit(
-                      () -> {
-                        SessionConsumerImpl consumer =
-                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                        consumer.onSessionReady(openSession);
-                      });
-                  return null;
-                }
-              })
+              (Answer<Void>)
+                  invocation -> {
+                    executor.submit(
+                        () -> {
+                          SessionConsumerImpl consumer =
+                              invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                          consumer.onSessionReady(openSession);
+                        });
+                    return null;
+                  })
           .when(sessionClient)
           .asyncBatchCreateSessions(
               Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
@@ -991,31 +954,27 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     when(response.getCommitTimestamp()).thenReturn(Timestamp.now());
     when(openSession.writeWithOptions(mutations)).thenReturn(response);
     doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    () -> {
-                      SessionConsumerImpl consumer =
-                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                      consumer.onSessionReady(closedSession);
-                    });
-                return null;
-              }
-            })
+            (Answer<Void>)
+                invocation -> {
+                  executor.submit(
+                      () -> {
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionReady(closedSession);
+                      });
+                  return null;
+                })
         .doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    () -> {
-                      SessionConsumerImpl consumer =
-                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                      consumer.onSessionReady(openSession);
-                    });
-                return null;
-              }
-            })
+            (Answer<Void>)
+                invocation -> {
+                  executor.submit(
+                      () -> {
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionReady(openSession);
+                      });
+                  return null;
+                })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
 
@@ -1040,31 +999,27 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     when(response.getCommitTimestamp()).thenReturn(Timestamp.now());
     when(openSession.writeAtLeastOnceWithOptions(mutations)).thenReturn(response);
     doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    () -> {
-                      SessionConsumerImpl consumer =
-                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                      consumer.onSessionReady(closedSession);
-                    });
-                return null;
-              }
-            })
+            (Answer<Void>)
+                invocation -> {
+                  executor.submit(
+                      () -> {
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionReady(closedSession);
+                      });
+                  return null;
+                })
         .doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    () -> {
-                      SessionConsumerImpl consumer =
-                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                      consumer.onSessionReady(openSession);
-                    });
-                return null;
-              }
-            })
+            (Answer<Void>)
+                invocation -> {
+                  executor.submit(
+                      () -> {
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionReady(openSession);
+                      });
+                  return null;
+                })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     FakeClock clock = new FakeClock();
@@ -1085,31 +1040,27 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     final SessionImpl openSession = mockSession();
     when(openSession.executePartitionedUpdate(statement)).thenReturn(1L);
     doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    () -> {
-                      SessionConsumerImpl consumer =
-                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                      consumer.onSessionReady(closedSession);
-                    });
-                return null;
-              }
-            })
+            (Answer<Void>)
+                invocation -> {
+                  executor.submit(
+                      () -> {
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionReady(closedSession);
+                      });
+                  return null;
+                })
         .doAnswer(
-            new Answer<Void>() {
-              @Override
-              public Void answer(final InvocationOnMock invocation) {
-                executor.submit(
-                    () -> {
-                      SessionConsumerImpl consumer =
-                          invocation.getArgumentAt(2, SessionConsumerImpl.class);
-                      consumer.onSessionReady(openSession);
-                    });
-                return null;
-              }
-            })
+            (Answer<Void>)
+                invocation -> {
+                  executor.submit(
+                      () -> {
+                        SessionConsumerImpl consumer =
+                            invocation.getArgumentAt(2, SessionConsumerImpl.class);
+                        consumer.onSessionReady(openSession);
+                      });
+                  return null;
+                })
         .when(sessionClient)
         .asyncBatchCreateSessions(Mockito.eq(1), Mockito.anyBoolean(), any(SessionConsumer.class));
     FakeClock clock = new FakeClock();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -72,6 +72,7 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -944,7 +945,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
   public void testSessionNotFoundWrite() {
     SpannerException sessionNotFound =
         SpannerExceptionFactoryTest.newSessionNotFoundException(sessionName);
-    List<Mutation> mutations = Arrays.asList(Mutation.newInsertBuilder("FOO").build());
+    List<Mutation> mutations = Collections.singletonList(Mutation.newInsertBuilder("FOO").build());
     final SessionImpl closedSession = mockSession();
     when(closedSession.writeWithOptions(mutations)).thenThrow(sessionNotFound);
 
@@ -989,7 +990,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
   public void testSessionNotFoundWriteAtLeastOnce() {
     SpannerException sessionNotFound =
         SpannerExceptionFactoryTest.newSessionNotFoundException(sessionName);
-    List<Mutation> mutations = Arrays.asList(Mutation.newInsertBuilder("FOO").build());
+    List<Mutation> mutations = Collections.singletonList(Mutation.newInsertBuilder("FOO").build());
     final SessionImpl closedSession = mockSession();
     when(closedSession.writeAtLeastOnceWithOptions(mutations)).thenThrow(sessionNotFound);
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpanTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpanTest.java
@@ -19,10 +19,8 @@ package com.google.cloud.spanner;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
-import com.google.api.core.ApiFunction;
 import com.google.api.gax.grpc.testing.LocalChannelProvider;
 import com.google.api.gax.retrying.RetrySettings;
-import com.google.api.gax.rpc.UnaryCallSettings.Builder;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
@@ -172,12 +170,9 @@ public class SpanTest {
     builder
         .getSpannerStubSettingsBuilder()
         .applyToAllUnaryMethods(
-            new ApiFunction<Builder<?, ?>, Void>() {
-              @Override
-              public Void apply(Builder<?, ?> input) {
-                input.setRetrySettings(retrySettings);
-                return null;
-              }
+            input -> {
+              input.setRetrySettings(retrySettings);
+              return null;
             });
     builder
         .getSpannerStubSettingsBuilder()

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerApiFuturesTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerApiFuturesTest.java
@@ -102,7 +102,7 @@ public class SpannerApiFuturesTest {
   public void testGetCancellationException() {
     ApiFuture<Void> fut =
         new ForwardingApiFuture<Void>(ApiFutures.<Void>immediateFuture(null)) {
-          public Void get() throws InterruptedException {
+          public Void get() {
             throw new CancellationException("test cancellation exception");
           }
         };

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerApiFuturesTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerApiFuturesTest.java
@@ -83,7 +83,7 @@ public class SpannerApiFuturesTest {
   @Test
   public void testGetInterruptedException() {
     ApiFuture<Void> fut =
-        new ForwardingApiFuture<Void>(ApiFutures.<Void>immediateFuture(null)) {
+        new ForwardingApiFuture<Void>(ApiFutures.immediateFuture(null)) {
           public Void get() throws InterruptedException {
             throw new InterruptedException("test interrupted exception");
           }
@@ -101,7 +101,7 @@ public class SpannerApiFuturesTest {
   @Test
   public void testGetCancellationException() {
     ApiFuture<Void> fut =
-        new ForwardingApiFuture<Void>(ApiFutures.<Void>immediateFuture(null)) {
+        new ForwardingApiFuture<Void>(ApiFutures.immediateFuture(null)) {
           public Void get() {
             throw new CancellationException("test cancellation exception");
           }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerExceptionFactoryTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerExceptionFactoryTest.java
@@ -149,7 +149,7 @@ public class SpannerExceptionFactoryTest {
     SpannerException e =
         SpannerExceptionFactory.newSpannerException(new StatusRuntimeException(status, trailers));
     assertThat(e).isInstanceOf(AbortedException.class);
-    assertThat(((AbortedException) e).getRetryDelayInMillis()).isEqualTo(1001L);
+    assertThat(e.getRetryDelayInMillis()).isEqualTo(1001L);
   }
 
   @Test
@@ -158,7 +158,7 @@ public class SpannerExceptionFactoryTest {
     SpannerException e =
         SpannerExceptionFactory.newSpannerException(new StatusRuntimeException(status));
     assertThat(e).isInstanceOf(AbortedException.class);
-    assertThat(((AbortedException) e).getRetryDelayInMillis()).isEqualTo(-1L);
+    assertThat(e.getRetryDelayInMillis()).isEqualTo(-1L);
   }
 
   @Test
@@ -170,7 +170,7 @@ public class SpannerExceptionFactoryTest {
     SpannerException e =
         SpannerExceptionFactory.newSpannerException(new StatusRuntimeException(status, trailers));
     assertThat(e).isInstanceOf(AbortedException.class);
-    assertThat(((AbortedException) e).getRetryDelayInMillis()).isEqualTo(-1L);
+    assertThat(e.getRetryDelayInMillis()).isEqualTo(-1L);
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerGaxRetryTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerGaxRetryTest.java
@@ -22,11 +22,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import com.google.api.core.ApiFunction;
 import com.google.api.gax.grpc.testing.LocalChannelProvider;
 import com.google.api.gax.retrying.RetrySettings;
-import com.google.api.gax.rpc.UnaryCallSettings;
-import com.google.api.gax.rpc.UnaryCallSettings.Builder;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
@@ -161,12 +158,9 @@ public class SpannerGaxRetryTest {
     builder
         .getSpannerStubSettingsBuilder()
         .applyToAllUnaryMethods(
-            new ApiFunction<UnaryCallSettings.Builder<?, ?>, Void>() {
-              @Override
-              public Void apply(Builder<?, ?> input) {
-                input.setRetrySettings(retrySettings);
-                return null;
-              }
+            input -> {
+              input.setRetrySettings(retrySettings);
+              return null;
             });
     builder
         .getSpannerStubSettingsBuilder()

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerImplTest.java
@@ -64,7 +64,7 @@ public class SpannerImplTest {
     when(spannerOptions.getPrefetchChunks()).thenReturn(1);
     when(spannerOptions.getRetrySettings()).thenReturn(RetrySettings.newBuilder().build());
     when(spannerOptions.getClock()).thenReturn(NanoClock.getDefaultClock());
-    when(spannerOptions.getSessionLabels()).thenReturn(Collections.<String, String>emptyMap());
+    when(spannerOptions.getSessionLabels()).thenReturn(Collections.emptyMap());
     impl = new SpannerImpl(rpc, spannerOptions);
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
@@ -558,13 +558,7 @@ public class SpannerOptionsTest {
 
   @Test
   public void testDefaultQueryOptions() {
-    SpannerOptions.useEnvironment(
-        new SpannerOptions.SpannerEnvironment() {
-          @Override
-          public String getOptimizerVersion() {
-            return "";
-          }
-        });
+    SpannerOptions.useEnvironment(() -> "");
     SpannerOptions options =
         SpannerOptions.newBuilder()
             .setDefaultQueryOptions(
@@ -579,13 +573,7 @@ public class SpannerOptionsTest {
         .isEqualTo(QueryOptions.getDefaultInstance());
 
     // Now simulate that the user has set an environment variable for the query optimizer version.
-    SpannerOptions.useEnvironment(
-        new SpannerOptions.SpannerEnvironment() {
-          @Override
-          public String getOptimizerVersion() {
-            return "2";
-          }
-        });
+    SpannerOptions.useEnvironment(() -> "2");
     // Create options with '1' as the default query optimizer version. This should be overridden by
     // the environment variable.
     options =

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
@@ -50,6 +50,7 @@ import com.google.spanner.v1.ReadRequest;
 import com.google.spanner.v1.RollbackRequest;
 import com.google.spanner.v1.SpannerGrpc;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -140,7 +141,7 @@ public class SpannerOptionsTest {
     List<? extends UnaryCallSettings<?, ?>> callsWithRetry1 =
         Arrays.asList(stubSettings.listSessionsSettings(), stubSettings.commitSettings());
     List<? extends UnaryCallSettings<?, ?>> callsWithRetry2 =
-        Arrays.asList(stubSettings.batchCreateSessionsSettings());
+        Collections.singletonList(stubSettings.batchCreateSessionsSettings());
     List<? extends UnaryCallSettings<?, ?>> callsWithRetry3 =
         Arrays.asList(
             stubSettings.createSessionSettings(),
@@ -276,7 +277,7 @@ public class SpannerOptionsTest {
             stubSettings.getDatabaseSettings(),
             stubSettings.getDatabaseDdlSettings());
     List<? extends UnaryCallSettings<?, ?>> callsWithRetryPolicy2 =
-        Arrays.asList(stubSettings.getIamPolicySettings());
+        Collections.singletonList(stubSettings.getIamPolicySettings());
     List<? extends UnaryCallSettings<?, ?>> callsWithNoRetry2 =
         Arrays.asList(
             stubSettings.setIamPolicySettings(), stubSettings.testIamPermissionsSettings());
@@ -375,7 +376,7 @@ public class SpannerOptionsTest {
             stubSettings.getInstanceSettings(),
             stubSettings.listInstancesSettings());
     List<? extends UnaryCallSettings<?, ?>> callsWithRetryPolicy2 =
-        Arrays.asList(stubSettings.getIamPolicySettings());
+        Collections.singletonList(stubSettings.getIamPolicySettings());
     List<? extends UnaryCallSettings<?, ?>> callsWithNoRetryPolicy1 =
         Arrays.asList(stubSettings.createInstanceSettings(), stubSettings.updateInstanceSettings());
     List<? extends UnaryCallSettings<?, ?>> callsWithNoRetryPolicy2 =

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsThreadTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsThreadTest.java
@@ -18,13 +18,11 @@ package com.google.cloud.spanner;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.api.core.ApiFunction;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.connection.AbstractMockServerTest;
 import com.google.common.base.Stopwatch;
 import com.google.spanner.admin.database.v1.ListDatabasesResponse;
 import com.google.spanner.admin.instance.v1.ListInstancesResponse;
-import io.grpc.ManagedChannelBuilder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -54,12 +52,9 @@ public class SpannerOptionsThreadTest extends AbstractMockServerTest {
         .setProjectId("p")
         // Set a custom channel configurator to allow http instead of https.
         .setChannelConfigurator(
-            new ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder>() {
-              @Override
-              public ManagedChannelBuilder apply(ManagedChannelBuilder input) {
-                input.usePlaintext();
-                return input;
-              }
+            input -> {
+              input.usePlaintext();
+              return input;
             })
         .setHost("http://localhost:" + getPort())
         .setCredentials(NoCredentials.getInstance())

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsThreadTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsThreadTest.java
@@ -46,7 +46,6 @@ public class SpannerOptionsThreadTest extends AbstractMockServerTest {
 
   private final DatabaseId dbId = DatabaseId.of("p", "i", "d");
 
-  @SuppressWarnings("rawtypes")
   private SpannerOptions createOptions() {
     return SpannerOptions.newBuilder()
         .setProjectId("p")

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsThreadTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsThreadTest.java
@@ -23,6 +23,7 @@ import com.google.cloud.spanner.connection.AbstractMockServerTest;
 import com.google.common.base.Stopwatch;
 import com.google.spanner.admin.database.v1.ListDatabasesResponse;
 import com.google.spanner.admin.instance.v1.ListInstancesResponse;
+import io.grpc.ManagedChannelBuilder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -50,11 +51,7 @@ public class SpannerOptionsThreadTest extends AbstractMockServerTest {
     return SpannerOptions.newBuilder()
         .setProjectId("p")
         // Set a custom channel configurator to allow http instead of https.
-        .setChannelConfigurator(
-            input -> {
-              input.usePlaintext();
-              return input;
-            })
+        .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
         .setHost("http://localhost:" + getPort())
         .setCredentials(NoCredentials.getInstance())
         .build();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerRetryHelperTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerRetryHelperTest.java
@@ -218,6 +218,7 @@ public class SpannerRetryHelperTest {
                 try {
                   Thread.sleep(Long.MAX_VALUE);
                 } catch (InterruptedException e) {
+                  // Ignored exception
                 }
               }
             });

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/StandardBenchmarkMockServer.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/StandardBenchmarkMockServer.java
@@ -21,7 +21,6 @@ import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
 import com.google.cloud.spanner.connection.RandomResultSetGenerator;
-import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.google.protobuf.AbstractMessage;
 import com.google.protobuf.ListValue;
@@ -131,14 +130,7 @@ class StandardBenchmarkMockServer {
   }
 
   int countRequests(final Class<? extends AbstractMessage> type) {
-    return Collections2.filter(
-            mockSpanner.getRequests(),
-            new Predicate<AbstractMessage>() {
-              @Override
-              public boolean apply(AbstractMessage input) {
-                return input.getClass().equals(type);
-              }
-            })
+    return Collections2.filter(mockSpanner.getRequests(), input -> input.getClass().equals(type))
         .size();
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionContextImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionContextImplTest.java
@@ -31,7 +31,7 @@ import com.google.rpc.Status;
 import com.google.spanner.v1.CommitRequest;
 import com.google.spanner.v1.ExecuteBatchDmlRequest;
 import com.google.spanner.v1.ExecuteBatchDmlResponse;
-import java.util.Arrays;
+import java.util.Collections;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -99,7 +99,7 @@ public class TransactionContextImplTest {
             .setTransactionId(ByteString.copyFromUtf8("test"))
             .setOptions(Options.fromTransactionOptions())
             .build()) {
-      impl.batchUpdate(Arrays.asList(statement));
+      impl.batchUpdate(Collections.singletonList(statement));
     }
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerAbortedTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerAbortedTest.java
@@ -37,6 +37,7 @@ import io.grpc.Server;
 import io.grpc.inprocess.InProcessServerBuilder;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -130,10 +131,14 @@ public class TransactionManagerAbortedTest {
     mockSpanner = new MockSpannerServiceImpl();
     mockSpanner.setAbortProbability(0.0D); // We don't want any unpredictable aborted transactions.
     mockSpanner.putStatementResult(
-        StatementResult.read("FOO", KeySet.all(), Arrays.asList("BAR"), READ_RESULTSET));
+        StatementResult.read(
+            "FOO", KeySet.all(), Collections.singletonList("BAR"), READ_RESULTSET));
     mockSpanner.putStatementResult(
         StatementResult.read(
-            "FOO", KeySet.singleKey(Key.of()), Arrays.asList("BAR"), READ_ROW_RESULTSET));
+            "FOO",
+            KeySet.singleKey(Key.of()),
+            Collections.singletonList("BAR"),
+            READ_ROW_RESULTSET));
     mockSpanner.putStatementResult(StatementResult.query(SELECT1AND2, SELECT1AND2_RESULTSET));
     mockSpanner.putStatementResult(StatementResult.update(UPDATE_STATEMENT, UPDATE_COUNT));
     mockSpanner.putStatementResult(
@@ -335,7 +340,7 @@ public class TransactionManagerAbortedTest {
           if (attempts == 1) {
             mockSpanner.abortNextTransaction();
           }
-          try (ResultSet rs = txn.read("FOO", KeySet.all(), Arrays.asList("BAR"))) {
+          try (ResultSet rs = txn.read("FOO", KeySet.all(), Collections.singletonList("BAR"))) {
             int rows = 0;
             while (rs.next()) {
               rows++;
@@ -368,7 +373,7 @@ public class TransactionManagerAbortedTest {
             mockSpanner.abortNextTransaction();
           }
           try (ResultSet rs =
-              txn.readUsingIndex("FOO", "INDEX", KeySet.all(), Arrays.asList("BAR"))) {
+              txn.readUsingIndex("FOO", "INDEX", KeySet.all(), Collections.singletonList("BAR"))) {
             int rows = 0;
             while (rs.next()) {
               rows++;
@@ -400,7 +405,7 @@ public class TransactionManagerAbortedTest {
           if (attempts == 1) {
             mockSpanner.abortNextTransaction();
           }
-          Struct row = txn.readRow("FOO", Key.of(), Arrays.asList("BAR"));
+          Struct row = txn.readRow("FOO", Key.of(), Collections.singletonList("BAR"));
           assertThat(row.getLong(0), is(equalTo(1L)));
           manager.commit();
           break;
@@ -427,7 +432,8 @@ public class TransactionManagerAbortedTest {
           if (attempts == 1) {
             mockSpanner.abortNextTransaction();
           }
-          Struct row = txn.readRowUsingIndex("FOO", "INDEX", Key.of(), Arrays.asList("BAR"));
+          Struct row =
+              txn.readRowUsingIndex("FOO", "INDEX", Key.of(), Collections.singletonList("BAR"));
           assertThat(row.getLong(0), is(equalTo(1L)));
           manager.commit();
           break;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
@@ -245,7 +245,7 @@ public class TransactionManagerImplTest {
                 invocation ->
                     Collections.singletonList(
                         Session.newBuilder()
-                            .setName((String) invocation.getArguments()[0] + "/sessions/1")
+                            .setName(invocation.getArguments()[0] + "/sessions/1")
                             .setCreateTime(
                                 com.google.protobuf.Timestamp.newBuilder()
                                     .setSeconds(System.currentTimeMillis() * 1000))
@@ -304,7 +304,7 @@ public class TransactionManagerImplTest {
                 invocation ->
                     Collections.singletonList(
                         Session.newBuilder()
-                            .setName((String) invocation.getArguments()[0] + "/sessions/1")
+                            .setName(invocation.getArguments()[0] + "/sessions/1")
                             .setCreateTime(
                                 com.google.protobuf.Timestamp.newBuilder()
                                     .setSeconds(System.currentTimeMillis() * 1000))

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
@@ -234,7 +234,7 @@ public class TransactionManagerImplTest {
     SessionPoolOptions sessionPoolOptions =
         SessionPoolOptions.newBuilder().setMinSessions(0).setIncStep(1).build();
     when(options.getSessionPoolOptions()).thenReturn(sessionPoolOptions);
-    when(options.getSessionLabels()).thenReturn(Collections.<String, String>emptyMap());
+    when(options.getSessionLabels()).thenReturn(Collections.emptyMap());
     SpannerRpc rpc = mock(SpannerRpc.class);
     when(rpc.asyncDeleteSession(Mockito.anyString(), Mockito.anyMap()))
         .thenReturn(ApiFutures.immediateFuture(Empty.getDefaultInstance()));
@@ -291,7 +291,7 @@ public class TransactionManagerImplTest {
     SessionPoolOptions sessionPoolOptions =
         SessionPoolOptions.newBuilder().setMinSessions(0).setIncStep(1).build();
     when(options.getSessionPoolOptions()).thenReturn(sessionPoolOptions);
-    when(options.getSessionLabels()).thenReturn(Collections.<String, String>emptyMap());
+    when(options.getSessionLabels()).thenReturn(Collections.emptyMap());
     when(options.getDefaultQueryOptions(Mockito.any(DatabaseId.class)))
         .thenReturn(QueryOptions.getDefaultInstance());
     SpannerRpc rpc = mock(SpannerRpc.class);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.cloud.Timestamp;
 import com.google.cloud.grpc.GrpcTransportOptions;
@@ -46,7 +45,6 @@ import com.google.spanner.v1.Session;
 import com.google.spanner.v1.Transaction;
 import io.opencensus.trace.Span;
 import java.util.Collections;
-import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -57,7 +55,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.stubbing.Answer;
 
 @RunWith(JUnit4.class)
 public class TransactionManagerImplTest {
@@ -241,33 +238,30 @@ public class TransactionManagerImplTest {
     when(rpc.batchCreateSessions(
             Mockito.anyString(), Mockito.eq(1), Mockito.anyMap(), Mockito.anyMap()))
         .thenAnswer(
-            (Answer<List<Session>>)
-                invocation ->
-                    Collections.singletonList(
-                        Session.newBuilder()
-                            .setName(invocation.getArguments()[0] + "/sessions/1")
-                            .setCreateTime(
-                                com.google.protobuf.Timestamp.newBuilder()
-                                    .setSeconds(System.currentTimeMillis() * 1000))
-                            .build()));
+            invocation ->
+                Collections.singletonList(
+                    Session.newBuilder()
+                        .setName(invocation.getArguments()[0] + "/sessions/1")
+                        .setCreateTime(
+                            com.google.protobuf.Timestamp.newBuilder()
+                                .setSeconds(System.currentTimeMillis() * 1000))
+                        .build()));
     when(rpc.beginTransactionAsync(Mockito.any(BeginTransactionRequest.class), Mockito.anyMap()))
         .thenAnswer(
-            (Answer<ApiFuture<Transaction>>)
-                invocation ->
-                    ApiFutures.immediateFuture(
-                        Transaction.newBuilder()
-                            .setId(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
-                            .build()));
+            invocation ->
+                ApiFutures.immediateFuture(
+                    Transaction.newBuilder()
+                        .setId(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
+                        .build()));
     when(rpc.commitAsync(Mockito.any(CommitRequest.class), Mockito.anyMap()))
         .thenAnswer(
-            (Answer<ApiFuture<com.google.spanner.v1.CommitResponse>>)
-                invocation ->
-                    ApiFutures.immediateFuture(
-                        com.google.spanner.v1.CommitResponse.newBuilder()
-                            .setCommitTimestamp(
-                                com.google.protobuf.Timestamp.newBuilder()
-                                    .setSeconds(System.currentTimeMillis() * 1000))
-                            .build()));
+            invocation ->
+                ApiFutures.immediateFuture(
+                    com.google.spanner.v1.CommitResponse.newBuilder()
+                        .setCommitTimestamp(
+                            com.google.protobuf.Timestamp.newBuilder()
+                                .setSeconds(System.currentTimeMillis() * 1000))
+                        .build()));
     DatabaseId db = DatabaseId.of("test", "test", "test");
     try (SpannerImpl spanner = new SpannerImpl(rpc, options)) {
       DatabaseClient client = spanner.getDatabaseClient(db);
@@ -300,54 +294,50 @@ public class TransactionManagerImplTest {
     when(rpc.batchCreateSessions(
             Mockito.anyString(), Mockito.eq(1), Mockito.anyMap(), Mockito.anyMap()))
         .thenAnswer(
-            (Answer<List<Session>>)
-                invocation ->
-                    Collections.singletonList(
-                        Session.newBuilder()
-                            .setName(invocation.getArguments()[0] + "/sessions/1")
-                            .setCreateTime(
-                                com.google.protobuf.Timestamp.newBuilder()
-                                    .setSeconds(System.currentTimeMillis() * 1000))
-                            .build()));
+            invocation ->
+                Collections.singletonList(
+                    Session.newBuilder()
+                        .setName(invocation.getArguments()[0] + "/sessions/1")
+                        .setCreateTime(
+                            com.google.protobuf.Timestamp.newBuilder()
+                                .setSeconds(System.currentTimeMillis() * 1000))
+                        .build()));
     when(rpc.beginTransactionAsync(Mockito.any(BeginTransactionRequest.class), Mockito.anyMap()))
         .thenAnswer(
-            (Answer<ApiFuture<Transaction>>)
-                invocation ->
-                    ApiFutures.immediateFuture(
-                        Transaction.newBuilder()
-                            .setId(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
-                            .build()));
+            invocation ->
+                ApiFutures.immediateFuture(
+                    Transaction.newBuilder()
+                        .setId(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
+                        .build()));
     final AtomicInteger transactionsStarted = new AtomicInteger();
     when(rpc.executeQuery(Mockito.any(ExecuteSqlRequest.class), Mockito.anyMap()))
         .thenAnswer(
-            (Answer<ResultSet>)
-                invocation -> {
-                  ResultSet.Builder builder =
-                      ResultSet.newBuilder()
-                          .setStats(ResultSetStats.newBuilder().setRowCountExact(1L).build());
-                  ExecuteSqlRequest request = invocation.getArgumentAt(0, ExecuteSqlRequest.class);
-                  if (request.getTransaction() != null && request.getTransaction().hasBegin()) {
-                    transactionsStarted.incrementAndGet();
-                    builder.setMetadata(
-                        ResultSetMetadata.newBuilder()
-                            .setTransaction(
-                                Transaction.newBuilder()
-                                    .setId(ByteString.copyFromUtf8("test-tx"))
-                                    .build())
-                            .build());
-                  }
-                  return builder.build();
-                });
+            invocation -> {
+              ResultSet.Builder builder =
+                  ResultSet.newBuilder()
+                      .setStats(ResultSetStats.newBuilder().setRowCountExact(1L).build());
+              ExecuteSqlRequest request = invocation.getArgumentAt(0, ExecuteSqlRequest.class);
+              if (request.getTransaction() != null && request.getTransaction().hasBegin()) {
+                transactionsStarted.incrementAndGet();
+                builder.setMetadata(
+                    ResultSetMetadata.newBuilder()
+                        .setTransaction(
+                            Transaction.newBuilder()
+                                .setId(ByteString.copyFromUtf8("test-tx"))
+                                .build())
+                        .build());
+              }
+              return builder.build();
+            });
     when(rpc.commitAsync(Mockito.any(CommitRequest.class), Mockito.anyMap()))
         .thenAnswer(
-            (Answer<ApiFuture<com.google.spanner.v1.CommitResponse>>)
-                invocation ->
-                    ApiFutures.immediateFuture(
-                        com.google.spanner.v1.CommitResponse.newBuilder()
-                            .setCommitTimestamp(
-                                com.google.protobuf.Timestamp.newBuilder()
-                                    .setSeconds(System.currentTimeMillis() * 1000))
-                            .build()));
+            invocation ->
+                ApiFutures.immediateFuture(
+                    com.google.spanner.v1.CommitResponse.newBuilder()
+                        .setCommitTimestamp(
+                            com.google.protobuf.Timestamp.newBuilder()
+                                .setSeconds(System.currentTimeMillis() * 1000))
+                        .build()));
     DatabaseId db = DatabaseId.of("test", "test", "test");
     try (SpannerImpl spanner = new SpannerImpl(rpc, options)) {
       DatabaseClient client = spanner.getDatabaseClient(db);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
@@ -45,7 +45,6 @@ import com.google.spanner.v1.ResultSetStats;
 import com.google.spanner.v1.Session;
 import com.google.spanner.v1.Transaction;
 import io.opencensus.trace.Span;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -244,7 +243,7 @@ public class TransactionManagerImplTest {
         .thenAnswer(
             (Answer<List<Session>>)
                 invocation ->
-                    Arrays.asList(
+                    Collections.singletonList(
                         Session.newBuilder()
                             .setName((String) invocation.getArguments()[0] + "/sessions/1")
                             .setCreateTime(
@@ -303,7 +302,7 @@ public class TransactionManagerImplTest {
         .thenAnswer(
             (Answer<List<Session>>)
                 invocation ->
-                    Arrays.asList(
+                    Collections.singletonList(
                         Session.newBuilder()
                             .setName((String) invocation.getArguments()[0] + "/sessions/1")
                             .setCreateTime(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
@@ -269,7 +269,7 @@ public class TransactionManagerImplTest {
             new Answer<ApiFuture<com.google.spanner.v1.CommitResponse>>() {
               @Override
               public ApiFuture<com.google.spanner.v1.CommitResponse> answer(
-                  InvocationOnMock invocation) throws Throwable {
+                  InvocationOnMock invocation) {
                 return ApiFutures.immediateFuture(
                     com.google.spanner.v1.CommitResponse.newBuilder()
                         .setCommitTimestamp(
@@ -312,8 +312,7 @@ public class TransactionManagerImplTest {
         .thenAnswer(
             new Answer<List<com.google.spanner.v1.Session>>() {
               @Override
-              public List<com.google.spanner.v1.Session> answer(InvocationOnMock invocation)
-                  throws Throwable {
+              public List<com.google.spanner.v1.Session> answer(InvocationOnMock invocation) {
                 return Arrays.asList(
                     com.google.spanner.v1.Session.newBuilder()
                         .setName((String) invocation.getArguments()[0] + "/sessions/1")
@@ -327,7 +326,7 @@ public class TransactionManagerImplTest {
         .thenAnswer(
             new Answer<ApiFuture<Transaction>>() {
               @Override
-              public ApiFuture<Transaction> answer(InvocationOnMock invocation) throws Throwable {
+              public ApiFuture<Transaction> answer(InvocationOnMock invocation) {
                 return ApiFutures.immediateFuture(
                     Transaction.newBuilder()
                         .setId(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
@@ -339,8 +338,7 @@ public class TransactionManagerImplTest {
         .thenAnswer(
             new Answer<com.google.spanner.v1.ResultSet>() {
               @Override
-              public com.google.spanner.v1.ResultSet answer(InvocationOnMock invocation)
-                  throws Throwable {
+              public com.google.spanner.v1.ResultSet answer(InvocationOnMock invocation) {
                 com.google.spanner.v1.ResultSet.Builder builder =
                     com.google.spanner.v1.ResultSet.newBuilder()
                         .setStats(ResultSetStats.newBuilder().setRowCountExact(1L).build());
@@ -363,7 +361,7 @@ public class TransactionManagerImplTest {
             new Answer<ApiFuture<com.google.spanner.v1.CommitResponse>>() {
               @Override
               public ApiFuture<com.google.spanner.v1.CommitResponse> answer(
-                  InvocationOnMock invocation) throws Throwable {
+                  InvocationOnMock invocation) {
                 return ApiFutures.immediateFuture(
                     com.google.spanner.v1.CommitResponse.newBuilder()
                         .setCommitTimestamp(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
@@ -154,7 +154,7 @@ public class TransactionRunnerImplTest {
                 invocation ->
                     Collections.singletonList(
                         Session.newBuilder()
-                            .setName((String) invocation.getArguments()[0] + "/sessions/1")
+                            .setName(invocation.getArguments()[0] + "/sessions/1")
                             .setCreateTime(
                                 Timestamp.newBuilder()
                                     .setSeconds(System.currentTimeMillis() * 1000))

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
@@ -152,7 +152,7 @@ public class TransactionRunnerImplTest {
         .thenAnswer(
             (Answer<List<Session>>)
                 invocation ->
-                    Arrays.asList(
+                    Collections.singletonList(
                         Session.newBuilder()
                             .setName((String) invocation.getArguments()[0] + "/sessions/1")
                             .setCreateTime(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
@@ -143,7 +143,7 @@ public class TransactionRunnerImplTest {
     SessionPoolOptions sessionPoolOptions =
         SessionPoolOptions.newBuilder().setMinSessions(0).setIncStep(1).build();
     when(options.getSessionPoolOptions()).thenReturn(sessionPoolOptions);
-    when(options.getSessionLabels()).thenReturn(Collections.<String, String>emptyMap());
+    when(options.getSessionLabels()).thenReturn(Collections.emptyMap());
     SpannerRpc rpc = mock(SpannerRpc.class);
     when(rpc.asyncDeleteSession(Mockito.anyString(), Mockito.anyMap()))
         .thenReturn(ApiFutures.immediateFuture(Empty.getDefaultInstance()));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
@@ -105,7 +105,7 @@ public class TransactionRunnerImplTest {
         .thenAnswer(
             new Answer<ResultSet>() {
               @Override
-              public ResultSet answer(InvocationOnMock invocation) throws Throwable {
+              public ResultSet answer(InvocationOnMock invocation) {
                 ResultSet.Builder builder =
                     ResultSet.newBuilder()
                         .setStats(ResultSetStats.newBuilder().setRowCountExact(1L).build());
@@ -178,8 +178,7 @@ public class TransactionRunnerImplTest {
         .thenAnswer(
             new Answer<ApiFuture<CommitResponse>>() {
               @Override
-              public ApiFuture<CommitResponse> answer(InvocationOnMock invocation)
-                  throws Throwable {
+              public ApiFuture<CommitResponse> answer(InvocationOnMock invocation) {
                 return ApiFutures.immediateFuture(
                     CommitResponse.newBuilder()
                         .setCommitTimestamp(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueBinderTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueBinderTest.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Collections;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -67,8 +68,9 @@ public class ValueBinderTest {
           // Array of structs.
           assertThat(binderMethod.getParameterTypes()).hasLength(2);
 
-          Value expected = (Value) method.invoke(Value.class, structType, Arrays.asList(struct));
-          assertThat(binderMethod.invoke(binder, structType, Arrays.asList(struct)))
+          Value expected =
+              (Value) method.invoke(Value.class, structType, Collections.singletonList(struct));
+          assertThat(binderMethod.invoke(binder, structType, Collections.singletonList(struct)))
               .isEqualTo(lastReturnValue);
           assertThat(lastValue).isEqualTo(expected);
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueTest.java
@@ -54,7 +54,7 @@ public class ValueTest {
   @SafeVarargs
   private static <T> Iterable<T> plainIterable(T... values) {
     final List<T> list = Lists.newArrayList(values);
-    return () -> list.iterator();
+    return list::iterator;
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueTest.java
@@ -54,8 +54,7 @@ public class ValueTest {
   /** Returns an {@code Iterable} over {@code values} that is not a {@code Collection}. */
   @SafeVarargs
   private static <T> Iterable<T> plainIterable(T... values) {
-    final List<T> list = Lists.newArrayList(values);
-    return list::iterator;
+    return Lists.newArrayList(values);
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueTest.java
@@ -1503,8 +1503,8 @@ public class ValueTest {
         Value.structArray(structType1, Arrays.asList(structValue1, null)),
         Value.structArray(structType1, Arrays.asList(structValue2, null)));
     tester.addEqualityGroup(
-        Value.structArray(structType1, Collections.singletonList((Struct) null)),
-        Value.structArray(structType1, Collections.singletonList((Struct) null)));
+        Value.structArray(structType1, Collections.singletonList(null)),
+        Value.structArray(structType1, Collections.singletonList(null)));
     tester.addEqualityGroup(
         Value.structArray(structType1, null), Value.structArray(structType1, null));
     tester.addEqualityGroup(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueTest.java
@@ -36,6 +36,7 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -563,7 +564,7 @@ public class ValueTest {
 
   @Test
   public void boolArrayTryGetInt64Array() {
-    Value value = Value.boolArray(Arrays.asList(true));
+    Value value = Value.boolArray(Collections.singletonList(true));
     try {
       value.getInt64Array();
       fail("Expected exception");
@@ -624,7 +625,7 @@ public class ValueTest {
 
   @Test
   public void int64ArrayTryGetBool() {
-    Value value = Value.int64Array(Arrays.asList(1234L));
+    Value value = Value.int64Array(Collections.singletonList(1234L));
     try {
       value.getBool();
       fail("Expected exception");
@@ -696,7 +697,7 @@ public class ValueTest {
 
   @Test
   public void float64ArrayTryGetInt64Array() {
-    Value value = Value.float64Array(Arrays.asList(.1));
+    Value value = Value.float64Array(Collections.singletonList(.1));
     try {
       value.getInt64Array();
       fail("Expected exception");
@@ -732,7 +733,7 @@ public class ValueTest {
 
   @Test
   public void numericArrayTryGetInt64Array() {
-    Value value = Value.numericArray(Arrays.asList(BigDecimal.valueOf(1, 1)));
+    Value value = Value.numericArray(Collections.singletonList(BigDecimal.valueOf(1, 1)));
 
     try {
       value.getInt64Array();
@@ -765,7 +766,7 @@ public class ValueTest {
 
   @Test
   public void stringArrayTryGetBytesArray() {
-    Value value = Value.stringArray(Arrays.asList("a"));
+    Value value = Value.stringArray(Collections.singletonList("a"));
     try {
       value.getBytesArray();
       fail("Expected exception");
@@ -799,7 +800,7 @@ public class ValueTest {
 
   @Test
   public void bytesArrayTryGetStringArray() {
-    Value value = Value.bytesArray(Arrays.asList(newByteArray("a")));
+    Value value = Value.bytesArray(Collections.singletonList(newByteArray("a")));
     try {
       value.getStringArray();
       fail("Expected exception");
@@ -873,7 +874,8 @@ public class ValueTest {
     Value v2 = Value.struct(struct.getType(), struct);
     assertThat(v2).isEqualTo(v1);
     try {
-      Value.struct(Type.struct(Arrays.asList(StructField.of("f3", Type.string()))), struct);
+      Value.struct(
+          Type.struct(Collections.singletonList(StructField.of("f3", Type.string()))), struct);
       fail("Expected exception");
     } catch (IllegalArgumentException e) {
       assertThat(e.getMessage().contains("Mismatch between struct value and type."));
@@ -1443,7 +1445,7 @@ public class ValueTest {
     tester.addEqualityGroup(Value.struct(structValue1), Value.struct(structValue2));
 
     Type structType1 = structValue1.getType();
-    Type structType2 = Type.struct(Arrays.asList(StructField.of("f1", Type.string())));
+    Type structType2 = Type.struct(Collections.singletonList(StructField.of("f1", Type.string())));
     tester.addEqualityGroup(Value.struct(structType1, null), Value.struct(structType1, null));
     tester.addEqualityGroup(Value.struct(structType2, null), Value.struct(structType2, null));
 
@@ -1452,7 +1454,7 @@ public class ValueTest {
         Value.boolArray(new boolean[] {false, true}),
         Value.boolArray(new boolean[] {true, false, true, false}, 1, 2),
         Value.boolArray(plainIterable(false, true)));
-    tester.addEqualityGroup(Value.boolArray(Arrays.asList(false)));
+    tester.addEqualityGroup(Value.boolArray(Collections.singletonList(false)));
     tester.addEqualityGroup(Value.boolArray((Iterable<Boolean>) null));
 
     tester.addEqualityGroup(
@@ -1460,7 +1462,7 @@ public class ValueTest {
         Value.int64Array(new long[] {1L, 2L}),
         Value.int64Array(new long[] {0L, 1L, 2L, 3L}, 1, 2),
         Value.int64Array(plainIterable(1L, 2L)));
-    tester.addEqualityGroup(Value.int64Array(Arrays.asList(3L)));
+    tester.addEqualityGroup(Value.int64Array(Collections.singletonList(3L)));
     tester.addEqualityGroup(Value.int64Array((Iterable<Long>) null));
 
     tester.addEqualityGroup(
@@ -1468,23 +1470,24 @@ public class ValueTest {
         Value.float64Array(new double[] {.1, .2}),
         Value.float64Array(new double[] {.0, .1, .2, .3}, 1, 2),
         Value.float64Array(plainIterable(.1, .2)));
-    tester.addEqualityGroup(Value.float64Array(Arrays.asList(.3)));
+    tester.addEqualityGroup(Value.float64Array(Collections.singletonList(.3)));
     tester.addEqualityGroup(Value.float64Array((Iterable<Double>) null));
 
     tester.addEqualityGroup(
         Value.numericArray(Arrays.asList(BigDecimal.valueOf(1, 1), BigDecimal.valueOf(2, 1))));
-    tester.addEqualityGroup(Value.numericArray(Arrays.asList(BigDecimal.valueOf(3, 1))));
+    tester.addEqualityGroup(
+        Value.numericArray(Collections.singletonList(BigDecimal.valueOf(3, 1))));
     tester.addEqualityGroup(Value.numericArray((Iterable<BigDecimal>) null));
 
     tester.addEqualityGroup(
         Value.stringArray(Arrays.asList("a", "b")), Value.stringArray(Arrays.asList("a", "b")));
-    tester.addEqualityGroup(Value.stringArray(Arrays.asList("c")));
+    tester.addEqualityGroup(Value.stringArray(Collections.singletonList("c")));
     tester.addEqualityGroup(Value.stringArray(null));
 
     tester.addEqualityGroup(
         Value.bytesArray(Arrays.asList(newByteArray("a"), newByteArray("b"))),
         Value.bytesArray(Arrays.asList(newByteArray("a"), newByteArray("b"))));
-    tester.addEqualityGroup(Value.bytesArray(Arrays.asList(newByteArray("c"))));
+    tester.addEqualityGroup(Value.bytesArray(Collections.singletonList(newByteArray("c"))));
     tester.addEqualityGroup(Value.bytesArray(null));
 
     tester.addEqualityGroup(
@@ -1501,8 +1504,8 @@ public class ValueTest {
         Value.structArray(structType1, Arrays.asList(structValue1, null)),
         Value.structArray(structType1, Arrays.asList(structValue2, null)));
     tester.addEqualityGroup(
-        Value.structArray(structType1, Arrays.asList((Struct) null)),
-        Value.structArray(structType1, Arrays.asList((Struct) null)));
+        Value.structArray(structType1, Collections.singletonList((Struct) null)),
+        Value.structArray(structType1, Collections.singletonList((Struct) null)));
     tester.addEqualityGroup(
         Value.structArray(structType1, null), Value.structArray(structType1, null));
     tester.addEqualityGroup(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueTest.java
@@ -36,7 +36,6 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,12 +54,7 @@ public class ValueTest {
   @SafeVarargs
   private static <T> Iterable<T> plainIterable(T... values) {
     final List<T> list = Lists.newArrayList(values);
-    return new Iterable<T>() {
-      @Override
-      public Iterator<T> iterator() {
-        return list.iterator();
-      }
-    };
+    return () -> list.iterator();
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueTest.java
@@ -719,7 +719,7 @@ public class ValueTest {
 
   @Test
   public void numericArrayNull() {
-    Value v = Value.numericArray((Iterable<BigDecimal>) null);
+    Value v = Value.numericArray(null);
     assertThat(v.isNull()).isTrue();
     assertThat(v.toString()).isEqualTo(NULL_STRING);
 
@@ -1477,7 +1477,7 @@ public class ValueTest {
         Value.numericArray(Arrays.asList(BigDecimal.valueOf(1, 1), BigDecimal.valueOf(2, 1))));
     tester.addEqualityGroup(
         Value.numericArray(Collections.singletonList(BigDecimal.valueOf(3, 1))));
-    tester.addEqualityGroup(Value.numericArray((Iterable<BigDecimal>) null));
+    tester.addEqualityGroup(Value.numericArray(null));
 
     tester.addEqualityGroup(
         Value.stringArray(Arrays.asList("a", "b")), Value.stringArray(Arrays.asList("a", "b")));
@@ -1566,7 +1566,7 @@ public class ValueTest {
         Value.numericArray(
             BrokenSerializationList.of(
                 BigDecimal.valueOf(1, 1), BigDecimal.valueOf(2, 1), BigDecimal.valueOf(3, 1))));
-    reserializeAndAssert(Value.numericArray((Iterable<BigDecimal>) null));
+    reserializeAndAssert(Value.numericArray(null));
 
     reserializeAndAssert(Value.timestamp(null));
     reserializeAndAssert(Value.timestamp(Value.COMMIT_TIMESTAMP));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbortedTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbortedTest.java
@@ -246,8 +246,7 @@ public class AbortedTest extends AbstractMockServerTest {
 
   ITConnection createConnection(TransactionRetryListener listener) {
     ITConnection connection =
-        super.createConnection(
-            ImmutableList.<StatementExecutionInterceptor>of(), ImmutableList.of(listener));
+        super.createConnection(ImmutableList.of(), ImmutableList.of(listener));
     connection.setAutocommit(false);
     return connection;
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbortedTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbortedTest.java
@@ -38,7 +38,7 @@ import com.google.spanner.v1.ExecuteBatchDmlRequest;
 import com.google.spanner.v1.ExecuteSqlRequest;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import java.util.Arrays;
+import java.util.Collections;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -150,7 +150,7 @@ public class AbortedTest extends AbstractMockServerTest {
         createConnection(createAbortFirstRetryListener(invalidStatement, notFound))) {
       connection.execute(INSERT_STATEMENT);
       try {
-        connection.executeBatchUpdate(Arrays.asList(invalidStatement));
+        connection.executeBatchUpdate(Collections.singletonList(invalidStatement));
         fail("missing expected exception");
       } catch (SpannerException e) {
         assertThat(e.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND);
@@ -230,7 +230,7 @@ public class AbortedTest extends AbstractMockServerTest {
     try (ITConnection connection =
         createConnection(createAbortFirstRetryListener(invalidStatement, notFound))) {
       try {
-        connection.executeBatchUpdate(Arrays.asList(invalidStatement));
+        connection.executeBatchUpdate(Collections.singletonList(invalidStatement));
         fail("missing expected exception");
       } catch (SpannerException e) {
         assertThat(e.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractConnectionImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractConnectionImplTest.java
@@ -39,6 +39,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.junit.AfterClass;
@@ -896,7 +897,7 @@ public abstract class AbstractConnectionImplTest {
       if (!isWriteAllowed() || !connection.isAutocommit()) {
         exception.expect(matchCode(ErrorCode.FAILED_PRECONDITION));
       }
-      connection.write(Arrays.asList(createTestMutation()));
+      connection.write(Collections.singletonList(createTestMutation()));
     }
   }
 
@@ -916,7 +917,7 @@ public abstract class AbstractConnectionImplTest {
       if (!isWriteAllowed() || connection.isAutocommit()) {
         exception.expect(matchCode(ErrorCode.FAILED_PRECONDITION));
       }
-      connection.bufferedWrite(Arrays.asList(createTestMutation()));
+      connection.bufferedWrite(Collections.singletonList(createTestMutation()));
     }
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractConnectionImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractConnectionImplTest.java
@@ -262,24 +262,18 @@ public abstract class AbstractConnectionImplTest {
 
         expectSpannerException(
             "Select should not be allowed after startBatchDml()",
-            new ConnectionConsumer() {
-              @Override
-              public void accept(Connection t) {
-                log("@EXPECT EXCEPTION FAILED_PRECONDITION");
-                log(SELECT + ";");
-                t.execute(Statement.of(SELECT));
-              }
+            t -> {
+              log("@EXPECT EXCEPTION FAILED_PRECONDITION");
+              log(SELECT + ";");
+              t.execute(Statement.of(SELECT));
             },
             connection);
         expectSpannerException(
             "DDL should not be allowed after startBatchDml()",
-            new ConnectionConsumer() {
-              @Override
-              public void accept(Connection t) {
-                log("@EXPECT EXCEPTION FAILED_PRECONDITION");
-                log(DDL + ";");
-                t.execute(Statement.of(DDL));
-              }
+            t -> {
+              log("@EXPECT EXCEPTION FAILED_PRECONDITION");
+              log(DDL + ";");
+              t.execute(Statement.of(DDL));
             },
             connection);
         log(UPDATE + ";");
@@ -312,24 +306,18 @@ public abstract class AbstractConnectionImplTest {
 
         expectSpannerException(
             "Select should not be allowed after startBatchDdl()",
-            new ConnectionConsumer() {
-              @Override
-              public void accept(Connection t) {
-                log("@EXPECT EXCEPTION FAILED_PRECONDITION");
-                log(SELECT + ";");
-                t.execute(Statement.of(SELECT));
-              }
+            t -> {
+              log("@EXPECT EXCEPTION FAILED_PRECONDITION");
+              log(SELECT + ";");
+              t.execute(Statement.of(SELECT));
             },
             connection);
         expectSpannerException(
             "Update should not be allowed after startBatchDdl()",
-            new ConnectionConsumer() {
-              @Override
-              public void accept(Connection t) {
-                log("@EXPECT EXCEPTION FAILED_PRECONDITION");
-                log(UPDATE + ";");
-                t.execute(Statement.of(UPDATE));
-              }
+            t -> {
+              log("@EXPECT EXCEPTION FAILED_PRECONDITION");
+              log(UPDATE + ";");
+              t.execute(Statement.of(UPDATE));
             },
             connection);
         log(DDL + ";");
@@ -399,13 +387,10 @@ public abstract class AbstractConnectionImplTest {
         } else {
           expectSpannerException(
               "Select should not be allowed after beginTransaction",
-              new ConnectionConsumer() {
-                @Override
-                public void accept(Connection t) {
-                  log("@EXPECT EXCEPTION FAILED_PRECONDITION");
-                  log(SELECT + ";");
-                  t.execute(Statement.of(SELECT));
-                }
+              t -> {
+                log("@EXPECT EXCEPTION FAILED_PRECONDITION");
+                log(SELECT + ";");
+                t.execute(Statement.of(SELECT));
               },
               connection);
         }
@@ -415,13 +400,10 @@ public abstract class AbstractConnectionImplTest {
         } else {
           expectSpannerException(
               "Update should not be allowed after beginTransaction",
-              new ConnectionConsumer() {
-                @Override
-                public void accept(Connection t) {
-                  log("@EXPECT EXCEPTION FAILED_PRECONDITION");
-                  log(UPDATE + ";");
-                  t.execute(Statement.of(UPDATE));
-                }
+              t -> {
+                log("@EXPECT EXCEPTION FAILED_PRECONDITION");
+                log(UPDATE + ";");
+                t.execute(Statement.of(UPDATE));
               },
               connection);
         }
@@ -431,13 +413,10 @@ public abstract class AbstractConnectionImplTest {
         } else {
           expectSpannerException(
               "DDL should not be allowed after beginTransaction",
-              new ConnectionConsumer() {
-                @Override
-                public void accept(Connection t) {
-                  log("@EXPECT EXCEPTION FAILED_PRECONDITION");
-                  log(DDL + ";");
-                  t.execute(Statement.of(DDL));
-                }
+              t -> {
+                log("@EXPECT EXCEPTION FAILED_PRECONDITION");
+                log(DDL + ";");
+                t.execute(Statement.of(DDL));
               },
               connection);
         }
@@ -469,13 +448,10 @@ public abstract class AbstractConnectionImplTest {
       } else {
         expectSpannerException(
             mode + " should not be allowed",
-            new ConnectionConsumer() {
-              @Override
-              public void accept(Connection t) {
-                log("@EXPECT EXCEPTION FAILED_PRECONDITION");
-                log("SET TRANSACTION " + mode.getStatementString() + ";");
-                t.setTransactionMode(mode);
-              }
+            t -> {
+              log("@EXPECT EXCEPTION FAILED_PRECONDITION");
+              log("SET TRANSACTION " + mode.getStatementString() + ";");
+              t.setTransactionMode(mode);
             },
             connection);
       }
@@ -577,16 +553,13 @@ public abstract class AbstractConnectionImplTest {
       } else {
         expectSpannerException(
             staleness.getMode() + " should not be allowed",
-            new ConnectionConsumer() {
-              @Override
-              public void accept(Connection t) {
-                log("@EXPECT EXCEPTION FAILED_PRECONDITION");
-                log(
-                    "SET READ_ONLY_STALENESS='"
-                        + ReadOnlyStalenessUtil.timestampBoundToString(staleness)
-                        + "';");
-                t.setReadOnlyStaleness(staleness);
-              }
+            t -> {
+              log("@EXPECT EXCEPTION FAILED_PRECONDITION");
+              log(
+                  "SET READ_ONLY_STALENESS='"
+                      + ReadOnlyStalenessUtil.timestampBoundToString(staleness)
+                      + "';");
+              t.setReadOnlyStaleness(staleness);
             },
             connection);
       }
@@ -772,13 +745,10 @@ public abstract class AbstractConnectionImplTest {
       } else {
         expectSpannerException(
             type + " should not be allowed",
-            new ConnectionConsumer() {
-              @Override
-              public void accept(Connection t) {
-                log("@EXPECT EXCEPTION FAILED_PRECONDITION");
-                log(getTestStatement(type).getSql() + ";");
-                t.execute(getTestStatement(type));
-              }
+            t -> {
+              log("@EXPECT EXCEPTION FAILED_PRECONDITION");
+              log(getTestStatement(type).getSql() + ";");
+              t.execute(getTestStatement(type));
             },
             connection);
       }
@@ -820,25 +790,17 @@ public abstract class AbstractConnectionImplTest {
         // it is a query, but queries are not allowed for this connection state
         expectSpannerException(
             type + " should not be allowed",
-            new ConnectionConsumer() {
-              @Override
-              public void accept(Connection t) {
-                log("@EXPECT EXCEPTION FAILED_PRECONDITION");
-                log(getTestStatement(type).getSql() + ";");
-                t.executeQuery(getTestStatement(type));
-              }
+            t -> {
+              log("@EXPECT EXCEPTION FAILED_PRECONDITION");
+              log(getTestStatement(type).getSql() + ";");
+              t.executeQuery(getTestStatement(type));
             },
             connection,
             ErrorCode.FAILED_PRECONDITION);
       } else {
         expectSpannerException(
             type + " should be an invalid argument",
-            new ConnectionConsumer() {
-              @Override
-              public void accept(Connection t) {
-                t.executeQuery(getTestStatement(type));
-              }
-            },
+            t -> t.executeQuery(getTestStatement(type)),
             connection,
             ErrorCode.INVALID_ARGUMENT);
       }
@@ -867,23 +829,13 @@ public abstract class AbstractConnectionImplTest {
           // it is a query, but queries are not allowed for this connection state
           expectSpannerException(
               type + " should not be allowed",
-              new ConnectionConsumer() {
-                @Override
-                public void accept(Connection t) {
-                  t.analyzeQuery(getTestStatement(type), currentMode);
-                }
-              },
+              t -> t.analyzeQuery(getTestStatement(type), currentMode),
               connection,
               ErrorCode.FAILED_PRECONDITION);
         } else {
           expectSpannerException(
               type + " should be an invalid argument",
-              new ConnectionConsumer() {
-                @Override
-                public void accept(Connection t) {
-                  t.analyzeQuery(getTestStatement(type), currentMode);
-                }
-              },
+              t -> t.analyzeQuery(getTestStatement(type), currentMode),
               connection,
               ErrorCode.INVALID_ARGUMENT);
         }
@@ -909,25 +861,17 @@ public abstract class AbstractConnectionImplTest {
         // it is an update statement, but updates are not allowed for this connection state
         expectSpannerException(
             type + "should not be allowed",
-            new ConnectionConsumer() {
-              @Override
-              public void accept(Connection t) {
-                log("@EXPECT EXCEPTION FAILED_PRECONDITION");
-                log(getTestStatement(type).getSql() + ";");
-                t.executeUpdate(getTestStatement(type));
-              }
+            t -> {
+              log("@EXPECT EXCEPTION FAILED_PRECONDITION");
+              log(getTestStatement(type).getSql() + ";");
+              t.executeUpdate(getTestStatement(type));
             },
             connection,
             ErrorCode.FAILED_PRECONDITION);
       } else {
         expectSpannerException(
             type + " should be an invalid argument",
-            new ConnectionConsumer() {
-              @Override
-              public void accept(Connection t) {
-                t.executeUpdate(getTestStatement(type));
-              }
-            },
+            t -> t.executeUpdate(getTestStatement(type)),
             connection,
             ErrorCode.INVALID_ARGUMENT);
       }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractMockServerTest.java
@@ -49,7 +49,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -212,8 +211,8 @@ public abstract class AbstractMockServerTest {
   ITConnection createConnection(
       AbortInterceptor interceptor, TransactionRetryListener transactionRetryListener) {
     return createConnection(
-        Arrays.<StatementExecutionInterceptor>asList(interceptor),
-        Arrays.<TransactionRetryListener>asList(transactionRetryListener));
+        Collections.singletonList(interceptor),
+        Collections.singletonList(transactionRetryListener));
   }
 
   ITConnection createConnection(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractMockServerTest.java
@@ -203,9 +203,7 @@ public abstract class AbstractMockServerTest {
   }
 
   ITConnection createConnection() {
-    return createConnection(
-        Collections.<StatementExecutionInterceptor>emptyList(),
-        Collections.<TransactionRetryListener>emptyList());
+    return createConnection(Collections.emptyList(), Collections.emptyList());
   }
 
   ITConnection createConnection(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractMockServerTest.java
@@ -216,10 +216,9 @@ public abstract class AbstractMockServerTest {
   ITConnection createConnection(
       List<StatementExecutionInterceptor> interceptors,
       List<TransactionRetryListener> transactionRetryListeners) {
-    StringBuilder url = new StringBuilder(getBaseUrl());
     ConnectionOptions.Builder builder =
         ConnectionOptions.newBuilder()
-            .setUri(url.toString())
+            .setUri(getBaseUrl())
             .setStatementExecutionInterceptors(interceptors);
     ConnectionOptions options = builder.build();
     ITConnection connection = createITConnection(options);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractMockServerTest.java
@@ -156,7 +156,7 @@ public abstract class AbstractMockServerTest {
   }
 
   @AfterClass
-  public static void stopServer() throws Exception {
+  public static void stopServer() {
     server.shutdown();
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AsyncStatementResultImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AsyncStatementResultImplTest.java
@@ -36,7 +36,7 @@ public class AsyncStatementResultImplTest {
   @Test
   public void testNoResultGetResultSetAsync() {
     AsyncStatementResult subject =
-        AsyncStatementResultImpl.noResult(ApiFutures.<Void>immediateFuture(null));
+        AsyncStatementResultImpl.noResult(ApiFutures.immediateFuture(null));
     assertThat(subject.getResultType()).isEqualTo(ResultType.NO_RESULT);
     try {
       subject.getResultSetAsync();
@@ -49,7 +49,7 @@ public class AsyncStatementResultImplTest {
   @Test
   public void testNoResultGetUpdateCountAsync() {
     AsyncStatementResult subject =
-        AsyncStatementResultImpl.noResult(ApiFutures.<Void>immediateFuture(null));
+        AsyncStatementResultImpl.noResult(ApiFutures.immediateFuture(null));
     assertThat(subject.getResultType()).isEqualTo(ResultType.NO_RESULT);
     try {
       subject.getUpdateCountAsync();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AutocommitDmlModeTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AutocommitDmlModeTest.java
@@ -35,7 +35,6 @@ import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 @RunWith(JUnit4.class)
@@ -60,14 +59,12 @@ public class AutocommitDmlModeTest {
     when(dbClient.readWriteTransaction()).thenReturn(txRunner);
     when(txRunner.run(any(TransactionCallable.class)))
         .thenAnswer(
-            new Answer<Long>() {
-              @Override
-              public Long answer(InvocationOnMock invocation) throws Throwable {
-                TransactionCallable<Long> callable =
-                    (TransactionCallable<Long>) invocation.getArguments()[0];
-                return callable.run(txContext);
-              }
-            });
+            (Answer<Long>)
+                invocation -> {
+                  TransactionCallable<Long> callable =
+                      (TransactionCallable<Long>) invocation.getArguments()[0];
+                  return callable.run(txContext);
+                });
 
     TransactionManager txManager = mock(TransactionManager.class);
     when(txManager.begin()).thenReturn(txContext);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AutocommitDmlModeTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AutocommitDmlModeTest.java
@@ -35,7 +35,6 @@ import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.stubbing.Answer;
 
 @RunWith(JUnit4.class)
 public class AutocommitDmlModeTest {
@@ -59,12 +58,11 @@ public class AutocommitDmlModeTest {
     when(dbClient.readWriteTransaction()).thenReturn(txRunner);
     when(txRunner.run(any(TransactionCallable.class)))
         .thenAnswer(
-            (Answer<Long>)
-                invocation -> {
-                  TransactionCallable<Long> callable =
-                      (TransactionCallable<Long>) invocation.getArguments()[0];
-                  return callable.run(txContext);
-                });
+            invocation -> {
+              TransactionCallable<Long> callable =
+                  (TransactionCallable<Long>) invocation.getArguments()[0];
+              return callable.run(txContext);
+            });
 
     TransactionManager txManager = mock(TransactionManager.class);
     when(txManager.begin()).thenReturn(txContext);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionAsyncApiAbortedTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionAsyncApiAbortedTest.java
@@ -290,7 +290,7 @@ public class ConnectionAsyncApiAbortedTest extends AbstractMockServerTest {
       // Wait until the query has actually executed.
       queryLatch.await(10L, TimeUnit.SECONDS);
       ApiFuture<Long> updateCount = connection.executeUpdateAsync(INSERT_STATEMENT);
-      updateCount.addListener(() -> updateLatch.countDown(), MoreExecutors.directExecutor());
+      updateCount.addListener(updateLatch::countDown, MoreExecutors.directExecutor());
 
       // We should not commit before the AsyncResultSet has finished.
       assertThat(get(finished)).isNull();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionAsyncApiAbortedTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionAsyncApiAbortedTest.java
@@ -114,8 +114,7 @@ public class ConnectionAsyncApiAbortedTest extends AbstractMockServerTest {
 
   ITConnection createConnection(TransactionRetryListener listener) {
     ITConnection connection =
-        super.createConnection(
-            ImmutableList.<StatementExecutionInterceptor>of(), ImmutableList.of(listener));
+        super.createConnection(ImmutableList.of(), ImmutableList.of(listener));
     connection.setAutocommit(false);
     return connection;
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionAsyncApiAbortedTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionAsyncApiAbortedTest.java
@@ -421,7 +421,7 @@ public class ConnectionAsyncApiAbortedTest extends AbstractMockServerTest {
   }
 
   @Test
-  public void testQueriesAbortedMidway_ResultsChanged() throws InterruptedException {
+  public void testQueriesAbortedMidway_ResultsChanged() {
     mockSpanner.setExecuteStreamingSqlExecutionTime(
         SimulatedExecutionTime.ofStreamException(
             mockSpanner.createAbortedException(ByteString.copyFromUtf8("test")),

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionImplTest.java
@@ -48,7 +48,6 @@ import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.ForwardingResultSet;
 import com.google.cloud.spanner.Options;
 import com.google.cloud.spanner.Options.QueryOption;
-import com.google.cloud.spanner.Options.TransactionOption;
 import com.google.cloud.spanner.ReadContext.QueryAnalyzeMode;
 import com.google.cloud.spanner.ReadOnlyTransaction;
 import com.google.cloud.spanner.ResultSet;
@@ -260,7 +259,7 @@ public class ConnectionImplTest {
     when(dbClient.singleUseReadOnlyTransaction(Matchers.any(TimestampBound.class)))
         .thenReturn(singleUseReadOnlyTx);
 
-    when(dbClient.transactionManager((TransactionOption[]) Mockito.anyVararg()))
+    when(dbClient.transactionManager(Mockito.anyVararg()))
         .thenAnswer(
             (Answer<TransactionManager>)
                 invocation -> {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionImplTest.java
@@ -406,7 +406,7 @@ public class ConnectionImplTest {
       assertThat(res.getResultSet().getBoolean("AUTOCOMMIT"), is(true));
 
       // set autocommit to false and assert that autocommit is false
-      res = subject.execute(Statement.of("set autocommit = false"));
+      subject.execute(Statement.of("set autocommit = false"));
       assertThat(subject.isAutocommit(), is(false));
       res = subject.execute(Statement.of("show variable autocommit"));
       assertThat(res.getResultType(), is(equalTo(ResultType.RESULT_SET)));
@@ -464,7 +464,7 @@ public class ConnectionImplTest {
       assertThat(res.getResultSet().getBoolean("READONLY"), is(false));
 
       // set read only to true and assert that read only is true
-      res = subject.execute(Statement.of("set readonly = true"));
+      subject.execute(Statement.of("set readonly = true"));
       assertThat(subject.isReadOnly(), is(true));
       res = subject.execute(Statement.of("show variable readonly"));
       assertThat(res.getResultType(), is(equalTo(ResultType.RESULT_SET)));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
@@ -250,6 +250,7 @@ public class ConnectionOptionsTest {
       builder.setUri(uri);
       fail(uri + " should be considered an invalid uri");
     } catch (IllegalArgumentException e) {
+      // Expected exception
     }
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
@@ -445,12 +445,11 @@ public class ConnectionOptionsTest {
     assertThat(options.getWarnings()).doesNotContain("lenient");
 
     try {
-      options =
-          ConnectionOptions.newBuilder()
-              .setUri(
-                  "cloudspanner:/projects/test-project-123/instances/test-instance/databases/test-database?bar=foo")
-              .setCredentialsUrl(FILE_TEST_PATH)
-              .build();
+      ConnectionOptions.newBuilder()
+          .setUri(
+              "cloudspanner:/projects/test-project-123/instances/test-instance/databases/test-database?bar=foo")
+          .setCredentialsUrl(FILE_TEST_PATH)
+          .build();
       fail("missing expected exception");
     } catch (IllegalArgumentException e) {
       assertThat(e.getMessage()).contains("bar");

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
@@ -28,6 +28,7 @@ import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerOptions;
 import java.util.Arrays;
+import java.util.Collections;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -326,7 +327,7 @@ public class ConnectionOptionsTest {
     final String baseUri =
         "cloudspanner:/projects/test-project-123/instances/test-instance/databases/test-database";
     assertThat(ConnectionOptions.parseProperties(baseUri + "?autocommit=true"))
-        .isEqualTo(Arrays.asList("autocommit"));
+        .isEqualTo(Collections.singletonList("autocommit"));
     assertThat(ConnectionOptions.parseProperties(baseUri + "?autocommit=true;readonly=false"))
         .isEqualTo(Arrays.asList("autocommit", "readonly"));
     assertThat(ConnectionOptions.parseProperties(baseUri + "?autocommit=true;READONLY=false"))

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionTest.java
@@ -27,9 +27,7 @@ import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.Statement;
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
-import com.google.protobuf.AbstractMessage;
 import com.google.spanner.v1.BatchCreateSessionsRequest;
 import com.google.spanner.v1.ExecuteSqlRequest;
 import com.google.spanner.v1.ExecuteSqlRequest.QueryOptions;
@@ -61,13 +59,7 @@ public class ConnectionTest {
     @Test
     public void testUseOptimizerVersionFromEnvironment() {
       try {
-        SpannerOptions.useEnvironment(
-            new SpannerOptions.SpannerEnvironment() {
-              @Override
-              public String getOptimizerVersion() {
-                return "20";
-              }
-            });
+        SpannerOptions.useEnvironment(() -> "20");
         try (Connection connection = createConnection()) {
           // Do a query and verify that the version from the environment is used.
           try (ResultSet rs = connection.executeQuery(SELECT_COUNT_STATEMENT)) {
@@ -204,13 +196,9 @@ public class ConnectionTest {
     public void testMinSessions() throws InterruptedException, TimeoutException {
       try (Connection connection = createConnection()) {
         mockSpanner.waitForRequestsToContain(
-            new Predicate<AbstractMessage>() {
-              @Override
-              public boolean apply(AbstractMessage input) {
-                return input instanceof BatchCreateSessionsRequest
-                    && ((BatchCreateSessionsRequest) input).getSessionCount() == 1;
-              }
-            },
+            input ->
+                input instanceof BatchCreateSessionsRequest
+                    && ((BatchCreateSessionsRequest) input).getSessionCount() == 1,
             5000L);
       }
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DdlBatchTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DdlBatchTest.java
@@ -61,7 +61,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentMatcher;
-import org.mockito.stubbing.Answer;
 
 @RunWith(JUnit4.class)
 public class DdlBatchTest {
@@ -88,11 +87,10 @@ public class DdlBatchTest {
       if (waitForMillis > 0L) {
         when(operation.get())
             .thenAnswer(
-                (Answer<Void>)
-                    invocation -> {
-                      Thread.sleep(waitForMillis);
-                      return null;
-                    });
+                invocation -> {
+                  Thread.sleep(waitForMillis);
+                  return null;
+                });
       } else if (exceptionOnGetResult) {
         when(operation.get())
             .thenThrow(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DdlBatchTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DdlBatchTest.java
@@ -61,7 +61,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentMatcher;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 @RunWith(JUnit4.class)
@@ -89,13 +88,11 @@ public class DdlBatchTest {
       if (waitForMillis > 0L) {
         when(operation.get())
             .thenAnswer(
-                new Answer<Void>() {
-                  @Override
-                  public Void answer(InvocationOnMock invocation) throws Throwable {
-                    Thread.sleep(waitForMillis);
-                    return null;
-                  }
-                });
+                (Answer<Void>)
+                    invocation -> {
+                      Thread.sleep(waitForMillis);
+                      return null;
+                    });
       } else if (exceptionOnGetResult) {
         when(operation.get())
             .thenThrow(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DdlBatchTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DdlBatchTest.java
@@ -226,7 +226,7 @@ public class DdlBatchTest {
   public void testWriteIterable() {
     DdlBatch batch = createSubject();
     try {
-      batch.writeAsync(Arrays.asList(Mutation.newInsertBuilder("foo").build()));
+      batch.writeAsync(Collections.singletonList(Mutation.newInsertBuilder("foo").build()));
       fail("expected FAILED_PRECONDITION");
     } catch (SpannerException e) {
       assertEquals(ErrorCode.FAILED_PRECONDITION, e.getErrorCode());

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DdlClientTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DdlClientTest.java
@@ -27,6 +27,7 @@ import com.google.api.gax.longrunning.OperationFuture;
 import com.google.cloud.spanner.DatabaseAdminClient;
 import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import org.junit.Test;
@@ -59,7 +60,7 @@ public class DdlClientTest {
     DdlClient subject = createSubject(client);
     String ddl = "CREATE TABLE FOO";
     subject.executeDdl(ddl);
-    verify(client).updateDatabaseDdl(instanceId, databaseId, Arrays.asList(ddl), null);
+    verify(client).updateDatabaseDdl(instanceId, databaseId, Collections.singletonList(ddl), null);
 
     subject = createSubject(client);
     List<String> ddlList = Arrays.asList("CREATE TABLE FOO", "DROP TABLE FOO");

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DirectExecuteResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DirectExecuteResultSetTest.java
@@ -32,6 +32,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,7 +45,7 @@ public class DirectExecuteResultSetTest {
     ResultSet delegate =
         ResultSets.forRows(
             Type.struct(StructField.of("test", Type.int64())),
-            Arrays.asList(Struct.newBuilder().set("test").to(1L).build()));
+            Collections.singletonList(Struct.newBuilder().set("test").to(1L).build()));
     return DirectExecuteResultSet.ofResultSet(delegate);
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DmlBatchTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DmlBatchTest.java
@@ -35,6 +35,7 @@ import com.google.cloud.spanner.connection.StatementParser.ParsedStatement;
 import com.google.cloud.spanner.connection.StatementParser.StatementType;
 import com.google.cloud.spanner.connection.UnitOfWork.UnitOfWorkState;
 import java.util.Arrays;
+import java.util.Collections;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -136,7 +137,7 @@ public class DmlBatchTest {
   public void testWriteIterable() {
     DmlBatch batch = createSubject();
     try {
-      batch.writeAsync(Arrays.asList(Mutation.newInsertBuilder("foo").build()));
+      batch.writeAsync(Collections.singletonList(Mutation.newInsertBuilder("foo").build()));
       fail("Expected exception");
     } catch (SpannerException e) {
       assertEquals(ErrorCode.FAILED_PRECONDITION, e.getErrorCode());

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DmlBatchTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DmlBatchTest.java
@@ -162,7 +162,7 @@ public class DmlBatchTest {
 
     UnitOfWork tx = mock(UnitOfWork.class);
     when(tx.executeBatchUpdateAsync(anyListOf(ParsedStatement.class)))
-        .thenReturn(ApiFutures.<long[]>immediateFailedFuture(mock(SpannerException.class)));
+        .thenReturn(ApiFutures.immediateFailedFuture(mock(SpannerException.class)));
     batch = createSubject(tx);
     assertThat(batch.getState(), is(UnitOfWorkState.STARTED));
     assertThat(batch.isActive(), is(true));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/EmulatorUtilTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/EmulatorUtilTest.java
@@ -77,7 +77,7 @@ public class EmulatorUtilTest {
     when(databaseClient.createDatabase(
             Matchers.eq("test-instance"),
             Matchers.eq("test-database"),
-            Matchers.eq(ImmutableList.<String>of())))
+            Matchers.eq(ImmutableList.of())))
         .thenReturn(databaseOperationFuture);
     when(databaseOperationFuture.get()).thenReturn(mock(Database.class));
 
@@ -92,8 +92,7 @@ public class EmulatorUtilTest {
                 .setInstanceConfigId(InstanceConfigId.of("test-project", "emulator-config"))
                 .setNodeCount(1)
                 .build());
-    verify(databaseClient)
-        .createDatabase("test-instance", "test-database", ImmutableList.<String>of());
+    verify(databaseClient).createDatabase("test-instance", "test-database", ImmutableList.of());
   }
 
   @Test
@@ -127,7 +126,7 @@ public class EmulatorUtilTest {
     when(databaseClient.createDatabase(
             Matchers.eq("test-instance"),
             Matchers.eq("test-database"),
-            Matchers.eq(ImmutableList.<String>of())))
+            Matchers.eq(ImmutableList.of())))
         .thenReturn(databaseOperationFuture);
     when(databaseOperationFuture.get())
         .thenThrow(
@@ -146,8 +145,7 @@ public class EmulatorUtilTest {
                 .setInstanceConfigId(InstanceConfigId.of("test-project", "emulator-config"))
                 .setNodeCount(1)
                 .build());
-    verify(databaseClient)
-        .createDatabase("test-instance", "test-database", ImmutableList.<String>of());
+    verify(databaseClient).createDatabase("test-instance", "test-database", ImmutableList.of());
   }
 
   @Test
@@ -235,7 +233,7 @@ public class EmulatorUtilTest {
     when(databaseClient.createDatabase(
             Matchers.eq("test-instance"),
             Matchers.eq("test-database"),
-            Matchers.eq(ImmutableList.<String>of())))
+            Matchers.eq(ImmutableList.of())))
         .thenReturn(databaseOperationFuture);
     when(databaseOperationFuture.get())
         .thenThrow(
@@ -279,7 +277,7 @@ public class EmulatorUtilTest {
     when(databaseClient.createDatabase(
             Matchers.eq("test-instance"),
             Matchers.eq("test-database"),
-            Matchers.eq(ImmutableList.<String>of())))
+            Matchers.eq(ImmutableList.of())))
         .thenReturn(databaseOperationFuture);
     when(databaseOperationFuture.get()).thenThrow(new InterruptedException());
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ITAbstractSpannerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ITAbstractSpannerTest.java
@@ -235,14 +235,11 @@ public abstract class ITAbstractSpannerTest {
    * @return the newly opened connection.
    */
   public ITConnection createConnection() {
-    return createConnection(
-        Collections.<StatementExecutionInterceptor>emptyList(),
-        Collections.<TransactionRetryListener>emptyList());
+    return createConnection(Collections.emptyList(), Collections.emptyList());
   }
 
   public ITConnection createConnection(AbortInterceptor interceptor) {
-    return createConnection(
-        Collections.singletonList(interceptor), Collections.<TransactionRetryListener>emptyList());
+    return createConnection(Collections.singletonList(interceptor), Collections.emptyList());
   }
 
   public ITConnection createConnection(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ITAbstractSpannerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ITAbstractSpannerTest.java
@@ -41,7 +41,6 @@ import io.grpc.protobuf.ProtoUtils;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
@@ -243,15 +242,14 @@ public abstract class ITAbstractSpannerTest {
 
   public ITConnection createConnection(AbortInterceptor interceptor) {
     return createConnection(
-        Arrays.<StatementExecutionInterceptor>asList(interceptor),
-        Collections.<TransactionRetryListener>emptyList());
+        Collections.singletonList(interceptor), Collections.<TransactionRetryListener>emptyList());
   }
 
   public ITConnection createConnection(
       AbortInterceptor interceptor, TransactionRetryListener transactionRetryListener) {
     return createConnection(
-        Arrays.<StatementExecutionInterceptor>asList(interceptor),
-        Arrays.<TransactionRetryListener>asList(transactionRetryListener));
+        Collections.singletonList(interceptor),
+        Collections.singletonList(transactionRetryListener));
   }
 
   /**

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/RandomResultSetGenerator.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/RandomResultSetGenerator.java
@@ -81,7 +81,7 @@ public class RandomResultSetGenerator {
             .build(),
       };
 
-  private static final ResultSetMetadata generateMetadata() {
+  private static ResultSetMetadata generateMetadata() {
     StructType.Builder rowTypeBuilder = StructType.newBuilder();
     for (int col = 0; col < TYPES.length; col++) {
       rowTypeBuilder.addFields(Field.newBuilder().setName("COL" + col).setType(TYPES[col])).build();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ReadWriteTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ReadWriteTransactionTest.java
@@ -170,7 +170,7 @@ public class ReadWriteTransactionTest {
     return ReadWriteTransaction.newBuilder()
         .setDatabaseClient(client)
         .setRetryAbortsInternally(withRetry)
-        .setTransactionRetryListeners(Collections.<TransactionRetryListener>emptyList())
+        .setTransactionRetryListeners(Collections.emptyList())
         .withStatementExecutor(new StatementExecutor())
         .build();
   }
@@ -462,7 +462,7 @@ public class ReadWriteTransactionTest {
       ReadWriteTransaction subject =
           ReadWriteTransaction.newBuilder()
               .setRetryAbortsInternally(true)
-              .setTransactionRetryListeners(Collections.<TransactionRetryListener>emptyList())
+              .setTransactionRetryListeners(Collections.emptyList())
               .setDatabaseClient(client)
               .withStatementExecutor(new StatementExecutor())
               .build();
@@ -489,7 +489,7 @@ public class ReadWriteTransactionTest {
     ReadWriteTransaction transaction =
         ReadWriteTransaction.newBuilder()
             .setRetryAbortsInternally(true)
-            .setTransactionRetryListeners(Collections.<TransactionRetryListener>emptyList())
+            .setTransactionRetryListeners(Collections.emptyList())
             .setDatabaseClient(client)
             .withStatementExecutor(new StatementExecutor())
             .build();
@@ -628,7 +628,7 @@ public class ReadWriteTransactionTest {
     ReadWriteTransaction transaction =
         ReadWriteTransaction.newBuilder()
             .setRetryAbortsInternally(true)
-            .setTransactionRetryListeners(Collections.<TransactionRetryListener>emptyList())
+            .setTransactionRetryListeners(Collections.emptyList())
             .setDatabaseClient(client)
             .withStatementExecutor(new StatementExecutor())
             .build();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ReadWriteTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ReadWriteTransactionTest.java
@@ -62,7 +62,6 @@ import java.util.Collections;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 @RunWith(JUnit4.class)
@@ -156,20 +155,18 @@ public class ReadWriteTransactionTest {
     DatabaseClient client = mock(DatabaseClient.class);
     when(client.transactionManager())
         .thenAnswer(
-            new Answer<TransactionManager>() {
-              @Override
-              public TransactionManager answer(InvocationOnMock invocation) {
-                TransactionContext txContext = mock(TransactionContext.class);
-                when(txContext.executeQuery(any(Statement.class)))
-                    .thenReturn(mock(ResultSet.class));
-                ResultSet rsWithStats = mock(ResultSet.class);
-                when(rsWithStats.getStats()).thenReturn(ResultSetStats.getDefaultInstance());
-                when(txContext.analyzeQuery(any(Statement.class), any(QueryAnalyzeMode.class)))
-                    .thenReturn(rsWithStats);
-                when(txContext.executeUpdate(any(Statement.class))).thenReturn(1L);
-                return new SimpleTransactionManager(txContext, commitBehavior);
-              }
-            });
+            (Answer<TransactionManager>)
+                invocation -> {
+                  TransactionContext txContext = mock(TransactionContext.class);
+                  when(txContext.executeQuery(any(Statement.class)))
+                      .thenReturn(mock(ResultSet.class));
+                  ResultSet rsWithStats = mock(ResultSet.class);
+                  when(rsWithStats.getStats()).thenReturn(ResultSetStats.getDefaultInstance());
+                  when(txContext.analyzeQuery(any(Statement.class), any(QueryAnalyzeMode.class)))
+                      .thenReturn(rsWithStats);
+                  when(txContext.executeUpdate(any(Statement.class))).thenReturn(1L);
+                  return new SimpleTransactionManager(txContext, commitBehavior);
+                });
     return ReadWriteTransaction.newBuilder()
         .setDatabaseClient(client)
         .setRetryAbortsInternally(withRetry)

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ReadWriteTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ReadWriteTransactionTest.java
@@ -62,7 +62,6 @@ import java.util.Collections;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.stubbing.Answer;
 
 @RunWith(JUnit4.class)
 public class ReadWriteTransactionTest {
@@ -155,18 +154,16 @@ public class ReadWriteTransactionTest {
     DatabaseClient client = mock(DatabaseClient.class);
     when(client.transactionManager())
         .thenAnswer(
-            (Answer<TransactionManager>)
-                invocation -> {
-                  TransactionContext txContext = mock(TransactionContext.class);
-                  when(txContext.executeQuery(any(Statement.class)))
-                      .thenReturn(mock(ResultSet.class));
-                  ResultSet rsWithStats = mock(ResultSet.class);
-                  when(rsWithStats.getStats()).thenReturn(ResultSetStats.getDefaultInstance());
-                  when(txContext.analyzeQuery(any(Statement.class), any(QueryAnalyzeMode.class)))
-                      .thenReturn(rsWithStats);
-                  when(txContext.executeUpdate(any(Statement.class))).thenReturn(1L);
-                  return new SimpleTransactionManager(txContext, commitBehavior);
-                });
+            invocation -> {
+              TransactionContext txContext = mock(TransactionContext.class);
+              when(txContext.executeQuery(any(Statement.class))).thenReturn(mock(ResultSet.class));
+              ResultSet rsWithStats = mock(ResultSet.class);
+              when(rsWithStats.getStats()).thenReturn(ResultSetStats.getDefaultInstance());
+              when(txContext.analyzeQuery(any(Statement.class), any(QueryAnalyzeMode.class)))
+                  .thenReturn(rsWithStats);
+              when(txContext.executeUpdate(any(Statement.class))).thenReturn(1L);
+              return new SimpleTransactionManager(txContext, commitBehavior);
+            });
     return ReadWriteTransaction.newBuilder()
         .setDatabaseClient(client)
         .setRetryAbortsInternally(withRetry)

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ReplaceableForwardingResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ReplaceableForwardingResultSetTest.java
@@ -34,6 +34,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,7 +47,7 @@ public class ReplaceableForwardingResultSetTest {
     ResultSet delegate =
         ResultSets.forRows(
             Type.struct(StructField.of("test", Type.int64())),
-            Arrays.asList(Struct.newBuilder().set("test").to(1L).build()));
+            Collections.singletonList(Struct.newBuilder().set("test").to(1L).build()));
     return new ReplaceableForwardingResultSet(delegate);
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SingleUseTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SingleUseTransactionTest.java
@@ -371,13 +371,11 @@ public class SingleUseTransactionTest {
     when(txContext.executeUpdate(Statement.of(VALID_UPDATE))).thenReturn(VALID_UPDATE_COUNT);
     when(txContext.executeUpdate(Statement.of(SLOW_UPDATE)))
         .thenAnswer(
-            new Answer<Long>() {
-              @Override
-              public Long answer(InvocationOnMock invocation) throws Throwable {
-                Thread.sleep(1000L);
-                return VALID_UPDATE_COUNT;
-              }
-            });
+            (Answer<Long>)
+                invocation -> {
+                  Thread.sleep(1000L);
+                  return VALID_UPDATE_COUNT;
+                });
     when(txContext.executeUpdate(Statement.of(INVALID_UPDATE)))
         .thenThrow(
             SpannerExceptionFactory.newSpannerException(ErrorCode.UNKNOWN, "invalid update"));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SingleUseTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SingleUseTransactionTest.java
@@ -695,6 +695,7 @@ public class SingleUseTransactionTest {
         get(subject.executeQueryAsync(createParsedQuery(VALID_QUERY), AnalyzeMode.NONE));
         fail("missing expected exception");
       } catch (IllegalStateException e) {
+        // Expected exception
       }
     }
 
@@ -708,6 +709,7 @@ public class SingleUseTransactionTest {
       get(subject.executeDdlAsync(ddl));
       fail("missing expected exception");
     } catch (IllegalStateException e) {
+      // Expected exception
     }
 
     ParsedStatement update = createParsedUpdate(VALID_UPDATE);
@@ -719,6 +721,7 @@ public class SingleUseTransactionTest {
       get(subject.executeUpdateAsync(update));
       fail("missing expected exception");
     } catch (IllegalStateException e) {
+      // Expected exception
     }
 
     subject = createSubject();
@@ -728,6 +731,7 @@ public class SingleUseTransactionTest {
       get(subject.writeAsync(Collections.singleton(Mutation.newInsertBuilder("FOO").build())));
       fail("missing expected exception");
     } catch (IllegalStateException e) {
+      // Expected exception
     }
 
     subject = createSubject();
@@ -738,6 +742,7 @@ public class SingleUseTransactionTest {
       get(subject.writeAsync(Arrays.asList(mutation, mutation)));
       fail("missing expected exception");
     } catch (IllegalStateException e) {
+      // Expected exception
     }
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SingleUseTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SingleUseTransactionTest.java
@@ -371,11 +371,10 @@ public class SingleUseTransactionTest {
     when(txContext.executeUpdate(Statement.of(VALID_UPDATE))).thenReturn(VALID_UPDATE_COUNT);
     when(txContext.executeUpdate(Statement.of(SLOW_UPDATE)))
         .thenAnswer(
-            (Answer<Long>)
-                invocation -> {
-                  Thread.sleep(1000L);
-                  return VALID_UPDATE_COUNT;
-                });
+            invocation -> {
+              Thread.sleep(1000L);
+              return VALID_UPDATE_COUNT;
+            });
     when(txContext.executeUpdate(Statement.of(INVALID_UPDATE)))
         .thenThrow(
             SpannerExceptionFactory.newSpannerException(ErrorCode.UNKNOWN, "invalid update"));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SpannerPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SpannerPoolTest.java
@@ -360,7 +360,7 @@ public class SpannerPoolTest {
   private static final long MILLISECOND = TimeUnit.NANOSECONDS.convert(1L, TimeUnit.MILLISECONDS);
 
   @Test
-  public void testAutomaticCloser() throws InterruptedException {
+  public void testAutomaticCloser() {
     FakeTicker ticker = new FakeTicker();
     SpannerPool pool = createSubjectAndMocks(TEST_AUTOMATIC_CLOSE_TIMEOUT_MILLIS, ticker);
     Spanner spanner1;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SqlScriptVerifier.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SqlScriptVerifier.java
@@ -124,12 +124,12 @@ public class SqlScriptVerifier extends AbstractSqlScriptVerifier {
     }
 
     @Override
-    protected int getColumnCount() throws Exception {
+    protected int getColumnCount() {
       return resultSet.getColumnCount();
     }
 
     @Override
-    protected Object getFirstValue() throws Exception {
+    protected Object getFirstValue() {
       return getValue(resultSet.getType().getStructFields().get(0).getName());
     }
   }
@@ -151,7 +151,7 @@ public class SqlScriptVerifier extends AbstractSqlScriptVerifier {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
       if (this.connection != null) {
         this.connection.close();
       }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementTimeoutTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementTimeoutTest.java
@@ -30,10 +30,8 @@ import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerExceptionFactory;
-import com.google.cloud.spanner.SpannerOptions.Builder;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.connection.AbstractConnectionImplTest.ConnectionConsumer;
-import com.google.cloud.spanner.connection.ConnectionOptions.SpannerOptionsConfigurator;
 import com.google.cloud.spanner.connection.ITAbstractSpannerTest.ITConnection;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.longrunning.Operation;
@@ -88,10 +86,8 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
         ConnectionOptions.newBuilder()
             .setUri(url.toString())
             .setConfigurator(
-                new SpannerOptionsConfigurator() {
-                  @Override
-                  public void configure(Builder options) {
-                    options
+                optionsConfigurator ->
+                    optionsConfigurator
                         .getDatabaseAdminStubSettingsBuilder()
                         .updateDatabaseDdlOperationSettings()
                         .setPollingAlgorithm(
@@ -101,9 +97,7 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
                                     .setMaxRetryDelay(Duration.ofMillis(1L))
                                     .setRetryDelayMultiplier(1.0)
                                     .setTotalTimeout(Duration.ofMinutes(10L))
-                                    .build()));
-                  }
-                })
+                                    .build())))
             .build();
     return createITConnection(options);
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementTimeoutTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementTimeoutTest.java
@@ -81,10 +81,9 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
   private static final int TIMEOUT_FOR_SLOW_STATEMENTS = 50;
 
   ITConnection createConnection() {
-    StringBuilder url = new StringBuilder(getBaseUrl());
     ConnectionOptions options =
         ConnectionOptions.newBuilder()
-            .setUri(url.toString())
+            .setUri(getBaseUrl())
             .setConfigurator(
                 optionsConfigurator ->
                     optionsConfigurator

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/it/ITAsyncTransactionRetryTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/it/ITAsyncTransactionRetryTest.java
@@ -29,7 +29,6 @@ import com.google.cloud.spanner.AbortedDueToConcurrentModificationException;
 import com.google.cloud.spanner.AbortedException;
 import com.google.cloud.spanner.AsyncResultSet;
 import com.google.cloud.spanner.AsyncResultSet.CallbackResponse;
-import com.google.cloud.spanner.AsyncResultSet.ReadyCallback;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.KeySet;
 import com.google.cloud.spanner.Mutation;
@@ -192,19 +191,16 @@ public class ITAsyncTransactionRetryTest extends ITAbstractSpannerTest {
         connection.executeQueryAsync(Statement.of("SELECT COUNT(*) AS C FROM TEST WHERE ID=1"))) {
       rs.setCallback(
           executor,
-          new ReadyCallback() {
-            @Override
-            public CallbackResponse cursorReady(AsyncResultSet resultSet) {
-              while (true) {
-                switch (resultSet.tryNext()) {
-                  case DONE:
-                    return CallbackResponse.DONE;
-                  case NOT_READY:
-                    return CallbackResponse.CONTINUE;
-                  case OK:
-                    count.set(resultSet.getLong("C"));
-                    break;
-                }
+          resultSet -> {
+            while (true) {
+              switch (resultSet.tryNext()) {
+                case DONE:
+                  return CallbackResponse.DONE;
+                case NOT_READY:
+                  return CallbackResponse.CONTINUE;
+                case OK:
+                  count.set(resultSet.getLong("C"));
+                  break;
               }
             }
           });
@@ -327,25 +323,22 @@ public class ITAsyncTransactionRetryTest extends ITAbstractSpannerTest {
           connection.executeQueryAsync(Statement.of("SELECT COUNT(*) AS C FROM TEST WHERE ID=1"))) {
         rs.setCallback(
             executor,
-            new ReadyCallback() {
-              @Override
-              public CallbackResponse cursorReady(AsyncResultSet resultSet) {
-                try {
-                  while (true) {
-                    switch (resultSet.tryNext()) {
-                      case DONE:
-                        return CallbackResponse.DONE;
-                      case NOT_READY:
-                        return CallbackResponse.CONTINUE;
-                      case OK:
-                        countAfterInsert.set(resultSet.getLong("C"));
-                        break;
-                    }
+            resultSet -> {
+              try {
+                while (true) {
+                  switch (resultSet.tryNext()) {
+                    case DONE:
+                      return CallbackResponse.DONE;
+                    case NOT_READY:
+                      return CallbackResponse.CONTINUE;
+                    case OK:
+                      countAfterInsert.set(resultSet.getLong("C"));
+                      break;
                   }
-                } catch (Throwable t) {
-                  countAfterInsert.setException(t);
-                  return CallbackResponse.DONE;
                 }
+              } catch (Throwable t) {
+                countAfterInsert.setException(t);
+                return CallbackResponse.DONE;
               }
             });
       }
@@ -447,24 +440,21 @@ public class ITAsyncTransactionRetryTest extends ITAbstractSpannerTest {
           connection.executeQueryAsync(Statement.of("SELECT * FROM TEST WHERE ID=1"))) {
         rs.setCallback(
             executor,
-            new ReadyCallback() {
-              @Override
-              public CallbackResponse cursorReady(AsyncResultSet resultSet) {
-                try {
-                  while (true) {
-                    switch (resultSet.tryNext()) {
-                      case DONE:
-                        return CallbackResponse.DONE;
-                      case NOT_READY:
-                        return CallbackResponse.CONTINUE;
-                      case OK:
-                        initialRecord.set(resultSet.getCurrentRowAsStruct());
-                    }
+            resultSet -> {
+              try {
+                while (true) {
+                  switch (resultSet.tryNext()) {
+                    case DONE:
+                      return CallbackResponse.DONE;
+                    case NOT_READY:
+                      return CallbackResponse.CONTINUE;
+                    case OK:
+                      initialRecord.set(resultSet.getCurrentRowAsStruct());
                   }
-                } catch (Throwable t) {
-                  initialRecord.setException(t);
-                  return CallbackResponse.DONE;
                 }
+              } catch (Throwable t) {
+                initialRecord.setException(t);
+                return CallbackResponse.DONE;
               }
             });
       }
@@ -480,24 +470,21 @@ public class ITAsyncTransactionRetryTest extends ITAbstractSpannerTest {
           connection.executeQueryAsync(Statement.of("SELECT * FROM TEST WHERE ID=1"))) {
         rs.setCallback(
             executor,
-            new ReadyCallback() {
-              @Override
-              public CallbackResponse cursorReady(AsyncResultSet resultSet) {
-                try {
-                  while (true) {
-                    switch (resultSet.tryNext()) {
-                      case DONE:
-                        return CallbackResponse.DONE;
-                      case NOT_READY:
-                        return CallbackResponse.CONTINUE;
-                      case OK:
-                        secondRecord.set(resultSet.getCurrentRowAsStruct());
-                    }
+            resultSet -> {
+              try {
+                while (true) {
+                  switch (resultSet.tryNext()) {
+                    case DONE:
+                      return CallbackResponse.DONE;
+                    case NOT_READY:
+                      return CallbackResponse.CONTINUE;
+                    case OK:
+                      secondRecord.set(resultSet.getCurrentRowAsStruct());
                   }
-                } catch (Throwable t) {
-                  secondRecord.setException(t);
-                  return CallbackResponse.DONE;
                 }
+              } catch (Throwable t) {
+                secondRecord.setException(t);
+                return CallbackResponse.DONE;
               }
             });
       }
@@ -565,18 +552,15 @@ public class ITAsyncTransactionRetryTest extends ITAbstractSpannerTest {
         // do nothing, just consume the result set
         rs.setCallback(
             executor,
-            new ReadyCallback() {
-              @Override
-              public CallbackResponse cursorReady(AsyncResultSet resultSet) {
-                while (true) {
-                  switch (resultSet.tryNext()) {
-                    case DONE:
-                      return CallbackResponse.DONE;
-                    case NOT_READY:
-                      return CallbackResponse.CONTINUE;
-                    case OK:
-                      break;
-                  }
+            resultSet -> {
+              while (true) {
+                switch (resultSet.tryNext()) {
+                  case DONE:
+                    return CallbackResponse.DONE;
+                  case NOT_READY:
+                    return CallbackResponse.CONTINUE;
+                  case OK:
+                    break;
                 }
               }
             });
@@ -611,18 +595,15 @@ public class ITAsyncTransactionRetryTest extends ITAbstractSpannerTest {
         get(
             rs.setCallback(
                 executor,
-                new ReadyCallback() {
-                  @Override
-                  public CallbackResponse cursorReady(AsyncResultSet resultSet) {
-                    while (true) {
-                      switch (resultSet.tryNext()) {
-                        case DONE:
-                          return CallbackResponse.DONE;
-                        case NOT_READY:
-                          return CallbackResponse.CONTINUE;
-                        case OK:
-                          break;
-                      }
+                resultSet -> {
+                  while (true) {
+                    switch (resultSet.tryNext()) {
+                      case DONE:
+                        return CallbackResponse.DONE;
+                      case NOT_READY:
+                        return CallbackResponse.CONTINUE;
+                      case OK:
+                        break;
                     }
                   }
                 }));
@@ -670,18 +651,15 @@ public class ITAsyncTransactionRetryTest extends ITAbstractSpannerTest {
         get(
             rs.setCallback(
                 executor,
-                new ReadyCallback() {
-                  @Override
-                  public CallbackResponse cursorReady(AsyncResultSet resultSet) {
-                    while (true) {
-                      switch (resultSet.tryNext()) {
-                        case DONE:
-                          return CallbackResponse.DONE;
-                        case NOT_READY:
-                          return CallbackResponse.CONTINUE;
-                        case OK:
-                          break;
-                      }
+                resultSet -> {
+                  while (true) {
+                    switch (resultSet.tryNext()) {
+                      case DONE:
+                        return CallbackResponse.DONE;
+                      case NOT_READY:
+                        return CallbackResponse.CONTINUE;
+                      case OK:
+                        break;
                     }
                   }
                 }));
@@ -727,18 +705,15 @@ public class ITAsyncTransactionRetryTest extends ITAbstractSpannerTest {
         get(
             rs.setCallback(
                 executor,
-                new ReadyCallback() {
-                  @Override
-                  public CallbackResponse cursorReady(AsyncResultSet resultSet) {
-                    while (true) {
-                      switch (resultSet.tryNext()) {
-                        case DONE:
-                          return CallbackResponse.DONE;
-                        case NOT_READY:
-                          return CallbackResponse.CONTINUE;
-                        case OK:
-                          break;
-                      }
+                resultSet -> {
+                  while (true) {
+                    switch (resultSet.tryNext()) {
+                      case DONE:
+                        return CallbackResponse.DONE;
+                      case NOT_READY:
+                        return CallbackResponse.CONTINUE;
+                      case OK:
+                        break;
                     }
                   }
                 }));
@@ -795,34 +770,31 @@ public class ITAsyncTransactionRetryTest extends ITAbstractSpannerTest {
         ApiFuture<Void> finished =
             rs.setCallback(
                 executor,
-                new ReadyCallback() {
-                  @Override
-                  public CallbackResponse cursorReady(AsyncResultSet resultSet) {
-                    try {
-                      while (true) {
-                        switch (resultSet.tryNext()) {
-                          case DONE:
-                            return CallbackResponse.DONE;
-                          case NOT_READY:
-                            return CallbackResponse.CONTINUE;
-                          case OK:
-                            count.incrementAndGet();
-                            lastSeenId.set(resultSet.getLong("ID"));
-                            break;
-                        }
-                        if (count.get() == 1) {
-                          // Let the other transaction proceed.
-                          latch1.countDown();
-                          // Wait until the transaction has been aborted and retried.
-                          if (!latch2.await(120L, TimeUnit.SECONDS)) {
-                            throw SpannerExceptionFactory.newSpannerException(
-                                ErrorCode.DEADLINE_EXCEEDED, "Timeout while waiting for latch2");
-                          }
+                resultSet -> {
+                  try {
+                    while (true) {
+                      switch (resultSet.tryNext()) {
+                        case DONE:
+                          return CallbackResponse.DONE;
+                        case NOT_READY:
+                          return CallbackResponse.CONTINUE;
+                        case OK:
+                          count.incrementAndGet();
+                          lastSeenId.set(resultSet.getLong("ID"));
+                          break;
+                      }
+                      if (count.get() == 1) {
+                        // Let the other transaction proceed.
+                        latch1.countDown();
+                        // Wait until the transaction has been aborted and retried.
+                        if (!latch2.await(120L, TimeUnit.SECONDS)) {
+                          throw SpannerExceptionFactory.newSpannerException(
+                              ErrorCode.DEADLINE_EXCEEDED, "Timeout while waiting for latch2");
                         }
                       }
-                    } catch (Throwable t) {
-                      throw SpannerExceptionFactory.asSpannerException(t);
                     }
+                  } catch (Throwable t) {
+                    throw SpannerExceptionFactory.asSpannerException(t);
                   }
                 });
         // Open a new connection and transaction and do an additional insert. This insert will be
@@ -885,19 +857,16 @@ public class ITAsyncTransactionRetryTest extends ITAbstractSpannerTest {
         ApiFuture<Void> finished =
             rs.setCallback(
                 executor,
-                new ReadyCallback() {
-                  @Override
-                  public CallbackResponse cursorReady(AsyncResultSet resultSet) {
-                    // do nothing, just consume the result set
-                    while (true) {
-                      switch (resultSet.tryNext()) {
-                        case DONE:
-                          return CallbackResponse.DONE;
-                        case NOT_READY:
-                          return CallbackResponse.CONTINUE;
-                        case OK:
-                          break;
-                      }
+                resultSet -> {
+                  // do nothing, just consume the result set
+                  while (true) {
+                    switch (resultSet.tryNext()) {
+                      case DONE:
+                        return CallbackResponse.DONE;
+                      case NOT_READY:
+                        return CallbackResponse.CONTINUE;
+                      case OK:
+                        break;
                     }
                   }
                 });
@@ -952,19 +921,16 @@ public class ITAsyncTransactionRetryTest extends ITAbstractSpannerTest {
         ApiFuture<Void> finished =
             rs.setCallback(
                 executor,
-                new ReadyCallback() {
-                  @Override
-                  public CallbackResponse cursorReady(AsyncResultSet resultSet) {
-                    // do nothing, just consume the result set
-                    while (true) {
-                      switch (resultSet.tryNext()) {
-                        case DONE:
-                          return CallbackResponse.DONE;
-                        case NOT_READY:
-                          return CallbackResponse.CONTINUE;
-                        case OK:
-                          break;
-                      }
+                resultSet -> {
+                  // do nothing, just consume the result set
+                  while (true) {
+                    switch (resultSet.tryNext()) {
+                      case DONE:
+                        return CallbackResponse.DONE;
+                      case NOT_READY:
+                        return CallbackResponse.CONTINUE;
+                      case OK:
+                        break;
                     }
                   }
                 });

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITAsyncAPITest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITAsyncAPITest.java
@@ -54,6 +54,7 @@ import com.google.cloud.spanner.testing.RemoteSpannerHelper;
 import com.google.common.util.concurrent.SettableFuture;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -105,7 +106,7 @@ public class ITAsyncAPITest {
 
   @Before
   public void setupData() {
-    client.write(Arrays.asList(Mutation.delete(TABLE_NAME, KeySet.all())));
+    client.write(Collections.singletonList(Mutation.delete(TABLE_NAME, KeySet.all())));
     // Includes k0..k14.  Note that strings k{10,14} sort between k1 and k2.
     List<Mutation> mutations = new ArrayList<>();
     for (int i = 0; i < 15; ++i) {
@@ -302,7 +303,8 @@ public class ITAsyncAPITest {
       assertThat(res.get()).isEqualTo(1L);
       assertThat(client.singleUse().readRow("TestTable", Key.of("k999"), ALL_COLUMNS)).isNotNull();
     } finally {
-      client.writeAtLeastOnce(Arrays.asList(Mutation.delete("TestTable", Key.of("k999"))));
+      client.writeAtLeastOnce(
+          Collections.singletonList(Mutation.delete("TestTable", Key.of("k999"))));
       assertThat(client.singleUse().readRow("TestTable", Key.of("k999"), ALL_COLUMNS)).isNull();
     }
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITAsyncAPITest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITAsyncAPITest.java
@@ -31,7 +31,6 @@ import com.google.cloud.spanner.AsyncResultSet;
 import com.google.cloud.spanner.AsyncResultSet.CallbackResponse;
 import com.google.cloud.spanner.AsyncRunner;
 import com.google.cloud.spanner.AsyncTransactionManager;
-import com.google.cloud.spanner.AsyncTransactionManager.AsyncTransactionFunction;
 import com.google.cloud.spanner.AsyncTransactionManager.TransactionContextFuture;
 import com.google.cloud.spanner.Database;
 import com.google.cloud.spanner.DatabaseClient;
@@ -340,17 +339,16 @@ public class ITAsyncAPITest {
           get(
               context
                   .then(
-                      (AsyncTransactionFunction<Void, Void>)
-                          (transaction, ignored) -> {
-                            transaction.buffer(
-                                Mutation.newInsertOrUpdateBuilder(TABLE_NAME)
-                                    .set("Key")
-                                    .to("k_commit_stats")
-                                    .set("StringValue")
-                                    .to("Should return commit stats")
-                                    .build());
-                            return ApiFutures.immediateFuture(null);
-                          },
+                      (transaction, ignored) -> {
+                        transaction.buffer(
+                            Mutation.newInsertOrUpdateBuilder(TABLE_NAME)
+                                .set("Key")
+                                .to("k_commit_stats")
+                                .set("StringValue")
+                                .to("Should return commit stats")
+                                .build());
+                        return ApiFutures.immediateFuture(null);
+                      },
                       executor)
                   .commitAsync());
           assertNotNull(get(manager.getCommitResponse()).getCommitStats());

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITAsyncAPITest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITAsyncAPITest.java
@@ -348,8 +348,7 @@ public class ITAsyncAPITest {
                   .then(
                       new AsyncTransactionFunction<Void, Void>() {
                         @Override
-                        public ApiFuture<Void> apply(TransactionContext transaction, Void input)
-                            throws Exception {
+                        public ApiFuture<Void> apply(TransactionContext transaction, Void input) {
                           transaction.buffer(
                               Mutation.newInsertOrUpdateBuilder(TABLE_NAME)
                                   .set("Key")

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITAsyncExamplesTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITAsyncExamplesTest.java
@@ -42,6 +42,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
@@ -348,12 +349,7 @@ public class ITAsyncExamplesTest {
             ApiFutures.allAsList(Arrays.asList(values1, values2)),
             input ->
                 Iterables.mergeSorted(
-                    input,
-                    (o1, o2) -> {
-                      // Compare based on numerical order (i.e. without the preceding 'v').
-                      return Integer.valueOf(o1.substring(1))
-                          .compareTo(Integer.valueOf(o2.substring(1)));
-                    }),
+                    input, Comparator.comparing(o -> Integer.valueOf(o.substring(1)))),
             executor);
     assertThat(allValues.get()).containsExactly("v1", "v2", "v3", "v10", "v11", "v12");
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITAsyncExamplesTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITAsyncExamplesTest.java
@@ -19,7 +19,6 @@ package com.google.cloud.spanner.it;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
-import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.core.SettableApiFuture;
@@ -39,13 +38,10 @@ import com.google.cloud.spanner.ReadOnlyTransaction;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
-import com.google.cloud.spanner.StructReader;
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
@@ -336,15 +332,7 @@ public class ITAsyncExamplesTest {
                   .bind("keys")
                   .toStringArray(keys1)
                   .build())) {
-        values1 =
-            rs.toListAsync(
-                new Function<StructReader, String>() {
-                  @Override
-                  public String apply(StructReader input) {
-                    return input.getString("StringValue");
-                  }
-                },
-                executor);
+        values1 = rs.toListAsync(input -> input.getString("StringValue"), executor);
       }
       try (AsyncResultSet rs =
           tx.executeQueryAsync(
@@ -352,35 +340,20 @@ public class ITAsyncExamplesTest {
                   .bind("keys")
                   .toStringArray(keys2)
                   .build())) {
-        values2 =
-            rs.toListAsync(
-                new Function<StructReader, String>() {
-                  @Override
-                  public String apply(StructReader input) {
-                    return input.getString("StringValue");
-                  }
-                },
-                executor);
+        values2 = rs.toListAsync(input -> input.getString("StringValue"), executor);
       }
     }
     ApiFuture<Iterable<String>> allValues =
         ApiFutures.transform(
             ApiFutures.allAsList(Arrays.asList(values1, values2)),
-            new ApiFunction<List<List<String>>, Iterable<String>>() {
-              @Override
-              public Iterable<String> apply(List<List<String>> input) {
-                return Iterables.mergeSorted(
+            input ->
+                Iterables.mergeSorted(
                     input,
-                    new Comparator<String>() {
-                      @Override
-                      public int compare(String o1, String o2) {
-                        // Compare based on numerical order (i.e. without the preceding 'v').
-                        return Integer.valueOf(o1.substring(1))
-                            .compareTo(Integer.valueOf(o2.substring(1)));
-                      }
-                    });
-              }
-            },
+                    (o1, o2) -> {
+                      // Compare based on numerical order (i.e. without the preceding 'v').
+                      return Integer.valueOf(o1.substring(1))
+                          .compareTo(Integer.valueOf(o2.substring(1)));
+                    }),
             executor);
     assertThat(allValues.get()).containsExactly("v1", "v2", "v3", "v10", "v11", "v12");
   }
@@ -404,59 +377,53 @@ public class ITAsyncExamplesTest {
           AsyncResultSet unevenRs = tx.executeQueryAsync(unevenStatement)) {
         evenRs.setCallback(
             executor,
-            new ReadyCallback() {
-              @Override
-              public CallbackResponse cursorReady(AsyncResultSet resultSet) {
-                try {
-                  while (true) {
-                    switch (resultSet.tryNext()) {
-                      case DONE:
-                        evenFinished.set(true);
-                        return CallbackResponse.DONE;
-                      case NOT_READY:
-                        return CallbackResponse.CONTINUE;
-                      case OK:
-                        synchronized (lock) {
-                          allValues.add(resultSet.getString("StringValue"));
-                        }
-                        evenReturnedFirstRow.countDown();
-                        return CallbackResponse.PAUSE;
-                    }
+            resultSet -> {
+              try {
+                while (true) {
+                  switch (resultSet.tryNext()) {
+                    case DONE:
+                      evenFinished.set(true);
+                      return CallbackResponse.DONE;
+                    case NOT_READY:
+                      return CallbackResponse.CONTINUE;
+                    case OK:
+                      synchronized (lock) {
+                        allValues.add(resultSet.getString("StringValue"));
+                      }
+                      evenReturnedFirstRow.countDown();
+                      return CallbackResponse.PAUSE;
                   }
-                } catch (Throwable t) {
-                  evenFinished.setException(t);
-                  return CallbackResponse.DONE;
                 }
+              } catch (Throwable t) {
+                evenFinished.setException(t);
+                return CallbackResponse.DONE;
               }
             });
 
         unevenRs.setCallback(
             executor,
-            new ReadyCallback() {
-              @Override
-              public CallbackResponse cursorReady(AsyncResultSet resultSet) {
-                try {
-                  // Make sure the even result set has returned the first before we start the uneven
-                  // results.
-                  evenReturnedFirstRow.await();
-                  while (true) {
-                    switch (resultSet.tryNext()) {
-                      case DONE:
-                        unevenFinished.set(true);
-                        return CallbackResponse.DONE;
-                      case NOT_READY:
-                        return CallbackResponse.CONTINUE;
-                      case OK:
-                        synchronized (lock) {
-                          allValues.add(resultSet.getString("StringValue"));
-                        }
-                        return CallbackResponse.PAUSE;
-                    }
+            resultSet -> {
+              try {
+                // Make sure the even result set has returned the first before we start the uneven
+                // results.
+                evenReturnedFirstRow.await();
+                while (true) {
+                  switch (resultSet.tryNext()) {
+                    case DONE:
+                      unevenFinished.set(true);
+                      return CallbackResponse.DONE;
+                    case NOT_READY:
+                      return CallbackResponse.CONTINUE;
+                    case OK:
+                      synchronized (lock) {
+                        allValues.add(resultSet.getString("StringValue"));
+                      }
+                      return CallbackResponse.PAUSE;
                   }
-                } catch (Throwable t) {
-                  unevenFinished.setException(t);
-                  return CallbackResponse.DONE;
                 }
+              } catch (Throwable t) {
+                unevenFinished.setException(t);
+                return CallbackResponse.DONE;
               }
             });
         while (!(evenFinished.isDone() && unevenFinished.isDone())) {
@@ -493,28 +460,25 @@ public class ITAsyncExamplesTest {
     try (AsyncResultSet rs = client.singleUse().readAsync(TABLE_NAME, KeySet.all(), ALL_COLUMNS)) {
       rs.setCallback(
           executor,
-          new ReadyCallback() {
-            @Override
-            public CallbackResponse cursorReady(AsyncResultSet resultSet) {
-              try {
-                while (true) {
-                  switch (resultSet.tryNext()) {
-                    case DONE:
-                      finished.set(true);
-                      return CallbackResponse.DONE;
-                    case NOT_READY:
-                      return CallbackResponse.CONTINUE;
-                    case OK:
-                      values.add(resultSet.getString("StringValue"));
-                      receivedFirstRow.countDown();
-                      cancelled.await();
-                      break;
-                  }
+          resultSet -> {
+            try {
+              while (true) {
+                switch (resultSet.tryNext()) {
+                  case DONE:
+                    finished.set(true);
+                    return CallbackResponse.DONE;
+                  case NOT_READY:
+                    return CallbackResponse.CONTINUE;
+                  case OK:
+                    values.add(resultSet.getString("StringValue"));
+                    receivedFirstRow.countDown();
+                    cancelled.await();
+                    break;
                 }
-              } catch (Throwable t) {
-                finished.setException(t);
-                return CallbackResponse.DONE;
               }
+            } catch (Throwable t) {
+              finished.setException(t);
+              return CallbackResponse.DONE;
             }
           });
       receivedFirstRow.await();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBackupTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBackupTest.java
@@ -51,7 +51,6 @@ import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.encryption.EncryptionConfigs;
 import com.google.cloud.spanner.testing.RemoteSpannerHelper;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Iterables;
 import com.google.longrunning.Operation;
@@ -732,42 +731,22 @@ public class ITBackupTest {
     assertThat(
             Iterables.any(
                 instance.listBackupOperations().iterateAll(),
-                new Predicate<Operation>() {
-                  @Override
-                  public boolean apply(Operation input) {
-                    return input.getName().equals(backupOperationName);
-                  }
-                }))
+                input -> input.getName().equals(backupOperationName)))
         .isTrue();
     assertThat(
             Iterables.any(
                 instance.listBackupOperations().iterateAll(),
-                new Predicate<Operation>() {
-                  @Override
-                  public boolean apply(Operation input) {
-                    return input.getName().equals(restoreOperationName);
-                  }
-                }))
+                input -> input.getName().equals(restoreOperationName)))
         .isFalse();
     assertThat(
             Iterables.any(
                 instance.listDatabaseOperations().iterateAll(),
-                new Predicate<Operation>() {
-                  @Override
-                  public boolean apply(Operation input) {
-                    return input.getName().equals(backupOperationName);
-                  }
-                }))
+                input -> input.getName().equals(backupOperationName)))
         .isFalse();
     assertThat(
             Iterables.any(
                 instance.listDatabaseOperations().iterateAll(),
-                new Predicate<Operation>() {
-                  @Override
-                  public boolean apply(Operation input) {
-                    return input.getName().equals(restoreOperationName);
-                  }
-                }))
+                input -> input.getName().equals(restoreOperationName)))
         .isTrue();
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBackupTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBackupTest.java
@@ -61,7 +61,6 @@ import com.google.spanner.admin.database.v1.RestoreDatabaseMetadata;
 import com.google.spanner.admin.database.v1.RestoreSourceType;
 import io.grpc.Status;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -227,7 +226,8 @@ public class ITBackupTest {
         dbAdminClient.createDatabase(
             testHelper.getInstanceId().getInstance(),
             testHelper.getUniqueDatabaseId() + "_db2",
-            Arrays.asList("CREATE TABLE BAR (ID INT64, NAME STRING(100)) PRIMARY KEY (ID)"));
+            Collections.singletonList(
+                "CREATE TABLE BAR (ID INT64, NAME STRING(100)) PRIMARY KEY (ID)"));
     // Make sure all databases are created before we try to create any backups.
     Database db1 = dbOp1.get();
     Database db2 = dbOp2.get();
@@ -236,7 +236,7 @@ public class ITBackupTest {
     // Insert some data into db2 to make sure the backup will have a size>0.
     DatabaseClient client = testHelper.getDatabaseClient(db2);
     client.writeAtLeastOnce(
-        Arrays.asList(
+        Collections.singletonList(
             Mutation.newInsertOrUpdateBuilder("BAR")
                 .set("ID")
                 .to(1L)
@@ -319,7 +319,7 @@ public class ITBackupTest {
     // Insert some more data into db2 to get a timestamp from the server.
     Timestamp commitTs =
         client.writeAtLeastOnce(
-            Arrays.asList(
+            Collections.singletonList(
                 Mutation.newInsertOrUpdateBuilder("BAR")
                     .set("ID")
                     .to(2L)

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBackupTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBackupTest.java
@@ -280,8 +280,8 @@ public class ITBackupTest {
 
     // Ensure both backups have been created before we proceed.
     logger.info("Waiting for backup operations to finish");
-    Backup backup1 = null;
-    Backup backup2 = null;
+    Backup backup1;
+    Backup backup2;
     Stopwatch watch = Stopwatch.createStarted();
     try {
       backup1 = op1.get(6L, TimeUnit.MINUTES);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBatchDmlTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBatchDmlTest.java
@@ -31,7 +31,7 @@ import com.google.cloud.spanner.TransactionRunner;
 import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.After;
 import org.junit.Assert;
@@ -67,14 +67,16 @@ public final class ITBatchDmlTest {
   public void createTable() throws Exception {
     String ddl =
         "CREATE TABLE T (" + "  K    STRING(MAX) NOT NULL," + "  V    INT64," + ") PRIMARY KEY (K)";
-    OperationFuture<Void, UpdateDatabaseDdlMetadata> op = db.updateDdl(Arrays.asList(ddl), null);
+    OperationFuture<Void, UpdateDatabaseDdlMetadata> op =
+        db.updateDdl(Collections.singletonList(ddl), null);
     op.get();
   }
 
   @After
   public void dropTable() throws Exception {
     String ddl = "DROP TABLE T";
-    OperationFuture<Void, UpdateDatabaseDdlMetadata> op = db.updateDdl(Arrays.asList(ddl), null);
+    OperationFuture<Void, UpdateDatabaseDdlMetadata> op =
+        db.updateDdl(Collections.singletonList(ddl), null);
     op.get();
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBatchReadTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBatchReadTest.java
@@ -158,7 +158,11 @@ public class ITBatchReadTest {
     batchTxn = client.batchReadOnlyTransaction(bound);
     List<Partition> partitions =
         batchTxn.partitionReadUsingIndex(
-            partitionParams, TABLE_NAME, INDEX_NAME, KeySet.all(), Arrays.asList("Fingerprint"));
+            partitionParams,
+            TABLE_NAME,
+            INDEX_NAME,
+            KeySet.all(),
+            Collections.singletonList("Fingerprint"));
     BatchTransactionId txnID = batchTxn.getBatchTransactionId();
     int numRowsRead = 0;
     for (Partition p : partitions) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITClosedSessionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITClosedSessionTest.java
@@ -252,7 +252,7 @@ public class ITClosedSessionTest {
           }
         } catch (AbortedException e) {
           Thread.sleep(e.getRetryDelayInMillis());
-          txn = manager.resetForRetry();
+          manager.resetForRetry();
         }
       }
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITClosedSessionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITClosedSessionTest.java
@@ -252,7 +252,7 @@ public class ITClosedSessionTest {
           }
         } catch (AbortedException e) {
           Thread.sleep(e.getRetryDelayInMillis());
-          manager.resetForRetry();
+          txn = manager.resetForRetry();
         }
       }
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITCommitTimestampTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITCommitTimestampTest.java
@@ -37,6 +37,7 @@ import com.google.cloud.spanner.connection.ConnectionOptions;
 import com.google.cloud.spanner.testing.RemoteSpannerHelper;
 import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -89,7 +90,7 @@ public class ITCommitTimestampTest {
   }
 
   private Timestamp write(Mutation m) {
-    return client.write(Arrays.asList(m));
+    return client.write(Collections.singletonList(m));
   }
 
   private Struct readRow(DatabaseClient client, String table, Key key, String... columns) {
@@ -316,7 +317,7 @@ public class ITCommitTimestampTest {
     // error_catalog error CommitTimestampOptionNotEnabled
     try {
       client.write(
-          Arrays.asList(
+          Collections.singletonList(
               Mutation.newInsertOrUpdateBuilder("T3")
                   .set("ts")
                   .to(Value.COMMIT_TIMESTAMP)
@@ -343,7 +344,7 @@ public class ITCommitTimestampTest {
     // error_catalog error CommitTimestampOptionNotEnabled
     try {
       client.write(
-          Arrays.asList(
+          Collections.singletonList(
               Mutation.newInsertOrUpdateBuilder("T1")
                   .set("ts")
                   .to(Value.COMMIT_TIMESTAMP)

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDMLTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDMLTest.java
@@ -36,7 +36,7 @@ import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.TransactionRunner;
 import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
-import java.util.Arrays;
+import java.util.Collections;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -80,7 +80,7 @@ public final class ITDMLTest {
 
   @Before
   public void increaseTestIdAndDeleteTestData() {
-    client.writeAtLeastOnce(Arrays.asList(Mutation.delete("T", KeySet.all())));
+    client.writeAtLeastOnce(Collections.singletonList(Mutation.delete("T", KeySet.all())));
     id++;
   }
 
@@ -136,7 +136,7 @@ public final class ITDMLTest {
     assertThat(
             client
                 .singleUse(TimestampBound.strong())
-                .readRow("T", Key.of(String.format("%d-boo1", id)), Arrays.asList("V"))
+                .readRow("T", Key.of(String.format("%d-boo1", id)), Collections.singletonList("V"))
                 .getLong(0))
         .isEqualTo(1);
 
@@ -147,7 +147,7 @@ public final class ITDMLTest {
     assertThat(
             client
                 .singleUse(TimestampBound.strong())
-                .readRow("T", Key.of(String.format("%d-boo1", id)), Arrays.asList("V"))
+                .readRow("T", Key.of(String.format("%d-boo1", id)), Collections.singletonList("V"))
                 .getLong(0))
         .isEqualTo(100);
 
@@ -156,7 +156,7 @@ public final class ITDMLTest {
     assertThat(
             client
                 .singleUse(TimestampBound.strong())
-                .readRow("T", Key.of(String.format("%d-boo1", id)), Arrays.asList("V")))
+                .readRow("T", Key.of(String.format("%d-boo1", id)), Collections.singletonList("V")))
         .isNull();
   }
 
@@ -166,21 +166,21 @@ public final class ITDMLTest {
     assertThat(
             client
                 .singleUse(TimestampBound.strong())
-                .readRow("T", Key.of(String.format("%d-boo1", id)), Arrays.asList("V"))
+                .readRow("T", Key.of(String.format("%d-boo1", id)), Collections.singletonList("V"))
                 .getLong(0))
         .isEqualTo(1);
     executeUpdate(DML_COUNT, updateDml());
     assertThat(
             client
                 .singleUse(TimestampBound.strong())
-                .readRow("T", Key.of(String.format("%d-boo1", id)), Arrays.asList("V"))
+                .readRow("T", Key.of(String.format("%d-boo1", id)), Collections.singletonList("V"))
                 .getLong(0))
         .isEqualTo(100);
     executeUpdate(DML_COUNT, deleteDml());
     assertThat(
             client
                 .singleUse(TimestampBound.strong())
-                .readRow("T", Key.of(String.format("%d-boo1", id)), Arrays.asList("V")))
+                .readRow("T", Key.of(String.format("%d-boo1", id)), Collections.singletonList("V")))
         .isNull();
   }
 
@@ -210,7 +210,7 @@ public final class ITDMLTest {
     assertThat(
             client
                 .singleUse(TimestampBound.strong())
-                .readRow("T", Key.of(String.format("%d-boo1", id)), Arrays.asList("V"))
+                .readRow("T", Key.of(String.format("%d-boo1", id)), Collections.singletonList("V"))
                 .getLong(0))
         .isEqualTo(500);
 
@@ -229,7 +229,8 @@ public final class ITDMLTest {
           assertThat(rowCount).isEqualTo(1);
           assertThat(
                   transaction
-                      .readRow("T", Key.of(String.format("%d-boo2", id)), Arrays.asList("v"))
+                      .readRow(
+                          "T", Key.of(String.format("%d-boo2", id)), Collections.singletonList("v"))
                       .getLong(0))
               .isEqualTo(2 * 2);
           return null;
@@ -270,7 +271,7 @@ public final class ITDMLTest {
             .read(
                 "T",
                 KeySet.range(KeyRange.prefix(Key.of(String.format("%d-boo", id)))),
-                Arrays.asList("K"));
+                Collections.singletonList("K"));
     assertThat(resultSet.next()).isFalse();
   }
 
@@ -297,7 +298,9 @@ public final class ITDMLTest {
     KeySet.Builder keys = KeySet.newBuilder();
     keys.addKey(Key.of(key1)).addKey(Key.of(key2));
     ResultSet resultSet =
-        client.singleUse(TimestampBound.strong()).read("T", keys.build(), Arrays.asList("K"));
+        client
+            .singleUse(TimestampBound.strong())
+            .read("T", keys.build(), Collections.singletonList("K"));
     int rowCount = 0;
     while (resultSet.next()) {
       rowCount++;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDatabaseAdminTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDatabaseAdminTest.java
@@ -126,7 +126,7 @@ public class ITDatabaseAdminTest {
     dbAdminClient.dropDatabase(instanceId, dbId);
     dbs.clear();
     try {
-      db = dbAdminClient.getDatabase(testHelper.getInstanceId().getInstance(), dbId);
+      dbAdminClient.getDatabase(testHelper.getInstanceId().getInstance(), dbId);
       fail("Expected exception");
     } catch (SpannerException ex) {
       assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDatabaseAdminTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDatabaseAdminTest.java
@@ -199,7 +199,7 @@ public class ITDatabaseAdminTest {
 
     String instanceId = testHelper.getInstanceId().getInstance();
     for (String dbId : dbIds) {
-      dbs.add(dbAdminClient.createDatabase(instanceId, dbId, ImmutableList.<String>of()).get());
+      dbs.add(dbAdminClient.createDatabase(instanceId, dbId, ImmutableList.of()).get());
     }
     Page<Database> page = dbAdminClient.listDatabases(instanceId, Options.pageSize(1));
     List<String> dbIdsGot = new ArrayList<>();
@@ -307,7 +307,7 @@ public class ITDatabaseAdminTest {
             client.createDatabase(
                 testHelper.getInstanceId().getInstance(),
                 initialDatabaseId,
-                Collections.<String>emptyList());
+                Collections.emptyList());
         databases.add(op.get());
         // Keep track of the original create time of this database, as we will drop this database
         // later and create another one with the exact same name. That means that the ListOperations
@@ -406,7 +406,7 @@ public class ITDatabaseAdminTest {
             client.createDatabase(
                 testHelper.getInstanceId().getInstance(),
                 initialDatabaseId,
-                Collections.<String>emptyList());
+                Collections.emptyList());
         // Check that the second database was created and has a greater creation time than the
         // first.
         Timestamp secondCreationTime = op.get().getCreateTime();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDatabaseTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDatabaseTest.java
@@ -109,7 +109,7 @@ public class ITDatabaseTest {
             .createDatabase(
                 db.getId().getInstanceId().getInstance(),
                 db.getId().getDatabase(),
-                Collections.<String>emptyList());
+                Collections.emptyList());
     Database newDb = op.get();
 
     // Queries using the same DatabaseClient should still return DatabaseNotFoundExceptions.

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDirectPathFallback.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDirectPathFallback.java
@@ -197,7 +197,7 @@ public class ITDirectPathFallback {
     assertWithMessage("Failed to upgrade back to DirectPath").that(exerciseDirectPath()).isTrue();
   }
 
-  private boolean exerciseDirectPath() throws InterruptedException, TimeoutException {
+  private boolean exerciseDirectPath() throws InterruptedException {
     Stopwatch stopwatch = Stopwatch.createStarted();
     numDpAddrRead.set(0);
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDirectPathFallback.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDirectPathFallback.java
@@ -19,7 +19,6 @@ package com.google.cloud.spanner.it;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.common.truth.TruthJUnit.assume;
 
-import com.google.api.core.ApiFunction;
 import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.auth.oauth2.ComputeEngineCredentials;
@@ -124,15 +123,12 @@ public class ITDirectPathFallback {
             .setEndpoint(DIRECT_PATH_ENDPOINT)
             .setPoolSize(1)
             .setChannelConfigurator(
-                new ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder>() {
-                  @Override
-                  public ManagedChannelBuilder apply(ManagedChannelBuilder builder) {
-                    injectNettyChannelHandler(builder);
-                    // Fail fast when blackhole is active
-                    builder.keepAliveTime(1, TimeUnit.SECONDS);
-                    builder.keepAliveTimeout(1, TimeUnit.SECONDS);
-                    return builder;
-                  }
+                managedChannelBuilder -> {
+                  injectNettyChannelHandler(managedChannelBuilder);
+                  // Fail fast when blackhole is active
+                  managedChannelBuilder.keepAliveTime(1, TimeUnit.SECONDS);
+                  managedChannelBuilder.keepAliveTimeout(1, TimeUnit.SECONDS);
+                  return managedChannelBuilder;
                 })
             .build());
     // Forcefully ignore GOOGLE_APPLICATION_CREDENTIALS

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITPitrUpdateDatabaseTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITPitrUpdateDatabaseTest.java
@@ -71,7 +71,7 @@ public class ITPitrUpdateDatabaseTest {
     databaseId = testHelper.getUniqueDatabaseId();
     dbAdminClient = testHelper.getClient().getDatabaseAdminClient();
 
-    createDatabase(dbAdminClient, instanceId, databaseId, Collections.<String>emptyList());
+    createDatabase(dbAdminClient, instanceId, databaseId, Collections.emptyList());
     metadata =
         updateVersionRetentionPeriod(
             dbAdminClient, instanceId, databaseId, VERSION_RETENTION_PERIOD);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITQueryTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITQueryTest.java
@@ -317,9 +317,7 @@ public class ITQueryTest {
   public void bindBoolArrayEmpty() {
     Struct row =
         execute(
-            Statement.newBuilder("SELECT @v")
-                .bind("v")
-                .toBoolArray(Collections.<Boolean>emptyList()),
+            Statement.newBuilder("SELECT @v").bind("v").toBoolArray(Collections.emptyList()),
             Type.array(Type.bool()));
     assertThat(row.isNull(0)).isFalse();
     assertThat(row.getBooleanList(0)).containsExactly();
@@ -348,7 +346,7 @@ public class ITQueryTest {
   public void bindInt64ArrayEmpty() {
     Struct row =
         execute(
-            Statement.newBuilder("SELECT @v").bind("v").toInt64Array(Collections.<Long>emptyList()),
+            Statement.newBuilder("SELECT @v").bind("v").toInt64Array(Collections.emptyList()),
             Type.array(Type.int64()));
     assertThat(row.isNull(0)).isFalse();
     assertThat(row.getLongList(0)).containsExactly();
@@ -389,9 +387,7 @@ public class ITQueryTest {
   public void bindFloat64ArrayEmpty() {
     Struct row =
         execute(
-            Statement.newBuilder("SELECT @v")
-                .bind("v")
-                .toFloat64Array(Collections.<Double>emptyList()),
+            Statement.newBuilder("SELECT @v").bind("v").toFloat64Array(Collections.emptyList()),
             Type.array(Type.float64()));
     assertThat(row.isNull(0)).isFalse();
     assertThat(row.getDoubleList(0)).containsExactly();
@@ -420,9 +416,7 @@ public class ITQueryTest {
   public void bindStringArrayEmpty() {
     Struct row =
         execute(
-            Statement.newBuilder("SELECT @v")
-                .bind("v")
-                .toStringArray(Collections.<String>emptyList()),
+            Statement.newBuilder("SELECT @v").bind("v").toStringArray(Collections.emptyList()),
             Type.array(Type.string()));
     assertThat(row.isNull(0)).isFalse();
     assertThat(row.getStringList(0)).containsExactly();
@@ -454,9 +448,7 @@ public class ITQueryTest {
   public void bindBytesArrayEmpty() {
     Struct row =
         execute(
-            Statement.newBuilder("SELECT @v")
-                .bind("v")
-                .toBytesArray(Collections.<ByteArray>emptyList()),
+            Statement.newBuilder("SELECT @v").bind("v").toBytesArray(Collections.emptyList()),
             Type.array(Type.bytes()));
     assertThat(row.isNull(0)).isFalse();
     assertThat(row.getBytesList(0)).isEmpty();
@@ -488,9 +480,7 @@ public class ITQueryTest {
   public void bindTimestampArrayEmpty() {
     Struct row =
         execute(
-            Statement.newBuilder("SELECT @v")
-                .bind("v")
-                .toTimestampArray(Collections.<Timestamp>emptyList()),
+            Statement.newBuilder("SELECT @v").bind("v").toTimestampArray(Collections.emptyList()),
             Type.array(Type.timestamp()));
     assertThat(row.isNull(0)).isFalse();
     assertThat(row.getTimestampList(0)).containsExactly();
@@ -522,7 +512,7 @@ public class ITQueryTest {
   public void bindDateArrayEmpty() {
     Struct row =
         execute(
-            Statement.newBuilder("SELECT @v").bind("v").toDateArray(Collections.<Date>emptyList()),
+            Statement.newBuilder("SELECT @v").bind("v").toDateArray(Collections.emptyList()),
             Type.array(Type.date()));
     assertThat(row.isNull(0)).isFalse();
     assertThat(row.getDateList(0)).containsExactly();
@@ -555,9 +545,7 @@ public class ITQueryTest {
     assumeFalse("Emulator does not yet support NUMERIC", EmulatorSpannerHelper.isUsingEmulator());
     Struct row =
         execute(
-            Statement.newBuilder("SELECT @v")
-                .bind("v")
-                .toNumericArray(Collections.<BigDecimal>emptyList()),
+            Statement.newBuilder("SELECT @v").bind("v").toNumericArray(Collections.emptyList()),
             Type.array(Type.numeric()));
     assertThat(row.isNull(0)).isFalse();
     assertThat(row.getBigDecimalList(0)).containsExactly();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITQueryTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITQueryTest.java
@@ -50,6 +50,7 @@ import com.google.spanner.v1.ResultSetStats;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -316,7 +317,9 @@ public class ITQueryTest {
   public void bindBoolArrayEmpty() {
     Struct row =
         execute(
-            Statement.newBuilder("SELECT @v").bind("v").toBoolArray(Arrays.<Boolean>asList()),
+            Statement.newBuilder("SELECT @v")
+                .bind("v")
+                .toBoolArray(Collections.<Boolean>emptyList()),
             Type.array(Type.bool()));
     assertThat(row.isNull(0)).isFalse();
     assertThat(row.getBooleanList(0)).containsExactly();
@@ -345,7 +348,7 @@ public class ITQueryTest {
   public void bindInt64ArrayEmpty() {
     Struct row =
         execute(
-            Statement.newBuilder("SELECT @v").bind("v").toInt64Array(Arrays.<Long>asList()),
+            Statement.newBuilder("SELECT @v").bind("v").toInt64Array(Collections.<Long>emptyList()),
             Type.array(Type.int64()));
     assertThat(row.isNull(0)).isFalse();
     assertThat(row.getLongList(0)).containsExactly();
@@ -386,7 +389,9 @@ public class ITQueryTest {
   public void bindFloat64ArrayEmpty() {
     Struct row =
         execute(
-            Statement.newBuilder("SELECT @v").bind("v").toFloat64Array(Arrays.<Double>asList()),
+            Statement.newBuilder("SELECT @v")
+                .bind("v")
+                .toFloat64Array(Collections.<Double>emptyList()),
             Type.array(Type.float64()));
     assertThat(row.isNull(0)).isFalse();
     assertThat(row.getDoubleList(0)).containsExactly();
@@ -415,7 +420,9 @@ public class ITQueryTest {
   public void bindStringArrayEmpty() {
     Struct row =
         execute(
-            Statement.newBuilder("SELECT @v").bind("v").toStringArray(Arrays.<String>asList()),
+            Statement.newBuilder("SELECT @v")
+                .bind("v")
+                .toStringArray(Collections.<String>emptyList()),
             Type.array(Type.string()));
     assertThat(row.isNull(0)).isFalse();
     assertThat(row.getStringList(0)).containsExactly();
@@ -447,7 +454,9 @@ public class ITQueryTest {
   public void bindBytesArrayEmpty() {
     Struct row =
         execute(
-            Statement.newBuilder("SELECT @v").bind("v").toBytesArray(Arrays.<ByteArray>asList()),
+            Statement.newBuilder("SELECT @v")
+                .bind("v")
+                .toBytesArray(Collections.<ByteArray>emptyList()),
             Type.array(Type.bytes()));
     assertThat(row.isNull(0)).isFalse();
     assertThat(row.getBytesList(0)).isEmpty();
@@ -481,7 +490,7 @@ public class ITQueryTest {
         execute(
             Statement.newBuilder("SELECT @v")
                 .bind("v")
-                .toTimestampArray(Arrays.<Timestamp>asList()),
+                .toTimestampArray(Collections.<Timestamp>emptyList()),
             Type.array(Type.timestamp()));
     assertThat(row.isNull(0)).isFalse();
     assertThat(row.getTimestampList(0)).containsExactly();
@@ -513,7 +522,7 @@ public class ITQueryTest {
   public void bindDateArrayEmpty() {
     Struct row =
         execute(
-            Statement.newBuilder("SELECT @v").bind("v").toDateArray(Arrays.<Date>asList()),
+            Statement.newBuilder("SELECT @v").bind("v").toDateArray(Collections.<Date>emptyList()),
             Type.array(Type.date()));
     assertThat(row.isNull(0)).isFalse();
     assertThat(row.getDateList(0)).containsExactly();
@@ -546,7 +555,9 @@ public class ITQueryTest {
     assumeFalse("Emulator does not yet support NUMERIC", EmulatorSpannerHelper.isUsingEmulator());
     Struct row =
         execute(
-            Statement.newBuilder("SELECT @v").bind("v").toNumericArray(Arrays.<BigDecimal>asList()),
+            Statement.newBuilder("SELECT @v")
+                .bind("v")
+                .toNumericArray(Collections.<BigDecimal>emptyList()),
             Type.array(Type.numeric()));
     assertThat(row.isNull(0)).isFalse();
     assertThat(row.getBigDecimalList(0)).containsExactly();
@@ -601,7 +612,10 @@ public class ITQueryTest {
     Struct p = structValue();
     try {
       execute(
-          Statement.newBuilder("SELECT @p").bind("p").toStructArray(p.getType(), asList(p)).build(),
+          Statement.newBuilder("SELECT @p")
+              .bind("p")
+              .toStructArray(p.getType(), Collections.singletonList(p))
+              .build(),
           p.getType());
       fail("Expected exception");
     } catch (SpannerException ex) {
@@ -760,8 +774,8 @@ public class ITQueryTest {
 
   @Test
   public void bindEmptyArrayOfStruct() {
-    Type elementType = Type.struct(asList(Type.StructField.of("f1", Type.date())));
-    List<Struct> p = asList();
+    Type elementType = Type.struct(Collections.singletonList(StructField.of("f1", Type.date())));
+    List<Struct> p = Collections.emptyList();
     assertThat(p).isEmpty();
 
     List<Struct> rows =

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITReadOnlyTxnTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITReadOnlyTxnTest.java
@@ -34,7 +34,7 @@ import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.TimestampBound;
 import com.google.common.collect.ImmutableList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.NavigableMap;
 import java.util.TreeMap;
@@ -101,7 +101,7 @@ public class ITReadOnlyTxnTest {
     String value = "v" + i;
     Mutation m = Mutation.newInsertOrUpdateBuilder(TABLE_NAME).set("StringValue").to(value).build();
     long minCommitNanoTime = System.nanoTime();
-    Timestamp timestamp = client.writeAtLeastOnce(Arrays.asList(m));
+    Timestamp timestamp = client.writeAtLeastOnce(Collections.singletonList(m));
     if (historyBuilder != null) {
       historyBuilder.add(new History(timestamp, value, minCommitNanoTime));
     }
@@ -114,7 +114,7 @@ public class ITReadOnlyTxnTest {
   }
 
   private static Struct readRow(ReadContext ctx) {
-    return ctx.readRow(TABLE_NAME, Key.of(), Arrays.asList("StringValue"));
+    return ctx.readRow(TABLE_NAME, Key.of(), Collections.singletonList("StringValue"));
   }
 
   private static Struct queryRow(ReadContext ctx) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITSpannerOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITSpannerOptionsTest.java
@@ -41,12 +41,12 @@ public class ITSpannerOptionsTest {
   private static Database db;
 
   @BeforeClass
-  public static void setUp() throws Exception {
+  public static void setUp() {
     db = env.getTestHelper().createTestDatabase();
   }
 
   @AfterClass
-  public static void tearDown() throws Exception {
+  public static void tearDown() {
     db.drop();
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionManagerAsyncTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionManagerAsyncTest.java
@@ -44,6 +44,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -222,7 +223,7 @@ public class ITTransactionManagerAsyncTest {
         isUsingEmulator());
 
     client.write(
-        Arrays.asList(
+        Collections.singletonList(
             Mutation.newInsertBuilder("T").set("K").to("Key3").set("BoolValue").to(true).build()));
     try (AsyncTransactionManager manager1 = client.transactionManagerAsync()) {
       TransactionContextFuture txn1 = manager1.beginAsync();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionManagerAsyncTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionManagerAsyncTest.java
@@ -111,8 +111,7 @@ public class ITTransactionManagerAsyncTest {
           txn.then(
                   new AsyncTransactionFunction<Void, Void>() {
                     @Override
-                    public ApiFuture<Void> apply(TransactionContext txn, Void input)
-                        throws Exception {
+                    public ApiFuture<Void> apply(TransactionContext txn, Void input) {
                       txn.buffer(
                           Mutation.newInsertBuilder("T")
                               .set("K")
@@ -149,8 +148,7 @@ public class ITTransactionManagerAsyncTest {
           txn.then(
                   new AsyncTransactionFunction<Void, Void>() {
                     @Override
-                    public ApiFuture<Void> apply(TransactionContext txn, Void input)
-                        throws Exception {
+                    public ApiFuture<Void> apply(TransactionContext txn, Void input) {
                       txn.buffer(
                           Mutation.newInsertBuilder("InvalidTable")
                               .set("K")
@@ -195,7 +193,7 @@ public class ITTransactionManagerAsyncTest {
         txn.then(
             new AsyncTransactionFunction<Void, Void>() {
               @Override
-              public ApiFuture<Void> apply(TransactionContext txn, Void input) throws Exception {
+              public ApiFuture<Void> apply(TransactionContext txn, Void input) {
                 txn.buffer(
                     Mutation.newInsertBuilder("T")
                         .set("K")
@@ -245,8 +243,7 @@ public class ITTransactionManagerAsyncTest {
               txn1.then(
                   new AsyncTransactionFunction<Void, Struct>() {
                     @Override
-                    public ApiFuture<Struct> apply(TransactionContext txn, Void input)
-                        throws Exception {
+                    public ApiFuture<Struct> apply(TransactionContext txn, Void input) {
                       return txn.readRowAsync("T", Key.of("Key3"), Arrays.asList("K", "BoolValue"));
                     }
                   },
@@ -257,8 +254,7 @@ public class ITTransactionManagerAsyncTest {
               txn2.then(
                   new AsyncTransactionFunction<Void, Struct>() {
                     @Override
-                    public ApiFuture<Struct> apply(TransactionContext txn, Void input)
-                        throws Exception {
+                    public ApiFuture<Struct> apply(TransactionContext txn, Void input) {
                       return txn.readRowAsync("T", Key.of("Key3"), Arrays.asList("K", "BoolValue"));
                     }
                   },
@@ -268,8 +264,7 @@ public class ITTransactionManagerAsyncTest {
               txn1Step1.then(
                   new AsyncTransactionFunction<Struct, Void>() {
                     @Override
-                    public ApiFuture<Void> apply(TransactionContext txn, Struct input)
-                        throws Exception {
+                    public ApiFuture<Void> apply(TransactionContext txn, Struct input) {
                       txn.buffer(
                           Mutation.newUpdateBuilder("T")
                               .set("K")
@@ -307,7 +302,7 @@ public class ITTransactionManagerAsyncTest {
           txn2.then(
               new AsyncTransactionFunction<Void, Void>() {
                 @Override
-                public ApiFuture<Void> apply(TransactionContext txn, Void input) throws Exception {
+                public ApiFuture<Void> apply(TransactionContext txn, Void input) {
                   txn.buffer(
                       Mutation.newUpdateBuilder("T")
                           .set("K")

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionManagerAsyncTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionManagerAsyncTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assume.assumeFalse;
 import com.google.api.core.ApiFutures;
 import com.google.cloud.spanner.AbortedException;
 import com.google.cloud.spanner.AsyncTransactionManager;
-import com.google.cloud.spanner.AsyncTransactionManager.AsyncTransactionFunction;
 import com.google.cloud.spanner.AsyncTransactionManager.AsyncTransactionStep;
 import com.google.cloud.spanner.AsyncTransactionManager.TransactionContextFuture;
 import com.google.cloud.spanner.Database;
@@ -108,17 +107,16 @@ public class ITTransactionManagerAsyncTest {
         assertThat(manager.getState()).isEqualTo(TransactionState.STARTED);
         try {
           txn.then(
-                  (AsyncTransactionFunction<Void, Void>)
-                      (transaction, ignored) -> {
-                        transaction.buffer(
-                            Mutation.newInsertBuilder("T")
-                                .set("K")
-                                .to("Key1")
-                                .set("BoolValue")
-                                .to(true)
-                                .build());
-                        return ApiFutures.immediateFuture(null);
-                      },
+                  (transaction, ignored) -> {
+                    transaction.buffer(
+                        Mutation.newInsertBuilder("T")
+                            .set("K")
+                            .to("Key1")
+                            .set("BoolValue")
+                            .to(true)
+                            .build());
+                    return ApiFutures.immediateFuture(null);
+                  },
                   executor)
               .commitAsync()
               .get();
@@ -143,17 +141,16 @@ public class ITTransactionManagerAsyncTest {
       while (true) {
         try {
           txn.then(
-                  (AsyncTransactionFunction<Void, Void>)
-                      (transaction, ignored) -> {
-                        transaction.buffer(
-                            Mutation.newInsertBuilder("InvalidTable")
-                                .set("K")
-                                .to("Key1")
-                                .set("BoolValue")
-                                .to(true)
-                                .build());
-                        return ApiFutures.immediateFuture(null);
-                      },
+                  (transaction, ignored) -> {
+                    transaction.buffer(
+                        Mutation.newInsertBuilder("InvalidTable")
+                            .set("K")
+                            .to("Key1")
+                            .set("BoolValue")
+                            .to(true)
+                            .build());
+                    return ApiFutures.immediateFuture(null);
+                  },
                   executor)
               .commitAsync()
               .get();
@@ -186,17 +183,16 @@ public class ITTransactionManagerAsyncTest {
       TransactionContextFuture txn = manager.beginAsync();
       while (true) {
         txn.then(
-            (AsyncTransactionFunction<Void, Void>)
-                (transaction, ignored) -> {
-                  transaction.buffer(
-                      Mutation.newInsertBuilder("T")
-                          .set("K")
-                          .to("Key2")
-                          .set("BoolValue")
-                          .to(true)
-                          .build());
-                  return ApiFutures.immediateFuture(null);
-                },
+            (transaction, ignored) -> {
+              transaction.buffer(
+                  Mutation.newInsertBuilder("T")
+                      .set("K")
+                      .to("Key2")
+                      .set("BoolValue")
+                      .to(true)
+                      .build());
+              return ApiFutures.immediateFuture(null);
+            },
             executor);
         try {
           manager.rollbackAsync();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionManagerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionManagerTest.java
@@ -39,6 +39,7 @@ import com.google.cloud.spanner.TransactionManager;
 import com.google.cloud.spanner.TransactionManager.TransactionState;
 import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
+import java.util.Collections;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -165,7 +166,7 @@ public class ITTransactionManagerTest {
         isUsingEmulator());
 
     client.write(
-        Arrays.asList(
+        Collections.singletonList(
             Mutation.newInsertBuilder("T").set("K").to("Key3").set("BoolValue").to(true).build()));
     try (TransactionManager manager1 = client.transactionManager()) {
       TransactionContext txn1 = manager1.begin();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionTest.java
@@ -54,6 +54,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.google.common.util.concurrent.Uninterruptibles;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Vector;
 import java.util.concurrent.CountDownLatch;
@@ -90,7 +91,7 @@ public class ITTransactionTest {
 
   @Before
   public void removeTestData() {
-    client.writeAtLeastOnce(Arrays.asList(Mutation.delete("T", KeySet.all())));
+    client.writeAtLeastOnce(Collections.singletonList(Mutation.delete("T", KeySet.all())));
   }
 
   private static String uniqueKey() {
@@ -106,7 +107,8 @@ public class ITTransactionTest {
 
     // Initial value.
     client.write(
-        Arrays.asList(Mutation.newInsertBuilder("T").set("K").to(key).set("V").to(0).build()));
+        Collections.singletonList(
+            Mutation.newInsertBuilder("T").set("K").to(key).set("V").to(0).build()));
 
     final int numThreads = 3;
 
@@ -155,7 +157,7 @@ public class ITTransactionTest {
     assertThat(
             client
                 .singleUse(TimestampBound.strong())
-                .readRow("T", Key.of(key), Arrays.asList("V"))
+                .readRow("T", Key.of(key), Collections.singletonList("V"))
                 .getLong(0))
         .isEqualTo((long) numThreads);
   }
@@ -164,7 +166,8 @@ public class ITTransactionTest {
   public void basicsUsingRead() throws InterruptedException {
     assumeFalse("Emulator does not support multiple parallel transactions", isUsingEmulator());
 
-    doBasicsTest((context, key) -> context.readRow("T", Key.of(key), Arrays.asList("V")));
+    doBasicsTest(
+        (context, key) -> context.readRow("T", Key.of(key), Collections.singletonList("V")));
   }
 
   @Test
@@ -212,7 +215,9 @@ public class ITTransactionTest {
     }
 
     Struct row =
-        client.singleUse(TimestampBound.strong()).readRow("T", Key.of(key), Arrays.asList("K"));
+        client
+            .singleUse(TimestampBound.strong())
+            .readRow("T", Key.of(key), Collections.singletonList("K"));
     assertThat(row).isNull();
   }
 
@@ -235,7 +240,9 @@ public class ITTransactionTest {
     }
 
     Struct row =
-        client.singleUse(TimestampBound.strong()).readRow("T", Key.of(key), Arrays.asList("K"));
+        client
+            .singleUse(TimestampBound.strong())
+            .readRow("T", Key.of(key), Collections.singletonList("K"));
     assertThat(row).isNull();
   }
 
@@ -352,13 +359,13 @@ public class ITTransactionTest {
     assertThat(
             client
                 .singleUse(TimestampBound.strong())
-                .readRow("T", Key.of(key1), Arrays.asList("V"))
+                .readRow("T", Key.of(key1), Collections.singletonList("V"))
                 .getLong(0))
         .isEqualTo(1);
     assertThat(
             client
                 .singleUse(TimestampBound.strong())
-                .readRow("T", Key.of(key2), Arrays.asList("V"))
+                .readRow("T", Key.of(key2), Collections.singletonList("V"))
                 .getLong(0))
         .isEqualTo(2);
   }
@@ -420,7 +427,7 @@ public class ITTransactionTest {
                     "Test",
                     "Index",
                     KeySet.all(),
-                    Arrays.asList("Fingerprint"));
+                    Collections.singletonList("Fingerprint"));
 
                 return null;
               });

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionTest.java
@@ -333,8 +333,7 @@ public class ITTransactionTest {
                           } catch (SpannerException e) {
                             if (e.getErrorCode() == ErrorCode.ABORTED) {
                               assertThat(e).isInstanceOf(AbortedException.class);
-                              assertThat(((AbortedException) e).getRetryDelayInMillis())
-                                  .isNotEqualTo(-1L);
+                              assertThat(e.getRetryDelayInMillis()).isNotEqualTo(-1L);
                             }
                             throw new RuntimeException("Swallowed exception: " + e.getMessage());
                           }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionTest.java
@@ -282,7 +282,9 @@ public class ITTransactionTest {
                     .run(
                         transaction -> {
                           try {
-                            Struct row = transaction.readRow("T", Key.of(key1), Arrays.asList("V"));
+                            Struct row =
+                                transaction.readRow(
+                                    "T", Key.of(key1), Collections.singletonList("V"));
                             t1Started.countDown();
                             Uninterruptibles.awaitUninterruptibly(t2Running);
                             transaction.buffer(
@@ -318,10 +320,14 @@ public class ITTransactionTest {
                     .run(
                         transaction -> {
                           try {
-                            Struct r1 = transaction.readRow("T", Key.of(key1), Arrays.asList("V"));
+                            Struct r1 =
+                                transaction.readRow(
+                                    "T", Key.of(key1), Collections.singletonList("V"));
                             t2Running.countDown();
                             Uninterruptibles.awaitUninterruptibly(t1Done);
-                            Struct r2 = transaction.readRow("T", Key.of(key2), Arrays.asList("V"));
+                            Struct r2 =
+                                transaction.readRow(
+                                    "T", Key.of(key2), Collections.singletonList("V"));
                             transaction.buffer(
                                 Mutation.newUpdateBuilder("T")
                                     .set("K")

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITTransactionTest.java
@@ -298,8 +298,7 @@ public class ITTransactionTest {
                           } catch (SpannerException e) {
                             if (e.getErrorCode() == ErrorCode.ABORTED) {
                               assertThat(e).isInstanceOf(AbortedException.class);
-                              assertThat(((AbortedException) e).getRetryDelayInMillis())
-                                  .isNotEqualTo(-1L);
+                              assertThat(e.getRetryDelayInMillis()).isNotEqualTo(-1L);
                             }
                             throw new RuntimeException("Swallowed exception: " + e.getMessage());
                           }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITVPCNegativeTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITVPCNegativeTest.java
@@ -49,7 +49,7 @@ import com.google.longrunning.OperationsSettings;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
@@ -189,7 +189,7 @@ public class ITVPCNegativeTest {
     ResultSet rs =
         databaseClient
             .singleUse()
-            .read("nonexistent-table", KeySet.all(), Arrays.asList("nonexistent-col"));
+            .read("nonexistent-table", KeySet.all(), Collections.singletonList("nonexistent-col"));
     try {
       // Tests that the initial create session request returns a permission denied.
       rs.next();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITWriteTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITWriteTest.java
@@ -47,6 +47,7 @@ import com.google.common.collect.ImmutableList;
 import io.grpc.Context;
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -133,7 +134,7 @@ public class ITWriteTest {
   private String lastKey;
 
   private Timestamp write(Mutation m) {
-    return client.write(Arrays.asList(m));
+    return client.write(Collections.singletonList(m));
   }
 
   private Mutation.WriteBuilder baseInsert() {
@@ -149,7 +150,7 @@ public class ITWriteTest {
   @Test
   public void writeAtLeastOnce() {
     client.writeAtLeastOnce(
-        Arrays.asList(
+        Collections.singletonList(
             Mutation.newInsertOrUpdateBuilder("T")
                 .set("K")
                 .to(lastKey = uniqueString())
@@ -166,7 +167,7 @@ public class ITWriteTest {
     assumeFalse("Emulator does not return commit statistics", isUsingEmulator());
     CommitResponse response =
         client.writeWithOptions(
-            Arrays.asList(
+            Collections.singletonList(
                 Mutation.newInsertOrUpdateBuilder("T")
                     .set("K")
                     .to(lastKey = uniqueString())
@@ -185,7 +186,7 @@ public class ITWriteTest {
     assumeFalse("Emulator does not return commit statistics", isUsingEmulator());
     CommitResponse response =
         client.writeAtLeastOnceWithOptions(
-            Arrays.asList(
+            Collections.singletonList(
                 Mutation.newInsertOrUpdateBuilder("T")
                     .set("K")
                     .to(lastKey = uniqueString())
@@ -202,7 +203,7 @@ public class ITWriteTest {
   @Test
   public void writeAlreadyExists() {
     client.write(
-        Arrays.asList(
+        Collections.singletonList(
             Mutation.newInsertBuilder("T")
                 .set("K")
                 .to(lastKey = "key1")
@@ -215,7 +216,7 @@ public class ITWriteTest {
 
     try {
       client.write(
-          Arrays.asList(
+          Collections.singletonList(
               Mutation.newInsertBuilder("T")
                   .set("K")
                   .to(lastKey)
@@ -235,7 +236,7 @@ public class ITWriteTest {
   @Test
   public void emptyWrite() {
     try {
-      client.write(Arrays.<Mutation>asList());
+      client.write(Collections.emptyList());
       fail("Expected exception");
     } catch (SpannerException ex) {
       assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
@@ -570,7 +571,7 @@ public class ITWriteTest {
 
   @Test
   public void writeStringArrayEmpty() {
-    write(baseInsert().set("StringArrayValue").toStringArray(Arrays.<String>asList()).build());
+    write(baseInsert().set("StringArrayValue").toStringArray(Collections.emptyList()).build());
     Struct row = readLastRow("StringArrayValue");
     assertThat(row.isNull(0)).isFalse();
     assertThat(row.getStringList(0)).containsExactly();
@@ -594,7 +595,7 @@ public class ITWriteTest {
 
   @Test
   public void writeBytesArrayEmpty() {
-    write(baseInsert().set("BytesArrayValue").toBytesArray(Arrays.<ByteArray>asList()).build());
+    write(baseInsert().set("BytesArrayValue").toBytesArray(Collections.emptyList()).build());
     Struct row = readLastRow("BytesArrayValue");
     assertThat(row.isNull(0)).isFalse();
     assertThat(row.getBytesList(0)).containsExactly();
@@ -619,10 +620,7 @@ public class ITWriteTest {
   @Test
   public void writeTimestampArrayEmpty() {
     write(
-        baseInsert()
-            .set("TimestampArrayValue")
-            .toTimestampArray(Arrays.<Timestamp>asList())
-            .build());
+        baseInsert().set("TimestampArrayValue").toTimestampArray(Collections.emptyList()).build());
     Struct row = readLastRow("TimestampArrayValue");
     assertThat(row.isNull(0)).isFalse();
     assertThat(row.getTimestampList(0)).containsExactly();
@@ -651,7 +649,7 @@ public class ITWriteTest {
 
   @Test
   public void writeDateArrayEmpty() {
-    write(baseInsert().set("DateArrayValue").toDateArray(Arrays.<Date>asList()).build());
+    write(baseInsert().set("DateArrayValue").toDateArray(Collections.emptyList()).build());
     Struct row = readLastRow("DateArrayValue");
     assertThat(row.isNull(0)).isFalse();
     assertThat(row.getDateList(0)).containsExactly();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITWriteTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITWriteTest.java
@@ -676,11 +676,7 @@ public class ITWriteTest {
   @Test
   public void writeNumericArrayEmpty() {
     assumeFalse("Emulator does not yet support NUMERIC", EmulatorSpannerHelper.isUsingEmulator());
-    write(
-        baseInsert()
-            .set("NumericArrayValue")
-            .toNumericArray(ImmutableList.<BigDecimal>of())
-            .build());
+    write(baseInsert().set("NumericArrayValue").toNumericArray(ImmutableList.of()).build());
     Struct row = readLastRow("NumericArrayValue");
     assertThat(row.isNull(0)).isFalse();
     assertThat(row.getBigDecimalList(0)).containsExactly();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
@@ -516,7 +516,6 @@ public class GapicSpannerRpcTest {
     }
   }
 
-  @SuppressWarnings("rawtypes")
   private SpannerOptions createSpannerOptions() {
     String endpoint = address.getHostString() + ":" + server.getPort();
     return SpannerOptions.newBuilder()

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
-import com.google.api.core.ApiFunction;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.HeaderProvider;
@@ -43,7 +42,6 @@ import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.SpannerOptions.CallContextConfigurator;
-import com.google.cloud.spanner.SpannerOptions.CallCredentialsProvider;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.admin.database.v1.MockDatabaseAdminImpl;
 import com.google.cloud.spanner.admin.instance.v1.MockInstanceAdminImpl;
@@ -64,10 +62,8 @@ import com.google.spanner.v1.SpannerGrpc;
 import com.google.spanner.v1.StructType;
 import com.google.spanner.v1.StructType.Field;
 import com.google.spanner.v1.TypeCode;
-import io.grpc.CallCredentials;
 import io.grpc.Context;
 import io.grpc.Contexts;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
 import io.grpc.Metadata.Key;
 import io.grpc.MethodDescriptor;
@@ -319,13 +315,7 @@ public class GapicSpannerRpcTest {
         SpannerOptions.newBuilder()
             .setProjectId("some-project")
             .setCredentials(STATIC_CREDENTIALS)
-            .setCallCredentialsProvider(
-                new CallCredentialsProvider() {
-                  @Override
-                  public CallCredentials getCallCredentials() {
-                    return MoreCallCredentials.from(VARIABLE_CREDENTIALS);
-                  }
-                })
+            .setCallCredentialsProvider(() -> MoreCallCredentials.from(VARIABLE_CREDENTIALS))
             .build();
     GapicSpannerRpc rpc = new GapicSpannerRpc(options);
     // GoogleAuthLibraryCallCredentials doesn't implement equals, so we can only check for the
@@ -348,13 +338,7 @@ public class GapicSpannerRpcTest {
         SpannerOptions.newBuilder()
             .setProjectId("some-project")
             .setCredentials(STATIC_CREDENTIALS)
-            .setCallCredentialsProvider(
-                new CallCredentialsProvider() {
-                  @Override
-                  public CallCredentials getCallCredentials() {
-                    return null;
-                  }
-                })
+            .setCallCredentialsProvider(() -> null)
             .build();
     GapicSpannerRpc rpc = new GapicSpannerRpc(options);
     assertThat(
@@ -511,13 +495,10 @@ public class GapicSpannerRpcTest {
   public void testCustomUserAgent() {
     for (String headerId : new String[] {"user-agent", "User-Agent", "USER-AGENT"}) {
       final HeaderProvider userAgentHeaderProvider =
-          new HeaderProvider() {
-            @Override
-            public Map<String, String> getHeaders() {
-              final Map<String, String> headers = new HashMap<>();
-              headers.put(headerId, "test-agent");
-              return headers;
-            }
+          () -> {
+            final Map<String, String> headers = new HashMap<>();
+            headers.put(headerId, "test-agent");
+            return headers;
           };
       final SpannerOptions options =
           createSpannerOptions().toBuilder().setHeaderProvider(userAgentHeaderProvider).build();
@@ -542,25 +523,16 @@ public class GapicSpannerRpcTest {
         .setProjectId("[PROJECT]")
         // Set a custom channel configurator to allow http instead of https.
         .setChannelConfigurator(
-            new ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder>() {
-              @Override
-              public ManagedChannelBuilder apply(ManagedChannelBuilder input) {
-                input.usePlaintext();
-                return input;
-              }
+            input -> {
+              input.usePlaintext();
+              return input;
             })
         .setHost("http://" + endpoint)
         // Set static credentials that will return the static OAuth test token.
         .setCredentials(STATIC_CREDENTIALS)
         // Also set a CallCredentialsProvider. These credentials should take precedence above
         // the static credentials.
-        .setCallCredentialsProvider(
-            new CallCredentialsProvider() {
-              @Override
-              public CallCredentials getCallCredentials() {
-                return MoreCallCredentials.from(VARIABLE_CREDENTIALS);
-              }
-            })
+        .setCallCredentialsProvider(() -> MoreCallCredentials.from(VARIABLE_CREDENTIALS))
         .build();
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/SpannerMetadataProviderTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/SpannerMetadataProviderTest.java
@@ -44,7 +44,7 @@ public class SpannerMetadataProviderTest {
   @Test
   public void testGetResourceHeaderValue() {
     SpannerMetadataProvider metadataProvider =
-        SpannerMetadataProvider.create(ImmutableMap.<String, String>of(), "header3");
+        SpannerMetadataProvider.create(ImmutableMap.of(), "header3");
 
     assertEquals("projects/p", getResourceHeaderValue(metadataProvider, "garbage"));
     assertEquals("projects/p", getResourceHeaderValue(metadataProvider, "projects/p"));
@@ -75,11 +75,11 @@ public class SpannerMetadataProviderTest {
   @Test
   public void testNewExtraHeaders() {
     SpannerMetadataProvider metadataProvider =
-        SpannerMetadataProvider.create(ImmutableMap.<String, String>of(), "header1");
+        SpannerMetadataProvider.create(ImmutableMap.of(), "header1");
     Map<String, List<String>> extraHeaders = metadataProvider.newExtraHeaders(null, "value1");
     assertThat(extraHeaders)
         .containsExactlyEntriesIn(
-            ImmutableMap.<String, List<String>>of("header1", ImmutableList.<String>of("value1")));
+            ImmutableMap.<String, List<String>>of("header1", ImmutableList.of("value1")));
   }
 
   private String getResourceHeaderValue(


### PR DESCRIPTION
1. Removes final modifiers from private / static methods
2. Adds diamond operator to generic class calls
3. Simplifies boolean expressions
4. Removes redundant throws clauses (from tests / private methods)
5. Marks empty catch blocks with comments
6. Anonymous types replaced with lambdas
7. Uses comparator combinators
8. Lambdas replaced with method references
9. Make inner class static
10. Replaces empty Arrays.asList with Collections.emptyList
11. Removes redundant initializers
12. Removes redundant toString calls
13. Removes redundant type casts
14. Replaces unused StringBuilder with Strings
15. Removes redundant supressions
16. Uses Collections.singletonList instead of single argument Arrays.asList
