### PR TITLE
chore: update protected branches ci / releases

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -21,8 +21,4 @@ branches:
   - releaseType: java-lts
     bumpMinorPreMajor: true
     handleGHRelease: true
-    branch: 3.3.3-sp
-  - releaseType: java-lts
-    bumpMinorPreMajor: true
-    handleGHRelease: true
     branch: 6.4.4-sp

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -87,22 +87,6 @@ branchProtectionRules:
       - checkstyle
       - compile (8)
       - compile (11)
-  - pattern: 3.3.3-sp
-    isAdminEnforced: true
-    requiredApprovingReviewCount: 1
-    requiresCodeOwnerReviews: true
-    requiresStrictStatusChecks: false
-    requiredStatusCheckContexts:
-      - dependencies (8)
-      - dependencies (11)
-      - lint
-      - units (8)
-      - units (11)
-      - 'Kokoro - Test: Integration'
-      - cla/google
-      - checkstyle
-      - compile (8)
-      - compile (11)
   - pattern: 6.4.4-sp
     isAdminEnforced: true
     requiredApprovingReviewCount: 1

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -34,8 +34,6 @@ branchProtectionRules:
       - 'Kokoro - Test: Integration'
       - cla/google
       - checkstyle
-      - compile (8)
-      - compile (11)
   - pattern: 3.3.x
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -51,8 +49,6 @@ branchProtectionRules:
       - 'Kokoro - Test: Integration'
       - cla/google
       - checkstyle
-      - compile (8)
-      - compile (11)
   - pattern: 4.0.x
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -68,8 +64,6 @@ branchProtectionRules:
       - 'Kokoro - Test: Integration'
       - cla/google
       - checkstyle
-      - compile (8)
-      - compile (11)
   - pattern: 5.2.x
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -85,8 +79,6 @@ branchProtectionRules:
       - 'Kokoro - Test: Integration'
       - cla/google
       - checkstyle
-      - compile (8)
-      - compile (11)
   - pattern: 6.4.4-sp
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -100,8 +92,6 @@ branchProtectionRules:
       - 'Kokoro - Test: Integration'
       - cla/google
       - checkstyle
-      - compile (8)
-      - compile (11)
 permissionRules:
   - team: yoshi-admins
     permission: admin


### PR DESCRIPTION
- Removes 3.3.3-sp as protected branch (current LTS version is 6.4.4-sp)
- Removes sample compile step from protected branches CI