### PR TITLE
fix: do not serialize unnecessary fields

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ClientSideStatementImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ClientSideStatementImpl.java
@@ -131,10 +131,10 @@ class ClientSideStatementImpl implements ClientSideStatement {
   private ClientSideSetStatementImpl setStatement;
 
   /** The compiled regex pattern for recognizing this statement. */
-  private Pattern pattern;
+  private transient Pattern pattern;
 
   /** A reference to the executor that should be used. */
-  private ClientSideStatementExecutor executor;
+  private transient ClientSideStatementExecutor executor;
 
   /**
    * Compiles this {@link ClientSideStatementImpl}. Throws a {@link CompileException} if the


### PR DESCRIPTION
Do not serialize java.util.regex.Pattern and executor fields in client side statement. This caused an issue with Java 16 compilation, where an IllegalAccessException is thrown during JSON serialization of such fields.

```
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field private java.lang.String java.util.regex.Pattern.pattern accessible: module java.base does not "opens java.util.regex" to unnamed module @5fcbae9d
    at java.lang.reflect.AccessibleObject.checkCanSetAccessible (AccessibleObject.java:357)
    at java.lang.reflect.AccessibleObject.checkCanSetAccessible (AccessibleObject.java:297)
    at java.lang.reflect.Field.checkCanSetAccessible (Field.java:177)
    at java.lang.reflect.Field.setAccessible (Field.java:171)
    at com.google.gson.internal.reflect.UnsafeReflectionAccessor.makeAccessible (UnsafeReflectionAccessor.java:44)
    at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.getBoundFields (ReflectiveTypeAdapterFactory.java:159)
    at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.create (ReflectiveTypeAdapterFactory.java:102)
    at com.google.gson.Gson.getAdapter (Gson.java:458)
    at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.createBoundField (ReflectiveTypeAdapterFactory.java:117)
    at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.getBoundFields (ReflectiveTypeAdapterFactory.java:166)
    at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.create (ReflectiveTypeAdapterFactory.java:102)
    at com.google.gson.Gson.getAdapter (Gson.java:458)
    at com.google.gson.internal.bind.CollectionTypeAdapterFactory.create (CollectionTypeAdapterFactory.java:53)
    at com.google.gson.Gson.getAdapter (Gson.java:458)
    at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.createBoundField (ReflectiveTypeAdapterFactory.java:117)
    at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.getBoundFields (ReflectiveTypeAdapterFactory.java:166)
    at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.create (ReflectiveTypeAdapterFactory.java:102)
    at com.google.gson.Gson.getAdapter (Gson.java:458)
    at com.google.gson.Gson.fromJson (Gson.java:931)
    at com.google.gson.Gson.fromJson (Gson.java:870)
    at com.google.cloud.spanner.connection.ClientSideStatements.importStatements (ClientSideStatements.java:34)
```