### PR TITLE
test: drop old databases from instance before running integration tests.

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestEnv.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestEnv.java
@@ -172,7 +172,7 @@ public class IntegrationTestEnv extends ExternalResource {
     int OLD_DB_THRESHOLD_SECS = 24 * 60 * 60;
     Timestamp currentTimestamp = Timestamp.now();
 
-    Page<Database> page = databaseAdminClient.listDatabases(instanceId.getName());
+    Page<Database> page = databaseAdminClient.listDatabases(instanceId.getInstance());
 
     while (page != null) {
       for (Database db : page.iterateAll()) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestEnv.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestEnv.java
@@ -169,7 +169,7 @@ public class IntegrationTestEnv extends ExternalResource {
   }
 
   private void cleanUpOldDatabases(InstanceId instanceId) {
-    int OLD_DB_THRESHOLD_SECS = 24 * 60 * 60;
+    int OLD_DB_THRESHOLD_SECS = TimeUnit.SECONDS.convert(24L, TimeUnit.HOURS);
     Timestamp currentTimestamp = Timestamp.now();
     int numDropped = 0;
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestEnv.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestEnv.java
@@ -169,16 +169,17 @@ public class IntegrationTestEnv extends ExternalResource {
   }
 
   private void cleanUpOldDatabases(InstanceId instanceId) {
-    int OLD_DB_THRESHOLD_SECS = 24*60*60;
+    int OLD_DB_THRESHOLD_SECS = 24 * 60 * 60;
     Timestamp currentTimestamp = Timestamp.now();
 
-    Page<Database> page =
-        databaseAdminClient.listDatabases(instanceId.getName());
+    Page<Database> page = databaseAdminClient.listDatabases(instanceId.getName());
 
-    while(page != null) {
-      for(Database db : page.iterateAll()) {
+    while (page != null) {
+      for (Database db : page.iterateAll()) {
         long timeDiff = db.getCreateTime().getSeconds() - currentTimestamp.getSeconds();
-        if(timeDiff > OLD_DB_THRESHOLD_SECS) {
+        // Delete all databases which are more than OLD_DB_THRESHOLD_SECS seconds
+        // old.
+        if (timeDiff > OLD_DB_THRESHOLD_SECS) {
           db.drop();
         }
       }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestEnv.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestEnv.java
@@ -188,7 +188,7 @@ public class IntegrationTestEnv extends ExternalResource {
             db.drop();
             ++numDropped;
           }
-        } catch(SpannerException e) {
+        } catch (SpannerException e) {
           logger.log(Level.SEVERE, "Failed to drop test database " + db.getId(), e);
         }
       }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestEnv.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestEnv.java
@@ -183,7 +183,8 @@ public class IntegrationTestEnv extends ExternalResource {
           long timeDiff = db.getCreateTime().getSeconds() - currentTimestamp.getSeconds();
           // Delete all databases which are more than OLD_DB_THRESHOLD_SECS seconds
           // old.
-          if ((db.getId().getDatabase().matches(TEST_DB_REGEX)) && (timeDiff > OLD_DB_THRESHOLD_SECS)) {
+          if ((db.getId().getDatabase().matches(TEST_DB_REGEX))
+              && (timeDiff > OLD_DB_THRESHOLD_SECS)) {
             logger.log(Level.INFO, "Dropping test database {0}", db.getId());
             db.drop();
             ++numDropped;


### PR DESCRIPTION
This commit aims to resolve the RESOURCE_EXHAUSTED errors due to
number of databases in an instance reaching the maximum limit.

We delete all the databases of an instance, which are more than 24 hours old, before running the tests.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-spanner/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #1832  ☕️