### PR TITLE
feat: analyze update returns param types

### DIFF
--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -202,4 +202,19 @@
     <className>com/google/cloud/spanner/DatabaseClient</className>
     <method>java.lang.String getDatabaseRole()</method>
   </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/ResultSet</className>
+    <method>com.google.spanner.v1.ResultSetMetadata getMetadata()</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/TransactionContext</className>
+    <method>com.google.cloud.spanner.ResultSet analyzeUpdateStatement(com.google.cloud.spanner.Statement, com.google.cloud.spanner.ReadContext$QueryAnalyzeMode, com.google.cloud.spanner.Options$UpdateOption[])</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/connection/Connection</className>
+    <method>com.google.cloud.spanner.ResultSet analyzeUpdateStatement(com.google.cloud.spanner.Statement, com.google.cloud.spanner.ReadContext$QueryAnalyzeMode, com.google.cloud.spanner.Options$UpdateOption[])</method>
+  </difference>
 </differences>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
@@ -93,6 +93,7 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
   static class GrpcResultSet extends AbstractResultSet<List<Object>> {
     private final GrpcValueIterator iterator;
     private final Listener listener;
+    private ResultSetMetadata metadata;
     private GrpcStruct currRow;
     private SpannerException error;
     private ResultSetStats statistics;
@@ -117,7 +118,7 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
       }
       try {
         if (currRow == null) {
-          ResultSetMetadata metadata = iterator.getMetadata();
+          metadata = iterator.getMetadata();
           if (metadata.hasTransaction()) {
             listener.onTransactionMetadata(
                 metadata.getTransaction(), iterator.isWithBeginTransaction());
@@ -144,6 +145,12 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
     @Nullable
     public ResultSetStats getStats() {
       return statistics;
+    }
+
+    @Override
+    public ResultSetMetadata getMetadata() {
+      checkState(metadata != null, "next() call required");
+      return metadata;
     }
 
     @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
@@ -29,6 +29,7 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.spanner.v1.ResultSetMetadata;
 import com.google.spanner.v1.ResultSetStats;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -570,6 +571,11 @@ class AsyncResultSetImpl extends ForwardingStructReader implements ListenableAsy
   @Override
   public ResultSetStats getStats() {
     return delegateResultSet.get().getStats();
+  }
+
+  @Override
+  public ResultSetMetadata getMetadata() {
+    return delegateResultSet.get().getMetadata();
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ForwardingResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ForwardingResultSet.java
@@ -19,6 +19,7 @@ package com.google.cloud.spanner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.spanner.v1.ResultSetMetadata;
 import com.google.spanner.v1.ResultSetStats;
 
 /** Forwarding implementation of ResultSet that forwards all calls to a delegate. */
@@ -75,5 +76,10 @@ public class ForwardingResultSet extends ForwardingStructReader implements Resul
   @Override
   public ResultSetStats getStats() {
     return delegate.get().getStats();
+  }
+
+  @Override
+  public ResultSetMetadata getMetadata() {
+    return delegate.get().getMetadata();
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/NoRowsResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/NoRowsResultSet.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+import com.google.spanner.v1.ResultSet;
+import com.google.spanner.v1.ResultSetMetadata;
+import com.google.spanner.v1.ResultSetStats;
+import java.util.List;
+import javax.annotation.Nullable;
+
+class NoRowsResultSet extends AbstractResultSet<List<Object>> {
+  private final ResultSetStats stats;
+  private final ResultSetMetadata metadata;
+
+  NoRowsResultSet(ResultSet resultSet) {
+    this.stats = resultSet.getStats();
+    this.metadata = resultSet.getMetadata();
+  }
+
+  @Override
+  protected GrpcStruct currRow() {
+    throw SpannerExceptionFactory.newSpannerException(
+        ErrorCode.FAILED_PRECONDITION, "This result set has no rows");
+  }
+
+  @Override
+  public boolean next() throws SpannerException {
+    return false;
+  }
+
+  @Override
+  public void close() {}
+
+  @Nullable
+  @Override
+  public ResultSetStats getStats() {
+    return stats;
+  }
+
+  @Override
+  public ResultSetMetadata getMetadata() {
+    return metadata;
+  }
+
+  @Override
+  public Type getType() {
+    return Type.struct();
+  }
+}

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ResultSet.java
@@ -79,7 +79,5 @@ public interface ResultSet extends AutoCloseable, StructReader {
    * Returns the {@link ResultSetMetadata} for this {@link ResultSet}. This is method may only be
    * called after calling {@link ResultSet#next()} at least once.
    */
-  default ResultSetMetadata getMetadata() {
-    throw new UnsupportedOperationException();
-  }
+  ResultSetMetadata getMetadata();
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ResultSet.java
@@ -79,5 +79,7 @@ public interface ResultSet extends AutoCloseable, StructReader {
    * Returns the {@link ResultSetMetadata} for this {@link ResultSet}. This is method may only be
    * called after calling {@link ResultSet#next()} at least once.
    */
-  ResultSetMetadata getMetadata();
+  default ResultSetMetadata getMetadata() {
+    throw new UnsupportedOperationException("Method should be overridden");
+  }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ResultSet.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spanner;
 
 import com.google.cloud.spanner.Options.QueryOption;
+import com.google.spanner.v1.ResultSetMetadata;
 import com.google.spanner.v1.ResultSetStats;
 import javax.annotation.Nullable;
 
@@ -73,4 +74,12 @@ public interface ResultSet extends AutoCloseable, StructReader {
    */
   @Nullable
   ResultSetStats getStats();
+
+  /**
+   * Returns the {@link ResultSetMetadata} for this {@link ResultSet}. This is method may only be
+   * called after calling {@link ResultSet#next()} at least once.
+   */
+  default ResultSetMetadata getMetadata() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ResultSets.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ResultSets.java
@@ -29,6 +29,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.spanner.v1.ResultSetMetadata;
 import com.google.spanner.v1.ResultSetStats;
 import java.math.BigDecimal;
 import java.util.List;
@@ -156,6 +157,11 @@ public final class ResultSets {
     public ResultSetStats getStats() {
       throw new UnsupportedOperationException(
           "ResultSetStats are available only for results returned from analyzeQuery() calls");
+    }
+
+    @Override
+    public ResultSetMetadata getMetadata() {
+      throw new UnsupportedOperationException();
     }
 
     @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ResultSets.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ResultSets.java
@@ -161,7 +161,8 @@ public final class ResultSets {
 
     @Override
     public ResultSetMetadata getMetadata() {
-      throw new UnsupportedOperationException();
+      throw new UnsupportedOperationException(
+          "ResultSetMetadata are available only for results that were returned from Cloud Spanner");
     }
 
     @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -717,18 +717,14 @@ class SessionPool {
     @Override
     public ResultSetStats analyzeUpdate(
         Statement statement, QueryAnalyzeMode analyzeMode, UpdateOption... options) {
-      try {
-        return delegate.analyzeUpdate(statement, analyzeMode, options);
-      } catch (SessionNotFoundException e) {
-        throw handler.handleSessionNotFound(e);
-      }
+      return analyzeUpdateStatement(statement, analyzeMode, options).getStats();
     }
 
     @Override
-    public com.google.spanner.v1.ResultSet analyzeStatement(
-        Statement statement, UpdateOption... options) {
+    public ResultSet analyzeUpdateStatement(
+        Statement statement, QueryAnalyzeMode analyzeMode, UpdateOption... options) {
       try {
-        return delegate.analyzeStatement(statement, options);
+        return delegate.analyzeUpdateStatement(statement, analyzeMode, options);
       } catch (SessionNotFoundException e) {
         throw handler.handleSessionNotFound(e);
       }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -725,6 +725,16 @@ class SessionPool {
     }
 
     @Override
+    public com.google.spanner.v1.ResultSet analyzeStatement(
+        Statement statement, UpdateOption... options) {
+      try {
+        return delegate.analyzeStatement(statement, options);
+      } catch (SessionNotFoundException e) {
+        throw handler.handleSessionNotFound(e);
+      }
+    }
+
+    @Override
     public long executeUpdate(Statement statement, UpdateOption... options) {
       try {
         return delegate.executeUpdate(statement, options);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContext.java
@@ -18,7 +18,6 @@ package com.google.cloud.spanner;
 
 import com.google.api.core.ApiFuture;
 import com.google.cloud.spanner.Options.UpdateOption;
-import com.google.spanner.v1.ResultSet;
 import com.google.spanner.v1.ResultSetStats;
 
 /**
@@ -135,16 +134,28 @@ public interface TransactionContext extends ReadContext {
    * the statement. {@link com.google.cloud.spanner.ReadContext.QueryAnalyzeMode#PROFILE} executes
    * the DML statement, returns the modified row count and execution statistics, and the effects of
    * the DML statement will be visible to subsequent operations in the transaction.
+   *
+   * @deprecated Use {@link #analyzeUpdateStatement(Statement, QueryAnalyzeMode, UpdateOption...)}
+   *     instead to get both statement plan and parameter metadata
    */
+  @Deprecated
   default ResultSetStats analyzeUpdate(
       Statement statement, QueryAnalyzeMode analyzeMode, UpdateOption... options) {
     throw new UnsupportedOperationException("method should be overwritten");
   }
 
-  /** Analyzes a SQL statement and returns the execution plan, metadata and the names and types of the parameters in the SQL statement. The statement may be a query or DML statement. */
-  default ResultSet analyzeStatement(Statement statement, UpdateOption... options) {
-    throw new UnsupportedOperationException("method should be overwritten");
-  }
+  /**
+   * Analyzes a DML statement and returns query plan and statement parameter metadata and optionally
+   * execution statistics information.
+   *
+   * <p>{@link com.google.cloud.spanner.ReadContext.QueryAnalyzeMode#PLAN} only returns the plan and
+   * parameter metadata for the statement. {@link
+   * com.google.cloud.spanner.ReadContext.QueryAnalyzeMode#PROFILE} executes the DML statement,
+   * returns the modified row count and execution statistics, and the effects of the DML statement
+   * will be visible to subsequent operations in the transaction.
+   */
+  ResultSet analyzeUpdateStatement(
+      Statement statement, QueryAnalyzeMode analyzeMode, UpdateOption... options);
 
   /**
    * Executes a list of DML statements in a single request. The statements will be executed in order

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContext.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner;
 
 import com.google.api.core.ApiFuture;
 import com.google.cloud.spanner.Options.UpdateOption;
+import com.google.spanner.v1.ResultSet;
 import com.google.spanner.v1.ResultSetStats;
 
 /**
@@ -137,6 +138,11 @@ public interface TransactionContext extends ReadContext {
    */
   default ResultSetStats analyzeUpdate(
       Statement statement, QueryAnalyzeMode analyzeMode, UpdateOption... options) {
+    throw new UnsupportedOperationException("method should be overwritten");
+  }
+
+  /** Analyzes a SQL statement and returns the execution plan, metadata and the names and types of the parameters in the SQL statement. The statement may be a query or DML statement. */
+  default ResultSet analyzeStatement(Statement statement, UpdateOption... options) {
     throw new UnsupportedOperationException("method should be overwritten");
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
@@ -29,6 +29,7 @@ import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Options.QueryOption;
 import com.google.cloud.spanner.Options.RpcPriority;
+import com.google.cloud.spanner.Options.UpdateOption;
 import com.google.cloud.spanner.ReadContext.QueryAnalyzeMode;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerBatchUpdateException;
@@ -968,6 +969,11 @@ public interface Connection extends AutoCloseable {
    * the DML statement will be visible to subsequent operations in the transaction.
    */
   default ResultSetStats analyzeUpdate(Statement update, QueryAnalyzeMode analyzeMode) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  /** Analyzes a SQL statement and returns the query plan, metadata and parameter info. */
+  default com.google.spanner.v1.ResultSet analyzeStatement(Statement statement, UpdateOption... options) {
     throw new UnsupportedOperationException("Not implemented");
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
@@ -971,6 +971,7 @@ public interface Connection extends AutoCloseable {
    * the DML statement will be visible to subsequent operations in the transaction.
    *
    * @deprecated Use {@link #analyzeUpdateStatement(Statement, QueryAnalyzeMode, UpdateOption...)}
+   *     instead
    */
   @Deprecated
   default ResultSetStats analyzeUpdate(Statement update, QueryAnalyzeMode analyzeMode) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
@@ -967,15 +967,26 @@ public interface Connection extends AutoCloseable {
    * the statement. {@link com.google.cloud.spanner.ReadContext.QueryAnalyzeMode#PROFILE} executes
    * the DML statement, returns the modified row count and execution statistics, and the effects of
    * the DML statement will be visible to subsequent operations in the transaction.
+   *
+   * @deprecated Use {@link #analyzeUpdateStatement(Statement, QueryAnalyzeMode, UpdateOption...)}
    */
+  @Deprecated
   default ResultSetStats analyzeUpdate(Statement update, QueryAnalyzeMode analyzeMode) {
     throw new UnsupportedOperationException("Not implemented");
   }
 
-  /** Analyzes a SQL statement and returns the query plan, metadata and parameter info. */
-  default com.google.spanner.v1.ResultSet analyzeStatement(Statement statement, UpdateOption... options) {
-    throw new UnsupportedOperationException("Not implemented");
-  }
+  /**
+   * Analyzes a DML statement and returns execution plan, undeclared parameters and optionally
+   * execution statistics information.
+   *
+   * <p>{@link com.google.cloud.spanner.ReadContext.QueryAnalyzeMode#PLAN} only returns the plan and
+   * undeclared parameters for the statement. {@link
+   * com.google.cloud.spanner.ReadContext.QueryAnalyzeMode#PROFILE} also executes the DML statement,
+   * returns the modified row count and execution statistics, and the effects of the DML statement
+   * will be visible to subsequent operations in the transaction.
+   */
+  ResultSet analyzeUpdateStatement(
+      Statement statement, QueryAnalyzeMode analyzeMode, UpdateOption... options);
 
   /**
    * Executes the given statement asynchronously as a DML statement. If the statement does not

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
@@ -985,8 +985,10 @@ public interface Connection extends AutoCloseable {
    * returns the modified row count and execution statistics, and the effects of the DML statement
    * will be visible to subsequent operations in the transaction.
    */
-  ResultSet analyzeUpdateStatement(
-      Statement statement, QueryAnalyzeMode analyzeMode, UpdateOption... options);
+  default ResultSet analyzeUpdateStatement(
+      Statement statement, QueryAnalyzeMode analyzeMode, UpdateOption... options) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
 
   /**
    * Executes the given statement asynchronously as a DML statement. If the statement does not

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
@@ -1016,7 +1016,7 @@ class ConnectionImpl implements Connection {
     if (parsedStatement.isUpdate()) {
       switch (parsedStatement.getType()) {
         case UPDATE:
-          return get(internalAnalyzeUpdateAsync(parsedStatement, AnalyzeMode.of(analyzeMode)));
+          return get(internalAnalyzeUpdateAsync(parsedStatement, AnalyzeMode.of(analyzeMode))).getStats();
         case CLIENT_SIDE:
         case QUERY:
         case DDL:
@@ -1027,6 +1027,25 @@ class ConnectionImpl implements Connection {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.INVALID_ARGUMENT,
         "Statement is not an update statement: " + parsedStatement.getSqlWithoutComments());
+  }
+
+  @Override
+  public com.google.spanner.v1.ResultSet analyzeStatement(Statement statement, UpdateOption... options) {
+    Preconditions.checkNotNull(statement);
+    ConnectionPreconditions.checkState(!isClosed(), CLOSED_ERROR_MSG);
+    ParsedStatement parsedStatement = getStatementParser().parse(statement);
+    switch (parsedStatement.getType()) {
+      case UPDATE:
+      case QUERY:
+        return get(internalAnalyzeUpdateAsync(parsedStatement, AnalyzeMode.PLAN, options));
+      case CLIENT_SIDE:
+      case DDL:
+      case UNKNOWN:
+      default:
+    }
+    throw SpannerExceptionFactory.newSpannerException(
+        ErrorCode.INVALID_ARGUMENT,
+        "Statement is not a query or an update statement: " + parsedStatement.getSqlWithoutComments());
   }
 
   @Override
@@ -1172,10 +1191,19 @@ class ConnectionImpl implements Connection {
         update, mergeUpdateRequestOptions(mergeUpdateStatementTag(options)));
   }
 
-  private ApiFuture<ResultSetStats> internalAnalyzeUpdateAsync(
+  private ApiFuture<com.google.spanner.v1.ResultSet> internalAnalyzeUpdateAsync(
       final ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options) {
     Preconditions.checkArgument(
         update.getType() == StatementType.UPDATE, "Statement must be an update");
+    UnitOfWork transaction = getCurrentUnitOfWorkOrStartNewUnitOfWork();
+    return transaction.analyzeUpdateAsync(
+        update, analyzeMode, mergeUpdateRequestOptions(mergeUpdateStatementTag(options)));
+  }
+
+  private ApiFuture<com.google.spanner.v1.ResultSet> internalAnalyzeStatementAsync(
+      final ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options) {
+    Preconditions.checkArgument(
+        update.getType() == StatementType.UPDATE || update.getType() == StatementType.QUERY, "Statement must be a query or an update");
     UnitOfWork transaction = getCurrentUnitOfWorkOrStartNewUnitOfWork();
     return transaction.analyzeUpdateAsync(
         update, analyzeMode, mergeUpdateRequestOptions(mergeUpdateStatementTag(options)));

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DdlBatch.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DdlBatch.java
@@ -203,7 +203,7 @@ class DdlBatch extends AbstractBaseUnitOfWork {
   }
 
   @Override
-  public ApiFuture<ResultSetStats> analyzeUpdateAsync(
+  public ApiFuture<com.google.spanner.v1.ResultSet> analyzeUpdateAsync(
       ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Analyzing updates is not allowed for DDL batches.");

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DdlBatch.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DdlBatch.java
@@ -38,7 +38,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.spanner.admin.database.v1.DatabaseAdminGrpc;
 import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
-import com.google.spanner.v1.ResultSetStats;
 import com.google.spanner.v1.SpannerGrpc;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -203,7 +202,7 @@ class DdlBatch extends AbstractBaseUnitOfWork {
   }
 
   @Override
-  public ApiFuture<com.google.spanner.v1.ResultSet> analyzeUpdateAsync(
+  public ApiFuture<ResultSet> analyzeUpdateAsync(
       ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Analyzing updates is not allowed for DDL batches.");

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DirectExecuteResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DirectExecuteResultSet.java
@@ -25,6 +25,7 @@ import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Value;
 import com.google.common.base.Preconditions;
+import com.google.spanner.v1.ResultSetMetadata;
 import com.google.spanner.v1.ResultSetStats;
 import java.math.BigDecimal;
 import java.util.List;
@@ -92,6 +93,11 @@ class DirectExecuteResultSet implements ResultSet {
       return delegate.getStats();
     }
     return null;
+  }
+
+  @Override
+  public ResultSetMetadata getMetadata() {
+    return delegate.getMetadata();
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DmlBatch.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DmlBatch.java
@@ -33,7 +33,6 @@ import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStateme
 import com.google.cloud.spanner.connection.AbstractStatementParser.StatementType;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.spanner.v1.ResultSetStats;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -163,7 +162,7 @@ class DmlBatch extends AbstractBaseUnitOfWork {
   }
 
   @Override
-  public ApiFuture<com.google.spanner.v1.ResultSet> analyzeUpdateAsync(
+  public ApiFuture<ResultSet> analyzeUpdateAsync(
       ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Analyzing updates is not allowed for DML batches.");

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DmlBatch.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DmlBatch.java
@@ -163,7 +163,7 @@ class DmlBatch extends AbstractBaseUnitOfWork {
   }
 
   @Override
-  public ApiFuture<ResultSetStats> analyzeUpdateAsync(
+  public ApiFuture<com.google.spanner.v1.ResultSet> analyzeUpdateAsync(
       ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Analyzing updates is not allowed for DML batches.");

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ReadOnlyTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ReadOnlyTransaction.java
@@ -30,6 +30,7 @@ import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStatement;
 import com.google.common.base.Preconditions;
+import com.google.spanner.v1.ResultSet;
 import com.google.spanner.v1.ResultSetStats;
 
 /**
@@ -165,7 +166,7 @@ class ReadOnlyTransaction extends AbstractMultiUseTransaction {
   }
 
   @Override
-  public ApiFuture<ResultSetStats> analyzeUpdateAsync(
+  public ApiFuture<ResultSet> analyzeUpdateAsync(
       ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION,

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ReadOnlyTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ReadOnlyTransaction.java
@@ -25,13 +25,12 @@ import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Options.UpdateOption;
 import com.google.cloud.spanner.ReadContext;
+import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStatement;
 import com.google.common.base.Preconditions;
-import com.google.spanner.v1.ResultSet;
-import com.google.spanner.v1.ResultSetStats;
 
 /**
  * Transaction that is used when a {@link Connection} is in read-only mode or when the transaction

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ReplaceableForwardingResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ReplaceableForwardingResultSet.java
@@ -27,6 +27,7 @@ import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Value;
 import com.google.common.base.Preconditions;
+import com.google.spanner.v1.ResultSetMetadata;
 import com.google.spanner.v1.ResultSetStats;
 import java.math.BigDecimal;
 import java.util.List;
@@ -92,6 +93,11 @@ class ReplaceableForwardingResultSet implements ResultSet {
   public ResultSetStats getStats() {
     checkClosed();
     return delegate.getStats();
+  }
+
+  @Override
+  public ResultSetMetadata getMetadata() {
+    return delegate.getMetadata();
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/UnitOfWork.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/UnitOfWork.java
@@ -178,21 +178,16 @@ interface UnitOfWork {
   ApiFuture<Long> executeUpdateAsync(ParsedStatement update, UpdateOption... options);
 
   /**
-   * Execute a DML statement on Spanner.
+   * Execute and/or analyze a DML statement on Spanner.
    *
-   * @param update The DML statement to execute.
+   * @param update The DML statement to analyze/execute.
    * @param analyzeMode Specifies the query/analyze mode to use for the DML statement.
    * @param options Update options to apply for the statement.
-   * @return an {@link ApiFuture} containing the {@link ResultSetStats} that were returned by this
-   *     statement.
+   * @return an {@link ApiFuture} containing the {@link ResultSet} that were returned by this
+   *     statement. The {@link ResultSet} will not contain any rows.
    */
-  ApiFuture<com.google.spanner.v1.ResultSet> analyzeUpdateAsync(
+  ApiFuture<ResultSet> analyzeUpdateAsync(
       ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options);
-
-  /**
-   * Analyze a statement in PLAN mode on Spanner. The statement may be either a query or a DML statement.
-   */
-  ApiFuture<ResultSet> analyzeStatementAsync(ParsedStatement statement, UpdateOption... options);
 
   /**
    * Execute a batch of DML statements on Spanner.

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/UnitOfWork.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/UnitOfWork.java
@@ -186,8 +186,13 @@ interface UnitOfWork {
    * @return an {@link ApiFuture} containing the {@link ResultSetStats} that were returned by this
    *     statement.
    */
-  ApiFuture<ResultSetStats> analyzeUpdateAsync(
+  ApiFuture<com.google.spanner.v1.ResultSet> analyzeUpdateAsync(
       ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options);
+
+  /**
+   * Analyze a statement in PLAN mode on Spanner. The statement may be either a query or a DML statement.
+   */
+  ApiFuture<ResultSet> analyzeStatementAsync(ParsedStatement statement, UpdateOption... options);
 
   /**
    * Execute a batch of DML statements on Spanner.

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -24,6 +24,7 @@ import static com.google.cloud.spanner.MockSpannerTestUtil.SELECT1;
 import static com.google.cloud.spanner.SpannerApiFutures.get;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -61,6 +62,12 @@ import com.google.spanner.v1.ExecuteSqlRequest.QueryMode;
 import com.google.spanner.v1.ExecuteSqlRequest.QueryOptions;
 import com.google.spanner.v1.ReadRequest;
 import com.google.spanner.v1.RequestOptions.Priority;
+import com.google.spanner.v1.ResultSetMetadata;
+import com.google.spanner.v1.ResultSetStats;
+import com.google.spanner.v1.StructType;
+import com.google.spanner.v1.StructType.Field;
+import com.google.spanner.v1.Type;
+import com.google.spanner.v1.TypeCode;
 import io.grpc.Context;
 import io.grpc.Server;
 import io.grpc.Status;
@@ -2326,5 +2333,52 @@ public class DatabaseClientImplTest {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
     assertEquals(TEST_DATABASE_ROLE, client.getDatabaseRole());
+  }
+
+  @Test
+  public void testAnalyzeUpdateStatement() {
+    String sql = "update foo set bar=1 where baz=@param";
+    mockSpanner.putStatementResult(
+        StatementResult.query(
+            Statement.of(sql),
+            com.google.spanner.v1.ResultSet.newBuilder()
+                .setMetadata(
+                    ResultSetMetadata.newBuilder()
+                        .setUndeclaredParameters(
+                            StructType.newBuilder()
+                                .addFields(
+                                    Field.newBuilder()
+                                        .setName("param")
+                                        .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                                        .build())
+                                .build())
+                        .build())
+                .setStats(ResultSetStats.newBuilder().setRowCountExact(0L).build())
+                .build()));
+    DatabaseClient client =
+        spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+    client
+        .readWriteTransaction()
+        .run(
+            transaction -> {
+              try (ResultSet resultSet =
+                  transaction.analyzeUpdateStatement(Statement.of(sql), QueryAnalyzeMode.PLAN)) {
+                assertFalse(resultSet.next());
+                assertNotNull(resultSet.getStats());
+                assertEquals(0L, resultSet.getStats().getRowCountExact());
+                assertNotNull(resultSet.getMetadata());
+                assertEquals(1, resultSet.getMetadata().getUndeclaredParameters().getFieldsCount());
+                assertEquals(
+                    "param",
+                    resultSet.getMetadata().getUndeclaredParameters().getFields(0).getName());
+                assertEquals(
+                    Type.newBuilder().setCode(TypeCode.STRING).build(),
+                    resultSet.getMetadata().getUndeclaredParameters().getFields(0).getType());
+              }
+              return null;
+            });
+    assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    ExecuteSqlRequest request = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(0);
+    assertEquals(QueryMode.PLAN, request.getQueryMode());
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionContextTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionContextTest.java
@@ -112,6 +112,12 @@ public class TransactionContextTest {
           }
 
           @Override
+          public ResultSet analyzeUpdateStatement(
+              Statement statement, QueryAnalyzeMode analyzeMode, UpdateOption... options) {
+            return null;
+          }
+
+          @Override
           public long executeUpdate(Statement statement, UpdateOption... options) {
             return 0;
           }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DirectExecuteResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DirectExecuteResultSetTest.java
@@ -55,6 +55,7 @@ public class DirectExecuteResultSetTest {
     List<String> excludedMethods =
         Arrays.asList(
             "getStats",
+            "getMetadata",
             "next",
             "close",
             "ofResultSet",
@@ -74,6 +75,7 @@ public class DirectExecuteResultSetTest {
     List<String> excludedMethods =
         Arrays.asList(
             "getStats",
+            "getMetadata",
             "next",
             "close",
             "getType",
@@ -95,6 +97,7 @@ public class DirectExecuteResultSetTest {
     List<String> excludedMethods =
         Arrays.asList(
             "getStats",
+            "getMetadata",
             "next",
             "close",
             "getType",

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ReplaceableForwardingResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ReplaceableForwardingResultSetTest.java
@@ -98,7 +98,8 @@ public class ReplaceableForwardingResultSetTest {
   @Test
   public void testMethodCallBeforeNext()
       throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-    List<String> excludedMethods = Arrays.asList("getStats", "next", "close", "equals", "hashCode");
+    List<String> excludedMethods =
+        Arrays.asList("getStats", "getMetadata", "next", "close", "equals", "hashCode");
     ReplaceableForwardingResultSet subject = createSubject();
     // Test that all methods throw an IllegalStateException except the excluded methods when called
     // before a call to ResultSet#next().
@@ -111,6 +112,7 @@ public class ReplaceableForwardingResultSetTest {
     List<String> excludedMethods =
         Arrays.asList(
             "getStats",
+            "getMetadata",
             "next",
             "close",
             "getType",
@@ -134,6 +136,7 @@ public class ReplaceableForwardingResultSetTest {
     List<String> excludedMethods =
         Arrays.asList(
             "getStats",
+            "getMetadata",
             "next",
             "close",
             "getType",


### PR DESCRIPTION
Add the method analyzeUpdateStatement that returns the undeclared
parameters in an update statement. This allows connection based APIs
to return more metadata for a statement than is currently possible:
1. JDBC should return the parameter data types when PreparedStatement#getMetaData()
   is called.
2. PGAdapter should return the parameter types when a DescribeStatement
   message is received.