### PR TITLE
fix(java): exclude tests that use Mockito from native image testing

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionClientTests.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionClientTests.java
@@ -54,7 +54,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 @RunWith(Parameterized.class)
-public class SessionClientTest {
+public class SessionClientTests {
   private final class TestExecutorFactory implements ExecutorFactory<ScheduledExecutorService> {
     @Override
     public ScheduledExecutorService get() {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DdlClientTests.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DdlClientTests.java
@@ -35,7 +35,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class DdlClientTest {
+public class DdlClientTests {
 
   private final String instanceId = "test-instance";
   private final String databaseId = "test-database";


### PR DESCRIPTION
Mockito dynamically loads classes at run-time and is currently incompatible with native image testing. Therefore, tests that use Mockito are resulting in the following error when they are executed with native image testing:

DdlClientTest:
```
  JUnit Vintage:DdlClientTest:testExecuteDdl
    MethodSource [className = 'com.google.cloud.spanner.connection.DdlClientTest', methodName = 'testExecuteDdl', methodParameterTypes = '']
    => com.oracle.svm.core.jdk.UnsupportedFeatureError: Proxy class defined by interfaces [interface org.mockito.plugins.PluginSwitch] not found. Generating proxy classes at runtime is not supported. Proxy classes need to be defined at image build time by specifying the list of interfaces that they implement. To define proxy classes use -H:DynamicProxyConfigurationFiles=<comma-separated-config-files> and -H:DynamicProxyConfigurationResources=<comma-separated-config-resources> options.
       com.oracle.svm.core.util.VMError.unsupportedFeature(VMError.java:87)
       com.oracle.svm.reflect.proxy.DynamicProxySupport.getProxyClass(DynamicProxySupport.java:146)
       java.lang.reflect.Proxy.getProxyConstructor(Proxy.java:66)
       java.lang.reflect.Proxy.newProxyInstance(Proxy.java:1006)
       org.mockito.internal.configuration.plugins.PluginLoader.loadPlugin(PluginLoader.java:81)
       org.mockito.internal.configuration.plugins.PluginLoader.loadPlugin(PluginLoader.java:54)
       org.mockito.internal.configuration.plugins.PluginRegistry.<init>(PluginRegistry.java:21)
       org.mockito.internal.configuration.plugins.Plugins.<clinit>(Plugins.java:22)
       org.mockito.internal.MockitoCore.<clinit>(MockitoCore.java:77)
       org.mockito.Mockito.<clinit>(Mockito.java:1614)
       [...]
```

SessionClientTest:
```
JUnit Vintage:SessionClientTest:[NumChannels = 8]:createAndCloseSession[NumChannels = 8]
    MethodSource [className = 'com.google.cloud.spanner.SessionClientTest', methodName = 'createAndCloseSession', methodParameterTypes = '']
    => java.lang.NoClassDefFoundError: Could not initialize class org.mockito.internal.configuration.plugins.Plugins
       org.mockito.internal.configuration.GlobalConfiguration.tryGetPluginAnnotationEngine(GlobalConfiguration.java:50)
       org.mockito.MockitoAnnotations.openMocks(MockitoAnnotations.java:81)
       org.mockito.MockitoAnnotations.initMocks(MockitoAnnotations.java:100)
       com.google.cloud.spanner.SessionClientTest.setUp(SessionClientTest.java:90)
       java.lang.reflect.Method.invoke(Method.java:566)
       org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
       org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
       org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
       org.junit.internal.runners.statements.RunBefores.invokeMethod(RunBefores.java:33)
       org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:24)
       [...]
```

Some background on how native image tests are opted in: The logic to opt libraries into native image testing lives in java-shared-config (see https://github.com/googleapis/java-shared-config/blob/1015b908c5aaa6f0b6c77759d86557ca26504868/pom.xml#L811) Currently tests with the IT* and *ClientTest pattern are opted in. The reason for this is to include integration tests in **all** libraries and unit tests in **only** generated libraries for native image testing (see this [logic](https://github.com/googleapis/gapic-generator/blob/857e2aab8017ecbb2abc9adc02d8571c02f94b3b/rules_gapic/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java#L82)  for the naming pattern the Gapic generator uses to generate unit tests). 

This PR excludes `SessionClientTest` and `DdlClientTest` from native image testing by renaming them to `SessionClientTests` and `DdlClientTests`. 

cc @ansh0l @meltsufin 