### PR TITLE
fixit: update region tag to match gold languages (spanner_postgresql_dml_delete_returning)

### DIFF
--- a/samples/snippets/src/main/java/com/example/spanner/PgDeleteUsingDmlReturningSample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/PgDeleteUsingDmlReturningSample.java
@@ -17,6 +17,7 @@
 package com.example.spanner;
 
 // [START spanner_postgresql_delete_dml_returning]
+// [START spanner_postgresql_dml_delete_returning]
 
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.DatabaseId;
@@ -71,4 +72,5 @@ public class PgDeleteUsingDmlReturningSample {
     }
   }
 }
+// [END spanner_postgresql_dml_delete_returning]
 // [END spanner_postgresql_delete_dml_returning]


### PR DESCRIPTION
### Fixes N/A

- Is related to [b/281694483](https://b.corp.google.com/issues/281694285)
- Updates the region tag to match other Gold languages
- Merge this PR and then merge [cl/]533581792(https://critique.corp.google.com/cl/533581792)
- Once the cl is merged we must remove the old region tag from this sample via: https://github.com/googleapis/java-spanner/pull/2447

