### PR TITLE
chore: make Partition class getters public

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ implementation 'com.google.cloud:google-cloud-spanner'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-spanner:6.33.0'
+implementation 'com.google.cloud:google-cloud-spanner:6.34.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.33.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.34.0"
 ```
 
 ## Authentication

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Partition.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Partition.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.spanner;
 
-import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import java.io.Serializable;
 import java.util.Objects;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Partition.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Partition.java
@@ -92,39 +92,39 @@ public class Partition implements Serializable {
     return new Partition(partitionToken, partitionOptions, statement, queryOption);
   }
 
-  ByteString getPartitionToken() {
+  public ByteString getPartitionToken() {
     return partitionToken;
   }
 
-  String getTable() {
+  public String getTable() {
     return table;
   }
 
-  KeySet getKeys() {
+  public KeySet getKeys() {
     return keys;
   }
 
-  Iterable<String> getColumns() {
+  public Iterable<String> getColumns() {
     return columns;
   }
 
-  String getIndex() {
+  public String getIndex() {
     return index;
   }
 
-  Options getReadOptions() {
+  public Options getReadOptions() {
     return readOptions;
   }
 
-  Statement getStatement() {
+  public Statement getStatement() {
     return statement;
   }
 
-  Options getQueryOptions() {
+  public Options getQueryOptions() {
     return queryOptions;
   }
 
-  PartitionOptions getPartitionOptions() {
+  public PartitionOptions getPartitionOptions() {
     return partitionOptions;
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Partition.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Partition.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner;
 
 import com.google.protobuf.ByteString;
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Objects;
 
 /**
@@ -105,7 +106,7 @@ public class Partition implements Serializable {
   }
 
   public Iterable<String> getColumns() {
-    return columns;
+    return Collections.unmodifiableList(columns);
   }
 
   public String getIndex() {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Partition.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Partition.java
@@ -16,9 +16,9 @@
 
 package com.google.cloud.spanner;
 
+import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.Objects;
 
 /**
@@ -106,7 +106,7 @@ public class Partition implements Serializable {
   }
 
   public Iterable<String> getColumns() {
-    return Collections.unmodifiableList(columns);
+    return ImmutableList.copyOf(columns);
   }
 
   public String getIndex() {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Partition.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Partition.java
@@ -97,35 +97,35 @@ public class Partition implements Serializable {
     return partitionToken;
   }
 
-  public String getTable() {
+  String getTable() {
     return table;
   }
 
-  public KeySet getKeys() {
+  KeySet getKeys() {
     return keys;
   }
 
-  public Iterable<String> getColumns() {
-    return ImmutableList.copyOf(columns);
+  Iterable<String> getColumns() {
+    return columns;
   }
 
-  public String getIndex() {
+  String getIndex() {
     return index;
   }
 
-  public Options getReadOptions() {
+  Options getReadOptions() {
     return readOptions;
   }
 
-  public Statement getStatement() {
+  Statement getStatement() {
     return statement;
   }
 
-  public Options getQueryOptions() {
+  Options getQueryOptions() {
     return queryOptions;
   }
 
-  public PartitionOptions getPartitionOptions() {
+  PartitionOptions getPartitionOptions() {
     return partitionOptions;
   }
 


### PR DESCRIPTION
Make getters in Partition class public so that they can be accessed outside com.google.cloud.spanner package.
