### PR TITLE
fix: Use the key instead of the value to verify the number of channels created in ChannelUsageTest

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ChannelUsageTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ChannelUsageTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spanner;
 
+import static io.grpc.Grpc.TRANSPORT_ATTR_REMOTE_ADDR;
 import static org.junit.Assert.assertEquals;
 
 import com.google.cloud.NoCredentials;
@@ -134,7 +135,7 @@ public class ChannelUsageTest {
                     Attributes.Key<InetSocketAddress> key =
                         (Attributes.Key<InetSocketAddress>)
                             attributes.keys().stream()
-                                .filter(k -> k.toString().equals("remote-addr"))
+                                .filter(k -> k.equals(TRANSPORT_ATTR_REMOTE_ADDR))
                                 .findFirst()
                                 .orElse(null);
                     if (key != null) {


### PR DESCRIPTION
This is to fix an issue where the test would fail if the value of the key changes in gRPC. See https://github.com/googleapis/java-spanner/pull/1960 for details.
