### PR TITLE
build: remove custom skip tests variable

### DIFF
--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -15,7 +15,6 @@
   </parent>
   <properties>
     <site.installationModule>google-cloud-spanner</site.installationModule>
-    <skipUTs>false</skipUTs>
   </properties>
 
 
@@ -51,7 +50,6 @@
             <id>default-test</id>
             <configuration>
               <excludedGroups>com.google.cloud.spanner.TracerTest,com.google.cloud.spanner.IntegrationTest</excludedGroups>
-              <skipTests>${skipUTs}</skipTests>
             </configuration>
           </execution>
           <execution>

--- a/samples/README.md
+++ b/samples/README.md
@@ -17,7 +17,7 @@ Install [Maven](http://maven.apache.org/).
 
 Build your project from the root directory (`java-spanner`):
 
-    mvn clean package -DskipTests -DskipUTs -Penable-samples
+    mvn clean package -DskipTests -Penable-samples
 
 Every subsequent command here should be run from a subdirectory (`cd samples/snippets`).
 


### PR DESCRIPTION
A custom `skipUTs` system property had been introduced to skip unit tests for the Spanner client library. None of the automated build scripts use this variable however, and instead use the standard `skipTests` variable. This caused all unit tests to be executed twice in the build scripts, which again could cause timeout errors, especially for the Windows builds.

Note: The `skipTests` system variable is defined in the shared configuration, and therefore does not need to be added to the pom files of the client library.