### PR TITLE
Revert "build(deps): update dependency org.jacoco:jacoco-maven-plugin to v0.8.9"

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.11.0')
+implementation platform('com.google.cloud:libraries-bom:26.12.0')
 
 implementation 'com.google.cloud:google-cloud-spanner'
 ```

--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -29,7 +29,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.9</version>
+        <version>0.8.8</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
Reverts googleapis/java-spanner#2363

@rajatbhatta It seems that we need to revert this, as the integration tests have started failing after this update with an error related to this version bump.