### PR TITLE
fix: stop invoking callback after pausing and cancelling result set

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
@@ -252,6 +252,13 @@ class AsyncResultSetImpl extends ForwardingStructReader implements ListenableAsy
             if (cursorReturnedDoneOrException) {
               break;
             }
+            if (state == State.CANCELLED) {
+              // The callback should always get at least one chance to catch the CANCELLED
+              // exception. It is however possible that the callback does not call tryNext(), and
+              // instead directly returns PAUSE or DONE. In those cases, the callback runner should
+              // also stop, even though the callback has not seen the CANCELLED state.
+              cursorReturnedDoneOrException = true;
+            }
           }
           CallbackResponse response;
           try {


### PR DESCRIPTION
An AsyncResultSet that was PAUSED and then CANCELLED, would continue to invoke the callback until the callback would call tryNext(). If the callback never called tryNext(), the spinning would continue until the entire result set had been consumed.

Fixes #1191
