### PR TITLE
test: backup operation could finish before it is cancelled

### DIFF
--- a/samples/snippets/src/main/java/com/example/spanner/SpannerSample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/SpannerSample.java
@@ -1620,6 +1620,8 @@ public class SpannerSample {
       if (pollingFuture.get().getErrorCode() == null) {
         // Backup was created before it could be cancelled. Delete the backup.
         backup.delete();
+        System.out.println("Backup operation for [" + backup.getId()
+            + "] successfully finished before it could be cancelled");
       } else if (pollingFuture.get().getErrorCode().getCode() == StatusCode.Code.CANCELLED) {
         System.out.println("Backup operation for [" + backup.getId() + "] successfully cancelled");
       }

--- a/samples/snippets/src/test/java/com/example/spanner/SpannerSampleIT.java
+++ b/samples/snippets/src/test/java/com/example/spanner/SpannerSampleIT.java
@@ -314,7 +314,7 @@ public class SpannerSampleIT {
 
     out = runSample("cancelcreatebackup");
     assertThat(out).contains(
-        "Backup operation for [" + backupId + "_cancel] successfully cancelled");
+        "Backup operation for [" + backupId + "_cancel] successfully");
 
     // TODO: remove try-catch when filtering on metadata fields works.
     try {


### PR DESCRIPTION
The test backup operation could finish before the sample can cancel it. If that happened, the sample would not print any information and the corresponding test case would fail, although the sample does take this into consideration as a valid scenario.

Fixes #1211
