### PR TITLE
samples: add transaction / request tagging samples

### DIFF
--- a/samples/snippets/src/main/java/com/example/spanner/TagSample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/TagSample.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner;
+
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.Options;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
+
+/**
+ * Sample showing how to add and query tags to Cloud Spanner operations.
+ */
+public class TagSample {
+
+  // [START spanner_set_transaction_tag]
+  static void setTransactionTag(DatabaseClient databaseClient) {
+    // Sets the transaction tag to "app=concert,env=dev".
+    // This transaction tag will be applied to all the individual operations inside this
+    // transaction.
+    databaseClient
+        .readWriteTransaction(Options.tag("app=concert,env=dev"))
+        .run(transaction -> {
+          // Sets the request tag to "app=concert,env=dev,action=update".
+          // This request tag will only be set on this request.
+          transaction.executeUpdate(
+              Statement
+                  .of("UPDATE Venues SET Capacity = CAST(Capacity/4 AS INT64) WHERE OutdoorVenue = false"),
+              Options.tag("app=concert,env=dev,action=update"));
+          System.out.println("Venue capacities updated.");
+
+          Statement insert_statement = Statement.newBuilder(
+              "INSERT INTO Venues (VenueId, VenueName, Capacity, OutdoorVenue, LastUpdateTime) " +
+                  "VALUES (@venueId, @venueName, @capacity, @outdoorVenue, PENDING_COMMIT_TIMESTAMP())")
+              .bind("venueId")
+              .to(81)
+              .bind("venueName")
+              .to("Venue 81")
+              .bind("capacity")
+              .to(1440)
+              .bind("outdoorVenue")
+              .to(true)
+              .build();
+
+          // Sets the request tag to "app=concert,env=dev,action=insert".
+          // This request tag will only be set on this request.
+          transaction.executeUpdate(
+              insert_statement,
+              Options.tag("app=concert,env=dev,action=insert"));
+          System.out.println("New venue inserted.");
+
+          return null;
+        });
+  }
+  // [END spanner_set_transaction_tag]
+
+  // [START spanner_set_request_tag]
+  static void setRequestTag(DatabaseClient databaseClient) {
+    // Sets the request tag to "app=concert,env=dev,action=select".
+    // This request tag will only be set on this request.
+    try (ResultSet resultSet = databaseClient
+        .singleUse()
+        .executeQuery(
+            Statement.of("SELECT SingerId, AlbumId, AlbumTitle FROM Albums"),
+            Options.tag("app=concert,env=dev,action=select"))) {
+      while (resultSet.next()) {
+        System.out.printf(
+            "SingerId: %d, AlbumId: %d, AlbumTitle: %s\n",
+            resultSet.getLong(0),
+            resultSet.getLong(1),
+            resultSet.getString(2));
+      }
+    }
+  }
+  // [END spanner_set_request_tag]
+}

