### PR TITLE
fix: do not delete session in close method for BatchReadOnlyTransactionImpl

### DIFF
--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -7,6 +7,11 @@
     <method>com.google.cloud.spanner.Dialect getDialect()</method>
   </difference>
   <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/BatchReadOnlyTransaction</className>
+    <method>void cleanup()</method>
+  </difference>
+  <difference>
     <differenceType>8001</differenceType>
     <className>com/google/cloud/spanner/connection/StatementParser</className>
   </difference>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchClientImpl.java
@@ -215,7 +215,7 @@ public class BatchClientImpl implements BatchClient {
     }
 
     /**
-     * Closes the session as part of the cleanup. It is the responsibility of the caller to make
+     * Closes the session as part of the cleanup. It is the responsibility of the caller to make a
      * call to this method once the transaction completes execution across all the channels (which
      * is understandably hard to identify). It is okay if the caller does not call the method
      * because the backend will anyways clean up the unused session.

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchClientImpl.java
@@ -214,9 +214,14 @@ public class BatchClientImpl implements BatchClient {
           partition.getPartitionToken());
     }
 
+    /**
+     * Closes the session as part of the cleanup. It is the responsibility of the caller to make
+     * call to this method once the transaction completes execution across all the channels (which
+     * is understandably hard to identify). It is okay if the caller does not call the method
+     * because the backend will anyways clean up the unused session.
+     */
     @Override
-    public void close() {
-      super.close();
+    public void cleanup() {
       session.close();
     }
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchReadOnlyTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchReadOnlyTransaction.java
@@ -199,10 +199,10 @@ public interface BatchReadOnlyTransaction extends ReadOnlyTransaction {
   BatchTransactionId getBatchTransactionId();
 
   /**
-   * Closes the session as part of the cleanup. It is the responsibility of the caller to make
-   * call to this method once the transaction completes execution across all the channels (which
-   * is understandably hard to identify). It is okay if the caller does not call the method
-   * because the backend will anyways clean up the unused session.
+   * Closes the session as part of the cleanup. It is the responsibility of the caller to make call
+   * to this method once the transaction completes execution across all the channels (which is
+   * understandably hard to identify). It is okay if the caller does not call the method because the
+   * backend will anyways clean up the unused session.
    */
   default void cleanup() {}
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchReadOnlyTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchReadOnlyTransaction.java
@@ -199,8 +199,8 @@ public interface BatchReadOnlyTransaction extends ReadOnlyTransaction {
   BatchTransactionId getBatchTransactionId();
 
   /**
-   * Closes the session as part of the cleanup. It is the responsibility of the caller to make a call
-   * to this method once the transaction completes execution across all the channels (which is
+   * Closes the session as part of the cleanup. It is the responsibility of the caller to make a
+   * call to this method once the transaction completes execution across all the channels (which is
    * understandably hard to identify). It is okay if the caller does not call the method because the
    * backend will anyways clean up the unused session.
    */

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchReadOnlyTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchReadOnlyTransaction.java
@@ -197,4 +197,12 @@ public interface BatchReadOnlyTransaction extends ReadOnlyTransaction {
    * BatchTransactionId guarantees the subsequent read/query to be executed at the same timestamp.
    */
   BatchTransactionId getBatchTransactionId();
+
+  /**
+   * Closes the session as part of the cleanup. It is the responsibility of the caller to make
+   * call to this method once the transaction completes execution across all the channels (which
+   * is understandably hard to identify). It is okay if the caller does not call the method
+   * because the backend will anyways clean up the unused session.
+   */
+  default void cleanup() {}
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchReadOnlyTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchReadOnlyTransaction.java
@@ -199,7 +199,7 @@ public interface BatchReadOnlyTransaction extends ReadOnlyTransaction {
   BatchTransactionId getBatchTransactionId();
 
   /**
-   * Closes the session as part of the cleanup. It is the responsibility of the caller to make call
+   * Closes the session as part of the cleanup. It is the responsibility of the caller to make a call
    * to this method once the transaction completes execution across all the channels (which is
    * understandably hard to identify). It is okay if the caller does not call the method because the
    * backend will anyways clean up the unused session.

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -1631,7 +1631,7 @@ public class DatabaseClientImplTest {
       try (ResultSet rs = transaction.execute(partitions.get(0))) {
         // Just iterate over the results to execute the query.
         while (rs.next()) {}
-      }  finally {
+      } finally {
         transaction.cleanup();
       }
       // Check if the last query executed is a DeleteSessionRequest and the second last query


### PR DESCRIPTION
-   remove session.close() from close() method implementation in
    BatchReadOnlyTransactionImpl class.

-   add a cleanup() method to BatchReadOnlyTransaction interface
    and give user the control to delete session when the session
    is no longer in use.

-   add tests for txn.cleanup() method.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-spanner/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #1651 ☕️
