### PR TITLE
feat: support analyzeUpdate

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/PartitionedDmlTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/PartitionedDmlTransaction.java
@@ -95,7 +95,7 @@ public class PartitionedDmlTransaction implements SessionImpl.SessionTransaction
               resumeToken = rs.getResumeToken();
             }
             if (rs.hasStats()) {
-              foundStats = true;
+              foundStats = rs.getStats().hasRowCountLowerBound();
               updateCount += rs.getStats().getRowCountLowerBound();
             }
           }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -67,6 +67,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.protobuf.Empty;
+import com.google.spanner.v1.ResultSetStats;
 import io.opencensus.common.Scope;
 import io.opencensus.metrics.DerivedLongCumulative;
 import io.opencensus.metrics.DerivedLongGauge;
@@ -711,6 +712,16 @@ class SessionPool {
     @Override
     public ApiFuture<Void> bufferAsync(Iterable<Mutation> mutations) {
       return delegate.bufferAsync(mutations);
+    }
+
+    @Override
+    public ResultSetStats analyzeUpdate(
+        Statement statement, QueryAnalyzeMode analyzeMode, UpdateOption... options) {
+      try {
+        return delegate.analyzeUpdate(statement, analyzeMode, options);
+      } catch (SessionNotFoundException e) {
+        throw handler.handleSessionNotFound(e);
+      }
     }
 
     @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContext.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner;
 
 import com.google.api.core.ApiFuture;
 import com.google.cloud.spanner.Options.UpdateOption;
+import com.google.spanner.v1.ResultSetStats;
 
 /**
  * Context for a single attempt of a locking read-write transaction. This type of transaction is the
@@ -125,6 +126,19 @@ public interface TransactionContext extends ReadContext {
    * of that statement is known and has been returned to the client.
    */
   ApiFuture<Long> executeUpdateAsync(Statement statement, UpdateOption... options);
+
+  /**
+   * Analyzes a DML statement and returns query plan and/or execution statistics information.
+   *
+   * <p>{@link com.google.cloud.spanner.ReadContext.QueryAnalyzeMode#PLAN} only returns the plan for
+   * the statement. {@link com.google.cloud.spanner.ReadContext.QueryAnalyzeMode#PROFILE} executes
+   * the DML statement, returns the modified row count and execution statistics, and the effects of
+   * the DML statement will be visible to subsequent operations in the transaction.
+   */
+  default ResultSetStats analyzeUpdate(
+      Statement statement, QueryAnalyzeMode analyzeMode, UpdateOption... options) {
+    throw new UnsupportedOperationException("method should be overwritten");
+  }
 
   /**
    * Executes a list of DML statements in a single request. The statements will be executed in order

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
@@ -37,6 +37,7 @@ import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.connection.StatementResult.ResultType;
 import com.google.spanner.v1.ExecuteBatchDmlRequest;
+import com.google.spanner.v1.ResultSetStats;
 import java.util.Iterator;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -922,7 +923,8 @@ public interface Connection extends AutoCloseable {
   AsyncResultSet executeQueryAsync(Statement query, QueryOption... options);
 
   /**
-   * Analyzes a query and returns query plan and/or query execution statistics information.
+   * Analyzes a query or a DML statement and returns query plan and/or query execution statistics
+   * information.
    *
    * <p>The query plan and query statistics information is contained in {@link
    * com.google.spanner.v1.ResultSetStats} that can be accessed by calling {@link
@@ -956,6 +958,18 @@ public interface Connection extends AutoCloseable {
    * @return the number of records that were inserted/updated/deleted by this statement
    */
   long executeUpdate(Statement update);
+
+  /**
+   * Analyzes a DML statement and returns query plan and/or execution statistics information.
+   *
+   * <p>{@link com.google.cloud.spanner.ReadContext.QueryAnalyzeMode#PLAN} only returns the plan for
+   * the statement. {@link com.google.cloud.spanner.ReadContext.QueryAnalyzeMode#PROFILE} executes
+   * the DML statement, returns the modified row count and execution statistics, and the effects of
+   * the DML statement will be visible to subsequent operations in the transaction.
+   */
+  default ResultSetStats analyzeUpdate(Statement update, QueryAnalyzeMode analyzeMode) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
 
   /**
    * Executes the given statement asynchronously as a DML statement. If the statement does not

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
@@ -48,6 +48,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.spanner.v1.ExecuteSqlRequest.QueryOptions;
+import com.google.spanner.v1.ResultSetStats;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -288,6 +289,9 @@ class ConnectionImpl implements Connection {
   public ApiFuture<Void> closeAsync() {
     if (!isClosed()) {
       List<ApiFuture<Void>> futures = new ArrayList<>();
+      if (isBatchActive()) {
+        abortBatch();
+      }
       if (isTransactionStarted()) {
         futures.add(rollbackAsync());
       }
@@ -965,6 +969,7 @@ class ConnectionImpl implements Connection {
         "Statement is not an update statement: " + parsedStatement.getSqlWithoutComments());
   }
 
+  @Override
   public ApiFuture<Long> executeUpdateAsync(Statement update) {
     Preconditions.checkNotNull(update);
     ConnectionPreconditions.checkState(!isClosed(), CLOSED_ERROR_MSG);
@@ -973,6 +978,27 @@ class ConnectionImpl implements Connection {
       switch (parsedStatement.getType()) {
         case UPDATE:
           return internalExecuteUpdateAsync(parsedStatement);
+        case CLIENT_SIDE:
+        case QUERY:
+        case DDL:
+        case UNKNOWN:
+        default:
+      }
+    }
+    throw SpannerExceptionFactory.newSpannerException(
+        ErrorCode.INVALID_ARGUMENT,
+        "Statement is not an update statement: " + parsedStatement.getSqlWithoutComments());
+  }
+
+  @Override
+  public ResultSetStats analyzeUpdate(Statement update, QueryAnalyzeMode analyzeMode) {
+    Preconditions.checkNotNull(update);
+    ConnectionPreconditions.checkState(!isClosed(), CLOSED_ERROR_MSG);
+    ParsedStatement parsedStatement = getStatementParser().parse(update);
+    if (parsedStatement.isUpdate()) {
+      switch (parsedStatement.getType()) {
+        case UPDATE:
+          return get(internalAnalyzeUpdateAsync(parsedStatement, AnalyzeMode.of(analyzeMode)));
         case CLIENT_SIDE:
         case QUERY:
         case DDL:
@@ -1096,7 +1122,9 @@ class ConnectionImpl implements Connection {
       final AnalyzeMode analyzeMode,
       final QueryOption... options) {
     Preconditions.checkArgument(
-        statement.getType() == StatementType.QUERY, "Statement must be a query");
+        statement.getType() == StatementType.QUERY
+            || (statement.getType() == StatementType.UPDATE && analyzeMode != AnalyzeMode.NONE),
+        "Statement must either be a query or a DML mode with analyzeMode!=NONE");
     UnitOfWork transaction = getCurrentUnitOfWorkOrStartNewUnitOfWork();
     return get(
         transaction.executeQueryAsync(
@@ -1124,6 +1152,15 @@ class ConnectionImpl implements Connection {
     UnitOfWork transaction = getCurrentUnitOfWorkOrStartNewUnitOfWork();
     return transaction.executeUpdateAsync(
         update, mergeUpdateRequestOptions(mergeUpdateStatementTag(options)));
+  }
+
+  private ApiFuture<ResultSetStats> internalAnalyzeUpdateAsync(
+      final ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options) {
+    Preconditions.checkArgument(
+        update.getType() == StatementType.UPDATE, "Statement must be an update");
+    UnitOfWork transaction = getCurrentUnitOfWorkOrStartNewUnitOfWork();
+    return transaction.analyzeUpdateAsync(
+        update, analyzeMode, mergeUpdateRequestOptions(mergeUpdateStatementTag(options)));
   }
 
   private ApiFuture<long[]> internalExecuteBatchUpdateAsync(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DdlBatch.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DdlBatch.java
@@ -38,6 +38,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.spanner.admin.database.v1.DatabaseAdminGrpc;
 import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
+import com.google.spanner.v1.ResultSetStats;
 import com.google.spanner.v1.SpannerGrpc;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -199,6 +200,13 @@ class DdlBatch extends AbstractBaseUnitOfWork {
   public ApiFuture<Long> executeUpdateAsync(ParsedStatement update, UpdateOption... options) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Executing updates is not allowed for DDL batches.");
+  }
+
+  @Override
+  public ApiFuture<ResultSetStats> analyzeUpdateAsync(
+      ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options) {
+    throw SpannerExceptionFactory.newSpannerException(
+        ErrorCode.FAILED_PRECONDITION, "Analyzing updates is not allowed for DDL batches.");
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DmlBatch.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DmlBatch.java
@@ -33,6 +33,7 @@ import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStateme
 import com.google.cloud.spanner.connection.AbstractStatementParser.StatementType;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.spanner.v1.ResultSetStats;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -159,6 +160,13 @@ class DmlBatch extends AbstractBaseUnitOfWork {
             + "\" is not a DML-statement.");
     statements.add(update);
     return ApiFutures.immediateFuture(-1L);
+  }
+
+  @Override
+  public ApiFuture<ResultSetStats> analyzeUpdateAsync(
+      ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options) {
+    throw SpannerExceptionFactory.newSpannerException(
+        ErrorCode.FAILED_PRECONDITION, "Analyzing updates is not allowed for DML batches.");
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ReadOnlyTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ReadOnlyTransaction.java
@@ -30,6 +30,7 @@ import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStatement;
 import com.google.common.base.Preconditions;
+import com.google.spanner.v1.ResultSetStats;
 
 /**
  * Transaction that is used when a {@link Connection} is in read-only mode or when the transaction
@@ -161,6 +162,14 @@ class ReadOnlyTransaction extends AbstractMultiUseTransaction {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION,
         "Update statements are not allowed for read-only transactions");
+  }
+
+  @Override
+  public ApiFuture<ResultSetStats> analyzeUpdateAsync(
+      ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options) {
+    throw SpannerExceptionFactory.newSpannerException(
+        ErrorCode.FAILED_PRECONDITION,
+        "Analyzing updates is not allowed for read-only transactions");
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/UnitOfWork.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/UnitOfWork.java
@@ -178,6 +178,18 @@ interface UnitOfWork {
   ApiFuture<Long> executeUpdateAsync(ParsedStatement update, UpdateOption... options);
 
   /**
+   * Execute a DML statement on Spanner.
+   *
+   * @param update The DML statement to execute.
+   * @param analyzeMode Specifies the query/analyze mode to use for the DML statement.
+   * @param options Update options to apply for the statement.
+   * @return an {@link ApiFuture} containing the {@link ResultSetStats} that were returned by this
+   *     statement.
+   */
+  ApiFuture<ResultSetStats> analyzeUpdateAsync(
+      ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options);
+
+  /**
    * Execute a batch of DML statements on Spanner.
    *
    * @param updates The DML statements to execute.

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -217,6 +217,9 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
         recordCount++;
         currentRow++;
       }
+      if (currentRow == resultSet.getRowsCount()) {
+        builder.setStats(resultSet.getStats());
+      }
       builder.setResumeToken(ByteString.copyFromUtf8(String.format("%09d", currentRow)));
       hasNext = currentRow < resultSet.getRowsCount();
       return builder.build();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AnalyzeStatementsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AnalyzeStatementsTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.connection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.spanner.ErrorCode;
+import com.google.cloud.spanner.MockSpannerServiceImpl;
+import com.google.cloud.spanner.ReadContext.QueryAnalyzeMode;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.SpannerException;
+import com.google.cloud.spanner.Statement;
+import com.google.spanner.v1.BeginTransactionRequest;
+import com.google.spanner.v1.CommitRequest;
+import com.google.spanner.v1.ExecuteSqlRequest;
+import com.google.spanner.v1.ExecuteSqlRequest.QueryMode;
+import com.google.spanner.v1.PlanNode;
+import com.google.spanner.v1.QueryPlan;
+import com.google.spanner.v1.ResultSetMetadata;
+import com.google.spanner.v1.ResultSetStats;
+import com.google.spanner.v1.StructType;
+import com.google.spanner.v1.StructType.Field;
+import com.google.spanner.v1.Type;
+import com.google.spanner.v1.TypeCode;
+import java.util.List;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class AnalyzeStatementsTest extends AbstractMockServerTest {
+  private static final Statement PLAN_QUERY =
+      Statement.of("SELECT * FROM SomeTable ORDER BY Value");
+  private static final Statement PLAN_UPDATE = Statement.of("UPDATE SomeTable SET Value=Value+1");
+
+  @BeforeClass
+  public static void setupAnalyzeResults() {
+    mockSpanner.putStatementResult(
+        MockSpannerServiceImpl.StatementResult.query(
+            PLAN_QUERY,
+            com.google.spanner.v1.ResultSet.newBuilder()
+                .setMetadata(
+                    ResultSetMetadata.newBuilder()
+                        .setRowType(
+                            StructType.newBuilder()
+                                .addFields(
+                                    Field.newBuilder()
+                                        .setType(Type.newBuilder().setCode(TypeCode.INT64).build())
+                                        .setName("Key")
+                                        .build())
+                                .addFields(
+                                    Field.newBuilder()
+                                        .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                                        .setName("Value")
+                                        .build())
+                                .build())
+                        .build())
+                .setStats(
+                    ResultSetStats.newBuilder()
+                        .setQueryPlan(
+                            QueryPlan.newBuilder()
+                                .addPlanNodes(
+                                    PlanNode.newBuilder().setDisplayName("some-plan-node").build())
+                                .build())
+                        .build())
+                .build()));
+    mockSpanner.putStatementResults(
+        MockSpannerServiceImpl.StatementResult.query(
+            PLAN_UPDATE,
+            com.google.spanner.v1.ResultSet.newBuilder()
+                .setMetadata(ResultSetMetadata.newBuilder().build())
+                .setStats(
+                    ResultSetStats.newBuilder()
+                        .setQueryPlan(
+                            QueryPlan.newBuilder()
+                                .addPlanNodes(
+                                    PlanNode.newBuilder().setDisplayName("some-plan-node").build())
+                                .build())
+                        .build())
+                .build()));
+  }
+
+  @After
+  public void clearRequests() {
+    mockSpanner.clearRequests();
+  }
+
+  @Test
+  public void testAnalyzeQuery() {
+    for (boolean readOnly : new boolean[] {true, false}) {
+      for (boolean autocommit : new boolean[] {true, false}) {
+        mockSpanner.clearRequests();
+
+        try (Connection connection = createConnection()) {
+          connection.setAutocommit(autocommit);
+          connection.setReadOnly(readOnly);
+
+          try (ResultSet resultSet = connection.analyzeQuery(PLAN_QUERY, QueryAnalyzeMode.PLAN)) {
+            // Stats are only available after ResultSet#next() has returned false.
+            assertFalse(resultSet.next());
+
+            assertNotNull(resultSet.getStats());
+            assertNotNull(resultSet.getStats().getQueryPlan());
+          }
+        }
+
+        List<ExecuteSqlRequest> requests = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class);
+        assertEquals(1, requests.size());
+        ExecuteSqlRequest request = requests.get(0);
+        assertEquals(PLAN_QUERY.getSql(), request.getSql());
+        assertEquals(QueryMode.PLAN, request.getQueryMode());
+        if (autocommit) {
+          // Autocommit should use a single-use read-only transaction.
+          assertTrue(request.getTransaction().hasSingleUse());
+          assertTrue(request.getTransaction().getSingleUse().hasReadOnly());
+        } else {
+          // Non-autocommit should start a transaction.
+          if (readOnly) {
+            // Read-only transaction begin is not inlined.
+            BeginTransactionRequest beginTransactionRequest =
+                mockSpanner.getRequestsOfType(BeginTransactionRequest.class).stream()
+                    .findFirst()
+                    .orElse(null);
+            assertNotNull(beginTransactionRequest);
+            assertTrue(beginTransactionRequest.getOptions().hasReadOnly());
+            assertTrue(request.getTransaction().hasId());
+          } else {
+            assertTrue(request.getTransaction().hasBegin());
+            assertTrue(request.getTransaction().getBegin().hasReadWrite());
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testAnalyzeUpdate() {
+    for (boolean autocommit : new boolean[] {true, false}) {
+      mockSpanner.clearRequests();
+
+      try (Connection connection = createConnection()) {
+        connection.setAutocommit(autocommit);
+
+        ResultSetStats stats = connection.analyzeUpdate(PLAN_UPDATE, QueryAnalyzeMode.PLAN);
+        assertNotNull(stats);
+        assertNotNull(stats.getQueryPlan());
+      }
+
+      List<ExecuteSqlRequest> requests = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class);
+      assertEquals(1, requests.size());
+      ExecuteSqlRequest request = requests.get(0);
+      assertEquals(PLAN_UPDATE.getSql(), request.getSql());
+      assertEquals(QueryMode.PLAN, request.getQueryMode());
+
+      // As it is a DML statement, we should always start a read/write transaction, even though it
+      // is not executed. This is required by Cloud Spanner.
+      assertTrue(request.getTransaction().hasBegin());
+      assertTrue(request.getTransaction().getBegin().hasReadWrite());
+
+      if (autocommit) {
+        // The read/write transaction should automatically be committed in case of autocommit.
+        assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
+      } else {
+        assertEquals(0, mockSpanner.countRequestsOfType(CommitRequest.class));
+      }
+    }
+  }
+
+  @Test
+  public void testAnalyzeUpdateReadOnly() {
+    for (boolean autocommit : new boolean[] {true, false}) {
+      mockSpanner.clearRequests();
+
+      try (Connection connection = createConnection()) {
+        connection.setReadOnly(true);
+        connection.setAutocommit(autocommit);
+
+        SpannerException exception =
+            assertThrows(
+                SpannerException.class,
+                () -> connection.analyzeUpdate(PLAN_UPDATE, QueryAnalyzeMode.PLAN));
+        assertEquals(ErrorCode.FAILED_PRECONDITION, exception.getErrorCode());
+      }
+
+      assertEquals(0, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+      assertEquals(0, mockSpanner.countRequestsOfType(CommitRequest.class));
+    }
+  }
+
+  @Test
+  public void testAnalyzeUpdateDdlBatch() {
+    try (Connection connection = createConnection()) {
+      connection.startBatchDdl();
+
+      SpannerException exception =
+          assertThrows(
+              SpannerException.class,
+              () -> connection.analyzeUpdate(PLAN_UPDATE, QueryAnalyzeMode.PLAN));
+      assertEquals(ErrorCode.FAILED_PRECONDITION, exception.getErrorCode());
+    }
+
+    assertEquals(0, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    assertEquals(0, mockSpanner.countRequestsOfType(CommitRequest.class));
+  }
+
+  @Test
+  public void testAnalyzeUpdateDmlBatch() {
+    try (Connection connection = createConnection()) {
+      connection.startBatchDml();
+
+      SpannerException exception =
+          assertThrows(
+              SpannerException.class,
+              () -> connection.analyzeUpdate(PLAN_UPDATE, QueryAnalyzeMode.PLAN));
+      assertEquals(ErrorCode.FAILED_PRECONDITION, exception.getErrorCode());
+    }
+
+    assertEquals(0, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    assertEquals(0, mockSpanner.countRequestsOfType(CommitRequest.class));
+  }
+}

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/it/ITReadWriteAutocommitSpannerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/it/ITReadWriteAutocommitSpannerTest.java
@@ -20,17 +20,22 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.ParallelIntegrationTest;
+import com.google.cloud.spanner.ReadContext.QueryAnalyzeMode;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerBatchUpdateException;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.connection.ITAbstractSpannerTest;
 import com.google.cloud.spanner.connection.SqlScriptVerifier;
+import com.google.spanner.v1.ResultSetStats;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import org.junit.FixMethodOrder;
@@ -169,6 +174,39 @@ public class ITReadWriteAutocommitSpannerTest extends ITAbstractSpannerTest {
         assertThat(rs.next(), is(true));
         assertThat(rs.getLong(0), is(equalTo(0L)));
       }
+    }
+  }
+
+  @Test
+  public void test06_AnalyzeUpdate() {
+    // PLAN should not execute the update.
+    try (ITConnection connection = createConnection()) {
+      ResultSetStats resultSetStats =
+          connection.analyzeUpdate(
+              Statement.of("UPDATE TEST SET NAME='test_updated' WHERE ID > 0"),
+              QueryAnalyzeMode.PLAN);
+      connection.commit();
+
+      assertNotNull(resultSetStats);
+      assertTrue(resultSetStats.hasQueryPlan());
+      assertFalse(resultSetStats.hasRowCountExact());
+      assertFalse(resultSetStats.hasQueryStats());
+    }
+
+    try (ITConnection connection = createConnection()) {
+      ResultSetStats resultSetStats =
+          connection.analyzeUpdate(
+              Statement.of("UPDATE TEST SET NAME='test_updated' WHERE ID > 0"),
+              QueryAnalyzeMode.PROFILE);
+      connection.commit();
+
+      // Executing the update in PROFILE mode should execute the update
+      assertNotNull(resultSetStats);
+      assertTrue(resultSetStats.hasQueryPlan());
+      assertTrue(resultSetStats.hasQueryStats());
+
+      assertTrue(resultSetStats.hasRowCountExact());
+      assertTrue(resultSetStats.getRowCountExact() > 0);
     }
   }
 }


### PR DESCRIPTION
Adds support for analyzeUpdate for DML statements, similarly to
analyzeQuery for DQL statements. Executing a DML statement in PLAN mode
only returns the query plan, but does not actually execute the
statement. Executing a DML statement in PROFILE mode executes the
statement and returns the query plan and execution statistics.

Fixes #1866
