### PR TITLE
feat: add bufferAsync methods

### DIFF
--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -605,4 +605,17 @@
     <className>com/google/cloud/spanner/StructReader</className>
     <method>com.google.cloud.spanner.Value getValue(java.lang.String)</method>
   </difference>
+
+  <!-- Adds bufferAsync to DatabaseClient -->
+  <!-- These are not breaking changes, since we provide default interface implementation -->
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/TransactionContext</className>
+    <method>com.google.api.core.ApiFuture bufferAsync(com.google.cloud.spanner.Mutation)</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/TransactionContext</className>
+    <method>com.google.api.core.ApiFuture bufferAsync(java.lang.Iterable)</method>
+  </difference>
 </differences>

--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -24,7 +24,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.6</version>
+        <version>0.8.7</version>
         <executions>
           <execution>
             <goals>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClient.java
@@ -431,8 +431,7 @@ public interface DatabaseClient {
    * lifecycle. This API is meant for advanced users. Most users should instead use the {@link
    * #runAsync()} API instead.
    *
-   * <p>Example of using {@link AsyncTransactionManager} with lambda expressions (Java 8 and
-   * higher).
+   * <p>Example of using {@link AsyncTransactionManager}.
    *
    * <pre>{@code
    * long singerId = 1L;
@@ -449,56 +448,11 @@ public interface DatabaseClient {
    *             .then(
    *                 (transaction, row) -> {
    *                   String name = row.getString(column);
-   *                   transaction.buffer(
+   *                   return transaction.bufferAsync(
    *                       Mutation.newUpdateBuilder("Singers")
    *                           .set(column)
    *                           .to(name.toUpperCase())
    *                           .build());
-   *                   return ApiFutures.immediateFuture(null);
-   *                 })
-   *             .commitAsync();
-   *     try {
-   *       commitTimestamp.get();
-   *       break;
-   *     } catch (AbortedException e) {
-   *       Thread.sleep(e.getRetryDelayInMillis());
-   *       transactionFuture = manager.resetForRetryAsync();
-   *     }
-   *   }
-   * }
-   * }</pre>
-   *
-   * <p>Example of using {@link AsyncTransactionManager} (Java 7).
-   *
-   * <pre>{@code
-   * final long singerId = 1L;
-   * try (AsyncTransactionManager manager = client().transactionManagerAsync()) {
-   *   TransactionContextFuture transactionFuture = manager.beginAsync();
-   *   while (true) {
-   *     final String column = "FirstName";
-   *     CommitTimestampFuture commitTimestamp =
-   *         transactionFuture.then(
-   *                 new AsyncTransactionFunction<Void, Struct>() {
-   *                   @Override
-   *                   public ApiFuture<Struct> apply(TransactionContext transaction, Void input)
-   *                       throws Exception {
-   *                     return transaction.readRowAsync(
-   *                         "Singers", Key.of(singerId), Collections.singleton(column));
-   *                   }
-   *                 })
-   *             .then(
-   *                 new AsyncTransactionFunction<Struct, Void>() {
-   *                   @Override
-   *                   public ApiFuture<Void> apply(TransactionContext transaction, Struct input)
-   *                       throws Exception {
-   *                     String name = input.getString(column);
-   *                     transaction.buffer(
-   *                         Mutation.newUpdateBuilder("Singers")
-   *                             .set(column)
-   *                             .to(name.toUpperCase())
-   *                             .build());
-   *                     return ApiFutures.immediateFuture(null);
-   *                   }
    *                 })
    *             .commitAsync();
    *     try {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -676,6 +676,11 @@ class SessionPool {
     }
 
     @Override
+    public ApiFuture<Void> bufferAsync(Mutation mutation) {
+      return delegate.bufferAsync(mutation);
+    }
+
+    @Override
     public Struct readRowUsingIndex(String table, String index, Key key, Iterable<String> columns) {
       try {
         return delegate.readRowUsingIndex(table, index, key, columns);
@@ -701,6 +706,11 @@ class SessionPool {
     @Override
     public void buffer(Iterable<Mutation> mutations) {
       delegate.buffer(mutations);
+    }
+
+    @Override
+    public ApiFuture<Void> bufferAsync(Iterable<Mutation> mutations) {
+      return delegate.bufferAsync(mutations);
     }
 
     @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContext.java
@@ -91,12 +91,22 @@ public interface TransactionContext extends ReadContext {
    */
   void buffer(Mutation mutation);
 
+  /** Same as {@link #buffer(Mutation)}, but is guaranteed to be non-blocking. */
+  default ApiFuture<Void> bufferAsync(Mutation mutation) {
+    throw new UnsupportedOperationException("method should be overwritten");
+  }
+
   /**
    * Buffers mutations to be applied if the transaction commits successfully. The effects of the
    * mutations will not be visible to subsequent operations in the transaction. All buffered
    * mutations will be applied atomically.
    */
   void buffer(Iterable<Mutation> mutations);
+
+  /** Same as {@link #buffer(Iterable)}, but is guaranteed to be non-blocking. */
+  default ApiFuture<Void> bufferAsync(Iterable<Mutation> mutations) {
+    throw new UnsupportedOperationException("method should be overwritten");
+  }
 
   /**
    * Executes the DML statement(s) and returns the number of rows modified. For non-DML statements,

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -610,6 +610,15 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
     }
 
     @Override
+    public ApiFuture<Void> bufferAsync(Mutation mutation) {
+      // Normally, we would call the async method from the sync method, but this is also safe as
+      // both are non-blocking anyways, and this prevents the creation of an ApiFuture that is not
+      // really used when the sync method is called.
+      buffer(mutation);
+      return ApiFutures.immediateFuture(null);
+    }
+
+    @Override
     public void buffer(Iterable<Mutation> mutations) {
       synchronized (lock) {
         checkNotNull(this.mutations, "Context is closed");
@@ -617,6 +626,15 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
           this.mutations.add(checkNotNull(mutation));
         }
       }
+    }
+
+    @Override
+    public ApiFuture<Void> bufferAsync(Iterable<Mutation> mutations) {
+      // Normally, we would call the async method from the sync method, but this is also safe as
+      // both are non-blocking anyways, and this prevents the creation of an ApiFuture that is not
+      // really used when the sync method is called.
+      buffer(mutations);
+      return ApiFutures.immediateFuture(null);
     }
 
     @Override

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerTest.java
@@ -204,7 +204,8 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
               transactionContextFuture
                   .then(
                       (transactionContext, ignored) ->
-                          transactionContext.bufferAsync(Mutation.delete("FOO", Key.of("foo"))),
+                          transactionContext.bufferAsync(
+                              Collections.singleton(Mutation.delete("FOO", Key.of("foo")))),
                       executor)
                   .commitAsync();
           assertNotNull(commitTimestamp.get());

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerTest.java
@@ -197,13 +197,14 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
   public void testAsyncTransactionManager_returnsCommitStats() throws Exception {
     try (AsyncTransactionManager manager =
         client().transactionManagerAsync(Options.commitStats())) {
-      TransactionContextFuture transaction = manager.beginAsync();
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
       while (true) {
         try {
           CommitTimestampFuture commitTimestamp =
-              transaction
+              transactionContextFuture
                   .then(
-                      AsyncTransactionManagerHelper.buffer(Mutation.delete("FOO", Key.of("foo"))),
+                      (transactionContext, ignored) ->
+                          transactionContext.bufferAsync(Mutation.delete("FOO", Key.of("foo"))),
                       executor)
                   .commitAsync();
           assertNotNull(commitTimestamp.get());
@@ -212,7 +213,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
           assertEquals(1L, manager.getCommitResponse().get().getCommitStats().getMutationCount());
           break;
         } catch (AbortedException e) {
-          transaction = manager.resetForRetryAsync();
+          transactionContextFuture = manager.resetForRetryAsync();
         }
       }
     }
@@ -220,23 +221,21 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
 
   @Test
   public void asyncTransactionManagerUpdate() throws Exception {
-    final SettableApiFuture<Long> updateCount = SettableApiFuture.create();
-
     try (AsyncTransactionManager manager = client().transactionManagerAsync()) {
-      TransactionContextFuture txn = manager.beginAsync();
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
       while (true) {
         try {
-          CommitTimestampFuture commitTimestamp =
-              txn.then(
-                      AsyncTransactionManagerHelper.executeUpdateAsync(
-                          updateCount, UPDATE_STATEMENT),
-                      executor)
-                  .commitAsync();
+          AsyncTransactionStep<Void, Long> updateCount =
+              transactionContextFuture.then(
+                  (transactionContext, ignored) ->
+                      transactionContext.executeUpdateAsync(UPDATE_STATEMENT),
+                  executor);
+          CommitTimestampFuture commitTimestamp = updateCount.commitAsync();
           assertThat(updateCount.get()).isEqualTo(UPDATE_COUNT);
           assertThat(commitTimestamp.get()).isNotNull();
           break;
         } catch (AbortedException e) {
-          txn = manager.resetForRetryAsync();
+          transactionContextFuture = manager.resetForRetryAsync();
         }
       }
     }
@@ -244,25 +243,23 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
 
   @Test
   public void asyncTransactionManagerIsNonBlocking() throws Exception {
-    SettableApiFuture<Long> updateCount = SettableApiFuture.create();
-
     mockSpanner.freeze();
     try (AsyncTransactionManager manager = clientWithEmptySessionPool().transactionManagerAsync()) {
-      TransactionContextFuture txn = manager.beginAsync();
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
       while (true) {
         try {
-          CommitTimestampFuture commitTimestamp =
-              txn.then(
-                      AsyncTransactionManagerHelper.executeUpdateAsync(
-                          updateCount, UPDATE_STATEMENT),
-                      executor)
-                  .commitAsync();
+          AsyncTransactionStep<Void, Long> updateCount =
+              transactionContextFuture.then(
+                  (transactionContext, ignored) ->
+                      transactionContext.executeUpdateAsync(UPDATE_STATEMENT),
+                  executor);
+          CommitTimestampFuture commitTimestamp = updateCount.commitAsync();
           mockSpanner.unfreeze();
           assertThat(updateCount.get(10L, TimeUnit.SECONDS)).isEqualTo(UPDATE_COUNT);
           assertThat(commitTimestamp.get(10L, TimeUnit.SECONDS)).isNotNull();
           break;
         } catch (AbortedException e) {
-          txn = manager.resetForRetryAsync();
+          transactionContextFuture = manager.resetForRetryAsync();
         }
       }
     }
@@ -271,9 +268,10 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
   @Test
   public void asyncTransactionManagerInvalidUpdate() throws Exception {
     try (AsyncTransactionManager manager = client().transactionManagerAsync()) {
-      TransactionContextFuture txn = manager.beginAsync();
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
       CommitTimestampFuture commitTimestamp =
-          txn.then(
+          transactionContextFuture
+              .then(
                   (transaction, ignored) ->
                       transaction.executeUpdateAsync(INVALID_UPDATE_STATEMENT),
                   executor)
@@ -286,33 +284,31 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
 
   @Test
   public void asyncTransactionManagerCommitAborted() throws Exception {
-    SettableApiFuture<Long> updateCount = SettableApiFuture.create();
     final AtomicInteger attempt = new AtomicInteger();
     try (AsyncTransactionManager manager = clientWithEmptySessionPool().transactionManagerAsync()) {
-      TransactionContextFuture txn = manager.beginAsync();
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
       while (true) {
         try {
           attempt.incrementAndGet();
-          CommitTimestampFuture commitTimestamp =
-              txn.then(
-                      AsyncTransactionManagerHelper.executeUpdateAsync(
-                          updateCount, UPDATE_STATEMENT),
-                      executor)
-                  .then(
-                      (transaction, ignored) -> {
-                        if (attempt.get() == 1) {
-                          mockSpanner.abortTransaction(transaction);
-                        }
-                        return ApiFutures.immediateFuture(null);
-                      },
-                      executor)
-                  .commitAsync();
+          AsyncTransactionStep<Void, Long> updateCount =
+              transactionContextFuture.then(
+                  (transaction, ignored) -> transaction.executeUpdateAsync(UPDATE_STATEMENT),
+                  executor);
+          updateCount.then(
+              (transaction, ignored) -> {
+                if (attempt.get() == 1) {
+                  mockSpanner.abortTransaction(transaction);
+                }
+                return ApiFutures.immediateFuture(null);
+              },
+              executor);
+          CommitTimestampFuture commitTimestamp = updateCount.commitAsync();
           assertThat(updateCount.get()).isEqualTo(UPDATE_COUNT);
           assertThat(commitTimestamp.get()).isNotNull();
           assertThat(attempt.get()).isEqualTo(2);
           break;
         } catch (AbortedException e) {
-          txn = manager.resetForRetryAsync();
+          transactionContextFuture = manager.resetForRetryAsync();
         }
       }
     }
@@ -320,42 +316,26 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
 
   @Test
   public void asyncTransactionManagerFireAndForgetInvalidUpdate() throws Exception {
-    final SettableApiFuture<Long> updateCount = SettableApiFuture.create();
-
-    try (AsyncTransactionManager mgr = clientWithEmptySessionPool().transactionManagerAsync()) {
-      TransactionContextFuture txn = mgr.beginAsync();
+    try (AsyncTransactionManager manager = clientWithEmptySessionPool().transactionManagerAsync()) {
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
       while (true) {
         try {
-          CommitTimestampFuture ts =
-              txn.then(
-                      (transaction, ignored) -> {
-                        // This fire-and-forget update statement should not fail the transaction.
-                        // The exception will however cause the transaction to be retried, as the
-                        // statement will not return a transaction id.
-                        transaction.executeUpdateAsync(INVALID_UPDATE_STATEMENT);
-                        ApiFutures.addCallback(
-                            transaction.executeUpdateAsync(UPDATE_STATEMENT),
-                            new ApiFutureCallback<Long>() {
-                              @Override
-                              public void onFailure(Throwable t) {
-                                updateCount.setException(t);
-                              }
-
-                              @Override
-                              public void onSuccess(Long result) {
-                                updateCount.set(result);
-                              }
-                            },
-                            MoreExecutors.directExecutor());
-                        return updateCount;
-                      },
-                      executor)
-                  .commitAsync();
-          assertThat(ts.get()).isNotNull();
-          assertThat(updateCount.get()).isEqualTo(UPDATE_COUNT);
+          AsyncTransactionStep<Void, Long> transaction =
+              transactionContextFuture.then(
+                  (transactionContext, ignored) -> {
+                    // This fire-and-forget update statement should not fail the transaction.
+                    // The exception will however cause the transaction to be retried, as the
+                    // statement will not return a transaction id.
+                    transactionContext.executeUpdateAsync(INVALID_UPDATE_STATEMENT);
+                    return transactionContext.executeUpdateAsync(UPDATE_STATEMENT);
+                  },
+                  executor);
+          CommitTimestampFuture commitTimestamp = transaction.commitAsync();
+          assertThat(commitTimestamp.get()).isNotNull();
+          assertThat(transaction.get()).isEqualTo(UPDATE_COUNT);
           break;
         } catch (AbortedException e) {
-          txn = mgr.resetForRetryAsync();
+          transactionContextFuture = manager.resetForRetryAsync();
         }
       }
     }
@@ -375,15 +355,19 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
 
   @Test
   public void asyncTransactionManagerChain() throws Exception {
-    try (AsyncTransactionManager mgr = client().transactionManagerAsync()) {
-      TransactionContextFuture txn = mgr.beginAsync();
+    try (AsyncTransactionManager manager = client().transactionManagerAsync()) {
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
       while (true) {
         try {
-          CommitTimestampFuture ts =
-              txn.then(AsyncTransactionManagerHelper.executeUpdateAsync(UPDATE_STATEMENT), executor)
+          CommitTimestampFuture commitTimestamp =
+              transactionContextFuture
                   .then(
-                      AsyncTransactionManagerHelper.readRowAsync(
-                          READ_TABLE_NAME, Key.of(1L), READ_COLUMN_NAMES),
+                      (transaction, ignored) -> transaction.executeUpdateAsync(UPDATE_STATEMENT),
+                      executor)
+                  .then(
+                      (transactionContext, ignored) ->
+                          transactionContext.readRowAsync(
+                              READ_TABLE_NAME, Key.of(1L), READ_COLUMN_NAMES),
                       executor)
                   .then(
                       (ignored, input) -> ApiFutures.immediateFuture(input.getString("Value")),
@@ -395,10 +379,10 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
                       },
                       executor)
                   .commitAsync();
-          assertThat(ts.get()).isNotNull();
+          assertThat(commitTimestamp.get()).isNotNull();
           break;
         } catch (AbortedException e) {
-          txn = mgr.resetForRetryAsync();
+          transactionContextFuture = manager.resetForRetryAsync();
         }
       }
     }
@@ -406,13 +390,15 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
 
   @Test
   public void asyncTransactionManagerChainWithErrorInTheMiddle() throws Exception {
-    try (AsyncTransactionManager mgr = client().transactionManagerAsync()) {
-      TransactionContextFuture txn = mgr.beginAsync();
+    try (AsyncTransactionManager manager = client().transactionManagerAsync()) {
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
       while (true) {
         try {
-          CommitTimestampFuture ts =
-              txn.then(
-                      AsyncTransactionManagerHelper.executeUpdateAsync(INVALID_UPDATE_STATEMENT),
+          CommitTimestampFuture commitTimestampFuture =
+              transactionContextFuture
+                  .then(
+                      (transactionContext, ignored) ->
+                          transactionContext.executeUpdateAsync(INVALID_UPDATE_STATEMENT),
                       executor)
                   .then(
                       (ignored1, ignored2) -> {
@@ -420,16 +406,12 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
                       },
                       executor)
                   .commitAsync();
-          ts.get();
+          SpannerException e =
+              assertThrows(SpannerException.class, () -> get(commitTimestampFuture));
+          assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
           break;
         } catch (AbortedException e) {
-          txn = mgr.resetForRetryAsync();
-        } catch (ExecutionException e) {
-          mgr.rollbackAsync();
-          assertThat(e.getCause()).isInstanceOf(SpannerException.class);
-          SpannerException se = (SpannerException) e.getCause();
-          assertThat(se.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
-          break;
+          transactionContextFuture = manager.resetForRetryAsync();
         }
       }
     }
@@ -437,16 +419,17 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
 
   @Test
   public void asyncTransactionManagerUpdateAborted() throws Exception {
-    try (AsyncTransactionManager mgr = client().transactionManagerAsync()) {
+    try (AsyncTransactionManager manager = client().transactionManagerAsync()) {
       // Temporarily set the result of the update to 2 rows.
       mockSpanner.putStatementResult(StatementResult.update(UPDATE_STATEMENT, UPDATE_COUNT + 1L));
       final AtomicInteger attempt = new AtomicInteger();
 
-      TransactionContextFuture txn = mgr.beginAsync();
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
       while (true) {
         try {
-          CommitTimestampFuture ts =
-              txn.then(
+          CommitTimestampFuture commitTimestampFuture =
+              transactionContextFuture
+                  .then(
                       (ignored1, ignored2) -> {
                         if (attempt.incrementAndGet() == 1) {
                           // Abort the first attempt.
@@ -460,12 +443,14 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
                       },
                       executor)
                   .then(
-                      AsyncTransactionManagerHelper.executeUpdateAsync(UPDATE_STATEMENT), executor)
+                      (transactionContext, ignored) ->
+                          transactionContext.executeUpdateAsync(UPDATE_STATEMENT),
+                      executor)
                   .commitAsync();
-          assertThat(ts.get()).isNotNull();
+          assertThat(commitTimestampFuture.get()).isNotNull();
           break;
         } catch (AbortedException e) {
-          txn = mgr.resetForRetryAsync();
+          transactionContextFuture = manager.resetForRetryAsync();
         }
       }
       assertThat(attempt.get()).isEqualTo(2);
@@ -477,12 +462,13 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
   @Test
   public void asyncTransactionManagerUpdateAbortedWithoutGettingResult() throws Exception {
     final AtomicInteger attempt = new AtomicInteger();
-    try (AsyncTransactionManager mgr = clientWithEmptySessionPool().transactionManagerAsync()) {
-      TransactionContextFuture txn = mgr.beginAsync();
+    try (AsyncTransactionManager manager = clientWithEmptySessionPool().transactionManagerAsync()) {
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
       while (true) {
         try {
-          CommitTimestampFuture ts =
-              txn.then(
+          CommitTimestampFuture commitTimestampFuture =
+              transactionContextFuture
+                  .then(
                       (transaction, ignored) -> {
                         if (attempt.incrementAndGet() == 1) {
                           mockSpanner.abortNextStatement();
@@ -498,7 +484,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
                       },
                       executor)
                   .commitAsync();
-          assertThat(ts.get()).isNotNull();
+          assertThat(commitTimestampFuture.get()).isNotNull();
           assertThat(attempt.get()).isEqualTo(2);
           // The server may receive 1 or 2 commit requests depending on whether the call to
           // commitAsync() already knows that the transaction has aborted. If it does, it will not
@@ -513,7 +499,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
                   CommitRequest.class);
           break;
         } catch (AbortedException e) {
-          txn = mgr.resetForRetryAsync();
+          transactionContextFuture = manager.resetForRetryAsync();
         }
       }
     }
@@ -571,45 +557,45 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
 
   @Test
   public void asyncTransactionManagerBatchUpdate() throws Exception {
-    final SettableApiFuture<long[]> result = SettableApiFuture.create();
-    try (AsyncTransactionManager mgr = client().transactionManagerAsync()) {
-      TransactionContextFuture txn = mgr.beginAsync();
+    try (AsyncTransactionManager manager = client().transactionManagerAsync()) {
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
       while (true) {
         try {
-          txn.then(
-                  AsyncTransactionManagerHelper.batchUpdateAsync(
-                      result, UPDATE_STATEMENT, UPDATE_STATEMENT),
-                  executor)
-              .commitAsync()
-              .get();
+          AsyncTransactionStep<Void, long[]> updateCounts =
+              transactionContextFuture.then(
+                  (transaction, ignored) ->
+                      transaction.batchUpdateAsync(
+                          ImmutableList.of(UPDATE_STATEMENT, UPDATE_STATEMENT)),
+                  executor);
+          get(updateCounts.commitAsync());
+          assertThat(get(updateCounts)).asList().containsExactly(UPDATE_COUNT, UPDATE_COUNT);
           break;
         } catch (AbortedException e) {
-          txn = mgr.resetForRetryAsync();
+          transactionContextFuture = manager.resetForRetryAsync();
         }
       }
     }
-    assertThat(result.get()).asList().containsExactly(UPDATE_COUNT, UPDATE_COUNT);
   }
 
   @Test
   public void asyncTransactionManagerIsNonBlockingWithBatchUpdate() throws Exception {
-    SettableApiFuture<long[]> res = SettableApiFuture.create();
     mockSpanner.freeze();
-    try (AsyncTransactionManager mgr = clientWithEmptySessionPool().transactionManagerAsync()) {
-      TransactionContextFuture txn = mgr.beginAsync();
+    try (AsyncTransactionManager manager = clientWithEmptySessionPool().transactionManagerAsync()) {
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
       while (true) {
         try {
-          CommitTimestampFuture ts =
-              txn.then(
-                      AsyncTransactionManagerHelper.batchUpdateAsync(res, UPDATE_STATEMENT),
-                      executor)
-                  .commitAsync();
+          AsyncTransactionStep<Void, long[]> updateCounts =
+              transactionContextFuture.then(
+                  (transactionContext, ignored) ->
+                      transactionContext.batchUpdateAsync(Collections.singleton(UPDATE_STATEMENT)),
+                  executor);
+          CommitTimestampFuture commitTimestampFuture = updateCounts.commitAsync();
           mockSpanner.unfreeze();
-          assertThat(ts.get()).isNotNull();
-          assertThat(res.get()).asList().containsExactly(UPDATE_COUNT);
+          assertThat(commitTimestampFuture.get()).isNotNull();
+          assertThat(updateCounts.get()).asList().containsExactly(UPDATE_COUNT);
           break;
         } catch (AbortedException e) {
-          txn = mgr.resetForRetryAsync();
+          transactionContextFuture = manager.resetForRetryAsync();
         }
       }
     }
@@ -617,17 +603,18 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
 
   @Test
   public void asyncTransactionManagerInvalidBatchUpdate() throws Exception {
-    SettableApiFuture<long[]> result = SettableApiFuture.create();
-    try (AsyncTransactionManager mgr = client().transactionManagerAsync()) {
-      TransactionContextFuture txn = mgr.beginAsync();
+    try (AsyncTransactionManager manager = client().transactionManagerAsync()) {
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
       SpannerException e =
           assertThrows(
               SpannerException.class,
               () ->
                   get(
-                      txn.then(
-                              AsyncTransactionManagerHelper.batchUpdateAsync(
-                                  result, UPDATE_STATEMENT, INVALID_UPDATE_STATEMENT),
+                      transactionContextFuture
+                          .then(
+                              (transactionContext, ignored) ->
+                                  transactionContext.batchUpdateAsync(
+                                      ImmutableList.of(UPDATE_STATEMENT, INVALID_UPDATE_STATEMENT)),
                               executor)
                           .commitAsync()));
       assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
@@ -637,31 +624,32 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
 
   @Test
   public void asyncTransactionManagerFireAndForgetInvalidBatchUpdate() throws Exception {
-    SettableApiFuture<long[]> result = SettableApiFuture.create();
-    try (AsyncTransactionManager mgr = clientWithEmptySessionPool().transactionManagerAsync()) {
-      TransactionContextFuture txn = mgr.beginAsync();
+    try (AsyncTransactionManager manager = clientWithEmptySessionPool().transactionManagerAsync()) {
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
       while (true) {
         try {
-          txn.then(
-                  (transaction, ignored) -> {
-                    transaction.batchUpdateAsync(
-                        ImmutableList.of(UPDATE_STATEMENT, INVALID_UPDATE_STATEMENT));
-                    return ApiFutures.immediateFuture(null);
-                  },
-                  executor)
-              .then(
-                  AsyncTransactionManagerHelper.batchUpdateAsync(
-                      result, UPDATE_STATEMENT, UPDATE_STATEMENT),
-                  executor)
-              .commitAsync()
-              .get();
+          AsyncTransactionStep<Void, long[]> updateCounts =
+              transactionContextFuture
+                  .then(
+                      (transactionContext, ignored) -> {
+                        transactionContext.batchUpdateAsync(
+                            ImmutableList.of(UPDATE_STATEMENT, INVALID_UPDATE_STATEMENT));
+                        return ApiFutures.<Void>immediateFuture(null);
+                      },
+                      executor)
+                  .then(
+                      (transactionContext, ignored) ->
+                          transactionContext.batchUpdateAsync(
+                              ImmutableList.of(UPDATE_STATEMENT, UPDATE_STATEMENT)),
+                      executor);
+          updateCounts.commitAsync().get();
+          assertThat(updateCounts.get()).asList().containsExactly(UPDATE_COUNT, UPDATE_COUNT);
           break;
         } catch (AbortedException e) {
-          txn = mgr.resetForRetryAsync();
+          transactionContextFuture = manager.resetForRetryAsync();
         }
       }
     }
-    assertThat(result.get()).asList().containsExactly(UPDATE_COUNT, UPDATE_COUNT);
     assertThat(mockSpanner.getRequestTypes())
         .containsExactly(
             BatchCreateSessionsRequest.class,
@@ -673,11 +661,12 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
   @Test
   public void asyncTransactionManagerBatchUpdateAborted() throws Exception {
     final AtomicInteger attempt = new AtomicInteger();
-    try (AsyncTransactionManager mgr = clientWithEmptySessionPool().transactionManagerAsync()) {
-      TransactionContextFuture txn = mgr.beginAsync();
+    try (AsyncTransactionManager manager = clientWithEmptySessionPool().transactionManagerAsync()) {
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
       while (true) {
         try {
-          txn.then(
+          transactionContextFuture
+              .then(
                   (transaction, ignored) -> {
                     if (attempt.incrementAndGet() == 1) {
                       return transaction.batchUpdateAsync(
@@ -692,7 +681,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
               .get();
           break;
         } catch (AbortedException e) {
-          txn = mgr.resetForRetryAsync();
+          transactionContextFuture = manager.resetForRetryAsync();
         }
       }
     }
@@ -711,16 +700,17 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
   @Test
   public void asyncTransactionManagerBatchUpdateAbortedBeforeFirstStatement() throws Exception {
     final AtomicInteger attempt = new AtomicInteger();
-    try (AsyncTransactionManager mgr = clientWithEmptySessionPool().transactionManagerAsync()) {
-      TransactionContextFuture txn = mgr.beginAsync();
+    try (AsyncTransactionManager manager = clientWithEmptySessionPool().transactionManagerAsync()) {
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
       while (true) {
         try {
-          txn.then(
-                  (transaction, ignored) -> {
+          transactionContextFuture
+              .then(
+                  (transactionContext, ignored) -> {
                     if (attempt.incrementAndGet() == 1) {
                       mockSpanner.abortNextStatement();
                     }
-                    return transaction.batchUpdateAsync(
+                    return transactionContext.batchUpdateAsync(
                         ImmutableList.of(UPDATE_STATEMENT, UPDATE_STATEMENT));
                   },
                   executor)
@@ -728,7 +718,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
               .get();
           break;
         } catch (AbortedException e) {
-          txn = mgr.resetForRetryAsync();
+          transactionContextFuture = manager.resetForRetryAsync();
         }
       }
     }
@@ -746,28 +736,30 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
 
   @Test
   public void asyncTransactionManagerWithBatchUpdateCommitAborted() throws Exception {
-    try (AsyncTransactionManager mgr = clientWithEmptySessionPool().transactionManagerAsync()) {
+    try (AsyncTransactionManager manager = clientWithEmptySessionPool().transactionManagerAsync()) {
       // Temporarily set the result of the update to 2 rows.
       mockSpanner.putStatementResult(StatementResult.update(UPDATE_STATEMENT, UPDATE_COUNT + 1L));
       final AtomicInteger attempt = new AtomicInteger();
-      TransactionContextFuture txn = mgr.beginAsync();
+      TransactionContextFuture txn = manager.beginAsync();
       while (true) {
-        final SettableApiFuture<long[]> result = SettableApiFuture.create();
         try {
-          txn.then(
-                  (ignored1, ignored2) -> {
-                    if (attempt.get() > 0) {
-                      // Set the result of the update statement back to 1 row.
-                      mockSpanner.putStatementResult(
-                          StatementResult.update(UPDATE_STATEMENT, UPDATE_COUNT));
-                    }
-                    return ApiFutures.immediateFuture(null);
-                  },
-                  executor)
-              .then(
-                  AsyncTransactionManagerHelper.batchUpdateAsync(
-                      result, UPDATE_STATEMENT, UPDATE_STATEMENT),
-                  executor)
+          AsyncTransactionStep<Void, long[]> updateCounts =
+              txn.then(
+                      (ignored1, ignored2) -> {
+                        if (attempt.get() > 0) {
+                          // Set the result of the update statement back to 1 row.
+                          mockSpanner.putStatementResult(
+                              StatementResult.update(UPDATE_STATEMENT, UPDATE_COUNT));
+                        }
+                        return ApiFutures.<Void>immediateFuture(null);
+                      },
+                      executor)
+                  .then(
+                      (transactionContext, ignored) ->
+                          transactionContext.batchUpdateAsync(
+                              ImmutableList.of(UPDATE_STATEMENT, UPDATE_STATEMENT)),
+                      executor);
+          updateCounts
               .then(
                   (transaction, ignored) -> {
                     if (attempt.incrementAndGet() == 1) {
@@ -778,11 +770,11 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
                   executor)
               .commitAsync()
               .get();
-          assertThat(result.get()).asList().containsExactly(UPDATE_COUNT, UPDATE_COUNT);
+          assertThat(updateCounts.get()).asList().containsExactly(UPDATE_COUNT, UPDATE_COUNT);
           assertThat(attempt.get()).isEqualTo(2);
           break;
         } catch (AbortedException e) {
-          txn = mgr.resetForRetryAsync();
+          txn = manager.resetForRetryAsync();
         }
       }
     } finally {
@@ -801,12 +793,13 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
   @Test
   public void asyncTransactionManagerBatchUpdateAbortedWithoutGettingResult() throws Exception {
     final AtomicInteger attempt = new AtomicInteger();
-    try (AsyncTransactionManager mgr = clientWithEmptySessionPool().transactionManagerAsync()) {
-      TransactionContextFuture txn = mgr.beginAsync();
+    try (AsyncTransactionManager manager = clientWithEmptySessionPool().transactionManagerAsync()) {
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
       while (true) {
         try {
-          txn.then(
-                  (transaction, ignored) -> {
+          transactionContextFuture
+              .then(
+                  (transactionContext, ignored) -> {
                     if (attempt.incrementAndGet() == 1) {
                       mockSpanner.abortNextStatement();
                     }
@@ -816,7 +809,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
                     // directly in the transaction manager if the ABORTED error has already been
                     // returned by the batch update call before the commit call starts.
                     // Otherwise, the backend will return an ABORTED error for the commit call.
-                    transaction.batchUpdateAsync(
+                    transactionContext.batchUpdateAsync(
                         ImmutableList.of(UPDATE_STATEMENT, UPDATE_STATEMENT));
                     return ApiFutures.immediateFuture(null);
                   },
@@ -825,7 +818,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
               .get();
           break;
         } catch (AbortedException e) {
-          txn = mgr.resetForRetryAsync();
+          transactionContextFuture = manager.resetForRetryAsync();
         }
       }
     }
@@ -860,16 +853,18 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
             Status.RESOURCE_EXHAUSTED
                 .withDescription("mutation limit exceeded")
                 .asRuntimeException()));
-    try (AsyncTransactionManager mgr = clientWithEmptySessionPool().transactionManagerAsync()) {
-      TransactionContextFuture txn = mgr.beginAsync();
+    try (AsyncTransactionManager manager = clientWithEmptySessionPool().transactionManagerAsync()) {
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
       SpannerException e =
           assertThrows(
               SpannerException.class,
               () ->
                   get(
-                      txn.then(
-                              AsyncTransactionManagerHelper.batchUpdateAsync(
-                                  UPDATE_STATEMENT, UPDATE_STATEMENT),
+                      transactionContextFuture
+                          .then(
+                              (transactionContext, ignored) ->
+                                  transactionContext.batchUpdateAsync(
+                                      ImmutableList.of(UPDATE_STATEMENT, UPDATE_STATEMENT)),
                               executor)
                           .commitAsync()));
       assertThat(e.getErrorCode()).isEqualTo(ErrorCode.RESOURCE_EXHAUSTED);
@@ -882,13 +877,14 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
 
   @Test
   public void asyncTransactionManagerWaitsUntilAsyncBatchUpdateHasFinished() throws Exception {
-    try (AsyncTransactionManager mgr = clientWithEmptySessionPool().transactionManagerAsync()) {
-      TransactionContextFuture txn = mgr.beginAsync();
+    try (AsyncTransactionManager manager = clientWithEmptySessionPool().transactionManagerAsync()) {
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
       while (true) {
         try {
-          txn.then(
-                  (transaction, ignored) -> {
-                    transaction.batchUpdateAsync(ImmutableList.of(UPDATE_STATEMENT));
+          transactionContextFuture
+              .then(
+                  (transactionContext, ignored) -> {
+                    transactionContext.batchUpdateAsync(ImmutableList.of(UPDATE_STATEMENT));
                     return ApiFutures.immediateFuture(null);
                   },
                   executor)
@@ -896,7 +892,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
               .get();
           break;
         } catch (AbortedException e) {
-          txn = mgr.resetForRetryAsync();
+          transactionContextFuture = manager.resetForRetryAsync();
         }
       }
     }
@@ -907,55 +903,53 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
 
   @Test
   public void asyncTransactionManagerReadRow() throws Exception {
-    ApiFuture<String> val;
-    try (AsyncTransactionManager mgr = client().transactionManagerAsync()) {
-      TransactionContextFuture txn = mgr.beginAsync();
+    try (AsyncTransactionManager manager = client().transactionManagerAsync()) {
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
       while (true) {
         try {
-          AsyncTransactionStep<Struct, String> step;
-          val =
-              step =
-                  txn.then(
-                          AsyncTransactionManagerHelper.readRowAsync(
+          AsyncTransactionStep<Struct, String> value =
+              transactionContextFuture
+                  .then(
+                      (transactionContext, ignored) ->
+                          transactionContext.readRowAsync(
                               READ_TABLE_NAME, Key.of(1L), READ_COLUMN_NAMES),
-                          executor)
-                      .then(
-                          (ignored, input) -> ApiFutures.immediateFuture(input.getString("Value")),
-                          executor);
-          step.commitAsync().get();
+                      executor)
+                  .then(
+                      (ignored, input) -> ApiFutures.immediateFuture(input.getString("Value")),
+                      executor);
+          value.commitAsync().get();
+          assertThat(value.get()).isEqualTo("v1");
           break;
         } catch (AbortedException e) {
-          txn = mgr.resetForRetryAsync();
+          transactionContextFuture = manager.resetForRetryAsync();
         }
       }
     }
-    assertThat(val.get()).isEqualTo("v1");
   }
 
   @Test
   public void asyncTransactionManagerRead() throws Exception {
-    AsyncTransactionStep<Void, List<String>> res;
-    try (AsyncTransactionManager mgr = client().transactionManagerAsync()) {
-      TransactionContextFuture txn = mgr.beginAsync();
+    try (AsyncTransactionManager manager = client().transactionManagerAsync()) {
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
       while (true) {
         try {
-          res =
-              txn.then(
-                  (transaction, ignored) ->
-                      transaction
+          AsyncTransactionStep<Void, List<String>> values =
+              transactionContextFuture.then(
+                  (transactionContext, ignored) ->
+                      transactionContext
                           .readAsync(READ_TABLE_NAME, KeySet.all(), READ_COLUMN_NAMES)
                           .toListAsync(
                               input -> input.getString("Value"), MoreExecutors.directExecutor()),
                   executor);
           // Commit the transaction.
-          res.commitAsync().get();
+          values.commitAsync().get();
+          assertThat(values.get()).containsExactly("v1", "v2", "v3");
           break;
         } catch (AbortedException e) {
-          txn = mgr.resetForRetryAsync();
+          transactionContextFuture = manager.resetForRetryAsync();
         }
       }
     }
-    assertThat(res.get()).containsExactly("v1", "v2", "v3");
   }
 
   @Test
@@ -966,24 +960,24 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
             MockSpannerTestUtil.READ_FIRST_NAME_SINGERS_RESULTSET));
     final long singerId = 1L;
     try (AsyncTransactionManager manager = client().transactionManagerAsync()) {
-      TransactionContextFuture txn = manager.beginAsync();
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
       while (true) {
         final String column = "FirstName";
         CommitTimestampFuture commitTimestamp =
-            txn.then(
-                    (transaction, ignored) ->
-                        transaction.readRowAsync(
+            transactionContextFuture
+                .then(
+                    (transactionContext, ignored) ->
+                        transactionContext.readRowAsync(
                             "Singers", Key.of(singerId), Collections.singleton(column)),
                     executor)
                 .then(
                     (transaction, input) -> {
                       String name = input.getString(column);
-                      transaction.buffer(
+                      return transaction.bufferAsync(
                           Mutation.newUpdateBuilder("Singers")
                               .set(column)
                               .to(name.toUpperCase())
                               .build());
-                      return ApiFutures.immediateFuture(null);
                     },
                     executor)
                 .commitAsync();
@@ -991,8 +985,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
           commitTimestamp.get();
           break;
         } catch (AbortedException e) {
-          Thread.sleep(e.getRetryDelayInMillis());
-          txn = manager.resetForRetryAsync();
+          transactionContextFuture = manager.resetForRetryAsync();
         }
       }
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionContextImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionContextImplTest.java
@@ -138,6 +138,14 @@ public class TransactionContextImplTest {
     }
   }
 
+  @Test
+  public void testCannotCommitTwice() {
+    try (TransactionContextImpl context = createContext()) {
+      context.commit();
+      assertThrows(IllegalStateException.class, () -> context.commit());
+    }
+  }
+
   @Test(expected = AbortedException.class)
   public void batchDmlAborted() {
     batchDml(Code.ABORTED_VALUE);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionContextImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionContextImplTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spanner;
 
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Mockito.mock;
@@ -26,19 +27,116 @@ import com.google.api.core.ApiFutures;
 import com.google.cloud.spanner.TransactionRunnerImpl.TransactionContextImpl;
 import com.google.cloud.spanner.spi.v1.SpannerRpc;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Timestamp;
 import com.google.rpc.Code;
 import com.google.rpc.Status;
 import com.google.spanner.v1.CommitRequest;
 import com.google.spanner.v1.ExecuteBatchDmlRequest;
 import com.google.spanner.v1.ExecuteBatchDmlResponse;
 import java.util.Collections;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class TransactionContextImplTest {
+
+  @Mock private SpannerRpc rpc;
+
+  @Mock private SessionImpl session;
+
+  @SuppressWarnings("unchecked")
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    when(rpc.commitAsync(any(CommitRequest.class), anyMap()))
+        .thenReturn(
+            ApiFutures.immediateFuture(
+                com.google.spanner.v1.CommitResponse.newBuilder()
+                    .setCommitTimestamp(Timestamp.newBuilder().setSeconds(99L).setNanos(10).build())
+                    .build()));
+    when(session.getName()).thenReturn("test");
+  }
+
+  private TransactionContextImpl createContext() {
+    return TransactionContextImpl.newBuilder()
+        .setSession(session)
+        .setRpc(rpc)
+        .setTransactionId(ByteString.copyFromUtf8("test"))
+        .setOptions(Options.fromTransactionOptions())
+        .build();
+  }
+
+  @Test
+  public void testCanBufferBeforeCommit() {
+    try (TransactionContextImpl context = createContext()) {
+      context.buffer(Mutation.delete("test", KeySet.all()));
+    }
+  }
+
+  @Test
+  public void testCanBufferAsyncBeforeCommit() {
+    try (TransactionContextImpl context = createContext()) {
+      context.bufferAsync(Mutation.delete("test", KeySet.all()));
+    }
+  }
+
+  @Test
+  public void testCanBufferIterableBeforeCommit() {
+    try (TransactionContextImpl context = createContext()) {
+      context.buffer(Collections.singleton(Mutation.delete("test", KeySet.all())));
+    }
+  }
+
+  @Test
+  public void testCanBufferIterableAsyncBeforeCommit() {
+    try (TransactionContextImpl context = createContext()) {
+      context.bufferAsync(Collections.singleton(Mutation.delete("test", KeySet.all())));
+    }
+  }
+
+  @Test
+  public void testCannotBufferAfterCommit() {
+    try (TransactionContextImpl context = createContext()) {
+      context.commit();
+      assertThrows(
+          IllegalStateException.class, () -> context.buffer(Mutation.delete("test", KeySet.all())));
+    }
+  }
+
+  @Test
+  public void testCannotBufferAsyncAfterCommit() {
+    try (TransactionContextImpl context = createContext()) {
+      context.commit();
+      assertThrows(
+          IllegalStateException.class,
+          () -> context.bufferAsync(Mutation.delete("test", KeySet.all())));
+    }
+  }
+
+  @Test
+  public void testCannotBufferIterableAfterCommit() {
+    try (TransactionContextImpl context = createContext()) {
+      context.commit();
+      assertThrows(
+          IllegalStateException.class,
+          () -> context.buffer(Collections.singleton(Mutation.delete("test", KeySet.all()))));
+    }
+  }
+
+  @Test
+  public void testCannotBufferIterableAsyncAfterCommit() {
+    try (TransactionContextImpl context = createContext()) {
+      context.commit();
+      assertThrows(
+          IllegalStateException.class,
+          () -> context.bufferAsync(Collections.singleton(Mutation.delete("test", KeySet.all()))));
+    }
+  }
 
   @Test(expected = AbortedException.class)
   public void batchDmlAborted() {
@@ -53,13 +151,7 @@ public class TransactionContextImplTest {
   @SuppressWarnings("unchecked")
   @Test
   public void testReturnCommitStats() {
-    SessionImpl session = mock(SessionImpl.class);
-    when(session.getName()).thenReturn("test");
     ByteString transactionId = ByteString.copyFromUtf8("test");
-    SpannerRpc rpc = mock(SpannerRpc.class);
-    when(rpc.commitAsync(any(CommitRequest.class), anyMap()))
-        .thenReturn(
-            ApiFutures.immediateFuture(com.google.spanner.v1.CommitResponse.getDefaultInstance()));
 
     try (TransactionContextImpl context =
         TransactionContextImpl.newBuilder()

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionContextTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionContextTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+import static org.junit.Assert.assertThrows;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.spanner.Options.QueryOption;
+import com.google.cloud.spanner.Options.ReadOption;
+import com.google.cloud.spanner.Options.UpdateOption;
+import java.util.Collections;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TransactionContextTest {
+
+  @Test
+  public void testDefaultImplementations() {
+    try (TransactionContext context =
+        new TransactionContext() {
+          @Override
+          public AsyncResultSet readUsingIndexAsync(
+              String table,
+              String index,
+              KeySet keys,
+              Iterable<String> columns,
+              ReadOption... options) {
+            return null;
+          }
+
+          @Override
+          public ResultSet readUsingIndex(
+              String table,
+              String index,
+              KeySet keys,
+              Iterable<String> columns,
+              ReadOption... options) {
+            return null;
+          }
+
+          @Override
+          public ApiFuture<Struct> readRowUsingIndexAsync(
+              String table, String index, Key key, Iterable<String> columns) {
+            return null;
+          }
+
+          @Override
+          public Struct readRowUsingIndex(
+              String table, String index, Key key, Iterable<String> columns) {
+            return null;
+          }
+
+          @Override
+          public ApiFuture<Struct> readRowAsync(String table, Key key, Iterable<String> columns) {
+            return null;
+          }
+
+          @Override
+          public Struct readRow(String table, Key key, Iterable<String> columns) {
+            return null;
+          }
+
+          @Override
+          public AsyncResultSet readAsync(
+              String table, KeySet keys, Iterable<String> columns, ReadOption... options) {
+            return null;
+          }
+
+          @Override
+          public ResultSet read(
+              String table, KeySet keys, Iterable<String> columns, ReadOption... options) {
+            return null;
+          }
+
+          @Override
+          public AsyncResultSet executeQueryAsync(Statement statement, QueryOption... options) {
+            return null;
+          }
+
+          @Override
+          public ResultSet executeQuery(Statement statement, QueryOption... options) {
+            return null;
+          }
+
+          @Override
+          public void close() {}
+
+          @Override
+          public ResultSet analyzeQuery(Statement statement, QueryAnalyzeMode queryMode) {
+            return null;
+          }
+
+          @Override
+          public ApiFuture<Long> executeUpdateAsync(Statement statement, UpdateOption... options) {
+            return null;
+          }
+
+          @Override
+          public long executeUpdate(Statement statement, UpdateOption... options) {
+            return 0;
+          }
+
+          @Override
+          public void buffer(Iterable<Mutation> mutations) {}
+
+          @Override
+          public void buffer(Mutation mutation) {}
+
+          @Override
+          public ApiFuture<long[]> batchUpdateAsync(
+              Iterable<Statement> statements, UpdateOption... options) {
+            return null;
+          }
+
+          @Override
+          public long[] batchUpdate(Iterable<Statement> statements, UpdateOption... options) {
+            return null;
+          }
+        }) {
+      assertThrows(
+          UnsupportedOperationException.class,
+          () -> context.bufferAsync(Mutation.delete("foo", KeySet.all())));
+      assertThrows(
+          UnsupportedOperationException.class,
+          () -> context.bufferAsync(Collections.singleton(Mutation.delete("foo", KeySet.all()))));
+    }
+  }
+}


### PR DESCRIPTION
Adds bufferAsync methods to TransactionContext. The existing buffer methods were already non-blocking, but the async versions also return an ApiFuture, which make them easier to use when chaining multiple async calls together.

Also changes some calls in the AsyncTransactionManagerTest to use lambdas instead of the test helper methods.

Fixes #1126
