### PR TITLE
test: unskip cmmr tests

### DIFF
--- a/samples/install-without-bom/pom.xml
+++ b/samples/install-without-bom/pom.xml
@@ -143,6 +143,7 @@
         <configuration>
           <systemPropertyVariables>
             <spanner.test.instance>spanner-testing</spanner.test.instance>
+            <spanner.test.instance.mr>spanner-mr-testing</spanner.test.instance.mr>
             <spanner.test.instance.config>nam6</spanner.test.instance.config>
             <spanner.test.key.location>us-central1</spanner.test.key.location>
             <spanner.test.key.ring>spanner-test-keyring</spanner.test.key.ring>

--- a/samples/snapshot/pom.xml
+++ b/samples/snapshot/pom.xml
@@ -142,6 +142,7 @@
         <configuration>
           <systemPropertyVariables>
             <spanner.test.instance>spanner-testing</spanner.test.instance>
+            <spanner.test.instance.mr>spanner-mr-testing</spanner.test.instance.mr>
             <spanner.test.instance.config>nam6</spanner.test.instance.config>
             <spanner.test.key.location>us-central1</spanner.test.key.location>
             <spanner.test.key.ring>spanner-test-keyring</spanner.test.key.ring>

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -147,6 +147,7 @@
         <configuration>
           <systemPropertyVariables>
             <spanner.test.instance>spanner-testing</spanner.test.instance>
+            <spanner.test.instance.mr>spanner-mr-testing</spanner.test.instance.mr>
             <spanner.test.instance.config>nam6</spanner.test.instance.config>
             <spanner.test.key.location>us-central1</spanner.test.key.location>
             <spanner.test.key.ring>spanner-test-keyring</spanner.test.key.ring>

