### PR TITLE
chore: mark transaction context as closed after use

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -385,7 +385,7 @@ abstract class AbstractReadContext
   private boolean isValid = true;
 
   @GuardedBy("lock")
-  private boolean isClosed = false;
+  protected boolean isClosed = false;
 
   // A per-transaction sequence number used to identify this ExecuteSqlRequests. Required for DML,
   // ignored for query by the server.

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -1483,6 +1483,9 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
             .withDescription("No result found for " + statement.toString())
             .asRuntimeException();
       }
+      if (res.getType() == StatementResult.StatementResultType.EXCEPTION) {
+        throw res.getException();
+      }
       returnPartialResultSet(
           res.getResultSet(),
           transactionId,


### PR DESCRIPTION
A transaction context should be marked as closed after it has been used, so it can throw a logical error if someone tries to reuse it for a second transaction.
