### PR TITLE
chore: skip enforcer check on gRPC dependency (6.4.4-sp branch)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,29 @@
           <showDeprecation>true</showDeprecation>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M3</version>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <configuration>
+              <rules>
+                <requireUpperBoundDeps>
+                  <excludes>
+                    <exclude>io.grpc:grpc-api</exclude>
+                    <exclude>io.grpc:grpc-core</exclude>
+                  </excludes>
+                </requireUpperBoundDeps>
+              </rules>
+            </configuration>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Fixes #2141, where the build failed with the enforcer check:

```
[WARNING] Rule 2: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for io.grpc:grpc-api:1.36.3 paths to dependency are:
+-com.google.cloud:google-cloud-spanner:6.4.4-sp.7
  +-io.grpc:grpc-api:1.36.3
and
+-com.google.cloud:google-cloud-spanner:6.4.4-sp.7
  +-io.grpc:grpc-auth:1.36.3
    +-io.grpc:grpc-api:1.36.3
and
+-com.google.cloud:google-cloud-spanner:6.4.4-sp.7
  +-io.grpc:grpc-core:1.36.3
    +-io.grpc:grpc-api:1.36.3
and
+-com.google.cloud:google-cloud-spanner:6.4.4-sp.7
  +-io.grpc:grpc-protobuf:1.36.3
    +-io.grpc:grpc-api:1.36.3
...
```