--- a/samples/snippets/src/test/java/com/example/spanner/CreateDatabaseWithDefaultLeaderSampleIT.java
+++ b/samples/snippets/src/test/java/com/example/spanner/CreateDatabaseWithDefaultLeaderSampleIT.java
@@ -19,27 +19,35 @@ package com.example.spanner;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.spanner.InstanceConfig;
-import org.junit.Ignore;
+import com.google.cloud.spanner.InstanceConfigId;
 import org.junit.Test;
 
 public class CreateDatabaseWithDefaultLeaderSampleIT extends SampleTestBase {
 
-  @Ignore("Skipping until we have a MR instance to run this on")
   @Test
   public void testCreateDatabaseWithDefaultLeader() throws Exception {
     final String databaseId = idGenerator.generateDatabaseId();
 
     // Finds possible default leader
-    final InstanceConfig config = instanceAdminClient.getInstanceConfig(instanceConfigName);
+    final InstanceConfigId instanceConfigId = instanceAdminClient
+        .getInstance(multiRegionalInstanceId)
+        .getInstanceConfigId();
+    final InstanceConfig config = instanceAdminClient
+        .getInstanceConfig(instanceConfigId.getInstanceConfig());
     assertTrue(
-        "Expected instance config " + instanceConfigName + " to have at least one leader option",
+        "Expected instance config " + instanceConfigId + " to have at least one leader option",
         config.getLeaderOptions().size() > 0
     );
     final String defaultLeader = config.getLeaderOptions().get(0);
 
     // Runs sample
-    final String out = SampleRunner.runSample(() -> CreateDatabaseWithDefaultLeaderSample
-        .createDatabaseWithDefaultLeader(projectId, instanceId, databaseId, defaultLeader)
+    final String out = SampleRunner.runSample(() ->
+        CreateDatabaseWithDefaultLeaderSample.createDatabaseWithDefaultLeader(
+            projectId,
+            multiRegionalInstanceId,
+            databaseId,
+            defaultLeader
+        )
     );
 
     assertTrue(

--- a/samples/snippets/src/test/java/com/example/spanner/GetDatabaseDdlSampleIT.java
+++ b/samples/snippets/src/test/java/com/example/spanner/GetDatabaseDdlSampleIT.java
@@ -19,28 +19,31 @@ package com.example.spanner;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.spanner.InstanceConfig;
+import com.google.cloud.spanner.InstanceConfigId;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class GetDatabaseDdlSampleIT extends SampleTestBase {
 
-  @Ignore("Skipping until we have a MR instance to run this on")
   @Test
   public void testGetDatabaseDdl() throws Exception {
     // Finds a possible new leader option
-    final InstanceConfig config = instanceAdminClient.getInstanceConfig(instanceConfigName);
+    final InstanceConfigId instanceConfigId = instanceAdminClient
+        .getInstance(multiRegionalInstanceId)
+        .getInstanceConfigId();
+    final InstanceConfig config = instanceAdminClient
+        .getInstanceConfig(instanceConfigId.getInstanceConfig());
     assertTrue(
-        "Expected instance config " + instanceConfigName + " to have at least one leader option",
-        config.getLeaderOptions().size() > 1
+        "Expected instance config " + instanceConfigId + " to have at least one leader option",
+        config.getLeaderOptions().size() > 0
     );
     final String defaultLeader = config.getLeaderOptions().get(0);
 
     // Creates database
     final String databaseId = idGenerator.generateDatabaseId();
     databaseAdminClient.createDatabase(
-        instanceId,
+        multiRegionalInstanceId,
         databaseId,
         Arrays.asList(
             "CREATE TABLE Singers (Id INT64 NOT NULL) PRIMARY KEY (Id)",
@@ -54,7 +57,7 @@ public class GetDatabaseDdlSampleIT extends SampleTestBase {
 
     // Runs sample
     final String out = SampleRunner.runSample(() -> GetDatabaseDdlSample
-        .getDatabaseDdl(projectId, instanceId, databaseId)
+        .getDatabaseDdl(projectId, multiRegionalInstanceId, databaseId)
     );
 
     assertTrue(

--- a/samples/snippets/src/test/java/com/example/spanner/QueryInformationSchemaDatabaseOptionsSampleIT.java
+++ b/samples/snippets/src/test/java/com/example/spanner/QueryInformationSchemaDatabaseOptionsSampleIT.java
@@ -19,20 +19,23 @@ package com.example.spanner;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.spanner.InstanceConfig;
+import com.google.cloud.spanner.InstanceConfigId;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class QueryInformationSchemaDatabaseOptionsSampleIT extends SampleTestBase {
 
-  @Ignore("Skipping until we have a MR instance to run this on")
   @Test
   public void testQueryInformationSchemaDatabaseOptions() throws Exception {
     // Finds a possible new leader option
-    final InstanceConfig config = instanceAdminClient.getInstanceConfig(instanceConfigName);
+    final InstanceConfigId instanceConfigId = instanceAdminClient
+        .getInstance(multiRegionalInstanceId)
+        .getInstanceConfigId();
+    final InstanceConfig config = instanceAdminClient
+        .getInstanceConfig(instanceConfigId.getInstanceConfig());
     assertTrue(
-        "Expected instance config " + instanceConfigName + " to have at least one leader option",
+        "Expected instance config " + instanceConfigId + " to have at least one leader option",
         config.getLeaderOptions().size() > 0
     );
     final String defaultLeader = config.getLeaderOptions().get(0);
@@ -40,7 +43,7 @@ public class QueryInformationSchemaDatabaseOptionsSampleIT extends SampleTestBas
     // Creates database
     final String databaseId = idGenerator.generateDatabaseId();
     databaseAdminClient.createDatabase(
-        instanceId,
+        multiRegionalInstanceId,
         databaseId,
         Arrays.asList(
             "CREATE TABLE Singers (Id INT64 NOT NULL) PRIMARY KEY (Id)",
@@ -54,7 +57,7 @@ public class QueryInformationSchemaDatabaseOptionsSampleIT extends SampleTestBas
 
     // Runs sample
     final String out = SampleRunner.runSample(() -> QueryInformationSchemaDatabaseOptionsSample
-        .queryInformationSchemaDatabaseOptions(projectId, instanceId, databaseId)
+        .queryInformationSchemaDatabaseOptions(projectId, multiRegionalInstanceId, databaseId)
     );
 
     assertTrue(
@@ -62,7 +65,7 @@ public class QueryInformationSchemaDatabaseOptionsSampleIT extends SampleTestBas
             + " Output received was " + out,
         out.contains(
             "The default_leader for projects/"
-                + projectId + "/instances/" + instanceId + "/databases/" + databaseId
+                + projectId + "/instances/" + multiRegionalInstanceId + "/databases/" + databaseId
                 + " is " + defaultLeader
         )
     );

--- a/samples/snippets/src/test/java/com/example/spanner/SampleTestBase.java
+++ b/samples/snippets/src/test/java/com/example/spanner/SampleTestBase.java
@@ -39,6 +39,8 @@ public class SampleTestBase {
   protected static InstanceAdminClient instanceAdminClient;
   protected static String projectId;
   protected static final String instanceId = System.getProperty("spanner.test.instance");
+  protected static final String multiRegionalInstanceId =
+      System.getProperty("spanner.test.instance.mr");
   protected static final String instanceConfigName = System
       .getProperty("spanner.test.instance.config");
   protected static SampleIdGenerator idGenerator;
@@ -61,19 +63,28 @@ public class SampleTestBase {
     for (String databaseId : idGenerator.getDatabaseIds()) {
       try {
         databaseAdminClient.dropDatabase(instanceId, databaseId);
-      } catch (Exception e) {
-        System.out.println(
-            "Failed to drop database " + databaseId + " due to " + e.getMessage() + ", skipping..."
-        );
+      } catch (Exception e1) {
+        try {
+          databaseAdminClient.dropDatabase(multiRegionalInstanceId, databaseId);
+        } catch (Exception e2) {
+          System.out.println(
+              "Failed to drop database " + databaseId + " due to " + e2.getMessage()
+                  + ", skipping..."
+          );
+        }
       }
     }
     for (String backupId : idGenerator.getBackupIds()) {
       try {
         databaseAdminClient.deleteBackup(instanceId, backupId);
-      } catch (Exception e) {
-        System.out.println(
-            "Failed to delete backup " + backupId + " due to " + e.getMessage() + ", skipping..."
-        );
+      } catch (Exception e1) {
+        try {
+          databaseAdminClient.deleteBackup(multiRegionalInstanceId, backupId);
+        } catch (Exception e2) {
+          System.out.println(
+              "Failed to delete backup " + backupId + " due to " + e2.getMessage() + ", skipping..."
+          );
+        }
       }
     }
     spanner.close();

--- a/samples/snippets/src/test/java/com/example/spanner/UpdateDatabaseWithDefaultLeaderSampleIT.java
+++ b/samples/snippets/src/test/java/com/example/spanner/UpdateDatabaseWithDefaultLeaderSampleIT.java
@@ -20,26 +20,29 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.spanner.Database;
 import com.google.cloud.spanner.InstanceConfig;
+import com.google.cloud.spanner.InstanceConfigId;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class UpdateDatabaseWithDefaultLeaderSampleIT extends SampleTestBase {
 
-  @Ignore("Skipping until we have a MR instance to run this on")
   @Test
   public void testUpdateDatabaseWithDefaultLeader() throws Exception {
     // Create database
     final String databaseId = idGenerator.generateDatabaseId();
     final Database createdDatabase = databaseAdminClient
-        .createDatabase(instanceId, databaseId, Collections.emptyList())
+        .createDatabase(multiRegionalInstanceId, databaseId, Collections.emptyList())
         .get(5, TimeUnit.MINUTES);
     final String defaultLeader = createdDatabase.getDefaultLeader();
 
     // Finds a possible new leader option
-    final InstanceConfig instanceConfig = instanceAdminClient.getInstanceConfig(instanceConfigName);
-    final String newLeader = instanceConfig
+    final InstanceConfigId instanceConfigId = instanceAdminClient
+        .getInstance(multiRegionalInstanceId)
+        .getInstanceConfigId();
+    final InstanceConfig config = instanceAdminClient
+        .getInstanceConfig(instanceConfigId.getInstanceConfig());
+    final String newLeader = config
         .getLeaderOptions()
         .stream()
         .filter(leader -> !leader.equals(defaultLeader))
@@ -50,7 +53,7 @@ public class UpdateDatabaseWithDefaultLeaderSampleIT extends SampleTestBase {
 
     // Runs sample
     final String out = SampleRunner.runSample(() -> UpdateDatabaseWithDefaultLeaderSample
-        .updateDatabaseWithDefaultLeader(projectId, instanceId, databaseId, newLeader)
+        .updateDatabaseWithDefaultLeader(projectId, multiRegionalInstanceId, databaseId, newLeader)
     );
 
     assertTrue(


### PR DESCRIPTION
We have configured a multi-regional instance for CMMR sample tests, so we can unskip the tests now.