### PR TITLE
fixit: update region tag to match gold languages (spanner_dml_update_returning)

### DIFF
--- a/samples/snippets/src/main/java/com/example/spanner/UpdateUsingDmlReturningSample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/UpdateUsingDmlReturningSample.java
@@ -17,6 +17,7 @@
 package com.example.spanner;
 
 // [START spanner_update_dml_returning]
+// [START spanner_dml_update_returning]
 
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.DatabaseId;
@@ -73,4 +74,5 @@ public class UpdateUsingDmlReturningSample {
     }
   }
 }
+// [END spanner_dml_update_returning]
 // [END spanner_update_dml_returning]


### PR DESCRIPTION
### Fixes N/A

- Is related to [b/281694597](https://b.corp.google.com/issues/281694597)
- Updates the region tag to match other Gold languages
- Merge this PR and then merge [cl/533584267](https://critique.corp.google.com/cl/533584267)
- Once the cl is merged we must remove the old region tag from this sample via: https://github.com/googleapis/java-spanner/pull/2449

