### PR TITLE
fixit: update region tag to match gold languages

### DIFF
--- a/samples/snippets/src/main/java/com/example/spanner/PgInsertUsingDmlReturningSample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/PgInsertUsingDmlReturningSample.java
@@ -17,6 +17,7 @@
 package com.example.spanner;
 
 // [START spanner_postgresql_insert_dml_returning]
+// [START spanner_postgresql_dml_insert_returning]
 
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.DatabaseId;
@@ -73,4 +74,5 @@ public class PgInsertUsingDmlReturningSample {
     }
   }
 }
+// [END spanner_postgresql_dml_insert_returning]
 // [END spanner_postgresql_insert_dml_returning]


### PR DESCRIPTION
### Fixes N/A

- Is related to [b/281694285](https://b.corp.google.com/issues/281694285)
- Updates the region tag to match other Gold languages
- Merge this PR and then merge [cl/]533550399(https://critique.corp.google.com/cl/533550399)
- Once the cl is merged we must remove the old region tag from this sample via: https://github.com/googleapis/java-spanner/pull/2445

