### PR TITLE
chore: remove linkage monitor ci step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,22 +46,6 @@ jobs:
           java-version: ${{matrix.java}}
       - run: java -version
       - run: .kokoro/dependencies.sh
-  linkage-monitor:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 8
-      - run: java -version
-      - name: Install artifacts to local Maven repository
-        run: .kokoro/build.sh
-        shell: bash
-      - name: >-
-          Validate any conflicts with regard to com.google.cloud:libraries-bom
-          (latest release)
-        uses: >-
-          GoogleCloudPlatform/cloud-opensource-java/linkage-monitor@v1-linkagemonitor
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This only works with the latest version of the dependencies, so it won't work with the LTS versions.