### PR TITLE
Default Retention Period Feature: Handle null expire time in GapicSpanner RPC

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -1272,8 +1272,10 @@ public class GapicSpannerRpc implements SpannerRpc {
     final String backupId = backupInfo.getId().getBackup();
     final Backup.Builder backupBuilder =
         com.google.spanner.admin.database.v1.Backup.newBuilder()
-            .setDatabase(databaseName)
-            .setExpireTime(backupInfo.getExpireTime().toProto());
+            .setDatabase(databaseName);
+    if (backupInfo.getExpireTime() != null) {
+      backupBuilder.setExpireTime(backupInfo.getExpireTime().toProto());
+    }
     if (backupInfo.getVersionTime() != null) {
       backupBuilder.setVersionTime(backupInfo.getVersionTime().toProto());
     }


### PR DESCRIPTION
Context:
Today, cloud customers have to mandatorily specify the expiration timestamp at the time of create/copy backup. With the default retention period feature, the expiration timestamp is made optional at the time of create/copy backup. If the customer doesn't specify the expiration timestamp, the default retention period of the backup is set to 1 year.

Planned Changes:
Changes would be made in the following order -
1. Set the expire timestamp in the rpc layer only if the backup object has a valid expire timestamp
2. Remove the precondition checks on expire time from Backup.java and BackupInfo.java and add them in CopyBackup and UpdateBackup APIs in DatabaseAdminClient.java
3. Remove the precondition check in CreateBackup API in DatabaseAdminClient.java In this commit, change (1) is being made.

Fixes #279717031
