### PR TITLE
Configured jitpack.yml to use OpenJDK 11

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
Adding Jitpack Configuration file, it's required for Verily to start prototyping on Java Client