### PR TITLE
test: increase timeout to prevent flakiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ implementation 'com.google.cloud:google-cloud-spanner'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-spanner:6.27.0'
+implementation 'com.google.cloud:google-cloud-spanner:6.28.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.27.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.28.0"
 ```
 
 ## Authentication

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -1053,10 +1053,10 @@ public class DatabaseClientImplTest {
     mockSpanner.setExecuteSqlExecutionTime(SimulatedExecutionTime.ofMinimumAndRandomTime(10, 0));
     final RetrySettings retrySettings =
         RetrySettings.newBuilder()
-            .setInitialRpcTimeout(Duration.ofMillis(1L))
-            .setMaxRpcTimeout(Duration.ofMillis(1L))
+            .setInitialRpcTimeout(Duration.ofMillis(2L))
+            .setMaxRpcTimeout(Duration.ofMillis(2L))
             .setMaxAttempts(1)
-            .setTotalTimeout(Duration.ofMillis(1L))
+            .setTotalTimeout(Duration.ofMillis(2L))
             .build();
     SpannerOptions.Builder builder =
         SpannerOptions.newBuilder()

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -1053,10 +1053,10 @@ public class DatabaseClientImplTest {
     mockSpanner.setExecuteSqlExecutionTime(SimulatedExecutionTime.ofMinimumAndRandomTime(10, 0));
     final RetrySettings retrySettings =
         RetrySettings.newBuilder()
-            .setInitialRpcTimeout(Duration.ofMillis(2L))
-            .setMaxRpcTimeout(Duration.ofMillis(2L))
+            .setInitialRpcTimeout(Duration.ofMillis(10L))
+            .setMaxRpcTimeout(Duration.ofMillis(10L))
             .setMaxAttempts(1)
-            .setTotalTimeout(Duration.ofMillis(2L))
+            .setTotalTimeout(Duration.ofMillis(10L))
             .build();
     SpannerOptions.Builder builder =
         SpannerOptions.newBuilder()

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -1050,13 +1050,13 @@ public class DatabaseClientImplTest {
 
   @Test
   public void testPartitionedDmlDoesNotTimeout() {
-    mockSpanner.setExecuteSqlExecutionTime(SimulatedExecutionTime.ofMinimumAndRandomTime(10, 0));
+    mockSpanner.setExecuteSqlExecutionTime(SimulatedExecutionTime.ofMinimumAndRandomTime(20, 0));
     final RetrySettings retrySettings =
         RetrySettings.newBuilder()
-            .setInitialRpcTimeout(Duration.ofMillis(10L))
-            .setMaxRpcTimeout(Duration.ofMillis(10L))
+            .setInitialRpcTimeout(Duration.ofMillis(1L))
+            .setMaxRpcTimeout(Duration.ofMillis(1L))
             .setMaxAttempts(1)
-            .setTotalTimeout(Duration.ofMillis(10L))
+            .setTotalTimeout(Duration.ofMillis(1L))
             .build();
     SpannerOptions.Builder builder =
         SpannerOptions.newBuilder()


### PR DESCRIPTION
Increase test timeout to prevent flaky failures on slow build environments.

Fixes #1969 
