### PR TITLE
test: skip SpanTest when NoSuchFieldException

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpanTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpanTest.java
@@ -115,7 +115,7 @@ public class SpanTest {
       modifiersField = java.lang.reflect.Field.class.getDeclaredField("modifiers");
     } catch (NoSuchFieldException e) {
       // Halt the test and ignore it.
-      Assume.assumeTrue(false);
+      Assume.assumeFalse(true);
     }
     modifiersField.setAccessible(true);
     // Remove the final modifier from the 'traceComponent' field.

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpanTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpanTest.java
@@ -115,7 +115,9 @@ public class SpanTest {
       modifiersField = java.lang.reflect.Field.class.getDeclaredField("modifiers");
     } catch (NoSuchFieldException e) {
       // Halt the test and ignore it.
-      Assume.assumeFalse(true);
+      Assume.assumeTrue(
+          "Skipping test as reflection is not allowed on reflection class in this JDK build",
+          false);
     }
     modifiersField.setAccessible(true);
     // Remove the final modifier from the 'traceComponent' field.

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpanTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpanTest.java
@@ -110,8 +110,13 @@ public class SpanTest {
     // This is not possible in Java 12 and later.
     java.lang.reflect.Field field = Tracing.class.getDeclaredField("traceComponent");
     field.setAccessible(true);
-    java.lang.reflect.Field modifiersField =
-        java.lang.reflect.Field.class.getDeclaredField("modifiers");
+    java.lang.reflect.Field modifiersField = null;
+    try {
+      modifiersField = java.lang.reflect.Field.class.getDeclaredField("modifiers");
+    } catch (NoSuchFieldException e) {
+      // Halt the test and ignore it.
+      Assume.assumeTrue(false);
+    }
     modifiersField.setAccessible(true);
     // Remove the final modifier from the 'traceComponent' field.
     modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);


### PR DESCRIPTION
Latest internal jdk 11 build throws NoSuchFieldException when we use reflection on a reflection class. Gracefully skipping the test execution in such cases.