### PR TITLE
chore: removes clirr/linkage-monitor from 3.3.3-sp

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -81,9 +81,7 @@ branchProtectionRules:
     requiredStatusCheckContexts:
       - dependencies (8)
       - dependencies (11)
-      - linkage-monitor
       - lint
-      - clirr
       - units (8)
       - units (11)
       - 'Kokoro - Test: Integration'


### PR DESCRIPTION
Removes clirr and linkage-monitor as required CI steps from the LTS version, since they do not support old versions (not HEAD) of the library.