### PR TITLE
fix: prevent illegal negative timeout values into thread sleep() method while retrying exceptions in unit tests.

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITClosedSessionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITClosedSessionTest.java
@@ -252,7 +252,7 @@ public class ITClosedSessionTest {
           }
         } catch (AbortedException e) {
           long retryDelayInMillis = e.getRetryDelayInMillis();
-          if(retryDelayInMillis > 0) {
+          if (retryDelayInMillis > 0) {
             Thread.sleep(retryDelayInMillis);
           }
           txn = manager.resetForRetry();


### PR DESCRIPTION
* Issue - https://github.com/googleapis/java-spanner/issues/2206
* Root Cause - In cases where we are receiving `AbortedException`, the retry delay is set as `-1` for the exception. Negative value is not an acceptable input to `Thread.sleep()` method and hence we are getting `IllegalArgumentException`. This is resulting in flaky unit test behaviour.