### PR TITLE
chore: fix the required checks for PRs

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -17,9 +17,9 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
-      - samples/checkstyle
-      - samples/compile (8)
-      - samples/compile (11)
+      - checkstyle
+      - compile (8)
+      - compile (11)
   - pattern: 3.1.x
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -34,9 +34,9 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
-      - samples/checkstyle
-      - samples/compile (8)
-      - samples/compile (11)
+      - checkstyle
+      - compile (8)
+      - compile (11)
   - pattern: 3.3.x
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -51,9 +51,9 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
-      - samples/checkstyle
-      - samples/compile (8)
-      - samples/compile (11)
+      - checkstyle
+      - compile (8)
+      - compile (11)
   - pattern: 4.0.x
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -68,9 +68,9 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
-      - samples/checkstyle
-      - samples/compile (8)
-      - samples/compile (11)
+      - checkstyle
+      - compile (8)
+      - compile (11)
   - pattern: 5.2.x
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -85,9 +85,9 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
-      - samples/checkstyle
-      - samples/compile (8)
-      - samples/compile (11)
+      - checkstyle
+      - compile (8)
+      - compile (11)
   - pattern: 3.3.3-sp
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -101,9 +101,9 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
-      - samples/checkstyle
-      - samples/compile (8)
-      - samples/compile (11)
+      - checkstyle
+      - compile (8)
+      - compile (11)
 permissionRules:
   - team: yoshi-admins
     permission: admin


### PR DESCRIPTION
Uses the correct workflow name "checkstyle", "compile (8)" and "compile (11)" instead of prefixing it with "sample/".
