### PR TITLE
chore: remove gsql parsing escape

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/PostgreSQLStatementParser.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/PostgreSQLStatementParser.java
@@ -31,7 +31,6 @@ import javax.annotation.Nullable;
 public class PostgreSQLStatementParser extends AbstractStatementParser {
   PostgreSQLStatementParser() throws CompileException {
     super(
-        Dialect.POSTGRESQL,
         Collections.unmodifiableSet(
             ClientSideStatements.getInstance(Dialect.POSTGRESQL).getCompiledStatements()));
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerStatementParser.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerStatementParser.java
@@ -31,7 +31,6 @@ public class SpannerStatementParser extends AbstractStatementParser {
 
   public SpannerStatementParser() throws CompileException {
     super(
-        Dialect.GOOGLE_STANDARD_SQL,
         Collections.unmodifiableSet(
             ClientSideStatements.getInstance(Dialect.GOOGLE_STANDARD_SQL).getCompiledStatements()));
   }


### PR DESCRIPTION
Removes the `/*GSQL*/` escape hatch in the client side parsing, as it is no longer needed.

Fixes b/223655465