### PR TITLE
fix: set projectId to a default value in emulator case

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -1137,7 +1137,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
         // Default project id resolution might fail, but the emulator accepts any
         // project id, so we can safely use a dummy id.
         if (this.getProjectId() == null) {
-          this.setProjetcId("emulator-project-id");
+          this.setProjectId("emulator-project-id");
         }
       }
       return new SpannerOptions(this);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -1137,7 +1137,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
         // Default project id resolution might fail, but the emulator accepts any
         // project id, so we can safely use a dummy id.
         if (this.getProjectId() == null) {
-          this.setProjetcId("your-project-id");
+          this.setProjetcId("emulator-project-id");
         }
       }
       return new SpannerOptions(this);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -1137,8 +1137,8 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
         // Default project id resolution might fail, but in emulator case
         // any project id would work, one from credentials or filesystem isn't
         // strictly needed
-        if (super.getProjectId() == null) {
-          super.setProjetcId("your-project-id");
+        if (this.getProjectId() == null) {
+          this.setProjetcId("your-project-id");
         }
       }
       return new SpannerOptions(this);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -1134,6 +1134,12 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
         this.setChannelConfigurator(ManagedChannelBuilder::usePlaintext);
         // As we are using plain text, we should never send any credentials.
         this.setCredentials(NoCredentials.getInstance());
+        // Default project id resolution might fail, but in emulator case
+        // any project id would work, one from credentials or filesystem isn't
+        // strictly needed
+        if (super.getProjectId() == null) {
+          super.setProjetcId("your-project-id");
+        }
       }
       return new SpannerOptions(this);
     }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -1134,9 +1134,8 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
         this.setChannelConfigurator(ManagedChannelBuilder::usePlaintext);
         // As we are using plain text, we should never send any credentials.
         this.setCredentials(NoCredentials.getInstance());
-        // Default project id resolution might fail, but in emulator case
-        // any project id would work, one from credentials or filesystem isn't
-        // strictly needed
+        // Default project id resolution might fail, but the emulator accepts any
+        // project id, so we can safely use a dummy id.
         if (this.getProjectId() == null) {
           this.setProjetcId("your-project-id");
         }


### PR DESCRIPTION
Spanner client wants to have a projectId option set, by default it also tries to pick it up from [lots of places](https://github.com/googleapis/java-core/blob/375983090b3700b3fb6a1953626db7efca49cc51/google-cloud-core/src/main/java/com/google/cloud/ServiceOptions.java#L372)
For emulator case none of those may be present as it could be that neither gcloud nor default application credentials are configured, but emulator is accessible nevertheless.

Set default project id in SpannerOptions, value doesn't matter so much as emulator would be happy with any value it seems.
Note that alternatively it could be improved in base ServiceOptions, but not sure about assumptions there.

failure example in case where emulatorHost is set without projectId
```
  java.lang.IllegalArgumentException: A project ID is required for this service but could not be determined from the builder or the environment.  Please set a project ID using the builder.
  at com.google.common.base.Preconditions.checkArgument(Preconditions.java:142)
  at com.google.cloud.ServiceOptions.<init>(ServiceOptions.java:304)
  at com.google.cloud.spanner.SpannerOptions.<init>(SpannerOptions.java:533)
  at com.google.cloud.spanner.SpannerOptions.<init>(SpannerOptions.java:77)
  at com.google.cloud.spanner.SpannerOptions$Builder.build(SpannerOptions.java:1029)
  ```

Note that in non-emulator case one usually doesn't need to set projectId as it could be extracted from credentials

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-spanner/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️
