### PR TITLE
fix: retry on RST_STREAM internal error

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.2.0')
+implementation platform('com.google.cloud:libraries-bom:26.3.0')
 
 implementation 'com.google.cloud:google-cloud-spanner'
 ```

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/IsRetryableInternalError.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/IsRetryableInternalError.java
@@ -29,6 +29,8 @@ public class IsRetryableInternalError implements Predicate<Throwable> {
   private static final String EOS_ERROR_MESSAGE =
       "Received unexpected EOS on DATA frame from server";
 
+  private static final String RST_STREAM_ERROR_MESSAGE = "stream terminated by RST_STREAM";
+
   @Override
   public boolean apply(Throwable cause) {
     if (isInternalError(cause)) {
@@ -37,6 +39,8 @@ public class IsRetryableInternalError implements Predicate<Throwable> {
       } else if (cause.getMessage().contains(CONNECTION_CLOSED_ERROR_MESSAGE)) {
         return true;
       } else if (cause.getMessage().contains(EOS_ERROR_MESSAGE)) {
+        return true;
+      } else if (cause.getMessage().contains(RST_STREAM_ERROR_MESSAGE)) {
         return true;
       }
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IsRetryableInternalErrorTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IsRetryableInternalErrorTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spanner;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import com.google.api.gax.grpc.GrpcStatusCode;
 import com.google.api.gax.rpc.InternalException;
@@ -123,7 +124,7 @@ public class IsRetryableInternalErrorTest {
             GrpcStatusCode.of(Code.INTERNAL),
             false);
 
-    assertThat(predicate.apply(e)).isTrue();
+    assertTrue(predicate.apply(e));
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IsRetryableInternalErrorTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IsRetryableInternalErrorTest.java
@@ -115,6 +115,18 @@ public class IsRetryableInternalErrorTest {
   }
 
   @Test
+  public void rstStreamInternalExceptionIsRetryable() {
+    final InternalException e =
+        new InternalException(
+            "INTERNAL: stream terminated by RST_STREAM.",
+            null,
+            GrpcStatusCode.of(Code.INTERNAL),
+            false);
+
+    assertThat(predicate.apply(e)).isTrue();
+  }
+
+  @Test
   public void genericInternalExceptionIsNotRetryable() {
     final InternalException e =
         new InternalException("INTERNAL: Generic.", null, GrpcStatusCode.of(Code.INTERNAL), false);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/PartitionedDmlTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/PartitionedDmlTransactionTest.java
@@ -345,6 +345,45 @@ public class PartitionedDmlTransactionTest {
   }
 
   @Test
+  public void testExecuteStreamingPartitionedUpdateRSTstream() {
+    ResultSetStats stats = ResultSetStats.newBuilder().setRowCountLowerBound(1000L).build();
+    PartialResultSet p1 = PartialResultSet.newBuilder().setResumeToken(resumeToken).build();
+    PartialResultSet p2 = PartialResultSet.newBuilder().setStats(stats).build();
+    ServerStream<PartialResultSet> stream1 = mock(ServerStream.class);
+    Iterator<PartialResultSet> iterator = mock(Iterator.class);
+    when(iterator.hasNext()).thenReturn(true, true, false);
+    when(iterator.next())
+        .thenReturn(p1)
+        .thenThrow(
+            new InternalException(
+                "INTERNAL: stream terminated by RST_STREAM.",
+                null,
+                GrpcStatusCode.of(Code.INTERNAL),
+                true));
+    when(stream1.iterator()).thenReturn(iterator);
+    ServerStream<PartialResultSet> stream2 = mock(ServerStream.class);
+    when(stream2.iterator()).thenReturn(ImmutableList.of(p1, p2).iterator());
+    when(rpc.executeStreamingPartitionedDml(
+            Mockito.eq(executeRequestWithoutResumeToken), anyMap(), any(Duration.class)))
+        .thenReturn(stream1);
+    when(rpc.executeStreamingPartitionedDml(
+            Mockito.eq(executeRequestWithResumeToken), anyMap(), any(Duration.class)))
+        .thenReturn(stream2);
+
+    PartitionedDmlTransaction tx = new PartitionedDmlTransaction(session, rpc, ticker);
+    long count = tx.executeStreamingPartitionedUpdate(Statement.of(sql), Duration.ofMinutes(10));
+
+    assertThat(count).isEqualTo(1000L);
+    verify(rpc).beginTransaction(any(BeginTransactionRequest.class), anyMap());
+    verify(rpc)
+        .executeStreamingPartitionedDml(
+            Mockito.eq(executeRequestWithoutResumeToken), anyMap(), any(Duration.class));
+    verify(rpc)
+        .executeStreamingPartitionedDml(
+            Mockito.eq(executeRequestWithResumeToken), anyMap(), any(Duration.class));
+  }
+
+  @Test
   public void testExecuteStreamingPartitionedUpdateGenericInternalException() {
     PartialResultSet p1 = PartialResultSet.newBuilder().setResumeToken(resumeToken).build();
     ServerStream<PartialResultSet> stream1 = mock(ServerStream.class);


### PR DESCRIPTION
The Spanner server can return an internal error closing the connection stream. When this happens an InternalException is thrown with a specific EOS message.

This case need to be retried for all the operations.

- [x] PDML
- [ ] Mutations
- [ ] ReadOnlyTransactions
- [ ] ReadWriteTransactions
