### PR TITLE
chore: eol support for 3.1.x

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -2,10 +2,6 @@ releaseType: java-yoshi
 bumpMinorPreMajor: true
 handleGHRelease: true
 branches:
-  - branch: 3.1.x
-    releaseType: java-yoshi
-    bumpMinorPreMajor: true
-    handleGHRelease: true
   - branch: 3.3.x
     releaseType: java-yoshi
     bumpMinorPreMajor: true

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -20,21 +20,6 @@ branchProtectionRules:
       - compile (8)
       - compile (11)
       - OwlBot Post Processor
-  - pattern: 3.1.x
-    isAdminEnforced: true
-    requiredApprovingReviewCount: 1
-    requiresCodeOwnerReviews: true
-    requiresStrictStatusChecks: false
-    requiredStatusCheckContexts:
-      - dependencies (8)
-      - dependencies (11)
-      - lint
-      - units (7)
-      - units (8)
-      - units (11)
-      - 'Kokoro - Test: Integration'
-      - cla/google
-      - checkstyle
   - pattern: 3.3.x
     isAdminEnforced: true
     requiredApprovingReviewCount: 1

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:24.1.0')
+implementation platform('com.google.cloud:libraries-bom:24.1.1')
 
 implementation 'com.google.cloud:google-cloud-spanner'
 ```


### PR DESCRIPTION
End of life support for 3.1.x branch as of 2021-12-17. This change removes the configuration for this branch.