### PR TITLE
chore: adds branch 3.3.x as stable

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -4,6 +4,9 @@ branches:
 - branch: 3.1.x
   releaseType: java-yoshi
   bumpMinorPreMajor: true
+- branch: 3.3.x
+  releaseType: java-yoshi
+  bumpMinorPreMajor: true
 - branch: 4.0.x
   releaseType: java-yoshi
   bumpMinorPreMajor: true

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -57,9 +57,32 @@ branchProtectionRules:
   requiredStatusCheckContexts:
     - "dependencies (8)"
     - "dependencies (11)"
-    - "linkage-monitor"
     - "lint"
-    - "clirr"
+    - "units (7)"
+    - "units (8)"
+    - "units (11)"
+    - "Kokoro - Test: Integration"
+    - "cla/google"
+
+# Identifies the protection rule pattern. Name of the branch to be protected.
+# Defaults to `master`
+- pattern: 3.3.x
+  # Can admins overwrite branch protection.
+  # Defaults to `true`
+  isAdminEnforced: true
+  # Number of approving reviews required to update matching branches.
+  # Defaults to `1`
+  requiredApprovingReviewCount: 1
+  # Are reviews from code owners required to update matching branches.
+  # Defaults to `false`
+  requiresCodeOwnerReviews: true
+  # Require up to date branches
+  requiresStrictStatusChecks: false
+  # List of required status check contexts that must pass for commits to be accepted to matching branches.
+  requiredStatusCheckContexts:
+    - "dependencies (8)"
+    - "dependencies (11)"
+    - "lint"
     - "units (7)"
     - "units (8)"
     - "units (11)"
@@ -84,9 +107,7 @@ branchProtectionRules:
   requiredStatusCheckContexts:
     - "dependencies (8)"
     - "dependencies (11)"
-    - "linkage-monitor"
     - "lint"
-    - "clirr"
     - "units (7)"
     - "units (8)"
     - "units (11)"
@@ -111,9 +132,7 @@ branchProtectionRules:
   requiredStatusCheckContexts:
     - "dependencies (8)"
     - "dependencies (11)"
-    - "linkage-monitor"
     - "lint"
-    - "clirr"
     - "units (7)"
     - "units (8)"
     - "units (11)"


### PR DESCRIPTION
Also removes clirr / linkage monitor from non master branches since they only work for the master branch.