### PR TITLE
cleanup: remove old region tag

### DIFF
--- a/samples/snippets/src/main/java/com/example/spanner/PgInsertUsingDmlReturningSample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/PgInsertUsingDmlReturningSample.java
@@ -16,7 +16,6 @@
 
 package com.example.spanner;
 
-// [START spanner_postgresql_insert_dml_returning]
 // [START spanner_postgresql_dml_insert_returning]
 
 import com.google.cloud.spanner.DatabaseClient;
@@ -75,4 +74,3 @@ public class PgInsertUsingDmlReturningSample {
   }
 }
 // [END spanner_postgresql_dml_insert_returning]
-// [END spanner_postgresql_insert_dml_returning]


### PR DESCRIPTION
### Fixes N/A

- Related to PR: https://github.com/googleapis/java-spanner/pull/2444
- After [cl/533550399](https://critique.corp.google.com/cl/533550399) is merged we must merge this PR to remove the old region tag