### PR TITLE
feat: Track PG Adapter usage from user-agent headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ implementation 'com.google.cloud:google-cloud-spanner'
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-spanner:6.19.1'
+implementation 'com.google.cloud:google-cloud-spanner:6.20.0'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.19.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.20.0"
 ```
 
 ## Authentication

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -80,6 +80,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
   private static final String JDBC_API_CLIENT_LIB_TOKEN = "sp-jdbc";
   private static final String HIBERNATE_API_CLIENT_LIB_TOKEN = "sp-hib";
   private static final String LIQUIBASE_API_CLIENT_LIB_TOKEN = "sp-liq";
+  private static final String PG_ADAPTER_CLIENT_LIB_TOKEN = "pg-adapter";
 
   private static final String API_SHORT_NAME = "Spanner";
   private static final String DEFAULT_HOST = "https://spanner.googleapis.com";
@@ -657,7 +658,8 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
             ServiceOptions.getGoogApiClientLibName(),
             JDBC_API_CLIENT_LIB_TOKEN,
             HIBERNATE_API_CLIENT_LIB_TOKEN,
-            LIQUIBASE_API_CLIENT_LIB_TOKEN);
+            LIQUIBASE_API_CLIENT_LIB_TOKEN,
+            PG_ADAPTER_CLIENT_LIB_TOKEN);
     private TransportChannelProvider channelProvider;
 
     @SuppressWarnings("rawtypes")

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.spanner;
 import static com.google.common.truth.Truth.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -532,7 +533,7 @@ public class SpannerOptionsTest {
             .setProjectId("some-project")
             .setCredentials(NoCredentials.getInstance())
             .build();
-    assertThat(options.getClientLibToken()).isEqualTo(ServiceOptions.getGoogApiClientLibName());
+    assertEquals(options.getClientLibToken(), ServiceOptions.getGoogApiClientLibName());
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
@@ -502,6 +502,7 @@ public class SpannerOptionsTest {
   public void testSetClientLibToken() {
     final String jdbcToken = "sp-jdbc";
     final String hibernateToken = "sp-hib";
+    final String pgAdapterToken = "pg-adapter";
     SpannerOptions options =
         SpannerOptions.newBuilder()
             .setProjectId("some-project")
@@ -517,6 +518,14 @@ public class SpannerOptionsTest {
             .setClientLibToken(hibernateToken)
             .build();
     assertThat(options.getClientLibToken()).isEqualTo(hibernateToken);
+
+    options =
+        SpannerOptions.newBuilder()
+            .setProjectId("some-project")
+            .setCredentials(NoCredentials.getInstance())
+            .setClientLibToken(pgAdapterToken)
+            .build();
+    assertThat(options.getClientLibToken()).isEqualTo(pgAdapterToken);
 
     options =
         SpannerOptions.newBuilder()

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
@@ -526,7 +526,7 @@ public class SpannerOptionsTest {
             .setCredentials(NoCredentials.getInstance())
             .setClientLibToken(pgAdapterToken)
             .build();
-    assertThat(options.getClientLibToken()).isEqualTo(pgAdapterToken);
+    assertEquals(options.getClientLibToken(), pgAdapterToken);
 
     options =
         SpannerOptions.newBuilder()


### PR DESCRIPTION
Added the string "pg-adapter" in the list of allowed client library token, so that when PG Adapter connects via client library by passing the string "pg-adapter" in the user-agent header, it doesn't get discarded. Also, added the one test case to cover the same.

Fixes [b/213946108](http://b/213946108)
