### PR TITLE
fix: catch ExecutionException for op.getName

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/slow/ITBackupTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/slow/ITBackupTest.java
@@ -467,7 +467,7 @@ public class ITBackupTest {
         }
         try {
           client.cancelOperation(op.getName());
-        } catch (SpannerException e) {
+        } catch (SpannerException | ExecutionException e) {
           // Ignore, this can happen, as the restore operation sometimes fails to start if there
           // is already a restore operation running on the instance.
         }


### PR DESCRIPTION
Following exception is thrown:

java.util.concurrent.ExecutionException: com.google.api.gax.rpc.FailedPreconditionException: io.grpc.StatusRuntimeException: FAILED_PRECONDITION.

So, changing the catch in order to catch all appropriate exceptions.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-spanner/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #1652 ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
