### PR TITLE
feat: savepoint

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractBaseUnitOfWork.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractBaseUnitOfWork.java
@@ -21,6 +21,7 @@ import com.google.api.core.ApiFutures;
 import com.google.api.gax.grpc.GrpcCallContext;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.api.gax.rpc.ApiCallContext;
+import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.Options.RpcPriority;
 import com.google.cloud.spanner.SpannerException;
@@ -126,6 +127,28 @@ abstract class AbstractBaseUnitOfWork implements UnitOfWork {
     this.statementTimeout = builder.statementTimeout;
     this.transactionTag = builder.transactionTag;
     this.rpcPriority = builder.rpcPriority;
+  }
+
+  abstract String getUnitOfWorkName();
+
+  @Override
+  public void savepoint(String name, Dialect dialect) {
+    throw SpannerExceptionFactory.newSpannerException(
+        ErrorCode.FAILED_PRECONDITION, "Savepoint is not supported for " + getUnitOfWorkName());
+  }
+
+  @Override
+  public void releaseSavepoint(String name) {
+    throw SpannerExceptionFactory.newSpannerException(
+        ErrorCode.FAILED_PRECONDITION,
+        "Release savepoint is not supported for " + getUnitOfWorkName());
+  }
+
+  @Override
+  public void rollbackToSavepoint(String name) {
+    throw SpannerExceptionFactory.newSpannerException(
+        ErrorCode.FAILED_PRECONDITION,
+        "Rollback to savepoint is not supported for " + getUnitOfWorkName());
   }
 
   StatementExecutor getStatementExecutor() {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractMultiUseTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractMultiUseTransaction.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spanner.connection;
 
 import com.google.api.core.ApiFuture;
+import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.Options.QueryOption;
 import com.google.cloud.spanner.ReadContext;
@@ -24,14 +25,57 @@ import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStatement;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.spanner.v1.SpannerGrpc;
+import java.util.LinkedList;
+import java.util.Objects;
 
 /**
  * Base class for {@link Connection}-based transactions that can be used for multiple read and
  * read/write statements.
  */
 abstract class AbstractMultiUseTransaction extends AbstractBaseUnitOfWork {
+  static class Savepoint {
+    private final String name;
+
+    static Savepoint of(String name) {
+      return new Savepoint(name);
+    }
+
+    Savepoint(String name) {
+      this.name = name;
+    }
+
+    int getStatementPosition() {
+      return -1;
+    }
+
+    int getMutationPosition() {
+      return -1;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof Savepoint)) {
+        return false;
+      }
+      return Objects.equals(((Savepoint) o).name, name);
+    }
+
+    @Override
+    public int hashCode() {
+      return name.hashCode();
+    }
+
+    @Override
+    public String toString() {
+      return name;
+    }
+  }
+
+  private final LinkedList<Savepoint> savepoints = new LinkedList<>();
 
   AbstractMultiUseTransaction(Builder<?, ? extends AbstractMultiUseTransaction> builder) {
     super(builder);
@@ -93,5 +137,49 @@ abstract class AbstractMultiUseTransaction extends AbstractBaseUnitOfWork {
   public void abortBatch() {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Run batch is not supported for transactions");
+  }
+
+  abstract Savepoint savepoint(String name);
+
+  abstract void rollbackToSavepoint(Savepoint savepoint);
+
+  @VisibleForTesting
+  ImmutableList<Savepoint> getSavepoints() {
+    return ImmutableList.copyOf(savepoints);
+  }
+
+  @Override
+  public void savepoint(String name, Dialect dialect) {
+    if (dialect == Dialect.GOOGLE_STANDARD_SQL) {
+      // Check that there is no savepoint with this name.
+      if (savepoints.stream().anyMatch(savepoint -> savepoint.name.equals(name))) {
+        throw SpannerExceptionFactory.newSpannerException(
+            ErrorCode.INVALID_ARGUMENT, "Savepoint with name " + name + " already exists");
+      }
+    }
+    savepoints.add(savepoint(name));
+  }
+
+  @Override
+  public void releaseSavepoint(String name) {
+    savepoints.subList(getSavepointIndex(name), savepoints.size()).clear();
+  }
+
+  @Override
+  public void rollbackToSavepoint(String name) {
+    int index = getSavepointIndex(name);
+    rollbackToSavepoint(savepoints.get(index));
+    if (index < (savepoints.size() - 1)) {
+      savepoints.subList(index + 1, savepoints.size()).clear();
+    }
+  }
+
+  private int getSavepointIndex(String name) {
+    int index = savepoints.lastIndexOf(savepoint(name));
+    if (index == -1) {
+      throw SpannerExceptionFactory.newSpannerException(
+          ErrorCode.INVALID_ARGUMENT, "Savepoint with name " + name + " does not exist");
+    }
+    return index;
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
@@ -714,6 +714,53 @@ public interface Connection extends AutoCloseable {
   ApiFuture<Void> rollbackAsync();
 
   /**
+   * Creates a savepoint with the given name.
+   *
+   * <p>The uniqueness constraints on a savepoint name depends on the database dialect that is used:
+   *
+   * <ul>
+   *   <li>{@link Dialect#GOOGLE_STANDARD_SQL} requires that savepoint names are unique within a
+   *       transaction. The name of a savepoint that has been released or destroyed because the
+   *       transaction has rolled back to a savepoint that was defined before that savepoint can be
+   *       re-used within the transaction.
+   *   <li>{@link Dialect#POSTGRESQL} follows the rules for savepoint names in PostgreSQL. This
+   *       means that multiple savepoints in one transaction can have the same name, but only the
+   *       last savepoint with a given name is visible. See <a
+   *       href="https://www.postgresql.org/docs/current/sql-savepoint.html">PostgreSQL savepoint
+   *       documentation</a> for more information.
+   * </ul>
+   *
+   * @param name the name of the savepoint to create
+   * @throws SpannerException if a savepoint with the same name already exists and the dialect that
+   *     is used is {@link Dialect#GOOGLE_STANDARD_SQL}
+   * @throws SpannerException if there is no transaction on this connection
+   */
+  void savepoint(String name);
+
+  /**
+   * Releases the savepoint with the given name. The savepoint will be removed from the current
+   * transaction and can no longer be used for rolling back.
+   *
+   * @param name the name of the savepoint to release
+   * @throws SpannerException if no savepoint with the given name exists
+   */
+  void releaseSavepoint(String name);
+
+  /**
+   * Rolls back to the given savepoint. Rolling back to a savepoint undoes all changes and releases
+   * all locks that have been taken after the savepoint. Rolling back to a savepoint does not remove
+   * the savepoint from the transaction, and it is possible to roll back to the same savepoint
+   * multiple times.
+   *
+   * @param name the name of the savepoint to roll back to.
+   * @throws SpannerException if no savepoint with the given name exists.
+   * @throws AbortedDueToConcurrentModificationException if rolling back to the savepoint failed
+   *     because another transaction has modified the data that has been read or modified by this
+   *     transaction
+   */
+  void rollbackToSavepoint(String name);
+
+  /**
    * @return <code>true</code> if this connection has a transaction (that has not necessarily
    *     started). This method will only return false when the {@link Connection} is in autocommit
    *     mode and no explicit transaction has been started by calling {@link

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spanner.connection;
 
 import static com.google.cloud.spanner.SpannerApiFutures.get;
+import static com.google.cloud.spanner.connection.ConnectionPreconditions.checkValidIdentifier;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
@@ -838,6 +839,29 @@ class ConnectionImpl implements Connection {
       setDefaultTransactionOptions();
     }
     return res;
+  }
+
+  @Override
+  public void savepoint(String name) {
+    ConnectionPreconditions.checkState(isInTransaction(), "This connection has no transaction");
+    getCurrentUnitOfWorkOrStartNewUnitOfWork()
+        .savepoint(checkValidIdentifier(getDialect(), name), getDialect());
+  }
+
+  @Override
+  public void releaseSavepoint(String name) {
+    ConnectionPreconditions.checkState(
+        isTransactionStarted(), "This connection has no active transaction");
+    getCurrentUnitOfWorkOrStartNewUnitOfWork()
+        .releaseSavepoint(checkValidIdentifier(getDialect(), name));
+  }
+
+  @Override
+  public void rollbackToSavepoint(String name) {
+    ConnectionPreconditions.checkState(
+        isTransactionStarted(), "This connection has no active transaction");
+    getCurrentUnitOfWorkOrStartNewUnitOfWork()
+        .rollbackToSavepoint(checkValidIdentifier(getDialect(), name));
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionPreconditions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionPreconditions.java
@@ -16,9 +16,11 @@
 
 package com.google.cloud.spanner.connection;
 
+import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerExceptionFactory;
+import com.google.common.base.Strings;
 import javax.annotation.Nullable;
 
 /**
@@ -41,5 +43,25 @@ class ConnectionPreconditions {
       throw SpannerExceptionFactory.newSpannerException(
           ErrorCode.FAILED_PRECONDITION, String.valueOf(errorMessage));
     }
+  }
+
+  static void checkArgument(boolean expression, String message) {
+    if (!expression) {
+      throw SpannerExceptionFactory.newSpannerException(ErrorCode.INVALID_ARGUMENT, message);
+    }
+  }
+
+  /** Verifies that the given identifier is a valid identifier for the given dialect. */
+  static String checkValidIdentifier(Dialect dialect, String identifier) {
+    checkArgument(!Strings.isNullOrEmpty(identifier), "Identifier may not be null or empty");
+    switch (dialect) {
+      case GOOGLE_STANDARD_SQL:
+        break;
+      case POSTGRESQL:
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown dialect: " + dialect);
+    }
+    return identifier;
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DdlBatch.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DdlBatch.java
@@ -296,4 +296,9 @@ class DdlBatch extends AbstractBaseUnitOfWork {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Rollback is not allowed for DDL batches.");
   }
+
+  @Override
+  String getUnitOfWorkName() {
+    return "DDL batch";
+  }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DmlBatch.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DmlBatch.java
@@ -249,4 +249,9 @@ class DmlBatch extends AbstractBaseUnitOfWork {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Rollback is not allowed for DML batches.");
   }
+
+  @Override
+  String getUnitOfWorkName() {
+    return "DML batch";
+  }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ReadWriteTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ReadWriteTransaction.java
@@ -80,7 +80,8 @@ class ReadWriteTransaction extends AbstractMultiUseTransaction {
   private static final int MAX_INTERNAL_RETRIES = 50;
   private final long transactionId;
   private final DatabaseClient dbClient;
-  private final TransactionManager txManager;
+  private final TransactionOption[] transactionOptions;
+  private TransactionManager txManager;
   private final boolean retryAbortsInternally;
   private int transactionRetryAttempts;
   private int successfulRetries;
@@ -89,11 +90,14 @@ class ReadWriteTransaction extends AbstractMultiUseTransaction {
   private volatile SettableApiFuture<CommitResponse> commitResponseFuture;
   private volatile UnitOfWorkState state = UnitOfWorkState.STARTED;
   private volatile AbortedException abortedException;
+  private AbortedException rolledBackToSavepointException;
   private boolean timedOutOrCancelled = false;
   private final List<RetriableStatement> statements = new ArrayList<>();
   private final List<Mutation> mutations = new ArrayList<>();
   private Timestamp transactionStarted;
   final Object abortedLock = new Object();
+
+  private static final class RollbackToSavepointException extends Exception {}
 
   static class Builder extends AbstractMultiUseTransaction.Builder<Builder, ReadWriteTransaction> {
     private DatabaseClient dbClient;
@@ -146,7 +150,8 @@ class ReadWriteTransaction extends AbstractMultiUseTransaction {
     this.dbClient = builder.dbClient;
     this.retryAbortsInternally = builder.retryAbortsInternally;
     this.transactionRetryListeners = builder.transactionRetryListeners;
-    this.txManager = dbClient.transactionManager(extractOptions(builder));
+    this.transactionOptions = extractOptions(builder);
+    this.txManager = dbClient.transactionManager(this.transactionOptions);
   }
 
   private TransactionOption[] extractOptions(Builder builder) {
@@ -231,6 +236,11 @@ class ReadWriteTransaction extends AbstractMultiUseTransaction {
             + "or "
             + UnitOfWorkState.ABORTED
             + " is allowed.");
+    ConnectionPreconditions.checkState(
+        this.retryAbortsInternally || this.rolledBackToSavepointException == null,
+        "Cannot resume execution after rolling back to a savepoint if internal retries have been disabled. "
+            + "Call Connection#setRetryAbortsInternally(true) or execute `SET RETRY_ABORTS_INTERNALLY=TRUE` to enable "
+            + "resuming execution after rolling back to a savepoint.");
     checkTimedOut();
   }
 
@@ -271,6 +281,14 @@ class ReadWriteTransaction extends AbstractMultiUseTransaction {
             "This transaction has already been aborted. Rollback this transaction to start a new one.",
             this.abortedException);
       }
+    }
+  }
+
+  void checkRolledBackToSavepoint() {
+    if (this.rolledBackToSavepointException != null) {
+      AbortedException exception = this.rolledBackToSavepointException;
+      this.rolledBackToSavepointException = null;
+      throw exception;
     }
   }
 
@@ -690,6 +708,7 @@ class ReadWriteTransaction extends AbstractMultiUseTransaction {
       synchronized (abortedLock) {
         checkAborted();
         try {
+          checkRolledBackToSavepoint();
           return callable.call();
         } catch (final AbortedException aborted) {
           handleAborted(aborted);
@@ -792,7 +811,12 @@ class ReadWriteTransaction extends AbstractMultiUseTransaction {
               ErrorCode.CANCELLED, "The statement was cancelled");
         }
         try {
-          txContextFuture = ApiFutures.immediateFuture(txManager.resetForRetry());
+          if (aborted.getCause() instanceof RollbackToSavepointException) {
+            txManager = dbClient.transactionManager(transactionOptions);
+            txContextFuture = ApiFutures.immediateFuture(txManager.begin());
+          } else {
+            txContextFuture = ApiFutures.immediateFuture(txManager.resetForRetry());
+          }
           // Inform listeners about the transaction retry that is about to start.
           invokeTransactionRetryListenersOnStart();
           // Then retry all transaction statements.
@@ -899,7 +923,7 @@ class ReadWriteTransaction extends AbstractMultiUseTransaction {
         @Override
         public Void call() {
           try {
-            if (state != UnitOfWorkState.ABORTED) {
+            if (state != UnitOfWorkState.ABORTED && rolledBackToSavepointException == null) {
               // Make sure the transaction has actually started before we try to rollback.
               get(txContextFuture);
               txManager.rollback();
@@ -913,16 +937,69 @@ class ReadWriteTransaction extends AbstractMultiUseTransaction {
 
   @Override
   public ApiFuture<Void> rollbackAsync() {
+    return rollbackAsync(true);
+  }
+
+  private ApiFuture<Void> rollbackAsync(boolean updateStatus) {
     ConnectionPreconditions.checkState(
         state == UnitOfWorkState.STARTED || state == UnitOfWorkState.ABORTED,
         "This transaction has status " + state.name());
-    state = UnitOfWorkState.ROLLED_BACK;
+    if (updateStatus) {
+      state = UnitOfWorkState.ROLLED_BACK;
+    }
     if (txContextFuture != null && state != UnitOfWorkState.ABORTED) {
       return executeStatementAsync(
           ROLLBACK_STATEMENT, rollbackCallable, SpannerGrpc.getRollbackMethod());
     } else {
       return ApiFutures.immediateFuture(null);
     }
+  }
+
+  @Override
+  String getUnitOfWorkName() {
+    return "read/write transaction";
+  }
+
+  static class ReadWriteSavepoint extends Savepoint {
+    private final int statementPosition;
+    private final int mutationPosition;
+
+    ReadWriteSavepoint(String name, int statementPosition, int mutationPosition) {
+      super(name);
+      this.statementPosition = statementPosition;
+      this.mutationPosition = mutationPosition;
+    }
+
+    @Override
+    int getStatementPosition() {
+      return this.statementPosition;
+    }
+
+    @Override
+    int getMutationPosition() {
+      return this.mutationPosition;
+    }
+  }
+
+  @Override
+  Savepoint savepoint(String name) {
+    return new ReadWriteSavepoint(name, statements.size(), mutations.size());
+  }
+
+  @Override
+  void rollbackToSavepoint(Savepoint savepoint) {
+    get(rollbackAsync(false));
+    // Mark the state of the transaction as rolled back to a savepoint. This will ensure that the
+    // transaction will retry the next time a statement is actually executed.
+    this.rolledBackToSavepointException =
+        (AbortedException)
+            SpannerExceptionFactory.newSpannerException(
+                ErrorCode.ABORTED,
+                "Transaction has been rolled back to a savepoint",
+                new RollbackToSavepointException());
+    // Clear all statements and mutations after the savepoint.
+    this.statements.subList(savepoint.getStatementPosition(), this.statements.size()).clear();
+    this.mutations.subList(savepoint.getMutationPosition(), this.mutations.size()).clear();
   }
 
   /**

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SingleUseTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SingleUseTransaction.java
@@ -559,6 +559,11 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
   }
 
   @Override
+  String getUnitOfWorkName() {
+    return "single-use transaction";
+  }
+
+  @Override
   public ApiFuture<long[]> runBatchAsync() {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Run batch is not supported for single-use transactions");

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/UnitOfWork.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/UnitOfWork.java
@@ -20,6 +20,7 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.InternalApi;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.CommitResponse;
+import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Options.QueryOption;
 import com.google.cloud.spanner.Options.UpdateOption;
@@ -30,6 +31,7 @@ import com.google.cloud.spanner.TransactionContext;
 import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStatement;
 import com.google.spanner.v1.ResultSetStats;
 import java.util.concurrent.ExecutionException;
+import javax.annotation.Nonnull;
 
 /** Internal interface for transactions and batches on {@link Connection}s. */
 @InternalApi
@@ -86,6 +88,15 @@ interface UnitOfWork {
    * @return An {@link ApiFuture} that is done when the rollback has finished.
    */
   ApiFuture<Void> rollbackAsync();
+
+  /** @see Connection#savepoint(String) */
+  void savepoint(@Nonnull String name, @Nonnull Dialect dialect);
+
+  /** @see Connection#releaseSavepoint(String) */
+  void releaseSavepoint(@Nonnull String name);
+
+  /** @see Connection#rollbackToSavepoint(String) */
+  void rollbackToSavepoint(@Nonnull String name);
 
   /**
    * Sends the currently buffered statements in this unit of work to the database and ends the

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SavepointMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SavepointMockServerTest.java
@@ -1,0 +1,513 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.connection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.spanner.AbortedDueToConcurrentModificationException;
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.SpannerException;
+import com.google.cloud.spanner.Statement;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.AbstractMessage;
+import com.google.spanner.v1.BeginTransactionRequest;
+import com.google.spanner.v1.CommitRequest;
+import com.google.spanner.v1.ExecuteBatchDmlRequest;
+import com.google.spanner.v1.ExecuteSqlRequest;
+import com.google.spanner.v1.RollbackRequest;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class SavepointMockServerTest extends AbstractMockServerTest {
+
+  @Parameters(name = "dialect = {0}")
+  public static Object[] data() {
+    return Dialect.values();
+  }
+
+  @Parameter public Dialect dialect;
+
+  @Before
+  public void setupDialect() {
+    mockSpanner.putStatementResult(StatementResult.detectDialectResult(dialect));
+  }
+
+  @After
+  public void clearRequests() {
+    mockSpanner.clearRequests();
+    SpannerPool.closeSpannerPool();
+  }
+
+  @Test
+  public void testCreateSavepoint() {
+    try (Connection connection = createConnection()) {
+      connection.savepoint("s1");
+
+      if (dialect == Dialect.POSTGRESQL) {
+        // PostgreSQL allows multiple savepoints with the same name.
+        connection.savepoint("s1");
+      } else {
+        assertThrows(SpannerException.class, () -> connection.savepoint("s1"));
+      }
+    }
+  }
+
+  @Test
+  public void testReleaseSavepoint() {
+    try (Connection connection = createConnection()) {
+      connection.savepoint("s1");
+      connection.releaseSavepoint("s1");
+      assertThrows(SpannerException.class, () -> connection.releaseSavepoint("s1"));
+
+      connection.savepoint("s1");
+      connection.savepoint("s2");
+      connection.releaseSavepoint("s1");
+      // Releasing a savepoint also removes all savepoints after it.
+      assertThrows(SpannerException.class, () -> connection.releaseSavepoint("s2"));
+
+      if (dialect == Dialect.POSTGRESQL) {
+        // PostgreSQL allows multiple savepoints with the same name.
+        connection.savepoint("s1");
+        connection.savepoint("s2");
+        connection.savepoint("s1");
+        connection.releaseSavepoint("s1");
+        connection.releaseSavepoint("s2");
+        connection.releaseSavepoint("s1");
+        assertThrows(SpannerException.class, () -> connection.releaseSavepoint("s1"));
+      }
+    }
+  }
+
+  @Test
+  public void testRollbackToSavepoint() {
+    try (Connection connection = createConnection()) {
+      connection.savepoint("s1");
+      connection.rollbackToSavepoint("s1");
+      // Rolling back to a savepoint does not remove it, so we can roll back multiple times to the
+      // same savepoint.
+      connection.rollbackToSavepoint("s1");
+
+      connection.savepoint("s2");
+      connection.rollbackToSavepoint("s1");
+      // Rolling back to a savepoint removes all savepoints after it.
+      assertThrows(SpannerException.class, () -> connection.rollbackToSavepoint("s2"));
+
+      if (dialect == Dialect.POSTGRESQL) {
+        // PostgreSQL allows multiple savepoints with the same name.
+        connection.savepoint("s2");
+        connection.savepoint("s1");
+        connection.rollbackToSavepoint("s1");
+        connection.rollbackToSavepoint("s2");
+        connection.rollbackToSavepoint("s1");
+        connection.rollbackToSavepoint("s1");
+        connection.releaseSavepoint("s1");
+        assertThrows(SpannerException.class, () -> connection.rollbackToSavepoint("s1"));
+      }
+    }
+  }
+
+  @Test
+  public void testSavepointInAutoCommit() {
+    try (Connection connection = createConnection()) {
+      connection.setAutocommit(true);
+      assertThrows(SpannerException.class, () -> connection.savepoint("s1"));
+
+      // Starting a 'manual' transaction in autocommit mode should enable savepoints.
+      connection.beginTransaction();
+      connection.savepoint("s1");
+      connection.releaseSavepoint("s1");
+    }
+  }
+
+  @Test
+  public void testRollbackToSavepointInReadOnlyTransaction() {
+    try (Connection connection = createConnection()) {
+      connection.setReadOnly(true);
+
+      // Read-only transactions also support savepoints, but they do not do anything. This feature
+      // is here purely for compatibility.
+      connection.savepoint("s1");
+      try (ResultSet resultSet = connection.executeQuery(SELECT_RANDOM_STATEMENT)) {
+        int count = 0;
+        while (resultSet.next()) {
+          count++;
+        }
+        assertEquals(RANDOM_RESULT_SET_ROW_COUNT, count);
+      }
+
+      connection.rollbackToSavepoint("s1");
+      try (ResultSet resultSet = connection.executeQuery(SELECT_RANDOM_STATEMENT)) {
+        int count = 0;
+        while (resultSet.next()) {
+          count++;
+        }
+        assertEquals(RANDOM_RESULT_SET_ROW_COUNT, count);
+      }
+      // Committing a read-only transaction is necessary to mark the end of the transaction.
+      // It is a no-op on Cloud Spanner.
+      connection.commit();
+
+      assertEquals(1, mockSpanner.countRequestsOfType(BeginTransactionRequest.class));
+      BeginTransactionRequest beginRequest =
+          mockSpanner.getRequestsOfType(BeginTransactionRequest.class).get(0);
+      assertTrue(beginRequest.getOptions().hasReadOnly());
+      assertEquals(0, mockSpanner.countRequestsOfType(CommitRequest.class));
+    }
+  }
+
+  @Test
+  public void testRollbackToSavepointInReadWriteTransaction() {
+    try (Connection connection = createConnection()) {
+      connection.savepoint("s1");
+      try (ResultSet resultSet = connection.executeQuery(SELECT_RANDOM_STATEMENT)) {
+        int count = 0;
+        while (resultSet.next()) {
+          count++;
+        }
+        assertEquals(RANDOM_RESULT_SET_ROW_COUNT, count);
+      }
+
+      connection.rollbackToSavepoint("s1");
+      try (ResultSet resultSet = connection.executeQuery(SELECT_RANDOM_STATEMENT)) {
+        int count = 0;
+        while (resultSet.next()) {
+          count++;
+        }
+        assertEquals(RANDOM_RESULT_SET_ROW_COUNT, count);
+      }
+      connection.commit();
+
+      // Read/write transactions are started with inlined Begin transaction options.
+      assertEquals(0, mockSpanner.countRequestsOfType(BeginTransactionRequest.class));
+      assertEquals(1, mockSpanner.countRequestsOfType(RollbackRequest.class));
+      assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
+      assertEquals(2, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+
+      List<AbstractMessage> requests =
+          mockSpanner.getRequests().stream()
+              .filter(
+                  request ->
+                      request instanceof ExecuteSqlRequest
+                          || request instanceof RollbackRequest
+                          || request instanceof CommitRequest)
+              .collect(Collectors.toList());
+      assertEquals(4, requests.size());
+      int index = 0;
+      assertEquals(ExecuteSqlRequest.class, requests.get(index++).getClass());
+      assertEquals(RollbackRequest.class, requests.get(index++).getClass());
+      assertEquals(ExecuteSqlRequest.class, requests.get(index++).getClass());
+      assertEquals(CommitRequest.class, requests.get(index++).getClass());
+    }
+  }
+
+  @Test
+  public void testRollbackToSavepointWithDmlStatements() {
+    try (Connection connection = createConnection()) {
+      // First do a query that is included in the transaction.
+      try (ResultSet resultSet = connection.executeQuery(SELECT_RANDOM_STATEMENT)) {
+        int count = 0;
+        while (resultSet.next()) {
+          count++;
+        }
+        assertEquals(RANDOM_RESULT_SET_ROW_COUNT, count);
+      }
+      // Set a savepoint and execute a couple of DML statements.
+      connection.savepoint("s1");
+      connection.executeUpdate(INSERT_STATEMENT);
+      connection.savepoint("s2");
+      connection.executeUpdate(INSERT_STATEMENT);
+      // Rollback the last DML statement and commit.
+      connection.rollbackToSavepoint("s2");
+
+      connection.commit();
+
+      // Read/write transactions are started with inlined Begin transaction options.
+      assertEquals(0, mockSpanner.countRequestsOfType(BeginTransactionRequest.class));
+      assertEquals(1, mockSpanner.countRequestsOfType(RollbackRequest.class));
+      assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
+      assertEquals(5, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+
+      List<AbstractMessage> requests =
+          mockSpanner.getRequests().stream()
+              .filter(
+                  request ->
+                      request instanceof ExecuteSqlRequest
+                          || request instanceof RollbackRequest
+                          || request instanceof CommitRequest)
+              .collect(Collectors.toList());
+      assertEquals(7, requests.size());
+      int index = 0;
+      assertEquals(ExecuteSqlRequest.class, requests.get(index++).getClass());
+      assertEquals(ExecuteSqlRequest.class, requests.get(index++).getClass());
+      assertEquals(ExecuteSqlRequest.class, requests.get(index++).getClass());
+      assertEquals(RollbackRequest.class, requests.get(index++).getClass());
+      assertEquals(ExecuteSqlRequest.class, requests.get(index++).getClass());
+      assertEquals(ExecuteSqlRequest.class, requests.get(index++).getClass());
+      assertEquals(CommitRequest.class, requests.get(index++).getClass());
+    }
+  }
+
+  @Test
+  public void testRollbackToSavepointFails() {
+    Statement statement = Statement.of("select * from foo where bar=true");
+    int numRows = 10;
+    RandomResultSetGenerator generator = new RandomResultSetGenerator(numRows);
+    mockSpanner.putStatementResult(StatementResult.query(statement, generator.generate()));
+    try (Connection connection = createConnection()) {
+      try (ResultSet resultSet = connection.executeQuery(statement)) {
+        int count = 0;
+        while (resultSet.next()) {
+          count++;
+        }
+        assertEquals(numRows, count);
+      }
+      // Set a savepoint and execute a couple of DML statements.
+      connection.savepoint("s1");
+      connection.executeUpdate(INSERT_STATEMENT);
+      connection.executeUpdate(INSERT_STATEMENT);
+      // Change the result of the initial query.
+      mockSpanner.putStatementResult(StatementResult.query(statement, generator.generate()));
+      // Rollback to before the DML statements.
+      // This will succeed as long as we don't execute any further statements.
+      connection.rollbackToSavepoint("s1");
+
+      // Trying to commit the transaction or execute any other statements on the transaction will
+      // fail.
+      assertThrows(AbortedDueToConcurrentModificationException.class, connection::commit);
+
+      // Read/write transactions are started with inlined Begin transaction options.
+      assertEquals(0, mockSpanner.countRequestsOfType(BeginTransactionRequest.class));
+      assertEquals(2, mockSpanner.countRequestsOfType(RollbackRequest.class));
+      assertEquals(0, mockSpanner.countRequestsOfType(CommitRequest.class));
+      assertEquals(4, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+
+      List<AbstractMessage> requests =
+          mockSpanner.getRequests().stream()
+              .filter(
+                  request ->
+                      request instanceof ExecuteSqlRequest
+                          || request instanceof RollbackRequest
+                          || request instanceof CommitRequest)
+              .collect(Collectors.toList());
+      assertEquals(6, requests.size());
+      int index = 0;
+      assertEquals(ExecuteSqlRequest.class, requests.get(index++).getClass());
+      assertEquals(ExecuteSqlRequest.class, requests.get(index++).getClass());
+      assertEquals(ExecuteSqlRequest.class, requests.get(index++).getClass());
+      assertEquals(RollbackRequest.class, requests.get(index++).getClass());
+      assertEquals(ExecuteSqlRequest.class, requests.get(index++).getClass());
+      assertEquals(RollbackRequest.class, requests.get(index++).getClass());
+    }
+  }
+
+  @Test
+  public void testRollbackToSavepointSucceedsWithRollback() {
+    Statement statement = Statement.of("select * from foo where bar=true");
+    int numRows = 10;
+    RandomResultSetGenerator generator = new RandomResultSetGenerator(numRows);
+    mockSpanner.putStatementResult(StatementResult.query(statement, generator.generate()));
+    try (Connection connection = createConnection()) {
+      try (ResultSet resultSet = connection.executeQuery(statement)) {
+        int count = 0;
+        while (resultSet.next()) {
+          count++;
+        }
+        assertEquals(numRows, count);
+      }
+      // Change the result of the initial query and set a savepoint.
+      connection.savepoint("s1");
+      mockSpanner.putStatementResult(StatementResult.query(statement, generator.generate()));
+      // This will succeed as long as we don't execute any further statements.
+      connection.rollbackToSavepoint("s1");
+
+      // Rolling back the transaction should now be a no-op, as it has already been rolled back.
+      connection.rollback();
+
+      // Read/write transactions are started with inlined Begin transaction options.
+      assertEquals(0, mockSpanner.countRequestsOfType(BeginTransactionRequest.class));
+      assertEquals(1, mockSpanner.countRequestsOfType(RollbackRequest.class));
+      assertEquals(0, mockSpanner.countRequestsOfType(CommitRequest.class));
+      assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    }
+  }
+
+  @Test
+  public void testMultipleRollbacksWithChangedResults() {
+    Statement statement = Statement.of("select * from foo where bar=true");
+    int numRows = 10;
+    RandomResultSetGenerator generator = new RandomResultSetGenerator(numRows);
+    mockSpanner.putStatementResult(StatementResult.query(statement, generator.generate()));
+    try (Connection connection = createConnection()) {
+      try (ResultSet resultSet = connection.executeQuery(statement)) {
+        int count = 0;
+        while (resultSet.next()) {
+          count++;
+        }
+        assertEquals(numRows, count);
+      }
+      connection.savepoint("s1");
+      connection.executeUpdate(INSERT_STATEMENT);
+      connection.savepoint("s2");
+      connection.executeUpdate(INSERT_STATEMENT);
+
+      // Change the result of the initial query to make sure that any retry will fail.
+      mockSpanner.putStatementResult(StatementResult.query(statement, generator.generate()));
+      // This will succeed as long as we don't execute any further statements.
+      connection.rollbackToSavepoint("s2");
+      // Rolling back one further should also work.
+      connection.rollbackToSavepoint("s1");
+
+      // Rolling back the transaction should now be a no-op, as it has already been rolled back.
+      connection.rollback();
+
+      assertEquals(1, mockSpanner.countRequestsOfType(RollbackRequest.class));
+      assertEquals(0, mockSpanner.countRequestsOfType(CommitRequest.class));
+      assertEquals(3, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    }
+  }
+
+  @Test
+  public void testMultipleRollbacks() {
+    Statement statement = Statement.of("select * from foo where bar=true");
+    int numRows = 10;
+    RandomResultSetGenerator generator = new RandomResultSetGenerator(numRows);
+    mockSpanner.putStatementResult(StatementResult.query(statement, generator.generate()));
+    try (Connection connection = createConnection()) {
+      try (ResultSet resultSet = connection.executeQuery(statement)) {
+        int count = 0;
+        while (resultSet.next()) {
+          count++;
+        }
+        assertEquals(numRows, count);
+      }
+      connection.savepoint("s1");
+      connection.executeUpdate(INSERT_STATEMENT);
+      connection.savepoint("s2");
+      connection.executeUpdate(INSERT_STATEMENT);
+
+      // First roll back one step and then one more.
+      connection.rollbackToSavepoint("s2");
+      connection.rollbackToSavepoint("s1");
+
+      // This will only commit the SELECT query.
+      connection.commit();
+
+      assertEquals(1, mockSpanner.countRequestsOfType(RollbackRequest.class));
+      assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
+      assertEquals(4, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+
+      List<AbstractMessage> requests =
+          mockSpanner.getRequests().stream()
+              .filter(
+                  request ->
+                      request instanceof ExecuteSqlRequest
+                          || request instanceof RollbackRequest
+                          || request instanceof CommitRequest)
+              .collect(Collectors.toList());
+      assertEquals(6, requests.size());
+      int index = 0;
+      assertEquals(ExecuteSqlRequest.class, requests.get(index++).getClass());
+      assertEquals(ExecuteSqlRequest.class, requests.get(index++).getClass());
+      assertEquals(ExecuteSqlRequest.class, requests.get(index++).getClass());
+      assertEquals(RollbackRequest.class, requests.get(index++).getClass());
+      assertEquals(ExecuteSqlRequest.class, requests.get(index++).getClass());
+      assertEquals(CommitRequest.class, requests.get(index++).getClass());
+    }
+  }
+
+  @Test
+  public void testRollbackMutations() {
+    try (Connection connection = createConnection()) {
+      connection.bufferedWrite(Mutation.newInsertBuilder("foo1").build());
+      connection.savepoint("s1");
+      connection.executeUpdate(INSERT_STATEMENT);
+      connection.bufferedWrite(Mutation.newInsertBuilder("foo2").build());
+      connection.savepoint("s2");
+      connection.executeUpdate(INSERT_STATEMENT);
+      connection.bufferedWrite(Mutation.newInsertBuilder("foo3").build());
+
+      connection.rollbackToSavepoint("s1");
+
+      // This will only commit the first mutation.
+      connection.commit();
+
+      assertEquals(1, mockSpanner.countRequestsOfType(RollbackRequest.class));
+      assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
+      assertEquals(2, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+      CommitRequest commitRequest = mockSpanner.getRequestsOfType(CommitRequest.class).get(0);
+      assertEquals(1, commitRequest.getMutationsCount());
+      assertEquals("foo1", commitRequest.getMutations(0).getInsert().getTable());
+    }
+  }
+
+  @Test
+  public void testRollbackBatchDml() {
+    try (Connection connection = createConnection()) {
+      connection.executeUpdate(INSERT_STATEMENT);
+      connection.savepoint("s1");
+      connection.executeBatchUpdate(ImmutableList.of(INSERT_STATEMENT, INSERT_STATEMENT));
+      connection.savepoint("s2");
+
+      connection.executeUpdate(INSERT_STATEMENT);
+      connection.savepoint("s3");
+      connection.executeBatchUpdate(ImmutableList.of(INSERT_STATEMENT, INSERT_STATEMENT));
+      connection.savepoint("s4");
+
+      connection.rollbackToSavepoint("s2");
+
+      connection.commit();
+
+      assertEquals(1, mockSpanner.countRequestsOfType(RollbackRequest.class));
+      assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
+      assertEquals(3, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+      assertEquals(3, mockSpanner.countRequestsOfType(ExecuteBatchDmlRequest.class));
+
+      List<AbstractMessage> requests =
+          mockSpanner.getRequests().stream()
+              .filter(
+                  request ->
+                      request instanceof ExecuteSqlRequest
+                          || request instanceof RollbackRequest
+                          || request instanceof CommitRequest
+                          || request instanceof ExecuteBatchDmlRequest)
+              .collect(Collectors.toList());
+      assertEquals(8, requests.size());
+      int index = 0;
+      assertEquals(ExecuteSqlRequest.class, requests.get(index++).getClass());
+      assertEquals(ExecuteBatchDmlRequest.class, requests.get(index++).getClass());
+      assertEquals(ExecuteSqlRequest.class, requests.get(index++).getClass());
+      assertEquals(ExecuteBatchDmlRequest.class, requests.get(index++).getClass());
+      assertEquals(RollbackRequest.class, requests.get(index++).getClass());
+      assertEquals(ExecuteSqlRequest.class, requests.get(index++).getClass());
+      assertEquals(ExecuteBatchDmlRequest.class, requests.get(index++).getClass());
+      assertEquals(CommitRequest.class, requests.get(index++).getClass());
+    }
+  }
+}

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SavepointTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SavepointTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.connection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.SpannerException;
+import com.google.cloud.spanner.connection.AbstractMultiUseTransaction.Savepoint;
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SavepointTest {
+  static class TestTransaction extends ReadOnlyTransaction {
+    TestTransaction() {
+      super(ReadOnlyTransaction.newBuilder().withStatementExecutor(mock(StatementExecutor.class)));
+    }
+  }
+
+  @Test
+  public void testCreateSavepoint_GoogleSql() {
+    Dialect dialect = Dialect.GOOGLE_STANDARD_SQL;
+    TestTransaction transaction = new TestTransaction();
+
+    transaction.savepoint("s1", dialect);
+    assertEquals(ImmutableList.of(Savepoint.of("s1")), transaction.getSavepoints());
+
+    transaction.savepoint("s2", dialect);
+    assertEquals(
+        ImmutableList.of(Savepoint.of("s1"), Savepoint.of("s2")), transaction.getSavepoints());
+
+    // GoogleSql does not allow duplicate savepoint names.
+    assertThrows(SpannerException.class, () -> transaction.savepoint("s1", dialect));
+    assertThrows(SpannerException.class, () -> transaction.savepoint("s2", dialect));
+  }
+
+  @Test
+  public void testCreateSavepoint_PostgreSQL() {
+    Dialect dialect = Dialect.POSTGRESQL;
+    TestTransaction transaction = new TestTransaction();
+
+    transaction.savepoint("s1", dialect);
+    assertEquals(ImmutableList.of(Savepoint.of("s1")), transaction.getSavepoints());
+
+    transaction.savepoint("s2", dialect);
+    assertEquals(
+        ImmutableList.of(Savepoint.of("s1"), Savepoint.of("s2")), transaction.getSavepoints());
+
+    // PostgreSQL allows duplicate savepoint names.
+    transaction.savepoint("s2", dialect);
+    assertEquals(
+        ImmutableList.of(Savepoint.of("s1"), Savepoint.of("s2"), Savepoint.of("s2")),
+        transaction.getSavepoints());
+    transaction.savepoint("s1", dialect);
+    assertEquals(
+        ImmutableList.of(
+            Savepoint.of("s1"), Savepoint.of("s2"), Savepoint.of("s2"), Savepoint.of("s1")),
+        transaction.getSavepoints());
+  }
+
+  @Test
+  public void testReleaseSavepoint_GoogleSql() {
+    Dialect dialect = Dialect.GOOGLE_STANDARD_SQL;
+    TestTransaction transaction = new TestTransaction();
+
+    transaction.savepoint("s1", dialect);
+    assertEquals(ImmutableList.of(Savepoint.of("s1")), transaction.getSavepoints());
+    transaction.releaseSavepoint("s1");
+    assertEquals(ImmutableList.of(), transaction.getSavepoints());
+
+    transaction.savepoint("s1", dialect);
+    transaction.savepoint("s2", dialect);
+    assertEquals(
+        ImmutableList.of(Savepoint.of("s1"), Savepoint.of("s2")), transaction.getSavepoints());
+    transaction.releaseSavepoint("s2");
+    assertEquals(ImmutableList.of(Savepoint.of("s1")), transaction.getSavepoints());
+
+    transaction.savepoint("s2", dialect);
+    assertEquals(
+        ImmutableList.of(Savepoint.of("s1"), Savepoint.of("s2")), transaction.getSavepoints());
+    transaction.releaseSavepoint("s1");
+    assertEquals(ImmutableList.of(), transaction.getSavepoints());
+
+    assertThrows(SpannerException.class, () -> transaction.releaseSavepoint("s1"));
+
+    transaction.savepoint("s1", dialect);
+    assertThrows(SpannerException.class, () -> transaction.releaseSavepoint("s2"));
+    assertEquals(ImmutableList.of(Savepoint.of("s1")), transaction.getSavepoints());
+  }
+
+  @Test
+  public void testReleaseSavepoint_PostgreSQL() {
+    Dialect dialect = Dialect.POSTGRESQL;
+    TestTransaction transaction = new TestTransaction();
+
+    transaction.savepoint("s1", dialect);
+    assertEquals(ImmutableList.of(Savepoint.of("s1")), transaction.getSavepoints());
+    transaction.releaseSavepoint("s1");
+    assertEquals(ImmutableList.of(), transaction.getSavepoints());
+
+    transaction.savepoint("s1", dialect);
+    transaction.savepoint("s2", dialect);
+    assertEquals(
+        ImmutableList.of(Savepoint.of("s1"), Savepoint.of("s2")), transaction.getSavepoints());
+    transaction.releaseSavepoint("s2");
+    assertEquals(ImmutableList.of(Savepoint.of("s1")), transaction.getSavepoints());
+
+    transaction.savepoint("s2", dialect);
+    assertEquals(
+        ImmutableList.of(Savepoint.of("s1"), Savepoint.of("s2")), transaction.getSavepoints());
+    transaction.releaseSavepoint("s1");
+    assertEquals(ImmutableList.of(), transaction.getSavepoints());
+
+    assertThrows(SpannerException.class, () -> transaction.releaseSavepoint("s1"));
+
+    transaction.savepoint("s1", dialect);
+    assertThrows(SpannerException.class, () -> transaction.releaseSavepoint("s2"));
+    assertEquals(ImmutableList.of(Savepoint.of("s1")), transaction.getSavepoints());
+
+    transaction.savepoint("s2", dialect);
+    transaction.savepoint("s1", dialect);
+    assertEquals(
+        ImmutableList.of(Savepoint.of("s1"), Savepoint.of("s2"), Savepoint.of("s1")),
+        transaction.getSavepoints());
+    transaction.releaseSavepoint("s1");
+    assertEquals(
+        ImmutableList.of(Savepoint.of("s1"), Savepoint.of("s2")), transaction.getSavepoints());
+  }
+
+  @Test
+  public void testRollbackToSavepoint_GoogleSql() {
+    Dialect dialect = Dialect.GOOGLE_STANDARD_SQL;
+    TestTransaction transaction = new TestTransaction();
+
+    transaction.savepoint("s1", dialect);
+    assertEquals(ImmutableList.of(Savepoint.of("s1")), transaction.getSavepoints());
+    transaction.rollbackToSavepoint("s1");
+    assertEquals(ImmutableList.of(Savepoint.of("s1")), transaction.getSavepoints());
+
+    transaction.savepoint("s2", dialect);
+    assertEquals(
+        ImmutableList.of(Savepoint.of("s1"), Savepoint.of("s2")), transaction.getSavepoints());
+    transaction.rollbackToSavepoint("s2");
+    assertEquals(
+        ImmutableList.of(Savepoint.of("s1"), Savepoint.of("s2")), transaction.getSavepoints());
+
+    assertEquals(
+        ImmutableList.of(Savepoint.of("s1"), Savepoint.of("s2")), transaction.getSavepoints());
+    transaction.rollbackToSavepoint("s1");
+    assertEquals(ImmutableList.of(Savepoint.of("s1")), transaction.getSavepoints());
+
+    assertThrows(SpannerException.class, () -> transaction.rollbackToSavepoint("s2"));
+  }
+
+  @Test
+  public void testRollbackToSavepoint_PostgreSQL() {
+    Dialect dialect = Dialect.POSTGRESQL;
+    TestTransaction transaction = new TestTransaction();
+
+    transaction.savepoint("s1", dialect);
+    assertEquals(ImmutableList.of(Savepoint.of("s1")), transaction.getSavepoints());
+    transaction.rollbackToSavepoint("s1");
+    assertEquals(ImmutableList.of(Savepoint.of("s1")), transaction.getSavepoints());
+
+    transaction.savepoint("s2", dialect);
+    assertEquals(
+        ImmutableList.of(Savepoint.of("s1"), Savepoint.of("s2")), transaction.getSavepoints());
+    transaction.rollbackToSavepoint("s2");
+    assertEquals(
+        ImmutableList.of(Savepoint.of("s1"), Savepoint.of("s2")), transaction.getSavepoints());
+
+    assertEquals(
+        ImmutableList.of(Savepoint.of("s1"), Savepoint.of("s2")), transaction.getSavepoints());
+    transaction.rollbackToSavepoint("s1");
+    assertEquals(ImmutableList.of(Savepoint.of("s1")), transaction.getSavepoints());
+
+    assertThrows(SpannerException.class, () -> transaction.rollbackToSavepoint("s2"));
+    assertEquals(ImmutableList.of(Savepoint.of("s1")), transaction.getSavepoints());
+
+    transaction.savepoint("s2", dialect);
+    transaction.savepoint("s1", dialect);
+    assertEquals(
+        ImmutableList.of(Savepoint.of("s1"), Savepoint.of("s2"), Savepoint.of("s1")),
+        transaction.getSavepoints());
+    transaction.rollbackToSavepoint("s1");
+    assertEquals(
+        ImmutableList.of(Savepoint.of("s1"), Savepoint.of("s2"), Savepoint.of("s1")),
+        transaction.getSavepoints());
+  }
+}

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/it/ITSavepointTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/it/ITSavepointTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.connection.it;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.spanner.KeySet;
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.ParallelIntegrationTest;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.connection.ITAbstractSpannerTest;
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@Category(ParallelIntegrationTest.class)
+@RunWith(JUnit4.class)
+public class ITSavepointTest extends ITAbstractSpannerTest {
+  @Override
+  public void appendConnectionUri(StringBuilder uri) {
+    uri.append(";autocommit=false");
+  }
+
+  @Override
+  public boolean doCreateDefaultTestTable() {
+    return true;
+  }
+
+  @Before
+  public void clearTestData() {
+    try (ITConnection connection = createConnection()) {
+      connection.bufferedWrite(Mutation.delete("TEST", KeySet.all()));
+      connection.commit();
+    }
+  }
+
+  @Test
+  public void testRollbackDmlStatement() {
+    try (ITConnection connection = createConnection()) {
+      assertEquals(
+          1L,
+          connection.executeUpdate(
+              Statement.newBuilder("insert into test (id, name) values (@id, @name)")
+                  .bind("id")
+                  .to(1L)
+                  .bind("name")
+                  .to("One")
+                  .build()));
+      connection.savepoint("s1");
+      assertEquals(
+          1L,
+          connection.executeUpdate(
+              Statement.newBuilder("insert into test (id, name) values (@id, @name)")
+                  .bind("id")
+                  .to(2L)
+                  .bind("name")
+                  .to("Two")
+                  .build()));
+
+      connection.rollbackToSavepoint("s1");
+      connection.commit();
+
+      try (ResultSet resultSet = connection.executeQuery(Statement.of("select * from test"))) {
+        assertTrue(resultSet.next());
+        assertEquals(1L, resultSet.getLong(0));
+        assertEquals("One", resultSet.getString(1));
+        assertFalse(resultSet.next());
+      }
+    }
+  }
+
+  @Test
+  public void testRollbackMutations() {
+    try (ITConnection connection = createConnection()) {
+      connection.bufferedWrite(
+          Mutation.newInsertBuilder("test").set("id").to(1L).set("name").to("One").build());
+      connection.savepoint("s1");
+      connection.bufferedWrite(
+          Mutation.newInsertBuilder("test").set("id").to(2L).set("name").to("Two").build());
+      connection.savepoint("s2");
+      connection.bufferedWrite(
+          Mutation.newInsertBuilder("test").set("id").to(3L).set("name").to("Three").build());
+      connection.savepoint("s3");
+      connection.bufferedWrite(
+          Mutation.newInsertBuilder("test").set("id").to(4L).set("name").to("Four").build());
+      connection.savepoint("s4");
+
+      connection.rollbackToSavepoint("s2");
+      connection.commit();
+
+      try (ResultSet resultSet =
+          connection.executeQuery(Statement.of("select * from test order by id"))) {
+        assertTrue(resultSet.next());
+        assertEquals(1L, resultSet.getLong(0));
+        assertEquals("One", resultSet.getString(1));
+        assertTrue(resultSet.next());
+        assertEquals(2L, resultSet.getLong(0));
+        assertEquals("Two", resultSet.getString(1));
+        assertFalse(resultSet.next());
+      }
+    }
+  }
+
+  @Test
+  public void testRollbackBatchDmlStatement() {
+    try (ITConnection connection = createConnection()) {
+      assertArrayEquals(
+          new long[] {1L, 1L},
+          connection.executeBatchUpdate(
+              ImmutableList.of(
+                  Statement.newBuilder("insert into test (id, name) values (@id, @name)")
+                      .bind("id")
+                      .to(1L)
+                      .bind("name")
+                      .to("One")
+                      .build(),
+                  Statement.newBuilder("insert into test (id, name) values (@id, @name)")
+                      .bind("id")
+                      .to(2L)
+                      .bind("name")
+                      .to("Two")
+                      .build())));
+      connection.savepoint("s1");
+      assertArrayEquals(
+          new long[] {1L, 1L},
+          connection.executeBatchUpdate(
+              ImmutableList.of(
+                  Statement.newBuilder("insert into test (id, name) values (@id, @name)")
+                      .bind("id")
+                      .to(3L)
+                      .bind("name")
+                      .to("Three")
+                      .build(),
+                  Statement.newBuilder("insert into test (id, name) values (@id, @name)")
+                      .bind("id")
+                      .to(4L)
+                      .bind("name")
+                      .to("Four")
+                      .build())));
+
+      connection.rollbackToSavepoint("s1");
+      connection.commit();
+
+      try (ResultSet resultSet =
+          connection.executeQuery(Statement.of("select * from test order by id"))) {
+        assertTrue(resultSet.next());
+        assertEquals(1L, resultSet.getLong(0));
+        assertEquals("One", resultSet.getString(1));
+        assertTrue(resultSet.next());
+        assertEquals(2L, resultSet.getLong(0));
+        assertEquals("Two", resultSet.getString(1));
+        assertFalse(resultSet.next());
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds support for savepoints to the Connection API. Savepoints use the internal retry mechanism for read/write transactions to emulate actual savepoints. Rolling back to a savepoint is guaranteed to always work, but resuming the transaction after rolling back can fail if the underlying data has been modified, or if one or more of the statements before the savepoint that was rolled back to returns non-deterministic data.
