### PR TITLE
fix: return errors from BatchCreateSession to dialect detection

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -2210,6 +2210,9 @@ class SessionPool {
           break;
         }
       }
+      if (!dialect.isDone()) {
+        dialect.setException(e);
+      }
       if (isDatabaseOrInstanceNotFound(e)) {
         setResourceNotFoundException((ResourceNotFoundException) e);
         poolMaintainer.close();


### PR DESCRIPTION
Any error that was returned by BatchCreateSessions should also be set as
the result of the auto-detect dialect query, as the query will never be
able to return a result for the dialect when session creation fails.

Fixes #1759
