### PR TITLE
feat: Default Retention Period: Move null expire timestamp preconditions from Backup class to DatabaseAdminClient class 

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Backup.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Backup.java
@@ -108,7 +108,6 @@ public class Backup extends BackupInfo {
    * an expire time, the method will throw an {@link IllegalStateException}.
    */
   public void updateExpireTime() {
-    Preconditions.checkState(getExpireTime() != null, "This backup has no expire time");
     dbClient.updateBackup(instance(), backup(), getExpireTime());
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BackupInfo.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BackupInfo.java
@@ -144,7 +144,7 @@ public class BackupInfo {
 
     @Override
     public Builder setExpireTime(Timestamp expireTime) {
-      this.expireTime = Preconditions.checkNotNull(expireTime);
+      this.expireTime = expireTime;
       return this;
     }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseAdminClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseAdminClientImpl.java
@@ -180,6 +180,8 @@ class DatabaseAdminClientImpl implements DatabaseAdminClient {
       BackupId sourceBackupId, Backup destinationBackup) throws SpannerException {
     Preconditions.checkNotNull(sourceBackupId);
     Preconditions.checkNotNull(destinationBackup);
+    Preconditions.checkArgument(
+        destinationBackup.getExpireTime() != null, "Cannot copy a backup without an expire time");
 
     final OperationFuture<com.google.spanner.admin.database.v1.Backup, CopyBackupMetadata>
         rawOperationFuture = rpc.copyBackup(sourceBackupId, destinationBackup);
@@ -208,6 +210,8 @@ class DatabaseAdminClientImpl implements DatabaseAdminClient {
 
   @Override
   public Backup updateBackup(String instanceId, String backupId, Timestamp expireTime) {
+    Preconditions.checkArgument(
+        expireTime != null, "Cannot update a backup without an expire time");
     String backupName = getBackupName(instanceId, backupId);
     final com.google.spanner.admin.database.v1.Backup backup =
         com.google.spanner.admin.database.v1.Backup.newBuilder()

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -1271,8 +1271,7 @@ public class GapicSpannerRpc implements SpannerRpc {
     final String databaseName = backupInfo.getDatabase().getName();
     final String backupId = backupInfo.getId().getBackup();
     final Backup.Builder backupBuilder =
-        com.google.spanner.admin.database.v1.Backup.newBuilder()
-            .setDatabase(databaseName);
+        com.google.spanner.admin.database.v1.Backup.newBuilder().setDatabase(databaseName);
     if (backupInfo.getExpireTime() != null) {
       backupBuilder.setExpireTime(backupInfo.getExpireTime().toProto());
     }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -1272,8 +1272,10 @@ public class GapicSpannerRpc implements SpannerRpc {
     final String backupId = backupInfo.getId().getBackup();
     final Backup.Builder backupBuilder =
         com.google.spanner.admin.database.v1.Backup.newBuilder()
-            .setDatabase(databaseName)
-            .setExpireTime(backupInfo.getExpireTime().toProto());
+            .setDatabase(databaseName);
+    if (backupInfo.getExpireTime() != null) {
+      backupBuilder.setExpireTime(backupInfo.getExpireTime().toProto());
+    }
     if (backupInfo.getVersionTime() != null) {
       backupBuilder.setVersionTime(backupInfo.getVersionTime().toProto());
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BackupTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BackupTest.java
@@ -202,17 +202,6 @@ public class BackupTest {
   }
 
   @Test
-  public void updateExpireTimeWithoutExpireTime() {
-    Backup backup =
-        dbClient
-            .newBackupBuilder(BackupId.of("test-project", "test-instance", "test-backup"))
-            .build();
-    IllegalStateException e =
-        assertThrows(IllegalStateException.class, () -> backup.updateExpireTime());
-    assertNotNull(e.getMessage());
-  }
-
-  @Test
   public void restore() {
     Backup backup =
         dbClient

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminClientImplTest.java
@@ -594,6 +594,18 @@ public class DatabaseAdminClientImplTest {
     assertThat(op.get().getEncryptionInfo().getKmsKeyVersion()).isEqualTo(KMS_KEY_VERSION);
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void copyBackupWithNoExpireTime() {
+    OperationFuture<Backup, CopyBackupMetadata> rawOperationFuture =
+        OperationFutureUtil.immediateOperationFuture(
+            "copyBackup", getBackupProto(), CopyBackupMetadata.getDefaultInstance());
+    final com.google.cloud.spanner.Backup backup =
+        client.newBackupBuilder(BackupId.of(PROJECT_ID, INSTANCE_ID, BK_ID)).build();
+    when(rpc.copyBackup(BackupId.of(PROJECT_ID, INSTANCE_ID, SOURCE_BK), backup))
+        .thenReturn(rawOperationFuture);
+    client.copyBackup(INSTANCE_ID, SOURCE_BK, BK_ID, null);
+  }
+
   @Test
   public void deleteBackup() {
     client.deleteBackup(INSTANCE_ID, BK_ID);
@@ -639,6 +651,14 @@ public class DatabaseAdminClientImplTest {
                 .build());
     com.google.cloud.spanner.Backup updatedBackup = client.updateBackup(INSTANCE_ID, BK_ID, t);
     assertThat(updatedBackup.getExpireTime()).isEqualTo(t);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void updateBackupWithNoExpireTime() {
+    Backup backup = Backup.newBuilder().setName(BK_NAME).build();
+    when(rpc.updateBackup(backup, FieldMask.newBuilder().addPaths("expire_time").build()))
+        .thenReturn(Backup.newBuilder().setName(BK_NAME).setDatabase(DB_NAME).build());
+    client.updateBackup(INSTANCE_ID, BK_ID, null);
   }
 
   @Test


### PR DESCRIPTION
With the default retention period feature, null value for expiration is a valid value. However, this is not be a valid value in updateBackup path. So, any pre-conditions on null values should be in the API path and not in the object builder path. Thereby, moving precondition checks from backup class to DatabaseAdminClient class.

This is the second change in the line of planned changes - 
Planned Changes:
Changes would be made in the following order -
1. Set the expire timestamp in the rpc layer only if the backup object
   has a valid expire timestamp
2. Remove the precondition checks on expire time from Backup.java and
   BackupInfo.java and add them in CopyBackup and UpdateBackup APIs in
   DatabaseAdminClient.java
3. Remove the precondition check in CreateBackup API in
   DatabaseAdminClient.java

Fixes # 279731324