### PR TITLE
fix: shorten the test instance name

### DIFF
--- a/samples/snippets/src/test/java/com/example/spanner/SpannerSampleIT.java
+++ b/samples/snippets/src/test/java/com/example/spanner/SpannerSampleIT.java
@@ -416,7 +416,7 @@ public class SpannerSampleIT {
     InstanceAdminClient instanceAdminClient = spanner.getInstanceAdminClient();
     instanceAdminClient
         .createInstance(InstanceInfo.newBuilder(InstanceId.of(projectId, instanceId))
-            .setDisplayName("Encrypted Databases and Backups test instance")
+            .setDisplayName("Encrypted test instance")
             .setInstanceConfigId(InstanceConfigId.of(projectId, "regional-us-central1"))
             .setNodeCount(1).build())
         .get();


### PR DESCRIPTION
Shortens the display name of the test instance that is created for each sample test run.

(I've been able to verify that the test instance can now be created, but the test uses a fixed encryption key that is not available in my test project, so I've not been able to run the entire test. These tests are also only executed as part of the nightly build, so we'll only see the actual result tomorrow.)

Fixes #1277 
