### PR TITLE
fix: PostgreSQL parser should not treat \ as an escape char

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/PostgreSQLStatementParser.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/PostgreSQLStatementParser.java
@@ -226,7 +226,6 @@ public class PostgreSQLStatementParser extends AbstractStatementParser {
       char startQuote,
       String dollarTag,
       @Nullable StringBuilder result) {
-    boolean lastCharWasEscapeChar = false;
     int currentIndex = startIndex + 1;
     while (currentIndex < sql.length()) {
       char currentChar = sql.charAt(currentIndex);
@@ -238,8 +237,6 @@ public class PostgreSQLStatementParser extends AbstractStatementParser {
             appendIfNotNull(result, currentChar, dollarTag, currentChar);
             return currentIndex + tag.length() + 2;
           }
-        } else if (lastCharWasEscapeChar) {
-          lastCharWasEscapeChar = false;
         } else if (sql.length() > currentIndex + 1 && sql.charAt(currentIndex + 1) == startQuote) {
           // This is an escaped quote (e.g. 'foo''bar')
           appendIfNotNull(result, currentChar);
@@ -250,8 +247,6 @@ public class PostgreSQLStatementParser extends AbstractStatementParser {
           appendIfNotNull(result, currentChar);
           return currentIndex + 1;
         }
-      } else {
-        lastCharWasEscapeChar = currentChar == '\\';
       }
       currentIndex++;
       appendIfNotNull(result, currentChar);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementParserTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementParserTest.java
@@ -271,6 +271,25 @@ public class StatementParserTest {
   }
 
   @Test
+  public void testPostgreSQLDialectUnicodeEscapedIdentifiers() {
+    assumeTrue(dialect == Dialect.POSTGRESQL);
+
+    assertEquals("SELECT 'tricky' AS \"\\\"", parser.removeCommentsAndTrim("SELECT 'tricky' AS \"\\\""));
+    assertEquals("SELECT 'tricky' AS U&\"\\\" UESCAPE '!'", parser.removeCommentsAndTrim("SELECT 'tricky' AS U&\"\\\" UESCAPE '!'"));
+    assertEquals("SELECT '\\' AS \"tricky\"", parser.removeCommentsAndTrim("SELECT '\\' AS \"tricky\""));
+    assertEquals("SELECT 'foo''bar'", parser.removeCommentsAndTrim("SELECT 'foo''bar'"));
+    assertEquals("SELECT 'foo\"bar'", parser.removeCommentsAndTrim("SELECT 'foo\"bar'"));
+    assertEquals("SELECT 'foo\"\"bar'", parser.removeCommentsAndTrim("SELECT 'foo\"\"bar'"));
+    assertEquals("SELECT  'foo'", parser.removeCommentsAndTrim("SELECT /* This is a 'comment' */ 'foo'"));
+    assertEquals("SELECT  'foo'", parser.removeCommentsAndTrim("SELECT /* This is a '''comment''' */ 'foo'"));
+    assertEquals("SELECT  '''foo''' FROM bar", parser.removeCommentsAndTrim("SELECT /* This is a '''comment''' */ '''foo''' FROM bar"));
+    assertEquals(
+        "SELECT  '''foo''' FROM \"\"\"\\bar\\\"\"\"",
+        parser.removeCommentsAndTrim(
+            "SELECT /* This is a '''comment''' */ '''foo''' FROM \"\"\"\\bar\\\"\"\""));
+  }
+
+  @Test
   public void testPostgreSQLDialectSupportsEmbeddedComments() {
     assumeTrue(dialect == Dialect.POSTGRESQL);
 
@@ -1109,25 +1128,25 @@ public class StatementParserTest {
                 .sqlWithNamedParameters)
         .isEqualTo("$1'?test?\"?test?\"?'$2");
     assertThat(
-            parser.convertPositionalParametersToNamedParameters('?', "?'?it\\'?s'?")
+            parser.convertPositionalParametersToNamedParameters('?', "?'?it\\''?s'?")
                 .sqlWithNamedParameters)
-        .isEqualTo("$1'?it\\'?s'$2");
+        .isEqualTo("$1'?it\\''?s'$2");
     assertThat(
             parser.convertPositionalParametersToNamedParameters('?', "?'?it\\\"?s'?")
                 .sqlWithNamedParameters)
         .isEqualTo("$1'?it\\\"?s'$2");
     assertThat(
-            parser.convertPositionalParametersToNamedParameters('?', "?\"?it\\\"?s\"?")
+            parser.convertPositionalParametersToNamedParameters('?', "?\"?it\\\"\"?s\"?")
                 .sqlWithNamedParameters)
-        .isEqualTo("$1\"?it\\\"?s\"$2");
+        .isEqualTo("$1\"?it\\\"\"?s\"$2");
     assertThat(
-            parser.convertPositionalParametersToNamedParameters('?', "?'''?it\\'?s'''?")
+            parser.convertPositionalParametersToNamedParameters('?', "?'''?it\\''?s'''?")
                 .sqlWithNamedParameters)
-        .isEqualTo("$1'''?it\\'?s'''$2");
+        .isEqualTo("$1'''?it\\''?s'''$2");
     assertThat(
-            parser.convertPositionalParametersToNamedParameters('?', "?\"\"\"?it\\\"?s\"\"\"?")
+            parser.convertPositionalParametersToNamedParameters('?', "?\"\"\"?it\\\"\"?s\"\"\"?")
                 .sqlWithNamedParameters)
-        .isEqualTo("$1\"\"\"?it\\\"?s\"\"\"$2");
+        .isEqualTo("$1\"\"\"?it\\\"\"?s\"\"\"$2");
 
     assertThat(
             parser.convertPositionalParametersToNamedParameters('?', "?$$?it$?s$$?")
@@ -1144,13 +1163,13 @@ public class StatementParserTest {
 
     // Note: PostgreSQL allows a single-quoted string literal to contain line feeds.
     assertEquals(
-        "$1'?it\\'?s \n ?it\\'?s'$2",
-        parser.convertPositionalParametersToNamedParameters('?', "?'?it\\'?s \n ?it\\'?s'?")
+        "$1'?it\\''?s \n ?it\\''?s'$2",
+        parser.convertPositionalParametersToNamedParameters('?', "?'?it\\''?s \n ?it\\''?s'?")
             .sqlWithNamedParameters);
-    assertUnclosedLiteral("?'?it\\'?s \n ?it\\'?s?");
+    assertUnclosedLiteral("?'?it\\''?s \n ?it\\''?s?");
     assertEquals(
-        "$1'''?it\\'?s \n ?it\\'?s'$2",
-        parser.convertPositionalParametersToNamedParameters('?', "?'''?it\\'?s \n ?it\\'?s'?")
+        "$1'''?it\\''?s \n ?it\\''?s'$2",
+        parser.convertPositionalParametersToNamedParameters('?', "?'''?it\\''?s \n ?it\\''?s'?")
             .sqlWithNamedParameters);
 
     assertThat(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementParserTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementParserTest.java
@@ -274,15 +274,24 @@ public class StatementParserTest {
   public void testPostgreSQLDialectUnicodeEscapedIdentifiers() {
     assumeTrue(dialect == Dialect.POSTGRESQL);
 
-    assertEquals("SELECT 'tricky' AS \"\\\"", parser.removeCommentsAndTrim("SELECT 'tricky' AS \"\\\""));
-    assertEquals("SELECT 'tricky' AS U&\"\\\" UESCAPE '!'", parser.removeCommentsAndTrim("SELECT 'tricky' AS U&\"\\\" UESCAPE '!'"));
-    assertEquals("SELECT '\\' AS \"tricky\"", parser.removeCommentsAndTrim("SELECT '\\' AS \"tricky\""));
+    assertEquals(
+        "SELECT 'tricky' AS \"\\\"", parser.removeCommentsAndTrim("SELECT 'tricky' AS \"\\\""));
+    assertEquals(
+        "SELECT 'tricky' AS U&\"\\\" UESCAPE '!'",
+        parser.removeCommentsAndTrim("SELECT 'tricky' AS U&\"\\\" UESCAPE '!'"));
+    assertEquals(
+        "SELECT '\\' AS \"tricky\"", parser.removeCommentsAndTrim("SELECT '\\' AS \"tricky\""));
     assertEquals("SELECT 'foo''bar'", parser.removeCommentsAndTrim("SELECT 'foo''bar'"));
     assertEquals("SELECT 'foo\"bar'", parser.removeCommentsAndTrim("SELECT 'foo\"bar'"));
     assertEquals("SELECT 'foo\"\"bar'", parser.removeCommentsAndTrim("SELECT 'foo\"\"bar'"));
-    assertEquals("SELECT  'foo'", parser.removeCommentsAndTrim("SELECT /* This is a 'comment' */ 'foo'"));
-    assertEquals("SELECT  'foo'", parser.removeCommentsAndTrim("SELECT /* This is a '''comment''' */ 'foo'"));
-    assertEquals("SELECT  '''foo''' FROM bar", parser.removeCommentsAndTrim("SELECT /* This is a '''comment''' */ '''foo''' FROM bar"));
+    assertEquals(
+        "SELECT  'foo'", parser.removeCommentsAndTrim("SELECT /* This is a 'comment' */ 'foo'"));
+    assertEquals(
+        "SELECT  'foo'",
+        parser.removeCommentsAndTrim("SELECT /* This is a '''comment''' */ 'foo'"));
+    assertEquals(
+        "SELECT  '''foo''' FROM bar",
+        parser.removeCommentsAndTrim("SELECT /* This is a '''comment''' */ '''foo''' FROM bar"));
     assertEquals(
         "SELECT  '''foo''' FROM \"\"\"\\bar\\\"\"\"",
         parser.removeCommentsAndTrim(


### PR DESCRIPTION
The PostgreSQL parser that removes comments and checks the type of
statement should not consider a backslash inside a quoted literal or
identifier as an escape character. Instead, only double occurrences of
the same quotes as the begin/end quote should be considered as an escape
inside a quoted literal or identifier.

Fixes #1920