### PR TITLE
feat(default_retention_period): CreateBackup changes to support null expire time

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BackupInfo.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BackupInfo.java
@@ -144,7 +144,7 @@ public class BackupInfo {
 
     @Override
     public Builder setExpireTime(Timestamp expireTime) {
-      this.expireTime = Preconditions.checkNotNull(expireTime);
+      this.expireTime = expireTime;
       return this;
     }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Database.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Database.java
@@ -110,12 +110,10 @@ public class Database extends DatabaseInfo {
   }
 
   /**
-   * Backs up this database to the location specified by the {@link Backup}. The given {@link
-   * Backup} must have an expire time. The backup must belong to the same instance as this database.
+   * Backs up this database to the location specified by the {@link Backup}. The backup must belong
+   * to the same instance as this database.
    */
   public OperationFuture<Backup, CreateBackupMetadata> backup(Backup backup) {
-    Preconditions.checkArgument(
-        backup.getExpireTime() != null, "The backup does not have an expire time.");
     Preconditions.checkArgument(
         backup.getInstanceId().equals(getId().getInstanceId()),
         "The instance of the backup must be equal to the instance of this database.");

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseAdminClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseAdminClientImpl.java
@@ -132,8 +132,6 @@ class DatabaseAdminClientImpl implements DatabaseAdminClient {
   public OperationFuture<Backup, CreateBackupMetadata> createBackup(Backup backupInfo)
       throws SpannerException {
     Preconditions.checkArgument(
-        backupInfo.getExpireTime() != null, "Cannot create a backup without an expire time");
-    Preconditions.checkArgument(
         backupInfo.getDatabase() != null, "Cannot create a backup without a source database");
 
     final OperationFuture<com.google.spanner.admin.database.v1.Backup, CreateBackupMetadata>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -1339,9 +1339,10 @@ public class GapicSpannerRpc implements SpannerRpc {
         CopyBackupRequest.newBuilder()
             .setParent(instanceName)
             .setBackupId(backupId)
-            .setSourceBackup(sourceBackupId.getName())
-            .setExpireTime(destinationBackup.getExpireTime().toProto());
-
+            .setSourceBackup(sourceBackupId.getName());
+    if (destinationBackup.getExpireTime() != null) {
+      requestBuilder.setExpireTime(destinationBackup.getExpireTime().toProto());
+    }
     if (destinationBackup.getEncryptionConfig() != null) {
       requestBuilder.setEncryptionConfig(
           EncryptionConfigProtoMapper.copyBackupEncryptionConfig(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -1341,7 +1341,7 @@ public class GapicSpannerRpc implements SpannerRpc {
             .setBackupId(backupId)
             .setSourceBackup(sourceBackupId.getName());
     if (destinationBackup.getExpireTime() != null) {
-      requestBuilder.setExpireTime(destinationBackup.getExpireTime().toProto());
+        requestBuilder.setExpireTime(destinationBackup.getExpireTime().toProto());
     }
     if (destinationBackup.getEncryptionConfig() != null) {
       requestBuilder.setEncryptionConfig(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -1270,10 +1270,10 @@ public class GapicSpannerRpc implements SpannerRpc {
     final String instanceName = backupInfo.getInstanceId().getName();
     final String databaseName = backupInfo.getDatabase().getName();
     final String backupId = backupInfo.getId().getBackup();
-    final Backup.Builder backupBuilder =
-        com.google.spanner.admin.database.v1.Backup.newBuilder()
-            .setDatabase(databaseName)
-            .setExpireTime(backupInfo.getExpireTime().toProto());
+    final Backup.Builder backupBuilder = Backup.newBuilder().setDatabase(databaseName);
+    if (backupInfo.getExpireTime() != null) {
+      backupBuilder.setExpireTime(backupInfo.getExpireTime().toProto());
+    }
     if (backupInfo.getVersionTime() != null) {
       backupBuilder.setVersionTime(backupInfo.getVersionTime().toProto());
     }
@@ -1341,7 +1341,7 @@ public class GapicSpannerRpc implements SpannerRpc {
             .setBackupId(backupId)
             .setSourceBackup(sourceBackupId.getName());
     if (destinationBackup.getExpireTime() != null) {
-        requestBuilder.setExpireTime(destinationBackup.getExpireTime().toProto());
+      requestBuilder.setExpireTime(destinationBackup.getExpireTime().toProto());
     }
     if (destinationBackup.getEncryptionConfig() != null) {
       requestBuilder.setEncryptionConfig(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminClientImplTest.java
@@ -595,6 +595,21 @@ public class DatabaseAdminClientImplTest {
   }
 
   @Test
+  public void copyBackupWithNoExpireTime() throws ExecutionException, InterruptedException {
+    OperationFuture<Backup, CopyBackupMetadata> rawOperationFuture =
+        OperationFutureUtil.immediateOperationFuture(
+            "copyBackup", getBackupProto(), CopyBackupMetadata.getDefaultInstance());
+    final com.google.cloud.spanner.Backup backup =
+        client.newBackupBuilder(BackupId.of(PROJECT_ID, INSTANCE_ID, BK_ID)).build();
+    when(rpc.copyBackup(BackupId.of(PROJECT_ID, INSTANCE_ID, SOURCE_BK), backup))
+        .thenReturn(rawOperationFuture);
+    OperationFuture<com.google.cloud.spanner.Backup, CopyBackupMetadata> op =
+        client.copyBackup(INSTANCE_ID, SOURCE_BK, BK_ID, null);
+    assertThat(op.isDone()).isTrue();
+    assertThat(op.get().getId().getName()).isEqualTo(BK_NAME);
+  }
+
+  @Test
   public void deleteBackup() {
     client.deleteBackup(INSTANCE_ID, BK_ID);
     verify(rpc).deleteBackup(BK_NAME);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseAdminClientImplTest.java
@@ -600,7 +600,9 @@ public class DatabaseAdminClientImplTest {
         OperationFutureUtil.immediateOperationFuture(
             "copyBackup", getBackupProto(), CopyBackupMetadata.getDefaultInstance());
     final com.google.cloud.spanner.Backup backup =
-        client.newBackupBuilder(BackupId.of(PROJECT_ID, INSTANCE_ID, BK_ID)).build();
+        client
+            .newBackupBuilder(BackupId.of(PROJECT_ID, INSTANCE_ID, BK_ID))
+            .build();
     when(rpc.copyBackup(BackupId.of(PROJECT_ID, INSTANCE_ID, SOURCE_BK), backup))
         .thenReturn(rawOperationFuture);
     OperationFuture<com.google.cloud.spanner.Backup, CopyBackupMetadata> op =

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseTest.java
@@ -95,6 +95,17 @@ public class DatabaseTest {
   }
 
   @Test
+  public void backupWithoutExpireTime() {
+    Database db = createDatabase();
+    Backup backup =
+        dbClient
+            .newBackupBuilder(BackupId.of("test-project", "test-instance", "test-backup"))
+            .build();
+    db.backup(backup);
+    verify(dbClient).createBackup(backup.toBuilder().setDatabase(db.getId()).build());
+  }
+
+  @Test
   public void listDatabaseOperations() {
     Database db = createDatabase();
     db.listDatabaseOperations();


### PR DESCRIPTION
With the default retention period feature, null value for expiration time is a
valid value. Precondition checks in Database/backup and DatabaseAdminClientImpl/createBackup
restrict null from being passed to the underlying rpc layer. Removing these checks
and also ensuring null is properly handled in GapicSpannerRpc class.
Fixes #279731324 ☕️