### PR TITLE
fix: use information_schema instead of pg_catalog for dialect detection

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -1764,7 +1764,7 @@ class SessionPool {
       Statement.newBuilder(
               "SELECT 'POSTGRESQL' AS DIALECT\n"
                   + "FROM INFORMATION_SCHEMA.SCHEMATA\n"
-                  + "WHERE SCHEMA_NAME='pg_catalog'\n"
+                  + "WHERE SCHEMA_NAME='information_schema'\n"
                   + "UNION ALL\n"
                   + "SELECT 'GOOGLE_STANDARD_SQL' AS DIALECT\n"
                   + "FROM INFORMATION_SCHEMA.SCHEMATA\n"


### PR DESCRIPTION
Automatic dialect detection should not rely on `pg_catalog` being present in the `information_schema` to determine that it is a PostgreSQL database. Instead, the presence of an upper/lower case `INFORMATION_SCHEMA` / `information_schema` should be used to determine which of the two dialects is being used.
