### PR TITLE
docs: use 'latest' stats package in samples to prevent build failures

### DIFF
--- a/samples/snippets/src/main/java/com/example/spanner/SpannerSample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/SpannerSample.java
@@ -1510,7 +1510,9 @@ public class SpannerSample {
                 db, QueryOptions
                     .newBuilder()
                     .setOptimizerVersion("1")
-                    .setOptimizerStatisticsPackage("auto_20191128_14_47_22UTC")
+                    // The list of available statistics packages can be found by querying the
+                    // "INFORMATION_SCHEMA.SPANNER_STATISTICS" table.
+                    .setOptimizerStatisticsPackage("latest")
                     .build())
             .build();
     Spanner spanner = options.getService();
@@ -1538,6 +1540,8 @@ public class SpannerSample {
                     .withQueryOptions(QueryOptions
                         .newBuilder()
                         .setOptimizerVersion("1")
+                        // The list of available statistics packages can be found by querying the
+                        // "INFORMATION_SCHEMA.SPANNER_STATISTICS" table.
                         .setOptimizerStatisticsPackage("latest")
                         .build())
                     .build())) {


### PR DESCRIPTION
The list of available statistics packages will change over time, meaning that the samples need to use 'latest' to prevent build failures when a package has been cleaned up by the backend.

See also https://github.com/googleapis/nodejs-spanner/pull/1436

Fixes #1273
