### PR TITLE
test: increase wait for threads to shut down

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
@@ -297,16 +297,16 @@ public class GapicSpannerRpcTest {
                   < options.getNumChannels() * NUM_THREADS_PER_CHANNEL * openSpanners
                       + initialNumberOfThreads;
           sessionCount++) {
-        ResultSet rs = client.singleUse().executeQuery(SELECT1AND2);
+        ResultSet resultSet = client.singleUse().executeQuery(SELECT1AND2);
         // Execute ResultSet#next() to send the query to Spanner.
-        rs.next();
+        resultSet.next();
         // Delay closing the result set in order to force the use of multiple sessions.
         // As each session is linked to one transport channel, using multiple different
         // sessions should initialize multiple transport channels.
-        resultSets.add(rs);
+        resultSets.add(resultSet);
       }
-      for (ResultSet rs : resultSets) {
-        rs.close();
+      for (ResultSet resultSet : resultSets) {
+        resultSet.close();
       }
     }
     for (Spanner spanner : spanners) {
@@ -316,12 +316,12 @@ public class GapicSpannerRpcTest {
     Stopwatch watch = Stopwatch.createStarted();
     while (getNumberOfThreadsWithName(SPANNER_THREAD_NAME, false, initialNumberOfThreads)
             > initialNumberOfThreads
-        && watch.elapsed(TimeUnit.SECONDS) < 2) {
+        && watch.elapsed(TimeUnit.SECONDS) < 5) {
       Thread.sleep(10L);
     }
-    assertThat(
-        getNumberOfThreadsWithName(SPANNER_THREAD_NAME, true, initialNumberOfThreads),
-        is(equalTo(initialNumberOfThreads)));
+    assertEquals(
+        initialNumberOfThreads,
+        getNumberOfThreadsWithName(SPANNER_THREAD_NAME, true, initialNumberOfThreads));
   }
 
   @Test


### PR DESCRIPTION
Increases the allowed wait time for the threads to shut down. Note that the full wait time will only be used if the threads do not shut down timely, which means that this does not slow down the test case under normal circumstances.

Fixes #1217
