### PR TITLE
test: handle untyped null parameters in Mock Spanner server

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -2260,4 +2260,22 @@ public class DatabaseClientImplTest {
           StatementResult.detectDialectResult(Dialect.GOOGLE_STANDARD_SQL));
     }
   }
+
+  @Test
+  public void testUntypedNullParameters() {
+    Statement statement =
+        Statement.newBuilder("INSERT INTO FOO (BAR) VALUES (@p)")
+            .bind("p")
+            .to((Value) null)
+            .build();
+    mockSpanner.putStatementResult(StatementResult.update(statement, 1L));
+
+    DatabaseClient client =
+        spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+    Long updateCount =
+        client.readWriteTransaction().run(transaction -> transaction.executeUpdate(statement));
+
+    assertNotNull(updateCount);
+    assertEquals(1L, updateCount.longValue());
+  }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -1226,6 +1226,13 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
   private Statement buildStatement(
       String sql, Map<String, Type> paramTypes, com.google.protobuf.Struct params) {
     Statement.Builder builder = Statement.newBuilder(sql);
+    // Set all untyped null values first.
+    for (Entry<String, com.google.protobuf.Value> entry : params.getFieldsMap().entrySet()) {
+      if (entry.getValue().hasNullValue() && !paramTypes.containsKey(entry.getKey())) {
+        builder.bind(entry.getKey()).to((Value) null);
+      }
+    }
+
     for (Entry<String, Type> entry : paramTypes.entrySet()) {
       final String fieldName = entry.getKey();
       final Type fieldType = entry.getValue();


### PR DESCRIPTION
Support untyped null values in statement parameters for the mock Spanner
server used for testing.