### PR TITLE
test: fix mock server ARRAY<BYTES> parameter cast

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.9.0')
+implementation platform('com.google.cloud:libraries-bom:26.10.0')
 
 implementation 'com.google.cloud:google-cloud-spanner'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-spanner:6.36.1'
+implementation 'com.google.cloud:google-cloud-spanner:6.38.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.36.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.38.0"
 ```
 
 ## Authentication

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -21,6 +21,7 @@ import static com.google.cloud.spanner.MockSpannerTestUtil.READ_ONE_KEY_VALUE_RE
 import static com.google.cloud.spanner.MockSpannerTestUtil.READ_ONE_KEY_VALUE_STATEMENT;
 import static com.google.cloud.spanner.MockSpannerTestUtil.READ_TABLE_NAME;
 import static com.google.cloud.spanner.MockSpannerTestUtil.SELECT1;
+import static com.google.cloud.spanner.MockSpannerTestUtil.SELECT1_RESULTSET;
 import static com.google.cloud.spanner.SpannerApiFutures.get;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -2940,6 +2941,24 @@ public class DatabaseClientImplTest {
       assertEquals(
           Code.UNRECOGNIZED,
           resultSet.getType().getStructFields().get(6).getType().getArrayElementType().getCode());
+    }
+  }
+
+  @Test
+  public void testStatementWithBytesArrayParameter() {
+    Statement statement =
+        Statement.newBuilder("select id from test where b=@p1")
+            .bind("p1")
+            .toBytesArray(
+                ImmutableList.of(ByteArray.copyFrom("test1"), ByteArray.copyFrom("test2")))
+            .build();
+    mockSpanner.putStatementResult(StatementResult.query(statement, SELECT1_RESULTSET));
+    DatabaseClient client =
+        spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+    try (ResultSet resultSet = client.singleUse().executeQuery(statement)) {
+      assertTrue(resultSet.next());
+      assertEquals(1L, resultSet.getLong(0));
+      assertFalse(resultSet.next());
     }
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -20,6 +20,7 @@ import com.google.api.gax.grpc.testing.MockGrpcService;
 import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.spanner.AbstractResultSet.GrpcStruct;
+import com.google.cloud.spanner.AbstractResultSet.LazyByteArray;
 import com.google.cloud.spanner.SessionPool.SessionPoolTransactionContext;
 import com.google.cloud.spanner.TransactionRunnerImpl.TransactionContextImpl;
 import com.google.common.base.Optional;
@@ -1362,9 +1363,11 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
                 builder
                     .bind(fieldName)
                     .toBytesArray(
-                        (Iterable<ByteArray>)
-                            GrpcStruct.decodeArrayValue(
-                                com.google.cloud.spanner.Type.bytes(), value.getListValue()));
+                        Iterables.transform(
+                            (Iterable<LazyByteArray>)
+                                GrpcStruct.decodeArrayValue(
+                                    com.google.cloud.spanner.Type.bytes(), value.getListValue()),
+                            LazyByteArray::getByteArray));
                 break;
               case DATE:
                 builder


### PR DESCRIPTION
The recent change that made decoding BYTES and ARRAY<BYTES> lazy did not update all code paths in the mock Spanner server that is used for testing. This meant that tests that tried to use ARRAY<BYTES> query parameters would run into a ClassCastException. This problem only occurs in (internal) test code and does not affect user code.