### PR TITLE
feat: parse query parameters in PostgreSQL query

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/PostgreSQLStatementParser.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/PostgreSQLStatementParser.java
@@ -21,6 +21,9 @@ import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.common.base.Preconditions;
+import java.util.HashSet;
+import java.util.Set;
+import javax.annotation.Nullable;
 
 @InternalApi
 public class PostgreSQLStatementParser extends AbstractStatementParser {
@@ -149,30 +152,76 @@ public class PostgreSQLStatementParser extends AbstractStatementParser {
     return new ParametersInfo(paramIndex - 1, named.toString());
   }
 
-  private int skip(String sql, int currentIndex, StringBuilder result) {
+  /**
+   * Note: This is an internal API and breaking changes can be made without prior notice.
+   *
+   * <p>Returns the PostgreSQL-style query parameters ($1, $2, ...) in the given SQL string. The
+   * SQL-string is assumed to not contain any comments. Use {@link #removeCommentsAndTrim(String)}
+   * to remove all comments before calling this method. Occurrences of query-parameter like strings
+   * inside quoted identifiers or string literals are ignored.
+   *
+   * <p>The following example will return a set containing ("$1", "$2"). <code>
+   * select col1, col2, "col$4"
+   * from some_table
+   * where col1=$1 and col2=$2
+   * and not col3=$1 and col4='$3'
+   * </code>
+   *
+   * @param sql the SQL-string to check for parameters. Must not contain comments.
+   * @return A set containing all the parameters in the SQL-string.
+   */
+  @InternalApi
+  public Set<String> getQueryParameters(String sql) {
+    Preconditions.checkNotNull(sql);
+    int maxCount = countOccurrencesOf('$', sql);
+    Set<String> parameters = new HashSet<>(maxCount);
+    int currentIndex = 0;
+    while (currentIndex < sql.length() - 1) {
+      char c = sql.charAt(currentIndex);
+      if (c == '$' && Character.isDigit(sql.charAt(currentIndex + 1))) {
+        // Look ahead for the first non-digit. That is the end of the query parameter.
+        int endIndex = currentIndex + 2;
+        while (endIndex < sql.length() && Character.isDigit(sql.charAt(endIndex))) {
+          endIndex++;
+        }
+        parameters.add(sql.substring(currentIndex, endIndex));
+        currentIndex = endIndex;
+      } else {
+        currentIndex = skip(sql, currentIndex, null);
+      }
+    }
+    return parameters;
+  }
+
+  private int skip(String sql, int currentIndex, @Nullable StringBuilder result) {
     char currentChar = sql.charAt(currentIndex);
     if (currentChar == SINGLE_QUOTE || currentChar == DOUBLE_QUOTE) {
-      result.append(currentChar);
+      appendIfNotNull(result, currentChar);
       return skipQuoted(sql, currentIndex, currentChar, result);
     } else if (currentChar == DOLLAR) {
       String dollarTag = parseDollarQuotedString(sql, currentIndex + 1);
       if (dollarTag != null) {
-        result.append(currentChar).append(dollarTag).append(currentChar);
+        appendIfNotNull(result, currentChar, dollarTag, currentChar);
         return skipQuoted(
             sql, currentIndex + dollarTag.length() + 1, currentChar, dollarTag, result);
       }
     }
 
-    result.append(currentChar);
+    appendIfNotNull(result, currentChar);
     return currentIndex + 1;
   }
 
-  private int skipQuoted(String sql, int startIndex, char startQuote, StringBuilder result) {
+  private int skipQuoted(
+      String sql, int startIndex, char startQuote, @Nullable StringBuilder result) {
     return skipQuoted(sql, startIndex, startQuote, null, result);
   }
 
   private int skipQuoted(
-      String sql, int startIndex, char startQuote, String dollarTag, StringBuilder result) {
+      String sql,
+      int startIndex,
+      char startQuote,
+      String dollarTag,
+      @Nullable StringBuilder result) {
     boolean lastCharWasEscapeChar = false;
     int currentIndex = startIndex + 1;
     while (currentIndex < sql.length()) {
@@ -182,18 +231,19 @@ public class PostgreSQLStatementParser extends AbstractStatementParser {
           // Check if this is the end of the current dollar quoted string.
           String tag = parseDollarQuotedString(sql, currentIndex + 1);
           if (tag != null && tag.equals(dollarTag)) {
-            result.append(currentChar).append(tag).append(currentChar);
+            appendIfNotNull(result, currentChar, dollarTag, currentChar);
             return currentIndex + tag.length() + 2;
           }
         } else if (lastCharWasEscapeChar) {
           lastCharWasEscapeChar = false;
         } else if (sql.length() > currentIndex + 1 && sql.charAt(currentIndex + 1) == startQuote) {
           // This is an escaped quote (e.g. 'foo''bar')
-          result.append(currentChar).append(currentChar);
+          appendIfNotNull(result, currentChar);
+          appendIfNotNull(result, currentChar);
           currentIndex += 2;
           continue;
         } else {
-          result.append(currentChar);
+          appendIfNotNull(result, currentChar);
           return currentIndex + 1;
         }
       } else if (currentChar == '\\') {
@@ -202,9 +252,22 @@ public class PostgreSQLStatementParser extends AbstractStatementParser {
         lastCharWasEscapeChar = false;
       }
       currentIndex++;
-      result.append(currentChar);
+      appendIfNotNull(result, currentChar);
     }
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.INVALID_ARGUMENT, "SQL statement contains an unclosed literal: " + sql);
+  }
+
+  private void appendIfNotNull(@Nullable StringBuilder result, char currentChar) {
+    if (result != null) {
+      result.append(currentChar);
+    }
+  }
+
+  private void appendIfNotNull(
+      @Nullable StringBuilder result, char prefix, String tag, char suffix) {
+    if (result != null) {
+      result.append(prefix).append(tag).append(suffix);
+    }
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/PostgreSQLStatementParser.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/PostgreSQLStatementParser.java
@@ -56,94 +56,43 @@ public class PostgreSQLStatementParser extends AbstractStatementParser {
   @Override
   String removeCommentsAndTrimInternal(String sql) {
     Preconditions.checkNotNull(sql);
-    String currentTag = null;
-    boolean isInQuoted = false;
     boolean isInSingleLineComment = false;
     int multiLineCommentLevel = 0;
-    char startQuote = 0;
-    boolean lastCharWasEscapeChar = false;
     StringBuilder res = new StringBuilder(sql.length());
     int index = 0;
     while (index < sql.length()) {
       char c = sql.charAt(index);
-      if (isInQuoted) {
-        if ((c == '\n' || c == '\r') && startQuote != DOLLAR) {
-          throw SpannerExceptionFactory.newSpannerException(
-              ErrorCode.INVALID_ARGUMENT, "SQL statement contains an unclosed literal: " + sql);
-        } else if (c == startQuote) {
-          if (c == DOLLAR) {
-            // Check if this is the end of the current dollar quoted string.
-            String tag = parseDollarQuotedString(sql, index + 1);
-            if (tag != null && tag.equals(currentTag)) {
-              index += tag.length() + 1;
-              res.append(c);
-              res.append(tag);
-              isInQuoted = false;
-              startQuote = 0;
-            }
-          } else if (lastCharWasEscapeChar) {
-            lastCharWasEscapeChar = false;
-          } else if (sql.length() > index + 1 && sql.charAt(index + 1) == startQuote) {
-            // This is an escaped quote (e.g. 'foo''bar')
-            res.append(c);
-            index++;
-          } else {
-            isInQuoted = false;
-            startQuote = 0;
-          }
-        } else if (c == '\\') {
-          lastCharWasEscapeChar = true;
-        } else {
-          lastCharWasEscapeChar = false;
+      if (isInSingleLineComment) {
+        if (c == '\n') {
+          isInSingleLineComment = false;
+          // Include the line feed in the result.
+          res.append(c);
         }
-        res.append(c);
+      } else if (multiLineCommentLevel > 0) {
+        if (sql.length() > index + 1 && c == ASTERIKS && sql.charAt(index + 1) == SLASH) {
+          multiLineCommentLevel--;
+          index++;
+        } else if (sql.length() > index + 1 && c == SLASH && sql.charAt(index + 1) == ASTERIKS) {
+          multiLineCommentLevel++;
+          index++;
+        }
       } else {
-        // We are not in a quoted string.
-        if (isInSingleLineComment) {
-          if (c == '\n') {
-            isInSingleLineComment = false;
-            // Include the line feed in the result.
-            res.append(c);
-          }
-        } else if (multiLineCommentLevel > 0) {
-          if (sql.length() > index + 1 && c == ASTERIKS && sql.charAt(index + 1) == SLASH) {
-            multiLineCommentLevel--;
-            index++;
-          } else if (sql.length() > index + 1 && c == SLASH && sql.charAt(index + 1) == ASTERIKS) {
-            multiLineCommentLevel++;
-            index++;
-          }
+        // Check for -- which indicates the start of a single-line comment.
+        if (sql.length() > index + 1 && c == HYPHEN && sql.charAt(index + 1) == HYPHEN) {
+          // This is a single line comment.
+          isInSingleLineComment = true;
+          index += 2;
+          continue;
+        } else if (sql.length() > index + 1 && c == SLASH && sql.charAt(index + 1) == ASTERIKS) {
+          multiLineCommentLevel++;
+          index += 2;
+          continue;
         } else {
-          // Check for -- which indicates the start of a single-line comment.
-          if (sql.length() > index + 1 && c == HYPHEN && sql.charAt(index + 1) == HYPHEN) {
-            // This is a single line comment.
-            isInSingleLineComment = true;
-          } else if (sql.length() > index + 1 && c == SLASH && sql.charAt(index + 1) == ASTERIKS) {
-            multiLineCommentLevel++;
-            index++;
-          } else {
-            if (c == SINGLE_QUOTE || c == DOUBLE_QUOTE) {
-              isInQuoted = true;
-              startQuote = c;
-            } else if (c == DOLLAR) {
-              currentTag = parseDollarQuotedString(sql, index + 1);
-              if (currentTag != null) {
-                isInQuoted = true;
-                startQuote = DOLLAR;
-                index += currentTag.length() + 1;
-                res.append(c);
-                res.append(currentTag);
-              }
-            }
-            res.append(c);
-          }
+          index = skip(sql, index, res);
+          continue;
         }
       }
       index++;
-    }
-    if (isInQuoted) {
-      throw SpannerExceptionFactory.newSpannerException(
-          ErrorCode.INVALID_ARGUMENT, "SQL statement contains an unclosed literal: " + sql);
     }
     if (multiLineCommentLevel > 0) {
       throw SpannerExceptionFactory.newSpannerException(
@@ -184,73 +133,78 @@ public class PostgreSQLStatementParser extends AbstractStatementParser {
   ParametersInfo convertPositionalParametersToNamedParametersInternal(char paramChar, String sql) {
     Preconditions.checkNotNull(sql);
     final String namedParamPrefix = "$";
-    String currentTag = null;
-    boolean isInQuoted = false;
-    char startQuote = 0;
-    boolean lastCharWasEscapeChar = false;
     StringBuilder named = new StringBuilder(sql.length() + countOccurrencesOf(paramChar, sql));
     int index = 0;
     int paramIndex = 1;
     while (index < sql.length()) {
       char c = sql.charAt(index);
-      if (isInQuoted) {
-        if ((c == '\n' || c == '\r') && startQuote != DOLLAR) {
-          throw SpannerExceptionFactory.newSpannerException(
-              ErrorCode.INVALID_ARGUMENT, "SQL statement contains an unclosed literal: " + sql);
-        } else if (c == startQuote) {
-          if (c == DOLLAR) {
-            // Check if this is the end of the current dollar quoted string.
-            String tag = parseDollarQuotedString(sql, index + 1);
-            if (tag != null && tag.equals(currentTag)) {
-              index += tag.length() + 1;
-              named.append(c);
-              named.append(tag);
-              isInQuoted = false;
-              startQuote = 0;
-            }
-          } else if (lastCharWasEscapeChar) {
-            lastCharWasEscapeChar = false;
-          } else if (sql.length() > index + 1 && sql.charAt(index + 1) == startQuote) {
-            // This is an escaped quote (e.g. 'foo''bar')
-            named.append(c);
-            index++;
-          } else {
-            isInQuoted = false;
-            startQuote = 0;
-          }
-        } else if (c == '\\') {
-          lastCharWasEscapeChar = true;
-        } else {
-          lastCharWasEscapeChar = false;
-        }
-        named.append(c);
+      if (c == paramChar) {
+        named.append(namedParamPrefix).append(paramIndex);
+        paramIndex++;
+        index++;
       } else {
-        if (c == paramChar) {
-          named.append(namedParamPrefix + paramIndex);
-          paramIndex++;
-        } else {
-          if (c == SINGLE_QUOTE || c == DOUBLE_QUOTE) {
-            isInQuoted = true;
-            startQuote = c;
-          } else if (c == DOLLAR) {
-            currentTag = parseDollarQuotedString(sql, index + 1);
-            if (currentTag != null) {
-              isInQuoted = true;
-              startQuote = DOLLAR;
-              index += currentTag.length() + 1;
-              named.append(c);
-              named.append(currentTag);
-            }
-          }
-          named.append(c);
-        }
+        index = skip(sql, index, named);
       }
-      index++;
-    }
-    if (isInQuoted) {
-      throw SpannerExceptionFactory.newSpannerException(
-          ErrorCode.INVALID_ARGUMENT, "SQL statement contains an unclosed literal: " + sql);
     }
     return new ParametersInfo(paramIndex - 1, named.toString());
+  }
+
+  private int skip(String sql, int currentIndex, StringBuilder result) {
+    char currentChar = sql.charAt(currentIndex);
+    if (currentChar == SINGLE_QUOTE || currentChar == DOUBLE_QUOTE) {
+      result.append(currentChar);
+      return skipQuoted(sql, currentIndex, currentChar, result);
+    } else if (currentChar == DOLLAR) {
+      String dollarTag = parseDollarQuotedString(sql, currentIndex + 1);
+      if (dollarTag != null) {
+        result.append(currentChar).append(dollarTag).append(currentChar);
+        return skipQuoted(
+            sql, currentIndex + dollarTag.length() + 1, currentChar, dollarTag, result);
+      }
+    }
+
+    result.append(currentChar);
+    return currentIndex + 1;
+  }
+
+  private int skipQuoted(String sql, int startIndex, char startQuote, StringBuilder result) {
+    return skipQuoted(sql, startIndex, startQuote, null, result);
+  }
+
+  private int skipQuoted(
+      String sql, int startIndex, char startQuote, String dollarTag, StringBuilder result) {
+    boolean lastCharWasEscapeChar = false;
+    int currentIndex = startIndex + 1;
+    while (currentIndex < sql.length()) {
+      char currentChar = sql.charAt(currentIndex);
+      if (currentChar == startQuote) {
+        if (currentChar == DOLLAR) {
+          // Check if this is the end of the current dollar quoted string.
+          String tag = parseDollarQuotedString(sql, currentIndex + 1);
+          if (tag != null && tag.equals(dollarTag)) {
+            result.append(currentChar).append(tag).append(currentChar);
+            return currentIndex + tag.length() + 2;
+          }
+        } else if (lastCharWasEscapeChar) {
+          lastCharWasEscapeChar = false;
+        } else if (sql.length() > currentIndex + 1 && sql.charAt(currentIndex + 1) == startQuote) {
+          // This is an escaped quote (e.g. 'foo''bar')
+          result.append(currentChar).append(currentChar);
+          currentIndex += 2;
+          continue;
+        } else {
+          result.append(currentChar);
+          return currentIndex + 1;
+        }
+      } else if (currentChar == '\\') {
+        lastCharWasEscapeChar = true;
+      } else {
+        lastCharWasEscapeChar = false;
+      }
+      currentIndex++;
+      result.append(currentChar);
+    }
+    throw SpannerExceptionFactory.newSpannerException(
+        ErrorCode.INVALID_ARGUMENT, "SQL statement contains an unclosed literal: " + sql);
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementParserTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementParserTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.ErrorCode;
@@ -33,6 +34,7 @@ import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStateme
 import com.google.cloud.spanner.connection.AbstractStatementParser.StatementType;
 import com.google.cloud.spanner.connection.ClientSideStatementImpl.CompileException;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.truth.Truth;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -42,7 +44,6 @@ import java.util.Scanner;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -158,7 +159,7 @@ public class StatementParserTest {
 
   @Test
   public void testGoogleStandardSQLRemoveCommentsGsql() {
-    Assume.assumeTrue(dialect == Dialect.GOOGLE_STANDARD_SQL);
+    assumeTrue(dialect == Dialect.GOOGLE_STANDARD_SQL);
 
     assertThat(parser.removeCommentsAndTrim("/*GSQL*/")).isEqualTo("");
     assertThat(parser.removeCommentsAndTrim("/*GSQL*/SELECT * FROM FOO"))
@@ -183,7 +184,7 @@ public class StatementParserTest {
 
   @Test
   public void testPostgreSQLDialectRemoveCommentsGsql() {
-    Assume.assumeTrue(dialect == Dialect.POSTGRESQL);
+    assumeTrue(dialect == Dialect.POSTGRESQL);
 
     assertThat(parser.removeCommentsAndTrim("/*GSQL*/")).isEqualTo("/*GSQL*/");
     assertThat(parser.removeCommentsAndTrim("/*GSQL*/SELECT * FROM FOO"))
@@ -273,7 +274,7 @@ public class StatementParserTest {
 
   @Test
   public void testPostgresSQLDialectDollarQuoted() {
-    Assume.assumeTrue(dialect == Dialect.POSTGRESQL);
+    assumeTrue(dialect == Dialect.POSTGRESQL);
 
     assertThat(parser.removeCommentsAndTrim("$$foo$$")).isEqualTo("$$foo$$");
     assertThat(parser.removeCommentsAndTrim("$$--foo$$")).isEqualTo("$$--foo$$");
@@ -296,7 +297,7 @@ public class StatementParserTest {
 
   @Test
   public void testPostgreSQLDialectSupportsEmbeddedComments() {
-    Assume.assumeTrue(dialect == Dialect.POSTGRESQL);
+    assumeTrue(dialect == Dialect.POSTGRESQL);
 
     final String sql =
         "/* This is a comment /* This is an embedded comment */ This is after the embedded comment */ SELECT 1";
@@ -305,7 +306,7 @@ public class StatementParserTest {
 
   @Test
   public void testGoogleStandardSQLDialectDoesNotSupportEmbeddedComments() {
-    Assume.assumeTrue(dialect == Dialect.GOOGLE_STANDARD_SQL);
+    assumeTrue(dialect == Dialect.GOOGLE_STANDARD_SQL);
 
     final String sql =
         "/* This is a comment /* This is an embedded comment */ This is after the embedded comment */ SELECT 1";
@@ -315,7 +316,7 @@ public class StatementParserTest {
 
   @Test
   public void testPostgreSQLDialectUnterminatedComment() {
-    Assume.assumeTrue(dialect == Dialect.POSTGRESQL);
+    assumeTrue(dialect == Dialect.POSTGRESQL);
 
     final String sql =
         "/* This is a comment /* This is still a comment */ this is unterminated SELECT 1";
@@ -334,7 +335,7 @@ public class StatementParserTest {
 
   @Test
   public void testGoogleStandardSqlDialectDialectUnterminatedComment() {
-    Assume.assumeTrue(dialect == Dialect.GOOGLE_STANDARD_SQL);
+    assumeTrue(dialect == Dialect.GOOGLE_STANDARD_SQL);
 
     final String sql =
         "/* This is a comment /* This is still a comment */ this is unterminated SELECT 1";
@@ -360,7 +361,7 @@ public class StatementParserTest {
 
   @Test
   public void testGoogleStandardSQLDialectStatementWithHashTagSingleLineComment() {
-    Assume.assumeTrue(dialect == Dialect.GOOGLE_STANDARD_SQL);
+    assumeTrue(dialect == Dialect.GOOGLE_STANDARD_SQL);
 
     // Supports # based comments
     assertThat(
@@ -382,7 +383,7 @@ public class StatementParserTest {
 
   @Test
   public void testPostgreSQLDialectStatementWithHashTagSingleLineComment() {
-    Assume.assumeTrue(dialect == Dialect.POSTGRESQL);
+    assumeTrue(dialect == Dialect.POSTGRESQL);
 
     // Does not support # based comments
     assertThat(
@@ -615,7 +616,7 @@ public class StatementParserTest {
 
   @Test
   public void testGoogleStandardSQLDialectIsQuery_QueryHints() {
-    Assume.assumeTrue(dialect == Dialect.GOOGLE_STANDARD_SQL);
+    assumeTrue(dialect == Dialect.GOOGLE_STANDARD_SQL);
 
     // Supports query hints, PostgreSQL dialect does NOT
     // Valid query hints.
@@ -663,7 +664,7 @@ public class StatementParserTest {
 
   @Test
   public void testIsUpdate_QueryHints() {
-    Assume.assumeTrue(dialect == Dialect.GOOGLE_STANDARD_SQL);
+    assumeTrue(dialect == Dialect.GOOGLE_STANDARD_SQL);
 
     // Supports query hints, PostgreSQL dialect does NOT
     // Valid query hints.
@@ -1093,7 +1094,7 @@ public class StatementParserTest {
 
   @Test
   public void testGoogleStandardSQLDialectConvertPositionalParametersToNamedParameters() {
-    Assume.assumeTrue(dialect == Dialect.GOOGLE_STANDARD_SQL);
+    assumeTrue(dialect == Dialect.GOOGLE_STANDARD_SQL);
 
     assertThat(
             parser.convertPositionalParametersToNamedParameters(
@@ -1203,7 +1204,7 @@ public class StatementParserTest {
 
   @Test
   public void testPostgreSQLDialectDialectConvertPositionalParametersToNamedParameters() {
-    Assume.assumeTrue(dialect == Dialect.POSTGRESQL);
+    assumeTrue(dialect == Dialect.POSTGRESQL);
 
     assertThat(
             parser.convertPositionalParametersToNamedParameters(
@@ -1316,6 +1317,25 @@ public class StatementParserTest {
                     + "and col6 not in ($6, $7, $8) "
                     + "and col7 in ($9, $10, $11) "
                     + "and col8 between $12 and $13")));
+  }
+
+  @Test
+  public void testPostgreSQLGetQueryParameters() {
+    assumeTrue(dialect == Dialect.POSTGRESQL);
+
+    PostgreSQLStatementParser parser = (PostgreSQLStatementParser) this.parser;
+    assertEquals(ImmutableSet.of(), parser.getQueryParameters("select * from foo"));
+    assertEquals(
+        ImmutableSet.of("$1"), parser.getQueryParameters("select * from foo where bar=$1"));
+    assertEquals(
+        ImmutableSet.of("$1", "$2", "$3"),
+        parser.getQueryParameters("select $2 from foo where bar=$1 and baz=$3"));
+    assertEquals(
+        ImmutableSet.of("$1", "$3"),
+        parser.getQueryParameters("select '$2' from foo where bar=$1 and baz in ($1, $3)"));
+    assertEquals(
+        ImmutableSet.of("$1"),
+        parser.getQueryParameters("select '$2' from foo where bar=$1 and baz=$foo"));
   }
 
   private void assertUnclosedLiteral(String sql) {


### PR DESCRIPTION
Adds a helper method to get the parameters from a PostgreSQL query. This
is needed for DESCRIBE statement messages in PGAdapter, as it must
return the data types of all query parameters in a query string. Even
though this parser is not able to determine the parameter types, it is
able to determine the number of parameters. This again makes it possible
to PGAdapter to return Oid.UNSPECIFIED for each parameter in the query
string, which is enough for most clients.

cc @pratickchokhani