### PR TITLE
test: simplifying Java 8 test via jvm property

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -8,8 +8,7 @@ branchProtectionRules:
     requiresCodeOwnerReviews: true
     requiresStrictStatusChecks: false
     requiredStatusCheckContexts:
-      - dependencies (8)
-      - dependencies (11)
+      - dependencies (17)
       - lint
       - units (8)
       - units (11)
@@ -27,7 +26,6 @@ branchProtectionRules:
     requiresCodeOwnerReviews: true
     requiresStrictStatusChecks: false
     requiredStatusCheckContexts:
-      - dependencies (8)
       - dependencies (11)
       - lint
       - units (7)

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -40,7 +40,6 @@ branchProtectionRules:
     requiresCodeOwnerReviews: true
     requiresStrictStatusChecks: false
     requiredStatusCheckContexts:
-      - dependencies (8)
       - dependencies (11)
       - lint
       - units (7)
@@ -55,7 +54,6 @@ branchProtectionRules:
     requiresCodeOwnerReviews: true
     requiresStrictStatusChecks: false
     requiredStatusCheckContexts:
-      - dependencies (8)
       - dependencies (11)
       - lint
       - units (7)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,7 +85,7 @@ jobs:
     - uses: actions/setup-java@v3
       with:
         distribution: zulu
-        java-version: ${{'{{matrix.java}}'}}
+        java-version: ${{matrix.java}}
     - run: java -version
     - run: .kokoro/dependencies.sh
   lint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,7 @@ jobs:
       env:
         JOB_TYPE: test
   units-java8:
+    # Building using Java 17 and run the tests with Java 8 runtime
     name: "units (8)"
     runs-on: ubuntu-latest
     steps:
@@ -49,10 +50,8 @@ jobs:
       shell: bash
     - uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
         distribution: zulu
-    - run: echo "JAVA11_HOME=${JAVA_HOME}" >> $GITHUB_ENV
-      shell: bash
     - run: .kokoro/build.sh
       env:
         JOB_TYPE: test
@@ -80,25 +79,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11, 17]
+        java: [17]
     steps:
     - uses: actions/checkout@v3
-    # For Java 8 tests, use JDK 11 to compile
-    - if: ${{matrix.java}} == '8'
-      uses: actions/setup-java@v3
-      with:
-        java-version: 11
-        distribution: zulu
-    - if: ${{matrix.java}} == '8'
-      run: echo "JAVA11_HOME=${JAVA_HOME}" >> $GITHUB_ENV
-      shell: bash
     - uses: actions/setup-java@v3
       with:
         distribution: zulu
-        java-version: ${{matrix.java}}
-    - if: ${{matrix.java}} == '8'
-      run: echo "JAVA8_HOME=${JAVA_HOME}" >> $GITHUB_ENV
-      shell: bash
+        java-version: ${{'{{matrix.java}}'}}
     - run: java -version
     - run: .kokoro/dependencies.sh
   lint:
@@ -108,7 +95,7 @@ jobs:
     - uses: actions/setup-java@v3
       with:
         distribution: zulu
-        java-version: 11
+        java-version: 17
     - run: java -version
     - run: .kokoro/build.sh
       env:
@@ -120,7 +107,7 @@ jobs:
     - uses: actions/setup-java@v3
       with:
         distribution: zulu
-        java-version: 11
+        java-version: 17
     - run: java -version
     - run: .kokoro/build.sh
       env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
       with:
         java-version: 8
         distribution: zulu
-    - run: echo "JAVA8_HOME=${JAVA_HOME}" >> $GITHUB_ENV
+    - run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}/bin/java" >> $GITHUB_ENV
       shell: bash
     - uses: actions/setup-java@v3
       with:

--- a/.github/workflows/integration-tests-against-emulator.yaml
+++ b/.github/workflows/integration-tests-against-emulator.yaml
@@ -25,20 +25,15 @@ jobs:
       with:
         java-version: 11
         distribution: zulu
