### PR TITLE
fix: allow getting metadata without calling next()

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DirectExecuteResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DirectExecuteResultSet.java
@@ -96,31 +96,26 @@ class DirectExecuteResultSet implements ResultSet {
 
   @Override
   public Type getType() {
-    Preconditions.checkState(nextCalledByClient, MISSING_NEXT_CALL);
     return delegate.getType();
   }
 
   @Override
   public int getColumnCount() {
-    Preconditions.checkState(nextCalledByClient, MISSING_NEXT_CALL);
     return delegate.getColumnCount();
   }
 
   @Override
   public int getColumnIndex(String columnName) {
-    Preconditions.checkState(nextCalledByClient, MISSING_NEXT_CALL);
     return delegate.getColumnIndex(columnName);
   }
 
   @Override
   public Type getColumnType(int columnIndex) {
-    Preconditions.checkState(nextCalledByClient, MISSING_NEXT_CALL);
     return delegate.getColumnType(columnIndex);
   }
 
   @Override
   public Type getColumnType(String columnName) {
-    Preconditions.checkState(nextCalledByClient, MISSING_NEXT_CALL);
     return delegate.getColumnType(columnName);
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DirectExecuteResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DirectExecuteResultSetTest.java
@@ -53,7 +53,17 @@ public class DirectExecuteResultSetTest {
   public void testMethodCallBeforeNext()
       throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
     List<String> excludedMethods =
-        Arrays.asList("getStats", "next", "close", "ofResultSet", "equals", "hashCode");
+        Arrays.asList(
+            "getStats",
+            "next",
+            "close",
+            "ofResultSet",
+            "equals",
+            "hashCode",
+            "getType",
+            "getColumnCount",
+            "getColumnIndex",
+            "getColumnType");
     DirectExecuteResultSet subject = createSubject();
     callMethods(subject, excludedMethods, IllegalStateException.class);
   }


### PR DESCRIPTION
DirectExecuteResultSet, which is used in the Connection API, directly
executes any query that it is given without the need to call
ResultSet.next() first. This also makes it possible to get the ResultSet
metadata from the result without the need to calling ResultSet.next()
first.
