### PR TITLE
test: test embedded comment in comment

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementParserTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementParserTest.java
@@ -154,6 +154,13 @@ public class StatementParserTest {
                   + "line\n"
                   + "comment\n"
                   + "*/SELECT \"FOO\nBAR\" FROM \"BAR\" WHERE name='test\ntest' and id=1"));
+      assertEquals(
+          "SELECT 1",
+          parser.removeCommentsAndTrim(
+              "/* This block comment surrounds a query which itself has a block comment...\n"
+                  + "SELECT /* embedded single line */ 'embedded' AS x2;\n"
+                  + "*/\n"
+                  + "SELECT 1"));
     }
   }
 


### PR DESCRIPTION
Tests that block comments embedded in other block comments are parsed correctly by the PostgreSQL parser.