-    - run: echo "JAVA11_HOME=${JAVA_HOME}" >> $GITHUB_ENV
-      shell: bash
+    - name: Compiling main library
+      run: .kokoro/build.sh
     - uses: actions/setup-java@v3
       with:
         java-version: 8
         distribution: zulu
-    - run: echo "JAVA8_HOME=${JAVA_HOME}" >> $GITHUB_ENV
-      shell: bash
-    - run: java -version
-    - name: Compiling main library
-      run: .kokoro/build.sh
     - name: Running tests
       run: |
-        mvn -B -Dspanner.testenv.instance="" -Penable-integration-tests \
+        mvn -V -B -Dspanner.testenv.instance="" -Penable-integration-tests \
             -DtrimStackTrace=false -Dclirr.skip=true -Denforcer.skip=true \
             -Dmaven.main.skip=true -fae verify
       env:

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -23,8 +23,8 @@ cd ${scriptDir}/..
 # include common functions
 source ${scriptDir}/common.sh
 
-# units-java8 uses both JDK 11 and JDK 8. GraalVM dependencies require JDK 11 to
-# compile the classes touching GraalVM classes.
+# Kokoro integration test uses both JDK 11 and JDK 8. GraalVM dependencies
+# require JDK 11 to compile the classes touching GraalVM classes.
 if [ -n "${JAVA11_HOME}" ]; then
   setJava "${JAVA11_HOME}"
 fi
@@ -48,7 +48,7 @@ if [[ ! -z "${GOOGLE_APPLICATION_CREDENTIALS}" && "${GOOGLE_APPLICATION_CREDENTI
     export GOOGLE_APPLICATION_CREDENTIALS=$(realpath ${KOKORO_GFILE_DIR}/${GOOGLE_APPLICATION_CREDENTIALS})
 fi
 
-# units-java8 uses both JDK 11 and JDK 8. We ensure the generated class files
+# Kokoro integration test uses both JDK 11 and JDK 8. We ensure the generated class files
 # are compatible with Java 8 when running tests.
 if [ -n "${JAVA8_HOME}" ]; then
   setJava "${JAVA8_HOME}"

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -63,6 +63,7 @@ test)
     # https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#jvm
     # If we rely on certain things only available in newer JVM than Java 8, this
     # tests detect the usage.
+    echo "SUREFIRE_JVM_OPT: ${SUREFIRE_JVM_OPT}"
     mvn test -B -V \
       -Dclirr.skip=true \
       -Denforcer.skip=true \

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/v1/SpannerClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/v1/SpannerClient.java
@@ -184,9 +184,6 @@ public class SpannerClient implements BackgroundResource {
   protected SpannerClient(SpannerSettings settings) throws IOException {
     this.settings = settings;
     this.stub = ((SpannerStubSettings) settings.getStubSettings()).createStub();
-
-    // This is dummy statement to touch the Version class that is compiled for Java 11
-    System.out.println("org.graalvm.home.Version: " + org.graalvm.home.Version.parse("1.2.3"));
   }
 
   protected SpannerClient(SpannerStub stub) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/v1/SpannerClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/v1/SpannerClient.java
@@ -184,6 +184,9 @@ public class SpannerClient implements BackgroundResource {
   protected SpannerClient(SpannerSettings settings) throws IOException {
     this.settings = settings;
     this.stub = ((SpannerStubSettings) settings.getStubSettings()).createStub();
+
+    // This is dummy statement to touch the Version class that is compiled for Java 11
+    System.out.println("org.graalvm.home.Version: " + org.graalvm.home.Version.parse("1.2.3"));
   }
 
   protected SpannerClient(SpannerStub stub) {


### PR DESCRIPTION
I found we can simplify the Java 8 test via surefire's jvm property (document: https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#jvm)

Changing the required checks to use "dependencies (17)" only. There's no point running the dependencies checks for different JDK versions.

Once approved, I will change the required checks in repository settings to merge this pull request.


