### PR TITLE
chore(3.3.3-sp): dependencies check

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -7,6 +7,7 @@
   "issue_tracker": "https://issuetracker.google.com/issues?q=componentid:190851%2B%20status:open",
   "release_level": "ga",
   "language": "java",
+  "min_java_version": 8,
   "repo": "googleapis/java-spanner",
   "repo_short": "java-spanner",
   "distribution_name": "com.google.cloud:google-cloud-spanner",

--- a/google-cloud-spanner-bom/pom.xml
+++ b/google-cloud-spanner-bom/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>0.9.4</version>
+    <version>0.12.0</version>
   </parent>
 
   <name>Google Cloud Spanner BOM</name>

--- a/google-cloud-spanner-bom/pom.xml
+++ b/google-cloud-spanner-bom/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>0.12.0</version>
+    <version>0.9.4</version>
   </parent>
 
   <name>Google Cloud Spanner BOM</name>

--- a/google-cloud-spanner-bom/pom.xml
+++ b/google-cloud-spanner-bom/pom.xml
@@ -107,6 +107,20 @@
 
   <build>
     <plugins>
+      <!-- TODO: Remove this once the shared configuration updates to use Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <encoding>UTF-8</encoding>
+          <compilerArgument>-Xlint:unchecked</compilerArgument>
+          <compilerArgument>-Xlint:deprecation</compilerArgument>
+          <showDeprecation>true</showDeprecation>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>

--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -18,6 +18,7 @@
     <skipUTs>false</skipUTs>
   </properties>
 
+
   <build>
     <plugins>
       <plugin>

--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -16,8 +16,33 @@
   <properties>
     <site.installationModule>google-cloud-spanner</site.installationModule>
     <skipUTs>false</skipUTs>
+    <!-- finalized versions -->
+    <!-- JRE for Java 8. Beam's dependency (gcsio) uses JRE flavor -->
+    <guava.version>30.1.1-jre</guava.version>
+    <google.autovalue.version>1.8.1</google.autovalue.version>
+    <protobuf.version>3.16.0</protobuf.version>
+    <http.version>1.39.2-sp.1</http.version>
+    <io.grpc.version>1.36.2</io.grpc.version>
+    <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
+        When updating gax.version, update gax.httpjson.version too. -->
+    <gax.version>1.64.0-sp.1</gax.version>
+    <gax.httpjson.version>0.81.0-sp.1</gax.httpjson.version>
+    <google.api.client.version>1.31.3-sp.1</google.api.client.version>
+    <api.common.version>1.10.1-sp.1</api.common.version>
+    <google.auth.library.version>0.25.2-sp.1</google.auth.library.version>
+    <google.oauth.client.version>1.31.4-sp.1</google.oauth.client.version>
+    <google.cloud.spanner.version>3.3.3-sp.1</google.cloud.spanner.version>
+    <google.cloud.monitoring.version>2.1.0-sp.1</google.cloud.monitoring.version>
+    <google.cloud.trace.version>1.3.0-sp.1</google.cloud.trace.version>
+    <google.cloud.pubsub.version>1.111.0-sp.1</google.cloud.pubsub.version>
+    <google.cloud.bigquery.version>1.127.12-sp.1</google.cloud.bigquery.version>
+    <google.cloud.bigtable.version>1.22.0-sp.1</google.cloud.bigtable.version>
+    <bigtable-hbase-beam.version>1.20.0-sp.1</bigtable-hbase-beam.version>
+    <google.cloud.storage.version>1.113.14-sp.1</google.cloud.storage.version>
+    <datastore.v1.proto.client.version>1.6.4-sp.1</datastore.v1.proto.client.version>
+    <appengine.api.1.0.sdk.version>1.9.86</appengine.api.1.0.sdk.version>
+    <androidpublisher.version>v3-rev20210429-1.31.0</androidpublisher.version>
   </properties>
-
 
   <build>
     <plugins>
