### PR TITLE
chore: fix kokoro windows java 8 ci by setting correct JAVA11_HOME

### DIFF
--- a/.kokoro/build.bat
+++ b/.kokoro/build.bat
@@ -17,6 +17,6 @@
 
 set JAVA8_HOME=%JAVA_HOME:"=%
 choco install -y openjdk11
-set JAVA11_HOME=C:\Program Files\Eclipse Adoptium\jdk-11.0.17.8-hotspot\
+set JAVA11_HOME=C:\Program Files\Eclipse Adoptium\jdk-11.0.18.10-hotspot\
 
 "C:\Program Files\Git\bin\bash.exe" %~dp0build.sh

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ implementation 'com.google.cloud:google-cloud-spanner'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-spanner:6.36.1'
+implementation 'com.google.cloud:google-cloud-spanner:6.37.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.36.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.37.0"
 ```
 
 ## Authentication


### PR DESCRIPTION
The Windows build was failing due to incorrect JAVA11_HOME env.

```
Temurin11 has been installed.
  temurin11 may be able to be automatically uninstalled.
Environment Vars (like PATH) have changed. Close/reopen your shell to
 see the changes (or in powershell/cmd.exe just type `refreshenv`).
 The install of temurin11 was successful.
  Software installed to 'C:\Program Files\Eclipse Adoptium\jdk-11.0.18.10-hotspot\'

openjdk11 v11.0.16.20220913 [Approved]
openjdk11 package files install completed. Performing other installation steps.
 The install of openjdk11 was successful.
  Software install location not explicitly set, could be in package or
  default install location if installer.

Chocolatey installed 2/2 packages.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

T:\src>set JAVA11_HOME=C:\Program Files\Eclipse Adoptium\jdk-11.0.17.8-hotspot\

T:\src>"C:\Program Files\Git\bin\bash.exe" T:\src\github\java-spanner\.kokoro\build.sh
/c/ProgramData/chocolatey/lib/maven/apache-maven-3.8.4/bin/mvn: line 92: cd: C:\Program Files\Eclipse Adoptium\jdk-11.0.17.8-hotspot\: No such file or directory
The JAVA_HOME environment variable is not defined correctly,
this environment variable is needed to run this program.
```

This PR fixes the JAVA11_HOME env to its correct value.