### PR TITLE
fix: untyped null parameters would cause NPE

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -583,8 +583,10 @@ abstract class AbstractReadContext
     if (!stmtParameters.isEmpty()) {
       com.google.protobuf.Struct.Builder paramsBuilder = builder.getParamsBuilder();
       for (Map.Entry<String, Value> param : stmtParameters.entrySet()) {
-        paramsBuilder.putFields(param.getKey(), param.getValue().toProto());
-        builder.putParamTypes(param.getKey(), param.getValue().getType().toProto());
+        paramsBuilder.putFields(param.getKey(), Value.toProto(param.getValue()));
+        if (param.getValue() != null) {
+          builder.putParamTypes(param.getKey(), param.getValue().getType().toProto());
+        }
       }
     }
     if (withTransactionSelector) {
@@ -612,10 +614,12 @@ abstract class AbstractReadContext
         com.google.protobuf.Struct.Builder paramsBuilder =
             builder.getStatementsBuilder(idx).getParamsBuilder();
         for (Map.Entry<String, Value> param : stmtParameters.entrySet()) {
-          paramsBuilder.putFields(param.getKey(), param.getValue().toProto());
-          builder
-              .getStatementsBuilder(idx)
-              .putParamTypes(param.getKey(), param.getValue().getType().toProto());
+          paramsBuilder.putFields(param.getKey(), Value.toProto(param.getValue()));
+          if (param.getValue() != null) {
+            builder
+                .getStatementsBuilder(idx)
+                .putParamTypes(param.getKey(), param.getValue().getType().toProto());
+          }
         }
       }
       idx++;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchClientImpl.java
@@ -169,8 +169,10 @@ public class BatchClientImpl implements BatchClient {
       if (!stmtParameters.isEmpty()) {
         Struct.Builder paramsBuilder = builder.getParamsBuilder();
         for (Map.Entry<String, Value> param : stmtParameters.entrySet()) {
-          paramsBuilder.putFields(param.getKey(), param.getValue().toProto());
-          builder.putParamTypes(param.getKey(), param.getValue().getType().toProto());
+          paramsBuilder.putFields(param.getKey(), Value.toProto(param.getValue()));
+          if (param.getValue() != null) {
+            builder.putParamTypes(param.getKey(), param.getValue().getType().toProto());
+          }
         }
       }
       TransactionSelector selector = getTransactionSelector();

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/PartitionedDmlTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/PartitionedDmlTransaction.java
@@ -217,8 +217,10 @@ public class PartitionedDmlTransaction implements SessionImpl.SessionTransaction
     if (!statementParameters.isEmpty()) {
       com.google.protobuf.Struct.Builder paramsBuilder = requestBuilder.getParamsBuilder();
       for (Map.Entry<String, Value> param : statementParameters.entrySet()) {
-        paramsBuilder.putFields(param.getKey(), param.getValue().toProto());
-        requestBuilder.putParamTypes(param.getKey(), param.getValue().getType().toProto());
+        paramsBuilder.putFields(param.getKey(), Value.toProto(param.getValue()));
+        if (param.getValue() != null) {
+          requestBuilder.putParamTypes(param.getKey(), param.getValue().getType().toProto());
+        }
       }
     }
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Value.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Value.java
@@ -73,6 +73,9 @@ public abstract class Value implements Serializable {
    */
   public static final Timestamp COMMIT_TIMESTAMP = Timestamp.ofTimeMicroseconds(0L);
 
+  static final com.google.protobuf.Value NULL_PROTO =
+      com.google.protobuf.Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build();
+
   /** Constant to specify a PG Numeric NaN value. */
   public static final String NAN = "NaN";
 
@@ -622,6 +625,10 @@ public abstract class Value implements Serializable {
 
   // END OF PUBLIC API.
 
+  static com.google.protobuf.Value toProto(Value value) {
+    return value == null ? NULL_PROTO : value.toProto();
+  }
+
   abstract void toString(StringBuilder b);
 
   abstract com.google.protobuf.Value toProto();
@@ -737,9 +744,6 @@ public abstract class Value implements Serializable {
 
   /** Template class for {@code Value} implementations. */
   private abstract static class AbstractValue extends Value {
-    static final com.google.protobuf.Value NULL_PROTO =
-        com.google.protobuf.Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build();
-
     private final boolean isNull;
     private final Type type;
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/StatementTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/StatementTest.java
@@ -61,6 +61,8 @@ public class StatementTest {
             .append("bytes_field = @bytes_field ")
             .bind("bytes_field")
             .to(ByteArray.fromBase64("abcd"))
+            .bind("untyped_null_field")
+            .to((Value) null)
             .build();
     reserializeAndAssert(stmt);
   }
@@ -165,6 +167,9 @@ public class StatementTest {
     tester.addEqualityGroup(Statement.newBuilder("SELECT @x, @y").bind("y").to(2).build());
     tester.addEqualityGroup(
         Statement.newBuilder("SELECT @x, @y").bind("x").to(1).bind("y").to(2).build());
+    tester.addEqualityGroup(
+        Statement.newBuilder("SELECT @x, @y").bind("x").to((Value) null).build(),
+        Statement.newBuilder("SELECT @x, @y").bind("x").to((Value) null).build());
     tester.testEquals();
   }
 }


### PR DESCRIPTION
Adding an untyped null value as a parameter to a statement was not
possible, as:
1. The parameter collection would allow a null value to be added, but
   when the statement was built, it would throw a NullPointerException
   because it used an ImmutableMap internally, which does not support
   null values.
2. The translation from a hand-written Statement instance to a proto
   Statement instance would fail, as it did not take into account that
   the parameter could be null.

Fixes #1679
