### PR TITLE
fix: re-adds test-jar to bom definition

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -14,6 +14,7 @@
   "api_id": "spanner.googleapis.com",
   "transport": "grpc",
   "requires_billing": true,
-  "codeowner_team": "@googleapis/api-spanner-java"
+  "codeowner_team": "@googleapis/api-spanner-java",
+  "excluded_poms": "google-cloud-spanner-bom"
 }
 

--- a/google-cloud-spanner-bom/pom.xml
+++ b/google-cloud-spanner-bom/pom.xml
@@ -56,12 +56,6 @@
         <version>6.17.3-SNAPSHOT</version><!-- {x-version-update:google-cloud-spanner:current} -->
       </dependency>
       <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-spanner</artifactId>
-        <type>test-jar</type>
-        <version>6.17.3-SNAPSHOT</version><!-- {x-version-update:google-cloud-spanner:current} -->
-      </dependency>
-      <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-spanner-v1</artifactId>
         <version>6.17.3-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-spanner-v1:current} -->

--- a/google-cloud-spanner-bom/pom.xml
+++ b/google-cloud-spanner-bom/pom.xml
@@ -56,6 +56,12 @@
         <version>6.17.3-SNAPSHOT</version><!-- {x-version-update:google-cloud-spanner:current} -->
       </dependency>
       <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-spanner</artifactId>
+        <type>test-jar</type>
+        <version>6.17.3-SNAPSHOT</version><!-- {x-version-update:google-cloud-spanner:current} -->
+      </dependency>
+      <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-spanner-v1</artifactId>
         <version>6.17.3-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-spanner-v1:current} -->


### PR DESCRIPTION
The test jar was wrongly removed during the owlbot migration.

`google-cloud-spanner-bom` has been added to an exclude list for owlbot. This means owlbot will not add new dependencies to the bom when a new version is introduced. Renovate bot will still update the versions and no other owlbot feature changes.