### PR TITLE
chore: remove grpc-gcp version from pom.xml

### DIFF
--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -121,7 +121,6 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>grpc-gcp</artifactId>
-      <version>1.1.0</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>


### PR DESCRIPTION
The current version (1.1.0) of grpc-gcp is available via java-shared-dependencies.