### PR TITLE
chore: remove unused steps from sync repo settings

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -110,9 +110,6 @@ branchProtectionRules:
     requiresCodeOwnerReviews: true
     requiresStrictStatusChecks: false
     requiredStatusCheckContexts:
-      - dependencies (8)
-      - dependencies (11)
-      - linkage-monitor
       - lint
       - clirr
       - units (8)


### PR DESCRIPTION
Removes linkage-monitor and dependency checks from LTS branch (6.4.4).