### PR TITLE
fixit: update region tag to match gold languages (spanner_postgresql_dml_update_returning)

### DIFF
--- a/samples/snippets/src/main/java/com/example/spanner/PgUpdateUsingDmlReturningSample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/PgUpdateUsingDmlReturningSample.java
@@ -17,6 +17,7 @@
 package com.example.spanner;
 
 // [START spanner_postgresql_update_dml_returning]
+// [START spanner_postgresql_dml_update_returning]
 
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.DatabaseId;
@@ -73,4 +74,5 @@ public class PgUpdateUsingDmlReturningSample {
     }
   }
 }
+// [END spanner_postgresql_dml_update_returning]
 // [END spanner_postgresql_update_dml_returning]


### PR DESCRIPTION
### Fixes N/A

- Is related to [b/281694682](https://b.corp.google.com/issues/281694682)
- Updates the region tag to match other Gold languages
- Merge this PR and then merge [cl/533587262](https://critique.corp.google.com/cl/533587262)
- Once the cl is merged we must remove the old region tag from this sample via: https://github.com/googleapis/java-spanner/pull/2453

