### PR TITLE
cleanup: remove old region tag (spanner_update_dml_returning)

### DIFF
--- a/samples/snippets/src/main/java/com/example/spanner/UpdateUsingDmlReturningSample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/UpdateUsingDmlReturningSample.java
@@ -16,7 +16,6 @@
 
 package com.example.spanner;
 
-// [START spanner_update_dml_returning]
 // [START spanner_dml_update_returning]
 
 import com.google.cloud.spanner.DatabaseClient;
@@ -75,4 +74,3 @@ public class UpdateUsingDmlReturningSample {
   }
 }
 // [END spanner_dml_update_returning]
-// [END spanner_update_dml_returning]


### PR DESCRIPTION
### Fixes N/A

- Related to PR: https://github.com/googleapis/java-spanner/pull/2448
- After [cl/533584267](https://critique.corp.google.com/cl/533584267) is merged we must merge this PR to remove the old region tag