### PR TITLE
fix: ignore errors during Connection.close()

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:25.2.0')
+implementation platform('com.google.cloud:libraries-bom:25.3.0')
 
 implementation 'com.google.cloud:google-cloud-spanner'
 ```

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
@@ -294,12 +294,16 @@ class ConnectionImpl implements Connection {
     if (!isClosed()) {
       List<ApiFuture<Void>> futures = new ArrayList<>();
       if (isTransactionStarted()) {
-        futures.add(rollbackAsync());
+        try {
+          futures.add(rollbackAsync());
+        } catch (Exception exception) {
+          // ignore and continue to close the connection.
+        }
       }
       // Try to wait for the current statement to finish (if any) before we actually close the
       // connection.
       this.closed = true;
-      // Add a no-op statement to the execute. Once this has been executed, we know that all
+      // Add a no-op statement to the executor. Once this has been executed, we know that all
       // preceding statements have also been executed, as the executor is single-threaded and
       // executes all statements in order of submitting.
       futures.add(statementExecutor.submit(() -> null));


### PR DESCRIPTION
A connection will automatically rollback any active transactions when
the connection is closed. If the rollback would throw an exception, the
close would fail and the connection would still be marked as open. This
fix adds a simple ignore error handler when rolling back a transaction
when the connection is closed.
