### PR TITLE
test: fix NullPointerException in mock server

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.11.0')
+implementation platform('com.google.cloud:libraries-bom:26.12.0')
 
 implementation 'com.google.cloud:google-cloud-spanner'
 ```

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -84,6 +84,7 @@ import io.grpc.inprocess.InProcessServerBuilder;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
@@ -2950,7 +2951,7 @@ public class DatabaseClientImplTest {
         Statement.newBuilder("select id from test where b=@p1")
             .bind("p1")
             .toBytesArray(
-                ImmutableList.of(ByteArray.copyFrom("test1"), ByteArray.copyFrom("test2")))
+                Arrays.asList(ByteArray.copyFrom("test1"), null, ByteArray.copyFrom("test2")))
             .build();
     mockSpanner.putStatementResult(StatementResult.query(statement, SELECT1_RESULTSET));
     DatabaseClient client =

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -1367,7 +1367,8 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
                             (Iterable<LazyByteArray>)
                                 GrpcStruct.decodeArrayValue(
                                     com.google.cloud.spanner.Type.bytes(), value.getListValue()),
-                            LazyByteArray::getByteArray));
+                            lazyByteArray ->
+                                lazyByteArray == null ? null : lazyByteArray.getByteArray()));
                 break;
               case DATE:
                 builder


### PR DESCRIPTION
Fix a potential NullPointerException in the mock server when a statement uses a parameter of type ARRAY<BYTES> with a null element in the array.
