### PR TITLE
chore: ensure that java8 is used to run tests in kokoro windows job

### DIFF
--- a/.kokoro/build.bat
+++ b/.kokoro/build.bat
@@ -15,6 +15,7 @@
 :: downstream client libraries before they are released.
 :: See documentation in type-shell-output.bat
 
+set JAVA8_HOME=%JAVA_HOME:"=%
 choco install -y openjdk11
 set JAVA11_HOME=C:\Program Files\Eclipse Adoptium\jdk-11.0.17.8-hotspot\
 


### PR DESCRIPTION
Follow-up to #2207 