### PR TITLE
cleanup: remove old region tag (spanner_delete_dml_returning)

### DIFF
--- a/samples/snippets/src/main/java/com/example/spanner/DeleteUsingDmlReturningSample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/DeleteUsingDmlReturningSample.java
@@ -16,7 +16,6 @@
 
 package com.example.spanner;
 
-// [START spanner_delete_dml_returning]
 // [START spanner_dml_delete_returning]
 
 import com.google.cloud.spanner.DatabaseClient;
@@ -73,4 +72,3 @@ public class DeleteUsingDmlReturningSample {
   }
 }
 // [END spanner_dml_delete_returning]
-// [END spanner_delete_dml_returning]


### PR DESCRIPTION
### Fixes N/A

- Related to PR: https://github.com/googleapis/java-spanner/pull/2450
- After [cl/533585863](https://critique.corp.google.com/cl/533585863) is merged we must merge this PR to remove the old region tag