### PR TITLE
feat: support encoded credentials in connection URL

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/CredentialsService.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/CredentialsService.java
@@ -22,6 +22,8 @@ import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.io.BaseEncoding;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -67,6 +69,27 @@ class CredentialsService {
         msg = msg + credentialsUrl;
       }
       throw SpannerExceptionFactory.newSpannerException(ErrorCode.INVALID_ARGUMENT, msg, e);
+    }
+  }
+
+  GoogleCredentials decodeCredentials(String encodedCredentials) {
+    byte[] decodedBytes;
+    try {
+      decodedBytes = BaseEncoding.base64Url().decode(encodedCredentials);
+    } catch (IllegalArgumentException e) {
+      throw SpannerExceptionFactory.newSpannerException(
+          ErrorCode.INVALID_ARGUMENT,
+          "The encoded credentials could not be decoded as a base64 string. "
+              + "Please ensure that the provided string is a valid base64 string.",
+          e);
+    }
+    try {
+      return GoogleCredentials.fromStream(new ByteArrayInputStream(decodedBytes));
+    } catch (IllegalArgumentException | IOException e) {
+      throw SpannerExceptionFactory.newSpannerException(
+          ErrorCode.INVALID_ARGUMENT,
+          "The encoded credentials do not contain a valid Google Cloud credentials JSON string.",
+          e);
     }
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner.connection;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -27,6 +28,10 @@ import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerOptions;
+import com.google.common.io.BaseEncoding;
+import com.google.common.io.Files;
+import java.io.File;
+import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Test;
@@ -508,5 +513,64 @@ public class ConnectionOptionsTest {
       assertThat(e.getMessage())
           .contains("Invalid credentials path specified: /some/non/existing/path");
     }
+  }
+
+  @Test
+  public void testNonBase64EncodedCredentials() {
+    String uri =
+        "cloudspanner:/projects/test-project/instances/test-instance/databases/test-database?encodedCredentials=not-a-base64-string/";
+    SpannerException e =
+        assertThrows(
+            SpannerException.class, () -> ConnectionOptions.newBuilder().setUri(uri).build());
+    assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCode());
+    assertThat(e.getMessage())
+        .contains("The encoded credentials could not be decoded as a base64 string.");
+  }
+
+  @Test
+  public void testInvalidEncodedCredentials() throws UnsupportedEncodingException {
+    String uri =
+        String.format(
+            "cloudspanner:/projects/test-project/instances/test-instance/databases/test-database?encodedCredentials=%s",
+            BaseEncoding.base64Url().encode("not-a-credentials-JSON-string".getBytes("UTF-8")));
+    SpannerException e =
+        assertThrows(
+            SpannerException.class, () -> ConnectionOptions.newBuilder().setUri(uri).build());
+    assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCode());
+    assertThat(e.getMessage())
+        .contains(
+            "The encoded credentials do not contain a valid Google Cloud credentials JSON string.");
+  }
+
+  @Test
+  public void testValidEncodedCredentials() throws Exception {
+    String encoded =
+        BaseEncoding.base64Url().encode(Files.asByteSource(new File(FILE_TEST_PATH)).read());
+    String uri =
+        String.format(
+            "cloudspanner:/projects/test-project/instances/test-instance/databases/test-database?encodedCredentials=%s",
+            encoded);
+
+    ConnectionOptions options = ConnectionOptions.newBuilder().setUri(uri).build();
+    assertEquals(
+        new CredentialsService().createCredentials(FILE_TEST_PATH), options.getCredentials());
+  }
+
+  @Test
+  public void testSetCredentialsAndEncodedCredentials() throws Exception {
+    String encoded =
+        BaseEncoding.base64Url().encode(Files.asByteSource(new File(FILE_TEST_PATH)).read());
+    String uri =
+        String.format(
+            "cloudspanner:/projects/test-project/instances/test-instance/databases/test-database?credentials=%s;encodedCredentials=%s",
+            FILE_TEST_PATH, encoded);
+
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> ConnectionOptions.newBuilder().setUri(uri).build());
+    assertThat(e.getMessage())
+        .contains(
+            "Cannot specify both a credentials URL and encoded credentials. Only set one of the properties.");
   }
 }


### PR DESCRIPTION
This enables a user to specify a base64 encoded JSON string that contains the credentials that should be used for the connection. This removes the requirement to write the JSON string to a file before it can be used for a connection.

This property is the same as the `spring.cloud.gcp.spanner.credentials.encoded-key` property that is supported by [spring-data-cloud-spanner](https://docs.spring.io/spring-cloud-gcp/docs/1.1.0.M1/reference/html/_spring_data_cloud_spanner.html). 

Fixes https://github.com/googleapis/java-spanner-jdbc/issues/486
