### PR TITLE
feat(Default Retention Period): CopyBackup changes to support null ex…

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BackupInfo.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BackupInfo.java
@@ -144,7 +144,7 @@ public class BackupInfo {
 
     @Override
     public Builder setExpireTime(Timestamp expireTime) {
-      this.expireTime = Preconditions.checkNotNull(expireTime);
+      this.expireTime = expireTime;
       return this;
     }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -1339,9 +1339,10 @@ public class GapicSpannerRpc implements SpannerRpc {
         CopyBackupRequest.newBuilder()
             .setParent(instanceName)
             .setBackupId(backupId)
-            .setSourceBackup(sourceBackupId.getName())
-            .setExpireTime(destinationBackup.getExpireTime().toProto());
-
+            .setSourceBackup(sourceBackupId.getName());
+    if (destinationBackup.getExpireTime() != null) {
+      requestBuilder.setExpireTime(destinationBackup.getExpireTime().toProto());
+    }
     if (destinationBackup.getEncryptionConfig() != null) {
       requestBuilder.setEncryptionConfig(
           EncryptionConfigProtoMapper.copyBackupEncryptionConfig(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminClientImplTest.java
@@ -595,6 +595,21 @@ public class DatabaseAdminClientImplTest {
   }
 
   @Test
+  public void copyBackupWithNoExpireTime() throws ExecutionException, InterruptedException {
+    OperationFuture<Backup, CopyBackupMetadata> rawOperationFuture =
+        OperationFutureUtil.immediateOperationFuture(
+            "copyBackup", getBackupProto(), CopyBackupMetadata.getDefaultInstance());
+    final com.google.cloud.spanner.Backup backup =
+        client.newBackupBuilder(BackupId.of(PROJECT_ID, INSTANCE_ID, BK_ID)).build();
+    when(rpc.copyBackup(BackupId.of(PROJECT_ID, INSTANCE_ID, SOURCE_BK), backup))
+        .thenReturn(rawOperationFuture);
+    OperationFuture<com.google.cloud.spanner.Backup, CopyBackupMetadata> op =
+        client.copyBackup(INSTANCE_ID, SOURCE_BK, BK_ID, null);
+    assertThat(op.isDone()).isTrue();
+    assertThat(op.get().getId().getName()).isEqualTo(BK_NAME);
+  }
+
+  @Test
   public void deleteBackup() {
     client.deleteBackup(INSTANCE_ID, BK_ID);
     verify(rpc).deleteBackup(BK_NAME);


### PR DESCRIPTION
…pire time

With the default retention period feature, null value for expiration is a valid value. Precondition check in setExpireTime restricts null from being passed to the CopyBackup method DatabaseAdminClient class. Removing it and adding an extra null check in GapicSpannerRpc java to handle the null expire time.

Fixes #279732156☕️