### PR TITLE
chore: mark transaction context as closed after use

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -385,7 +385,7 @@ abstract class AbstractReadContext
   private boolean isValid = true;
 
   @GuardedBy("lock")
-  private boolean isClosed = false;
+  protected boolean isClosed = false;
 
   // A per-transaction sequence number used to identify this ExecuteSqlRequests. Required for DML,
   // ignored for query by the server.

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -172,7 +172,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
      * transaction if the BeginTransaction option is included with the first statement of the
      * transaction.
      */
-    private volatile SettableApiFuture<ByteString> transactionIdFuture = null;
+    @VisibleForTesting volatile SettableApiFuture<ByteString> transactionIdFuture = null;
 
     @VisibleForTesting long waitForTransactionTimeoutMillis = 60_000L;
     private final boolean trackTransactionStarter;
@@ -205,6 +205,15 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
         if (runningAsyncOperations == 0) {
           finishedAsyncOperations.set(null);
         }
+      }
+    }
+
+    @Override
+    public void close() {
+      // Only mark the context as closed, but do not end the tracer span, as that is done by the
+      // commit and rollback methods.
+      synchronized (lock) {
+        isClosed = true;
       }
     }
 
@@ -280,6 +289,8 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
     volatile ApiFuture<CommitResponse> commitFuture;
 
     ApiFuture<CommitResponse> commitAsync() {
+      close();
+
       final SettableApiFuture<CommitResponse> res = SettableApiFuture.create();
       final SettableApiFuture<Void> finishOps;
       CommitRequest.Builder builder =
@@ -340,7 +351,10 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
                     .setReadWrite(TransactionOptions.ReadWrite.getDefaultInstance()));
           } else {
             requestBuilder.setTransactionId(
-                transactionId == null ? transactionIdFuture.get() : transactionId);
+                transactionId == null
+                    ? transactionIdFuture.get(
+                        waitForTransactionTimeoutMillis, TimeUnit.MILLISECONDS)
+                    : transactionId);
           }
           if (options.hasPriority() || getTransactionTag() != null) {
             RequestOptions.Builder requestOptionsBuilder = RequestOptions.newBuilder();
@@ -389,6 +403,8 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
               MoreExecutors.directExecutor());
         } catch (InterruptedException e) {
           res.setException(SpannerExceptionFactory.propagateInterrupt(e));
+        } catch (TimeoutException e) {
+          res.setException(SpannerExceptionFactory.propagateTimeout(e));
         } catch (ExecutionException e) {
           res.setException(
               SpannerExceptionFactory.newSpannerException(e.getCause() == null ? e : e.getCause()));
@@ -419,6 +435,8 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
     }
 
     ApiFuture<Empty> rollbackAsync() {
+      close();
+
       // It could be that there is no transaction if the transaction has been marked
       // withInlineBegin, and there has not been any query/update statement that has been executed.
       // In that case, we do not need to do anything, as there is no transaction.

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -76,6 +76,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.junit.After;
@@ -2148,5 +2149,33 @@ public class DatabaseClientImplTest {
     client.transactionManager().close();
 
     assertThat(checkedOut).isEmpty();
+  }
+
+  @Test
+  public void transactionContextFailsIfUsedMultipleTimes() {
+    DatabaseClient client =
+        spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+
+    Function<TransactionContext, Long> function =
+        new Function<TransactionContext, Long>() {
+          TransactionContext ctx;
+
+          @Override
+          public Long apply(TransactionContext transactionContext) {
+            if (ctx == null) {
+              ctx = transactionContext;
+            }
+            try (ResultSet rs = ctx.executeQuery(SELECT1)) {
+              while (rs.next()) {}
+            }
+            return 1L;
+          }
+        };
+    assertEquals(Long.valueOf(1L), client.readWriteTransaction().run(tx -> function.apply(tx)));
+    SpannerException exception =
+        assertThrows(
+            SpannerException.class,
+            () -> client.readWriteTransaction().run(tx -> function.apply(tx)));
+    assertTrue(exception.getMessage().contains("Context has been closed"));
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -1466,6 +1466,9 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
             .withDescription("No result found for " + statement.toString())
             .asRuntimeException();
       }
+      if (res.getType() == StatementResult.StatementResultType.EXCEPTION) {
+        throw res.getException();
+      }
       returnPartialResultSet(
           res.getResultSet(),
           transactionId,


### PR DESCRIPTION
A transaction context should be marked as closed after it has been used, so it can
throw a logical error if someone tries to reuse it for a second transaction.

Also adds a timeout to the wait function for a transaction ID in the Commit method.
