### PR TITLE
feat: use dummy emulator-project when no project is set

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -1164,6 +1164,16 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     SpannerOptions.environment = SpannerEnvironmentImpl.INSTANCE;
   }
 
+  @Override
+  protected String getDefaultProject() {
+    String projectId = getDefaultProjectId();
+    // The project id does not matter if we are using the emulator.
+    if (projectId == null && System.getenv("SPANNER_EMULATOR_HOST") != null) {
+      return "emulator-project";
+    }
+    return projectId;
+  }
+
   public TransportChannelProvider getChannelProvider() {
     return channelProvider;
   }


### PR DESCRIPTION
Use a dummy emulator-project when no default project is set for the environment
and the SPANNER_EMULATOR_HOST environment variable has been set.

Replaces #1345
