### PR TITLE
test: cleanup instance before running IT tests

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestEnv.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestEnv.java
@@ -98,7 +98,7 @@ public class IntegrationTestEnv extends ExternalResource {
       // Cleanup instance before using it again, so that we do not have
       // databases from previous runs. This is done to prevent frequent
       // RESOURCE_EXHAUSTED errors, due to number of databases per
-      // instance exceeding the maximum limit.
+      // instance reaching the maximum limit.
       cleanUpInstance();
       initializeInstance(instanceId);
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestEnv.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestEnv.java
@@ -95,6 +95,11 @@ public class IntegrationTestEnv extends ExternalResource {
     instanceAdminClient = testHelper.getClient().getInstanceAdminClient();
     logger.log(Level.FINE, "Test env endpoint is {0}", options.getHost());
     if (isOwnedInstance) {
+      // Cleanup instance before using it again, so that we do not have
+      // databases from previous runs. This is done to prevent frequent
+      // RESOURCE_EXHAUSTED errors, due to number of databases per
+      // instance exceeding the maximum limit.
+      cleanUpInstance();
       initializeInstance(instanceId);
     }
   }


### PR DESCRIPTION
As part of this commit, we cleanup instance before using it again, so that we do not have databases from previous runs. This is done to prevent frequent RESOURCE_EXHAUSTED errors, due to number of databases per instance reaching the maximum limit (100).

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-spanner/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #1832 ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
