### PR TITLE
refactor: Removing duplicate calls to set expiration time

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/slow/ITBackupTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/slow/ITBackupTest.java
@@ -282,7 +282,6 @@ public class ITBackupTest {
             .setDatabase(database.getId())
             .setExpireTime(expireTime)
             .setVersionTime(versionTime)
-            .setExpireTime(expireTime)
             .setEncryptionConfig(EncryptionConfigs.customerManagedEncryption(keyName))
             .build();
     OperationFuture<Backup, CreateBackupMetadata> operation =


### PR DESCRIPTION
Removing redundant calls to set the expiration time of backup. Expiration Time is already set in line 283.
