### PR TITLE
chore: add ci task to compile samples

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -18,7 +18,8 @@ branchProtectionRules:
       - 'Kokoro - Test: Integration'
       - cla/google
       - samples/checkstyle
-      - samples/compile
+      - samples/compile (8)
+      - samples/compile (11)
   - pattern: 3.1.x
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -34,7 +35,8 @@ branchProtectionRules:
       - 'Kokoro - Test: Integration'
       - cla/google
       - samples/checkstyle
-      - samples/compile
+      - samples/compile (8)
+      - samples/compile (11)
   - pattern: 3.3.x
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -50,7 +52,8 @@ branchProtectionRules:
       - 'Kokoro - Test: Integration'
       - cla/google
       - samples/checkstyle
-      - samples/compile
+      - samples/compile (8)
+      - samples/compile (11)
   - pattern: 4.0.x
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -66,7 +69,8 @@ branchProtectionRules:
       - 'Kokoro - Test: Integration'
       - cla/google
       - samples/checkstyle
-      - samples/compile
+      - samples/compile (8)
+      - samples/compile (11)
   - pattern: 5.2.x
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -82,7 +86,8 @@ branchProtectionRules:
       - 'Kokoro - Test: Integration'
       - cla/google
       - samples/checkstyle
-      - samples/compile
+      - samples/compile (8)
+      - samples/compile (11)
   - pattern: 3.3.3-sp
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -97,7 +102,8 @@ branchProtectionRules:
       - 'Kokoro - Test: Integration'
       - cla/google
       - samples/checkstyle
-      - samples/compile
+      - samples/compile (8)
+      - samples/compile (11)
 permissionRules:
   - team: yoshi-admins
     permission: admin

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -17,6 +17,8 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
+      - samples/checkstyle
+      - samples/compile
   - pattern: 3.1.x
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -31,6 +33,8 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
+      - samples/checkstyle
+      - samples/compile
   - pattern: 3.3.x
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -45,6 +49,8 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
+      - samples/checkstyle
+      - samples/compile
   - pattern: 4.0.x
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -59,6 +65,8 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
+      - samples/checkstyle
+      - samples/compile
   - pattern: 5.2.x
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -73,6 +81,8 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
+      - samples/checkstyle
+      - samples/compile
   - pattern: 3.3.3-sp
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -86,6 +96,8 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
+      - samples/checkstyle
+      - samples/compile
 permissionRules:
   - team: yoshi-admins
     permission: admin

--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -14,10 +14,13 @@ jobs:
         working-directory: samples/snippets
   compile:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [8, 11]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
-        java-version: 8
+        java-version: ${{matrix.java}}
     - name: Compile samples
       run: mvn -Penable-samples compile

--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -12,3 +12,12 @@ jobs:
       - name: Run checkstyle
         run: mvn -P lint --quiet --batch-mode checkstyle:check
         working-directory: samples/snippets
+  compile:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Compile samples
+      run: mvn -Penable-samples compile

--- a/synth.py
+++ b/synth.py
@@ -92,4 +92,5 @@ java.common_templates(excludes=[
     '.github/sync-repo-settings.yaml',
     '.github/release-please.yml',
     '.github/blunderbuss.yml',
+    '.github/workflows/samples.yaml',
 ])


### PR DESCRIPTION
Since the samples tests are not being run on every PR, we add a step to at least compile the samples to make sure we don't introduce any hard failures.