### PR TITLE
chore: make DatabaseClient accessible in the Connection API

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
@@ -23,6 +23,7 @@ import com.google.cloud.spanner.AbortedDueToConcurrentModificationException;
 import com.google.cloud.spanner.AbortedException;
 import com.google.cloud.spanner.AsyncResultSet;
 import com.google.cloud.spanner.CommitResponse;
+import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.Mutation;
@@ -1101,6 +1102,12 @@ public interface Connection extends AutoCloseable {
 
   /** The {@link Dialect} that is used by this {@link Connection}. */
   default Dialect getDialect() {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  /** The {@link DatabaseClient} that is used by this {@link Connection}. */
+  @InternalApi
+  default DatabaseClient getDatabaseClient() {
     throw new UnsupportedOperationException("Not implemented");
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
@@ -333,6 +333,11 @@ class ConnectionImpl implements Connection {
   }
 
   @Override
+  public DatabaseClient getDatabaseClient() {
+    return dbClient;
+  }
+
+  @Override
   public boolean isClosed() {
     return closed;
   }


### PR DESCRIPTION
Makes the underlying `DatabaseClient` accessible in the Connection API so this can be used by drivers that need direct access to it.

See https://github.com/GoogleCloudPlatform/pgadapter/blob/8f0d47785e04dc9db6ee275074777849f006d797/src/main/java/com/google/cloud/spanner/pgadapter/utils/MutationWriter.java#L439