### PR TITLE
feat: support parallel queries in Connection API

### DIFF
--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -222,4 +222,10 @@
     <className>com/google/cloud/spanner/connection/Connection</className>
     <method>com.google.cloud.spanner.ResultSet analyzeUpdateStatement(com.google.cloud.spanner.Statement, com.google.cloud.spanner.ReadContext$QueryAnalyzeMode, com.google.cloud.spanner.Options$UpdateOption[])</method>
   </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/connection/Connection</className>
+    <method>com.google.cloud.spanner.AsyncResultSet executeParallelQueryAsync(com.google.cloud.spanner.Statement, com.google.cloud.spanner.Options$QueryOption[])</method>
+  </difference>
+
 </differences>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractMultiUseTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractMultiUseTransaction.java
@@ -71,7 +71,8 @@ abstract class AbstractMultiUseTransaction extends AbstractBaseUnitOfWork {
           return DirectExecuteResultSet.ofResultSet(
               internalExecuteQuery(statement, analyzeMode, options));
         },
-        SpannerGrpc.getExecuteStreamingSqlMethod());
+        SpannerGrpc.getExecuteStreamingSqlMethod(),
+        getExecutionMode(options));
   }
 
   ResultSet internalExecuteQuery(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
@@ -926,6 +926,37 @@ public interface Connection extends AutoCloseable {
   AsyncResultSet executeQueryAsync(Statement query, QueryOption... options);
 
   /**
+   * Executes the given query asynchronously and potentially in parallel with other queries that are
+   * also executed this method and returns the result as an {@link AsyncResultSet}. This method is
+   * guaranteed to be non-blocking. If the statement does not contain a valid query, the method will
+   * throw a {@link SpannerException}. Note that this method may not be called for a DML statement.
+   *
+   * <p>See {@link AsyncResultSet#setCallback(java.util.concurrent.Executor,
+   * com.google.cloud.spanner.AsyncResultSet.ReadyCallback)} for more information on how to consume
+   * the results of the statement asynchronously.
+   *
+   * <p>It is also possible to consume the returned {@link AsyncResultSet} in the same way as a
+   * normal {@link ResultSet}, i.e. in a while-loop calling {@link AsyncResultSet#next()}.
+   *
+   * <p>NOTE: Executing parallel queries in a read/write transaction has a couple of limitations:
+   *
+   * <ol>
+   *   <li>The first query in a transaction will never execute in parallel with any other query, as
+   *       it is responsible for actually starting the transaction.
+   *   <li>Executing a parallel query in read/write transaction disables the automatic retry of the
+   *       transaction if the transaction is aborted by Cloud Spanner. Instead, the {@link
+   *       AbortedException} will be propagated and the application is responsible for retrying the
+   *       transaction. This is effectively the same as calling {@link
+   *       #setRetryAbortsInternally(boolean)} with <code>false</code> before executing the query.
+   * </ol>
+   *
+   * @param query The query statement to execute
+   * @param options the options to configure the query
+   * @return an {@link AsyncResultSet} with the results of the statement
+   */
+  AsyncResultSet executeParallelQueryAsync(Statement query, QueryOption... options);
+
+  /**
    * Analyzes a query or a DML statement and returns query plan and/or query execution statistics
    * information.
    *

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DdlBatch.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DdlBatch.java
@@ -34,6 +34,7 @@ import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStatement;
 import com.google.cloud.spanner.connection.AbstractStatementParser.StatementType;
 import com.google.cloud.spanner.connection.Connection.InternalMetadataQuery;
+import com.google.cloud.spanner.connection.StatementExecutor.ExecutionMode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.spanner.admin.database.v1.DatabaseAdminGrpc;
@@ -136,7 +137,10 @@ class DdlBatch extends AbstractBaseUnitOfWork {
                   DirectExecuteResultSet.ofResultSet(
                       dbClient.singleUse().executeQuery(statement.getStatement(), internalOptions));
           return executeStatementAsync(
-              statement, callable, SpannerGrpc.getExecuteStreamingSqlMethod());
+              statement,
+              callable,
+              SpannerGrpc.getExecuteStreamingSqlMethod(),
+              getExecutionMode(options));
         }
       }
     }
@@ -254,7 +258,10 @@ class DdlBatch extends AbstractBaseUnitOfWork {
         };
     this.state = UnitOfWorkState.RUNNING;
     return executeStatementAsync(
-        RUN_BATCH_STATEMENT, callable, DatabaseAdminGrpc.getUpdateDatabaseDdlMethod());
+        RUN_BATCH_STATEMENT,
+        callable,
+        DatabaseAdminGrpc.getUpdateDatabaseDdlMethod(),
+        ExecutionMode.SEQUENTIAL);
   }
 
   long[] extractUpdateCounts(OperationFuture<Void, UpdateDatabaseDdlMetadata> operation) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SingleUseTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SingleUseTransaction.java
@@ -42,6 +42,7 @@ import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.TransactionRunner;
 import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStatement;
 import com.google.cloud.spanner.connection.AbstractStatementParser.StatementType;
+import com.google.cloud.spanner.connection.StatementExecutor.ExecutionMode;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -220,7 +221,8 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
           }
         };
     readTimestamp = SettableApiFuture.create();
-    return executeStatementAsync(statement, callable, SpannerGrpc.getExecuteStreamingSqlMethod());
+    return executeStatementAsync(
+        statement, callable, SpannerGrpc.getExecuteStreamingSqlMethod(), getExecutionMode(options));
   }
 
   private ApiFuture<ResultSet> executeDmlReturningAsync(
@@ -244,7 +246,8 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
     return executeStatementAsync(
         update,
         callable,
-        ImmutableList.of(SpannerGrpc.getExecuteSqlMethod(), SpannerGrpc.getCommitMethod()));
+        ImmutableList.of(SpannerGrpc.getExecuteSqlMethod(), SpannerGrpc.getCommitMethod()),
+        ExecutionMode.SEQUENTIAL);
   }
 
   @Override
@@ -324,7 +327,8 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
             throw t;
           }
         };
-    return executeStatementAsync(ddl, callable, DatabaseAdminGrpc.getUpdateDatabaseDdlMethod());
+    return executeStatementAsync(
+        ddl, callable, DatabaseAdminGrpc.getUpdateDatabaseDdlMethod(), ExecutionMode.SEQUENTIAL);
   }
 
   @Override
@@ -447,7 +451,8 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
     return executeStatementAsync(
         update,
         callable,
-        ImmutableList.of(SpannerGrpc.getExecuteSqlMethod(), SpannerGrpc.getCommitMethod()));
+        ImmutableList.of(SpannerGrpc.getExecuteSqlMethod(), SpannerGrpc.getCommitMethod()),
+        ExecutionMode.SEQUENTIAL);
   }
 
   private ApiFuture<ResultSet> analyzeTransactionalUpdateAsync(
@@ -472,7 +477,8 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
     return executeStatementAsync(
         update,
         callable,
-        ImmutableList.of(SpannerGrpc.getExecuteSqlMethod(), SpannerGrpc.getCommitMethod()));
+        ImmutableList.of(SpannerGrpc.getExecuteSqlMethod(), SpannerGrpc.getCommitMethod()),
+        ExecutionMode.SEQUENTIAL);
   }
 
   private ApiFuture<Long> executePartitionedUpdateAsync(
@@ -488,7 +494,8 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
             throw t;
           }
         };
-    return executeStatementAsync(update, callable, SpannerGrpc.getExecuteStreamingSqlMethod());
+    return executeStatementAsync(
+        update, callable, SpannerGrpc.getExecuteStreamingSqlMethod(), ExecutionMode.SEQUENTIAL);
   }
 
   private ApiFuture<long[]> executeTransactionalBatchUpdateAsync(
@@ -516,7 +523,10 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
               });
         };
     return executeStatementAsync(
-        RUN_BATCH_STATEMENT, callable, SpannerGrpc.getExecuteBatchDmlMethod());
+        RUN_BATCH_STATEMENT,
+        callable,
+        SpannerGrpc.getExecuteBatchDmlMethod(),
+        ExecutionMode.SEQUENTIAL);
   }
 
   @Override
@@ -543,7 +553,8 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
             throw t;
           }
         };
-    return executeStatementAsync(COMMIT_STATEMENT, callable, SpannerGrpc.getCommitMethod());
+    return executeStatementAsync(
+        COMMIT_STATEMENT, callable, SpannerGrpc.getCommitMethod(), ExecutionMode.SEQUENTIAL);
   }
 
   @Override


### PR DESCRIPTION
Adds support for executing queries in parallel in the Connection API.

The Connection API already supported executing queries asynchronously, but this method would always execute all queries sequentially, even if multiple queries were queued up for async execution. This change adds a new method that users can use to specifically request queries to be executed in parallel. The method can only be used for queries. DML statements are not allowed, including DML statements with a returning clause.

The method has two limitations when executed in a read/write transaction:
1. If the first statement of a transaction is a parallel query, the query is still effectively executed as a sequential query. The reason for this is that the first query in a transaction is responsible for starting the transaction, and all following queries in the same transaction must wait for the first statement to return a transaction ID.
2. Parallel queries in read/write transactions disables automated retries of aborted transactions. Any aborted error that is returned by Cloud Spanner during a read/write transaction that uses parallel queries will be propagated to the application.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-spanner/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
