### PR TITLE
test: increase timeout to prevent flakiness

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplStressTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplStressTest.java
@@ -56,7 +56,7 @@ public class AsyncResultSetImplStressTest {
   private static final int TEST_RUNS = 25;
 
   /** Timeout is applied to each test case individually. */
-  @Rule public Timeout timeout = new Timeout(120, TimeUnit.SECONDS);
+  @Rule public Timeout timeout = new Timeout(240, TimeUnit.SECONDS);
 
   @Parameter(0)
   public int resultSetSize;


### PR DESCRIPTION
Increase test timeout to prevent flaky failures on (very) slow build environments.

Fixes #1204