@@ -121,78 +146,97 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
+      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-auth</artifactId>
+      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-context</artifactId>
+      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-core</artifactId>
+      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
+      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
+      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
+      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>api-common</artifactId>
+      <version>${api.common.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-common-protos</artifactId>
+      <version>${google.common-protos.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>grpc-google-common-protos</artifactId>
+      <version>${google.common-protos.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-iam-v1</artifactId>
+      <version>${iam.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-core</artifactId>
+      <version>${google.cloud.core.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-core-grpc</artifactId>
+      <version>${google.cloud.core.version}</version>
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-api</artifactId>
+      <version>${opencensus.version}</version>
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-contrib-grpc-util</artifactId>
+      <version>${opencensus.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
+      <version>${google.auth.library.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
+      <version>${http.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
@@ -221,35 +265,43 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax</artifactId>
+      <version>${gax.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
+      <version>${gax.version}</version>
     </dependency>
     <dependency>
       <groupId>org.threeten</groupId>
       <artifactId>threetenbp</artifactId>
+      <version>${threeten.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
+      <version>${findbugs.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+      <version>${gson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-credentials</artifactId>
+      <version>${google.auth.library.version}</version>
     </dependency>
     <!-- Dependency for DirectPath -->
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-alts</artifactId>
+      <version>${io.grpc.version}</version>
     </dependency>
 
     <!-- Test dependencies -->
@@ -265,6 +317,7 @@
       <artifactId>gax-grpc</artifactId>
       <classifier>testlib</classifier>
       <scope>test</scope>
+      <version>${gax.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.truth</groupId>
@@ -292,6 +345,7 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
       <scope>test</scope>
+      <version>${guava.version}</version>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
@@ -325,6 +379,7 @@
         <dependency>
           <groupId>javax.annotation</groupId>
           <artifactId>javax.annotation-api</artifactId>
+          <version>${javax.annotations.version}</version>
         </dependency>
       </dependencies>
     </profile>

--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -16,32 +16,6 @@
   <properties>
     <site.installationModule>google-cloud-spanner</site.installationModule>
     <skipUTs>false</skipUTs>
-    <!-- finalized versions -->
-    <!-- JRE for Java 8. Beam's dependency (gcsio) uses JRE flavor -->
-    <guava.version>30.1.1-jre</guava.version>
-    <google.autovalue.version>1.8.1</google.autovalue.version>
-    <protobuf.version>3.16.0</protobuf.version>
-    <http.version>1.39.2-sp.1</http.version>
-    <io.grpc.version>1.36.2</io.grpc.version>
-    <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
-        When updating gax.version, update gax.httpjson.version too. -->
-    <gax.version>1.64.0-sp.1</gax.version>
-    <gax.httpjson.version>0.81.0-sp.1</gax.httpjson.version>
-    <google.api.client.version>1.31.3-sp.1</google.api.client.version>
-    <api.common.version>1.10.1-sp.1</api.common.version>
-    <google.auth.library.version>0.25.2-sp.1</google.auth.library.version>
-    <google.oauth.client.version>1.31.4-sp.1</google.oauth.client.version>
-    <google.cloud.spanner.version>3.3.3-sp.1</google.cloud.spanner.version>
-    <google.cloud.monitoring.version>2.1.0-sp.1</google.cloud.monitoring.version>
-    <google.cloud.trace.version>1.3.0-sp.1</google.cloud.trace.version>
-    <google.cloud.pubsub.version>1.111.0-sp.1</google.cloud.pubsub.version>
-    <google.cloud.bigquery.version>1.127.12-sp.1</google.cloud.bigquery.version>
-    <google.cloud.bigtable.version>1.22.0-sp.1</google.cloud.bigtable.version>
-    <bigtable-hbase-beam.version>1.20.0-sp.1</bigtable-hbase-beam.version>
-    <google.cloud.storage.version>1.113.14-sp.1</google.cloud.storage.version>
-    <datastore.v1.proto.client.version>1.6.4-sp.1</datastore.v1.proto.client.version>
-    <appengine.api.1.0.sdk.version>1.9.86</appengine.api.1.0.sdk.version>
-    <androidpublisher.version>v3-rev20210429-1.31.0</androidpublisher.version>
   </properties>
 
   <build>

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerApiFuturesTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerApiFuturesTest.java
@@ -49,7 +49,7 @@ public class SpannerApiFuturesTest {
 
   @Test
   public void testGetOrNull() {
-    assertThat(SpannerApiFutures.getOrNull(null)).isNull();
+    assertThat(SpannerApiFutures.getOrNull((ApiFuture<Object>) null)).isNull();
   }
 
   @Test

--- a/grpc-google-cloud-spanner-admin-database-v1/pom.xml
+++ b/grpc-google-cloud-spanner-admin-database-v1/pom.xml
@@ -16,18 +16,22 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
+      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
+      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
+      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
@@ -36,18 +40,22 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value-annotations</artifactId>
+      <version>${auto-value-annotation.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-iam-v1</artifactId>
+      <version>${iam.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-common-protos</artifactId>
+      <version>${google.common-protos.version}</version>
     </dependency>
   </dependencies>
 
@@ -61,6 +69,7 @@
         <dependency>
           <groupId>javax.annotation</groupId>
           <artifactId>javax.annotation-api</artifactId>
+          <version>${javax.annotations.version}</version>
         </dependency>
       </dependencies>
     </profile>

--- a/grpc-google-cloud-spanner-admin-instance-v1/pom.xml
+++ b/grpc-google-cloud-spanner-admin-instance-v1/pom.xml
@@ -36,7 +36,6 @@
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-spanner-admin-instance-v1</artifactId>
-      <version>3.3.3-sp.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/grpc-google-cloud-spanner-admin-instance-v1/pom.xml
+++ b/grpc-google-cloud-spanner-admin-instance-v1/pom.xml
@@ -16,38 +16,47 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
+      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
+      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
+      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-spanner-admin-instance-v1</artifactId>
+      <version>3.3.3-sp.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value-annotations</artifactId>
+      <version>${auto-value-annotation.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-iam-v1</artifactId>
+      <version>${iam.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-common-protos</artifactId>
+      <version>${google.common-protos.version}</version>
     </dependency>
   </dependencies>
 
@@ -61,6 +70,7 @@
         <dependency>
           <groupId>javax.annotation</groupId>
           <artifactId>javax.annotation-api</artifactId>
+          <version>${javax.annotations.version}</version>
         </dependency>
       </dependencies>
     </profile>

--- a/grpc-google-cloud-spanner-v1/pom.xml
+++ b/grpc-google-cloud-spanner-v1/pom.xml
@@ -16,18 +16,22 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
+      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
+      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
+      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
@@ -36,10 +40,12 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value-annotations</artifactId>
+      <version>${auto-value-annotation.version}</version>
     </dependency>
   </dependencies>
 
@@ -53,6 +59,7 @@
         <dependency>
           <groupId>javax.annotation</groupId>
           <artifactId>javax.annotation-api</artifactId>
+          <version>${javax.annotations.version}</version>
         </dependency>
       </dependencies>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,43 @@
     <github.global.server>github</github.global.server>
     <site.installationModule>google-cloud-spanner-parent</site.installationModule>
     <google.cloud.shared-dependencies.version>0.18.0</google.cloud.shared-dependencies.version>
+
+    <!-- finalized versions -->
+    <!-- JRE for Java 8. Beam's dependency (gcsio) uses JRE flavor -->
+    <guava.version>30.1.1-jre</guava.version>
+    <google.autovalue.version>1.8.1</google.autovalue.version>
+    <protobuf.version>3.16.0</protobuf.version>
+    <http.version>1.39.2-sp.1</http.version>
+    <io.grpc.version>1.36.2</io.grpc.version>
+    <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
+        When updating gax.version, update gax.httpjson.version too. -->
+    <gax.version>1.64.0-sp.1</gax.version>
+    <gax.httpjson.version>0.81.0-sp.1</gax.httpjson.version>
+    <google.api.client.version>1.31.3-sp.1</google.api.client.version>
+    <api.common.version>1.10.1-sp.1</api.common.version>
+    <google.auth.library.version>0.25.2-sp.1</google.auth.library.version>
+    <google.oauth.client.version>1.31.4-sp.1</google.oauth.client.version>
+    <google.cloud.spanner.version>3.3.3-sp.1</google.cloud.spanner.version>
+    <google.cloud.monitoring.version>2.1.0-sp.1</google.cloud.monitoring.version>
+    <google.cloud.trace.version>1.3.0-sp.1</google.cloud.trace.version>
+    <google.cloud.pubsub.version>1.111.0-sp.1</google.cloud.pubsub.version>
+    <google.cloud.bigquery.version>1.127.12-sp.1</google.cloud.bigquery.version>
+    <google.cloud.bigtable.version>1.22.0-sp.1</google.cloud.bigtable.version>
+    <bigtable-hbase-beam.version>1.20.0-sp.1</bigtable-hbase-beam.version>
+    <google.cloud.storage.version>1.113.14-sp.1</google.cloud.storage.version>
+    <datastore.v1.proto.client.version>1.6.4-sp.1</datastore.v1.proto.client.version>
+    <appengine.api.1.0.sdk.version>1.9.86</appengine.api.1.0.sdk.version>
+    <androidpublisher.version>v3-rev20210429-1.31.0</androidpublisher.version>
+
+    <google.common-protos.version>2.0.1</google.common-protos.version>
+    <iam.version>1.0.9</iam.version>
+    <google.cloud.core.version>1.94.1</google.cloud.core.version>
+    <opencensus.version>0.28.0</opencensus.version>
+    <threeten.version>1.5.1</threeten.version>
+    <findbugs.version>3.0.2</findbugs.version>
+    <gson.version>2.8.7</gson.version>
+    <javax.annotations.version>1.3.2</javax.annotations.version>
+    <errorprone.version>2.7.1</errorprone.version>
   </properties>
 
   <dependencyManagement>
@@ -104,20 +141,30 @@
         <version>3.3.3-sp.2-SNAPSHOT</version><!-- {x-version-update:google-cloud-spanner:current} -->
       </dependency>
 
+<!--      <dependency>-->
+<!--        <groupId>com.google.cloud</groupId>-->
+<!--        <artifactId>google-cloud-shared-dependencies</artifactId>-->
+<!--        <version>${google.cloud.shared-dependencies.version}</version>-->
+<!--        <type>pom</type>-->
+<!--        <scope>import</scope>-->
+<!--      </dependency>-->
       <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>${google.cloud.shared-dependencies.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+        <version>${errorprone.version}</version>
       </dependency>
-
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-netty-shaded</artifactId>
+        <version>${io.grpc.version}</version>
+      </dependency>
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.13.1</version>
+        <version>4.13.2</version>
         <scope>test</scope>
       </dependency>
+
       <dependency>
         <groupId>com.google.truth</groupId>
         <artifactId>truth</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,25 @@
     <module>google-cloud-spanner-bom</module>
   </modules>
 
+  <build>
+    <plugins>
+      <!-- TODO: Remove this once the shared configuration updates to use Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <encoding>UTF-8</encoding>
+          <compilerArgument>-Xlint:unchecked</compilerArgument>
+          <compilerArgument>-Xlint:deprecation</compilerArgument>
+          <showDeprecation>true</showDeprecation>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <reporting>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -65,32 +65,13 @@
     <site.installationModule>google-cloud-spanner-parent</site.installationModule>
     <google.cloud.shared-dependencies.version>0.18.0</google.cloud.shared-dependencies.version>
 
-    <!-- finalized versions -->
-    <!-- JRE for Java 8. Beam's dependency (gcsio) uses JRE flavor -->
     <guava.version>30.1.1-jre</guava.version>
-    <google.autovalue.version>1.8.1</google.autovalue.version>
     <protobuf.version>3.16.0</protobuf.version>
     <http.version>1.39.2-sp.1</http.version>
     <io.grpc.version>1.36.2</io.grpc.version>
-    <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
-        When updating gax.version, update gax.httpjson.version too. -->
     <gax.version>1.64.0-sp.1</gax.version>
-    <gax.httpjson.version>0.81.0-sp.1</gax.httpjson.version>
-    <google.api.client.version>1.31.3-sp.1</google.api.client.version>
     <api.common.version>1.10.1-sp.1</api.common.version>
     <google.auth.library.version>0.25.2-sp.1</google.auth.library.version>
-    <google.oauth.client.version>1.31.4-sp.1</google.oauth.client.version>
-    <google.cloud.spanner.version>3.3.3-sp.1</google.cloud.spanner.version>
-    <google.cloud.monitoring.version>2.1.0-sp.1</google.cloud.monitoring.version>
-    <google.cloud.trace.version>1.3.0-sp.1</google.cloud.trace.version>
-    <google.cloud.pubsub.version>1.111.0-sp.1</google.cloud.pubsub.version>
-    <google.cloud.bigquery.version>1.127.12-sp.1</google.cloud.bigquery.version>
-    <google.cloud.bigtable.version>1.22.0-sp.1</google.cloud.bigtable.version>
-    <bigtable-hbase-beam.version>1.20.0-sp.1</bigtable-hbase-beam.version>
-    <google.cloud.storage.version>1.113.14-sp.1</google.cloud.storage.version>
-    <datastore.v1.proto.client.version>1.6.4-sp.1</datastore.v1.proto.client.version>
-    <appengine.api.1.0.sdk.version>1.9.86</appengine.api.1.0.sdk.version>
-    <androidpublisher.version>v3-rev20210429-1.31.0</androidpublisher.version>
 
     <google.common-protos.version>2.0.1</google.common-protos.version>
     <iam.version>1.0.9</iam.version>

--- a/pom.xml
+++ b/pom.xml
@@ -121,14 +121,6 @@
         <artifactId>google-cloud-spanner</artifactId>
         <version>3.3.3-sp.2-SNAPSHOT</version><!-- {x-version-update:google-cloud-spanner:current} -->
       </dependency>
-
-<!--      <dependency>-->
-<!--        <groupId>com.google.cloud</groupId>-->
-<!--        <artifactId>google-cloud-shared-dependencies</artifactId>-->
-<!--        <version>${google.cloud.shared-dependencies.version}</version>-->
-<!--        <type>pom</type>-->
-<!--        <scope>import</scope>-->
-<!--      </dependency>-->
       <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
@@ -139,13 +131,13 @@
         <artifactId>grpc-netty-shaded</artifactId>
         <version>${io.grpc.version}</version>
       </dependency>
+
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.13.2</version>
         <scope>test</scope>
       </dependency>
-
       <dependency>
         <groupId>com.google.truth</groupId>
         <artifactId>truth</artifactId>

--- a/proto-google-cloud-spanner-admin-database-v1/pom.xml
+++ b/proto-google-cloud-spanner-admin-database-v1/pom.xml
@@ -16,22 +16,27 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-common-protos</artifactId>
+      <version>${google.common-protos.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>api-common</artifactId>
+      <version>${api.common.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-iam-v1</artifactId>
+      <version>${iam.version}</version>
     </dependency>
   </dependencies>
 

--- a/proto-google-cloud-spanner-admin-instance-v1/pom.xml
+++ b/proto-google-cloud-spanner-admin-instance-v1/pom.xml
@@ -16,22 +16,27 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-common-protos</artifactId>
+      <version>${google.common-protos.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>api-common</artifactId>
+      <version>${api.common.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-iam-v1</artifactId>
+      <version>${iam.version}</version>
     </dependency>
   </dependencies>
 

--- a/proto-google-cloud-spanner-v1/pom.xml
+++ b/proto-google-cloud-spanner-v1/pom.xml
@@ -16,18 +16,22 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-common-protos</artifactId>
+      <version>${google.common-protos.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>api-common</artifactId>
+      <version>${api.common.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
We had to do a couple of things in this PR:

1. We used the versions as specified 
https://github.com/GoogleCloudPlatform/cloud-opensource-java/blob/master/boms/cloud-lts-bom/pom.xml
2. We had to remove the dependency on google-cloud-shared-dependencies
3. There were some versions which were not specified in the above POM and we had to "guess" the best version taking in account maven build enforcer (which checks for transitive dependency version compatibilities).
4. We had compilation errors in the main and test code in regards to the google guava Predicate class. We had to implement the `test` method in addition to the `apply` method, since we are using Java 7 here and can not rely on `default` interface method definitions.