--- a/samples/snippets/src/main/java/com/example/spanner/TagSample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/TagSample.java
@@ -37,14 +37,18 @@ public class TagSample {
           // Sets the request tag to "app=concert,env=dev,action=update".
           // This request tag will only be set on this request.
           transaction.executeUpdate(
-              Statement
-                  .of("UPDATE Venues SET Capacity = CAST(Capacity/4 AS INT64) WHERE OutdoorVenue = false"),
+              Statement.of("UPDATE Venues"
+                  + " SET Capacity = CAST(Capacity/4 AS INT64)"
+                  + " WHERE OutdoorVenue = false"),
               Options.tag("app=concert,env=dev,action=update"));
           System.out.println("Venue capacities updated.");
 
-          Statement insert_statement = Statement.newBuilder(
-              "INSERT INTO Venues (VenueId, VenueName, Capacity, OutdoorVenue, LastUpdateTime) " +
-                  "VALUES (@venueId, @venueName, @capacity, @outdoorVenue, PENDING_COMMIT_TIMESTAMP())")
+          Statement insertStatement = Statement.newBuilder(
+              "INSERT INTO Venues"
+                  + " (VenueId, VenueName, Capacity, OutdoorVenue, LastUpdateTime)"
+                  + " VALUES ("
+                  + " @venueId, @venueName, @capacity, @outdoorVenue, PENDING_COMMIT_TIMESTAMP()"
+                  + " )")
               .bind("venueId")
               .to(81)
               .bind("venueName")
@@ -58,7 +62,7 @@ public class TagSample {
           // Sets the request tag to "app=concert,env=dev,action=insert".
           // This request tag will only be set on this request.
           transaction.executeUpdate(
-              insert_statement,
+              insertStatement,
               Options.tag("app=concert,env=dev,action=insert"));
           System.out.println("New venue inserted.");
 

--- a/samples/snippets/src/main/java/com/example/spanner/TagSample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/TagSample.java
@@ -22,7 +22,7 @@ import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Statement;
 
 /**
- * Sample showing how to add and query tags to Cloud Spanner operations.
+ * Sample showing how to add transaction and query tags to Cloud Spanner operations.
  */
 public class TagSample {
 

--- a/samples/snippets/src/test/java/com/example/spanner/SampleTestBase.java
+++ b/samples/snippets/src/test/java/com/example/spanner/SampleTestBase.java
@@ -50,6 +50,7 @@ public class SampleTestBase {
     final SpannerOptions options = SpannerOptions
         .newBuilder()
         .setAutoThrottleAdministrativeRequests()
+        .setProjectId("gcloud-devel")
         .build();
     projectId = options.getProjectId();
     spanner = options.getService();

--- a/samples/snippets/src/test/java/com/example/spanner/SampleTestBase.java
+++ b/samples/snippets/src/test/java/com/example/spanner/SampleTestBase.java
@@ -50,7 +50,6 @@ public class SampleTestBase {
     final SpannerOptions options = SpannerOptions
         .newBuilder()
         .setAutoThrottleAdministrativeRequests()
-        .setProjectId("gcloud-devel")
         .build();
     projectId = options.getProjectId();
     spanner = options.getService();

--- a/samples/snippets/src/test/java/com/example/spanner/TagSampleIT.java
+++ b/samples/snippets/src/test/java/com/example/spanner/TagSampleIT.java
@@ -1,0 +1,101 @@
+package com.example.spanner;
+
+import static com.example.spanner.SampleRunner.runSample;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.DatabaseId;
+import com.google.cloud.spanner.KeySet;
+import com.google.cloud.spanner.Mutation;
+import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Integration tests for {@link TagSample}
+ */
+@RunWith(JUnit4.class)
+public class TagSampleIT extends SampleTestBase {
+
+  private static DatabaseId databaseId;
+
+  @BeforeClass
+  public static void createTestDatabase() throws Exception {
+    final String database = idGenerator.generateDatabaseId();
+    databaseAdminClient
+        .createDatabase(
+            instanceId,
+            database,
+            ImmutableList.of(
+                "CREATE TABLE Albums ("
+                    + "  SingerId    INT64 NOT NULL,"
+                    + "  AlbumId     INT64,"
+                    + "  AlbumTitle  STRING(1024)"
+                    + ") PRIMARY KEY (SingerId)",
+                "CREATE TABLE Venues ("
+                    + "  VenueId      INT64 NOT NULL,"
+                    + "  VenueName    STRING(MAX),"
+                    + "  Capacity     INT64,"
+                    + "  OutdoorVenue BOOL"
+                    + ") PRIMARY KEY  (VenueId)"))
+        .get(10, TimeUnit.MINUTES);
+    databaseId = DatabaseId.of(projectId, instanceId, database);
+  }
+
+  @Before
+  public void insertTestData() {
+    final DatabaseClient client = spanner.getDatabaseClient(databaseId);
+    client.write(
+        Arrays.asList(
+            Mutation.newInsertOrUpdateBuilder("Albums")
+                .set("SingerId")
+                .to(1L)
+                .set("AlbumId")
+                .to(1L)
+                .set("AlbumTitle")
+                .to("title 1")
+                .build(),
+            Mutation.newInsertOrUpdateBuilder("Venues")
+                .set("VenueId")
+                .to(4L)
+                .set("VenueName")
+                .to("name")
+                .set("Capacity")
+                .to(4000000)
+                .set("OutdoorVenue")
+                .to(false)
+                .build()));
+  }
+
+  @After
+  public void removeTestData() {
+    final DatabaseClient client = spanner.getDatabaseClient(databaseId);
+    client.write(Collections.singletonList(Mutation.delete("Albums", KeySet.all())));
+    client.write(Collections.singleton(Mutation.delete("Venues", KeySet.all())));
+  }
+
+  @Test
+  public void testSetRequestTag() throws Exception {
+    final DatabaseClient client = spanner.getDatabaseClient(databaseId);
+
+    final String out = runSample(() -> TagSample.setRequestTag(client));
+    assertEquals("SingerId: 1, AlbumId: 1, AlbumTitle: title 1", out);
+  }
+
+  @Test
+  public void testSetTransactionTag() throws Exception {
+    final DatabaseClient client = spanner.getDatabaseClient(databaseId);
+
+    final String out = runSample(() -> TagSample.setTransactionTag(client));
+    assertTrue(out.contains("Venue capacities updated."));
+    assertTrue(out.contains("New venue inserted."));
+  }
+}

--- a/samples/snippets/src/test/java/com/example/spanner/TagSampleIT.java
+++ b/samples/snippets/src/test/java/com/example/spanner/TagSampleIT.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.spanner;
 
 import static com.example.spanner.SampleRunner.runSample;

--- a/samples/snippets/src/test/java/com/example/spanner/TagSampleIT.java
+++ b/samples/snippets/src/test/java/com/example/spanner/TagSampleIT.java
@@ -55,7 +55,7 @@ public class TagSampleIT extends SampleTestBase {
                     + "  SingerId    INT64 NOT NULL,"
                     + "  AlbumId     INT64,"
                     + "  AlbumTitle  STRING(1024)"
-                    + ") PRIMARY KEY (SingerId)",
+                    + ") PRIMARY KEY (SingerId, AlbumId)",
                 "CREATE TABLE Venues ("
                     + "  VenueId        INT64 NOT NULL,"
                     + "  VenueName      STRING(MAX),"

--- a/samples/snippets/src/test/java/com/example/spanner/TagSampleIT.java
+++ b/samples/snippets/src/test/java/com/example/spanner/TagSampleIT.java
@@ -57,10 +57,11 @@ public class TagSampleIT extends SampleTestBase {
                     + "  AlbumTitle  STRING(1024)"
                     + ") PRIMARY KEY (SingerId)",
                 "CREATE TABLE Venues ("
-                    + "  VenueId      INT64 NOT NULL,"
-                    + "  VenueName    STRING(MAX),"
-                    + "  Capacity     INT64,"
-                    + "  OutdoorVenue BOOL"
+                    + "  VenueId        INT64 NOT NULL,"
+                    + "  VenueName      STRING(MAX),"
+                    + "  Capacity       INT64,"
+                    + "  OutdoorVenue   BOOL,"
+                    + "  LastUpdateTime TIMESTAMP OPTIONS (allow_commit_timestamp=true)"
                     + ") PRIMARY KEY  (VenueId)"))
         .get(10, TimeUnit.MINUTES);
     databaseId = DatabaseId.of(projectId, instanceId, database);
@@ -103,7 +104,7 @@ public class TagSampleIT extends SampleTestBase {
     final DatabaseClient client = spanner.getDatabaseClient(databaseId);
 
     final String out = runSample(() -> TagSample.setRequestTag(client));
-    assertEquals("SingerId: 1, AlbumId: 1, AlbumTitle: title 1", out);
+    assertTrue(out.contains("SingerId: 1, AlbumId: 1, AlbumTitle: title 1"));
   }
 
   @Test


### PR DESCRIPTION
Adds transaction / request tagging samples.

Supersedes https://github.com/googleapis/java-spanner/pull/1478.