### PR TITLE
test: increase timeout and enable tests on emulator

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDatabaseTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDatabaseTest.java
@@ -16,10 +16,8 @@
 
 package com.google.cloud.spanner.it;
 
-import static com.google.cloud.spanner.testing.EmulatorSpannerHelper.isUsingEmulator;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
 
 import com.google.api.client.util.ExponentialBackOff;
 import com.google.api.gax.longrunning.OperationFuture;
@@ -62,11 +60,6 @@ public class ITDatabaseTest {
 
   @Test
   public void databaseDeletedTest() throws Exception {
-    // TODO: Remove the following line once the emulator returns ResourceInfo for Database not found
-    // errors.
-    assumeFalse(
-        "Emulator does not return ResourceInfo for Database not found errors", isUsingEmulator());
-
     // Create a test db, do a query, then delete it and verify that it returns
     // DatabaseNotFoundExceptions.
     Database db = env.getTestHelper().createTestDatabase();
@@ -83,7 +76,7 @@ public class ITDatabaseTest {
     ExponentialBackOff backoff =
         new ExponentialBackOff.Builder()
             .setInitialIntervalMillis(1000)
-            .setMaxElapsedTimeMillis(35000)
+            .setMaxElapsedTimeMillis(65000)
             .setMaxIntervalMillis(5000)
             .build();
     DatabaseNotFoundException notFoundException = null;
@@ -132,11 +125,6 @@ public class ITDatabaseTest {
 
   @Test
   public void instanceNotFound() {
-    // TODO: Remove the following line when the emulator returns ResourceInfo for Instance not found
-    // errors.
-    assumeFalse(
-        "Emulator does not return ResourceInfo for Instance not found errors", isUsingEmulator());
-
     InstanceId testId = env.getTestHelper().getInstanceId();
     InstanceId nonExistingInstanceId =
         InstanceId.of(testId.getProject(), testId.getInstance() + "-na");


### PR DESCRIPTION
Increase the wait time for a `DatabaseNotFound` error, as it can take a little while before Cloud Spanner actually sends that error for a `SELECT 1` query.

Also enable the `ResourceNotFound` tests on the emulator, as the emulator now includes `ResourceInfo` in the returned errors.

Fixes #1272
