### PR TITLE
perf: only capture the call stack if the call is actually async

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractMultiUseTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractMultiUseTransaction.java
@@ -102,18 +102,21 @@ abstract class AbstractMultiUseTransaction extends AbstractBaseUnitOfWork {
    * Check that the current transaction actually has a valid underlying transaction. If not, the
    * method will throw a {@link SpannerException}.
    */
-  abstract void checkValidTransaction();
+  abstract void checkValidTransaction(CallType callType);
 
   /** Returns the {@link ReadContext} that can be used for queries on this transaction. */
   abstract ReadContext getReadContext();
 
+  @Override
   public ApiFuture<ResultSet> executeQueryAsync(
+      final CallType callType,
       final ParsedStatement statement,
       final AnalyzeMode analyzeMode,
       final QueryOption... options) {
     Preconditions.checkArgument(statement.isQuery(), "Statement is not a query");
-    checkValidTransaction();
+    checkValidTransaction(callType);
     return executeStatementAsync(
+        callType,
         statement,
         () -> {
           checkAborted();
@@ -133,7 +136,7 @@ abstract class AbstractMultiUseTransaction extends AbstractBaseUnitOfWork {
   }
 
   @Override
-  public ApiFuture<long[]> runBatchAsync() {
+  public ApiFuture<long[]> runBatchAsync(CallType callType) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Run batch is not supported for transactions");
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DdlBatch.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DdlBatch.java
@@ -115,8 +115,12 @@ class DdlBatch extends AbstractBaseUnitOfWork {
     return false;
   }
 
+  @Override
   public ApiFuture<ResultSet> executeQueryAsync(
-      final ParsedStatement statement, AnalyzeMode analyzeMode, QueryOption... options) {
+      CallType callType,
+      final ParsedStatement statement,
+      AnalyzeMode analyzeMode,
+      QueryOption... options) {
     if (options != null) {
       for (int i = 0; i < options.length; i++) {
         if (options[i] instanceof InternalMetadataQuery) {
@@ -136,7 +140,7 @@ class DdlBatch extends AbstractBaseUnitOfWork {
                   DirectExecuteResultSet.ofResultSet(
                       dbClient.singleUse().executeQuery(statement.getStatement(), internalOptions));
           return executeStatementAsync(
-              statement, callable, SpannerGrpc.getExecuteStreamingSqlMethod());
+              callType, statement, callable, SpannerGrpc.getExecuteStreamingSqlMethod());
         }
       }
     }
@@ -179,7 +183,7 @@ class DdlBatch extends AbstractBaseUnitOfWork {
   }
 
   @Override
-  public ApiFuture<Void> executeDdlAsync(ParsedStatement ddl) {
+  public ApiFuture<Void> executeDdlAsync(CallType callType, ParsedStatement ddl) {
     ConnectionPreconditions.checkState(
         state == UnitOfWorkState.STARTED,
         "The batch is no longer active and cannot be used for further statements");
@@ -196,33 +200,34 @@ class DdlBatch extends AbstractBaseUnitOfWork {
   }
 
   @Override
-  public ApiFuture<Long> executeUpdateAsync(ParsedStatement update, UpdateOption... options) {
+  public ApiFuture<Long> executeUpdateAsync(
+      CallType callType, ParsedStatement update, UpdateOption... options) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Executing updates is not allowed for DDL batches.");
   }
 
   @Override
   public ApiFuture<ResultSet> analyzeUpdateAsync(
-      ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options) {
+      CallType callType, ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Analyzing updates is not allowed for DDL batches.");
   }
 
   @Override
   public ApiFuture<long[]> executeBatchUpdateAsync(
-      Iterable<ParsedStatement> updates, UpdateOption... options) {
+      CallType callType, Iterable<ParsedStatement> updates, UpdateOption... options) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Executing batch updates is not allowed for DDL batches.");
   }
 
   @Override
-  public ApiFuture<Void> writeAsync(Iterable<Mutation> mutations) {
+  public ApiFuture<Void> writeAsync(CallType callType, Iterable<Mutation> mutations) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Writing mutations is not allowed for DDL batches.");
   }
 
   @Override
-  public ApiFuture<long[]> runBatchAsync() {
+  public ApiFuture<long[]> runBatchAsync(CallType callType) {
     ConnectionPreconditions.checkState(
         state == UnitOfWorkState.STARTED, "The batch is no longer active and cannot be ran");
     if (statements.isEmpty()) {
@@ -254,7 +259,7 @@ class DdlBatch extends AbstractBaseUnitOfWork {
         };
     this.state = UnitOfWorkState.RUNNING;
     return executeStatementAsync(
-        RUN_BATCH_STATEMENT, callable, DatabaseAdminGrpc.getUpdateDatabaseDdlMethod());
+        callType, RUN_BATCH_STATEMENT, callable, DatabaseAdminGrpc.getUpdateDatabaseDdlMethod());
   }
 
   long[] extractUpdateCounts(OperationFuture<Void, UpdateDatabaseDdlMetadata> operation) {
@@ -286,13 +291,13 @@ class DdlBatch extends AbstractBaseUnitOfWork {
   }
 
   @Override
-  public ApiFuture<Void> commitAsync() {
+  public ApiFuture<Void> commitAsync(CallType callType) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Commit is not allowed for DDL batches.");
   }
 
   @Override
-  public ApiFuture<Void> rollbackAsync() {
+  public ApiFuture<Void> rollbackAsync(CallType callType) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Rollback is not allowed for DDL batches.");
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DmlBatch.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DmlBatch.java
@@ -103,7 +103,10 @@ class DmlBatch extends AbstractBaseUnitOfWork {
 
   @Override
   public ApiFuture<ResultSet> executeQueryAsync(
-      ParsedStatement statement, AnalyzeMode analyzeMode, QueryOption... options) {
+      CallType callType,
+      ParsedStatement statement,
+      AnalyzeMode analyzeMode,
+      QueryOption... options) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Executing queries is not allowed for DML batches.");
   }
@@ -142,13 +145,14 @@ class DmlBatch extends AbstractBaseUnitOfWork {
   }
 
   @Override
-  public ApiFuture<Void> executeDdlAsync(ParsedStatement ddl) {
+  public ApiFuture<Void> executeDdlAsync(CallType callType, ParsedStatement ddl) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Executing DDL statements is not allowed for DML batches.");
   }
 
   @Override
-  public ApiFuture<Long> executeUpdateAsync(ParsedStatement update, UpdateOption... options) {
+  public ApiFuture<Long> executeUpdateAsync(
+      CallType callType, ParsedStatement update, UpdateOption... options) {
     ConnectionPreconditions.checkState(
         state == UnitOfWorkState.STARTED,
         "The batch is no longer active and cannot be used for further statements");
@@ -163,26 +167,26 @@ class DmlBatch extends AbstractBaseUnitOfWork {
 
   @Override
   public ApiFuture<ResultSet> analyzeUpdateAsync(
-      ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options) {
+      CallType callType, ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Analyzing updates is not allowed for DML batches.");
   }
 
   @Override
   public ApiFuture<long[]> executeBatchUpdateAsync(
-      Iterable<ParsedStatement> updates, UpdateOption... options) {
+      CallType callType, Iterable<ParsedStatement> updates, UpdateOption... options) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Executing batch updates is not allowed for DML batches.");
   }
 
   @Override
-  public ApiFuture<Void> writeAsync(Iterable<Mutation> mutations) {
+  public ApiFuture<Void> writeAsync(CallType callType, Iterable<Mutation> mutations) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Writing mutations is not allowed for DML batches.");
   }
 
   @Override
-  public ApiFuture<long[]> runBatchAsync() {
+  public ApiFuture<long[]> runBatchAsync(CallType callType) {
     ConnectionPreconditions.checkState(
         state == UnitOfWorkState.STARTED, "The batch is no longer active and cannot be ran");
     if (statements.isEmpty()) {
@@ -211,7 +215,8 @@ class DmlBatch extends AbstractBaseUnitOfWork {
     if (this.rpcPriority != null) {
       options[index++] = Options.priority(this.rpcPriority);
     }
-    ApiFuture<long[]> updateCounts = transaction.executeBatchUpdateAsync(statements, options);
+    ApiFuture<long[]> updateCounts =
+        transaction.executeBatchUpdateAsync(callType, statements, options);
     ApiFutures.addCallback(
         updateCounts,
         new ApiFutureCallback<long[]>() {
@@ -239,13 +244,13 @@ class DmlBatch extends AbstractBaseUnitOfWork {
   }
 
   @Override
-  public ApiFuture<Void> commitAsync() {
+  public ApiFuture<Void> commitAsync(CallType callType) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Commit is not allowed for DML batches.");
   }
 
   @Override
-  public ApiFuture<Void> rollbackAsync() {
+  public ApiFuture<Void> rollbackAsync(CallType callType) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Rollback is not allowed for DML batches.");
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ReadOnlyTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ReadOnlyTransaction.java
@@ -96,7 +96,7 @@ class ReadOnlyTransaction extends AbstractMultiUseTransaction {
   }
 
   @Override
-  void checkValidTransaction() {
+  void checkValidTransaction(CallType callType) {
     if (transaction == null) {
       transaction = dbClient.readOnlyTransaction(readOnlyStaleness);
     }
@@ -154,13 +154,14 @@ class ReadOnlyTransaction extends AbstractMultiUseTransaction {
   }
 
   @Override
-  public ApiFuture<Void> executeDdlAsync(ParsedStatement ddl) {
+  public ApiFuture<Void> executeDdlAsync(CallType callType, ParsedStatement ddl) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "DDL statements are not allowed for read-only transactions");
   }
 
   @Override
-  public ApiFuture<Long> executeUpdateAsync(ParsedStatement update, UpdateOption... options) {
+  public ApiFuture<Long> executeUpdateAsync(
+      CallType callType, ParsedStatement update, UpdateOption... options) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION,
         "Update statements are not allowed for read-only transactions");
@@ -168,7 +169,7 @@ class ReadOnlyTransaction extends AbstractMultiUseTransaction {
 
   @Override
   public ApiFuture<ResultSet> analyzeUpdateAsync(
-      ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options) {
+      CallType callType, ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION,
         "Analyzing updates is not allowed for read-only transactions");
@@ -176,19 +177,19 @@ class ReadOnlyTransaction extends AbstractMultiUseTransaction {
 
   @Override
   public ApiFuture<long[]> executeBatchUpdateAsync(
-      Iterable<ParsedStatement> updates, UpdateOption... options) {
+      CallType callType, Iterable<ParsedStatement> updates, UpdateOption... options) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Batch updates are not allowed for read-only transactions.");
   }
 
   @Override
-  public ApiFuture<Void> writeAsync(Iterable<Mutation> mutations) {
+  public ApiFuture<Void> writeAsync(CallType callType, Iterable<Mutation> mutations) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Mutations are not allowed for read-only transactions");
   }
 
   @Override
-  public ApiFuture<Void> commitAsync() {
+  public ApiFuture<Void> commitAsync(CallType callType) {
     if (this.transaction != null) {
       this.transaction.close();
     }
@@ -197,7 +198,7 @@ class ReadOnlyTransaction extends AbstractMultiUseTransaction {
   }
 
   @Override
-  public ApiFuture<Void> rollbackAsync() {
+  public ApiFuture<Void> rollbackAsync(CallType callType) {
     if (this.transaction != null) {
       this.transaction.close();
     }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SingleUseTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SingleUseTransaction.java
@@ -174,6 +174,7 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
 
   @Override
   public ApiFuture<ResultSet> executeQueryAsync(
+      final CallType callType,
       final ParsedStatement statement,
       final AnalyzeMode analyzeMode,
       final QueryOption... options) {
@@ -187,10 +188,10 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
 
     if (statement.isUpdate()) {
       if (analyzeMode != AnalyzeMode.NONE) {
-        return analyzeTransactionalUpdateAsync(statement, analyzeMode);
+        return analyzeTransactionalUpdateAsync(callType, statement, analyzeMode);
       }
       // DML with returning clause.
-      return executeDmlReturningAsync(statement, options);
+      return executeDmlReturningAsync(callType, statement, options);
     }
 
     final ReadOnlyTransaction currentTransaction =
@@ -220,11 +221,12 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
           }
         };
     readTimestamp = SettableApiFuture.create();
-    return executeStatementAsync(statement, callable, SpannerGrpc.getExecuteStreamingSqlMethod());
+    return executeStatementAsync(
+        callType, statement, callable, SpannerGrpc.getExecuteStreamingSqlMethod());
   }
 
   private ApiFuture<ResultSet> executeDmlReturningAsync(
-      final ParsedStatement update, QueryOption... options) {
+      CallType callType, final ParsedStatement update, QueryOption... options) {
     Callable<ResultSet> callable =
         () -> {
           try {
@@ -242,6 +244,7 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
           }
         };
     return executeStatementAsync(
+        callType,
         update,
         callable,
         ImmutableList.of(SpannerGrpc.getExecuteSqlMethod(), SpannerGrpc.getCommitMethod()));
@@ -297,7 +300,7 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
   }
 
   @Override
-  public ApiFuture<Void> executeDdlAsync(final ParsedStatement ddl) {
+  public ApiFuture<Void> executeDdlAsync(CallType callType, final ParsedStatement ddl) {
     Preconditions.checkNotNull(ddl);
     Preconditions.checkArgument(
         ddl.getType() == StatementType.DDL, "Statement is not a ddl statement");
@@ -324,11 +327,13 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
             throw t;
           }
         };
-    return executeStatementAsync(ddl, callable, DatabaseAdminGrpc.getUpdateDatabaseDdlMethod());
+    return executeStatementAsync(
+        callType, ddl, callable, DatabaseAdminGrpc.getUpdateDatabaseDdlMethod());
   }
 
   @Override
-  public ApiFuture<Long> executeUpdateAsync(ParsedStatement update, UpdateOption... options) {
+  public ApiFuture<Long> executeUpdateAsync(
+      CallType callType, ParsedStatement update, UpdateOption... options) {
     Preconditions.checkNotNull(update);
     Preconditions.checkArgument(update.isUpdate(), "Statement is not an update statement");
     ConnectionPreconditions.checkState(
@@ -340,12 +345,12 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
       case TRANSACTIONAL:
         res =
             ApiFutures.transform(
-                executeTransactionalUpdateAsync(update, AnalyzeMode.NONE, options),
+                executeTransactionalUpdateAsync(callType, update, AnalyzeMode.NONE, options),
                 Tuple::x,
                 MoreExecutors.directExecutor());
         break;
       case PARTITIONED_NON_ATOMIC:
-        res = executePartitionedUpdateAsync(update, options);
+        res = executePartitionedUpdateAsync(callType, update, options);
         break;
       default:
         throw SpannerExceptionFactory.newSpannerException(
@@ -356,7 +361,7 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
 
   @Override
   public ApiFuture<ResultSet> analyzeUpdateAsync(
-      ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options) {
+      CallType callType, ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options) {
     Preconditions.checkNotNull(update);
     Preconditions.checkArgument(update.isUpdate(), "Statement is not an update statement");
     ConnectionPreconditions.checkState(
@@ -367,14 +372,14 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
     checkAndMarkUsed();
 
     return ApiFutures.transform(
-        executeTransactionalUpdateAsync(update, analyzeMode, options),
+        executeTransactionalUpdateAsync(callType, update, analyzeMode, options),
         Tuple::y,
         MoreExecutors.directExecutor());
   }
 
   @Override
   public ApiFuture<long[]> executeBatchUpdateAsync(
-      Iterable<ParsedStatement> updates, UpdateOption... options) {
+      CallType callType, Iterable<ParsedStatement> updates, UpdateOption... options) {
     Preconditions.checkNotNull(updates);
     for (ParsedStatement update : updates) {
       Preconditions.checkArgument(
@@ -387,7 +392,7 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
 
     switch (autocommitDmlMode) {
       case TRANSACTIONAL:
-        return executeTransactionalBatchUpdateAsync(updates, options);
+        return executeTransactionalBatchUpdateAsync(callType, updates, options);
       case PARTITIONED_NON_ATOMIC:
         throw SpannerExceptionFactory.newSpannerException(
             ErrorCode.FAILED_PRECONDITION, "Batch updates are not allowed in " + autocommitDmlMode);
@@ -420,7 +425,10 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
   }
 
   private ApiFuture<Tuple<Long, ResultSet>> executeTransactionalUpdateAsync(
-      final ParsedStatement update, AnalyzeMode analyzeMode, final UpdateOption... options) {
+      CallType callType,
+      final ParsedStatement update,
+      AnalyzeMode analyzeMode,
+      final UpdateOption... options) {
     Callable<Tuple<Long, ResultSet>> callable =
         () -> {
           try {
@@ -445,13 +453,14 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
           }
         };
     return executeStatementAsync(
+        callType,
         update,
         callable,
         ImmutableList.of(SpannerGrpc.getExecuteSqlMethod(), SpannerGrpc.getCommitMethod()));
   }
 
   private ApiFuture<ResultSet> analyzeTransactionalUpdateAsync(
-      final ParsedStatement update, AnalyzeMode analyzeMode) {
+      CallType callType, final ParsedStatement update, AnalyzeMode analyzeMode) {
     Callable<ResultSet> callable =
         () -> {
           try {
@@ -470,13 +479,14 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
           }
         };
     return executeStatementAsync(
+        callType,
         update,
         callable,
         ImmutableList.of(SpannerGrpc.getExecuteSqlMethod(), SpannerGrpc.getCommitMethod()));
   }
 
   private ApiFuture<Long> executePartitionedUpdateAsync(
-      final ParsedStatement update, final UpdateOption... options) {
+      CallType callType, final ParsedStatement update, final UpdateOption... options) {
     Callable<Long> callable =
         () -> {
           try {
@@ -488,11 +498,14 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
             throw t;
           }
         };
-    return executeStatementAsync(update, callable, SpannerGrpc.getExecuteStreamingSqlMethod());
+    return executeStatementAsync(
+        callType, update, callable, SpannerGrpc.getExecuteStreamingSqlMethod());
   }
 
   private ApiFuture<long[]> executeTransactionalBatchUpdateAsync(
-      final Iterable<ParsedStatement> updates, final UpdateOption... options) {
+      final CallType callType,
+      final Iterable<ParsedStatement> updates,
+      final UpdateOption... options) {
     Callable<long[]> callable =
         () -> {
           writeTransaction = createWriteTransaction();
@@ -516,11 +529,11 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
               });
         };
     return executeStatementAsync(
-        RUN_BATCH_STATEMENT, callable, SpannerGrpc.getExecuteBatchDmlMethod());
+        callType, RUN_BATCH_STATEMENT, callable, SpannerGrpc.getExecuteBatchDmlMethod());
   }
 
   @Override
-  public ApiFuture<Void> writeAsync(final Iterable<Mutation> mutations) {
+  public ApiFuture<Void> writeAsync(CallType callType, final Iterable<Mutation> mutations) {
     Preconditions.checkNotNull(mutations);
     ConnectionPreconditions.checkState(
         !isReadOnly(), "Update statements are not allowed in read-only mode");
@@ -543,17 +556,18 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
             throw t;
           }
         };
-    return executeStatementAsync(COMMIT_STATEMENT, callable, SpannerGrpc.getCommitMethod());
+    return executeStatementAsync(
+        callType, COMMIT_STATEMENT, callable, SpannerGrpc.getCommitMethod());
   }
 
   @Override
-  public ApiFuture<Void> commitAsync() {
+  public ApiFuture<Void> commitAsync(CallType callType) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Commit is not supported for single-use transactions");
   }
 
   @Override
-  public ApiFuture<Void> rollbackAsync() {
+  public ApiFuture<Void> rollbackAsync(CallType callType) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Rollback is not supported for single-use transactions");
   }
@@ -564,7 +578,7 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
   }
 
   @Override
-  public ApiFuture<long[]> runBatchAsync() {
+  public ApiFuture<long[]> runBatchAsync(CallType callType) {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.FAILED_PRECONDITION, "Run batch is not supported for single-use transactions");
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/UnitOfWork.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/UnitOfWork.java
@@ -37,6 +37,11 @@ import javax.annotation.Nonnull;
 @InternalApi
 interface UnitOfWork {
 
+  enum CallType {
+    SYNC,
+    ASYNC
+  }
+
   /** A unit of work can be either a transaction or a DDL/DML batch. */
   enum Type {
     TRANSACTION,
@@ -76,18 +81,20 @@ interface UnitOfWork {
    * closes the {@link ReadContext}. This method will throw a {@link SpannerException} if called for
    * a {@link Type#BATCH}.
    *
+   * @param callType Indicates whether the top-level call is a sync or async call.
    * @return An {@link ApiFuture} that is done when the commit has finished.
    */
-  ApiFuture<Void> commitAsync();
+  ApiFuture<Void> commitAsync(CallType callType);
 
   /**
    * Rollbacks any changes in this unit of work. For read-only transactions, this only closes the
    * {@link ReadContext}. This method will throw a {@link SpannerException} if called for a {@link
    * Type#BATCH}.
    *
+   * @param callType Indicates whether the top-level call is a sync or async call.
    * @return An {@link ApiFuture} that is done when the rollback has finished.
    */
-  ApiFuture<Void> rollbackAsync();
+  ApiFuture<Void> rollbackAsync(CallType callType);
 
   /** @see Connection#savepoint(String) */
   void savepoint(@Nonnull String name, @Nonnull Dialect dialect);
@@ -103,11 +110,12 @@ interface UnitOfWork {
    * batch. This method will throw a {@link SpannerException} if called for a {@link
    * Type#TRANSACTION}.
    *
+   * @param callType Indicates whether the top-level call is a sync or async call.
    * @return an {@link ApiFuture} containing the update counts in case of a DML batch. Returns an
    *     array containing 1 for each successful statement and 0 for each failed statement or
    *     statement that was not executed in case of a DDL batch.
    */
-  ApiFuture<long[]> runBatchAsync();
+  ApiFuture<long[]> runBatchAsync(CallType callType);
 
   /**
    * Clears the currently buffered statements in this unit of work and ends the batch. This method
@@ -124,6 +132,7 @@ interface UnitOfWork {
    * AnalyzeMode#PLAN} or {@link AnalyzeMode#PROFILE}, the returned {@link ResultSet} will include
    * {@link ResultSetStats}.
    *
+   * @param callType Indicates whether the top-level call is a sync or async call.
    * @param statement The statement to execute.
    * @param analyzeMode Indicates whether to include {@link ResultSetStats} in the returned {@link
    *     ResultSet} or not. Cannot be used in combination with {@link QueryOption}s.
@@ -135,7 +144,10 @@ interface UnitOfWork {
    *     if a database error occurs.
    */
   ApiFuture<ResultSet> executeQueryAsync(
-      ParsedStatement statement, AnalyzeMode analyzeMode, QueryOption... options);
+      CallType callType,
+      ParsedStatement statement,
+      AnalyzeMode analyzeMode,
+      QueryOption... options);
 
   /**
    * @return the read timestamp of this transaction. Will throw a {@link SpannerException} if there
@@ -176,21 +188,24 @@ interface UnitOfWork {
    * @param ddl The DDL statement to execute.
    * @return an {@link ApiFuture} that is done when the DDL operation has finished.
    */
-  ApiFuture<Void> executeDdlAsync(ParsedStatement ddl);
+  ApiFuture<Void> executeDdlAsync(CallType callType, ParsedStatement ddl);
 
   /**
    * Execute a DML statement on Spanner.
    *
+   * @param callType Indicates whether the top-level call is a sync or async call.
    * @param update The DML statement to execute.
    * @param options Update options to apply for the statement.
    * @return an {@link ApiFuture} containing the number of records that were
    *     inserted/updated/deleted by this statement.
    */
-  ApiFuture<Long> executeUpdateAsync(ParsedStatement update, UpdateOption... options);
+  ApiFuture<Long> executeUpdateAsync(
+      CallType callType, ParsedStatement update, UpdateOption... options);
 
   /**
    * Execute and/or analyze a DML statement on Spanner.
    *
+   * @param callType Indicates whether the top-level call is a sync or async call.
    * @param update The DML statement to analyze/execute.
    * @param analyzeMode Specifies the query/analyze mode to use for the DML statement.
    * @param options Update options to apply for the statement.
@@ -198,11 +213,12 @@ interface UnitOfWork {
    *     statement. The {@link ResultSet} will not contain any rows.
    */
   ApiFuture<ResultSet> analyzeUpdateAsync(
-      ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options);
+      CallType callType, ParsedStatement update, AnalyzeMode analyzeMode, UpdateOption... options);
 
   /**
    * Execute a batch of DML statements on Spanner.
    *
+   * @param callType Indicates whether the top-level call is a sync or async call.
    * @param updates The DML statements to execute.
    * @param options Update options to apply for the statement.
    * @return an {@link ApiFuture} containing an array with the number of records that were
@@ -210,7 +226,7 @@ interface UnitOfWork {
    * @see TransactionContext#batchUpdate(Iterable)
    */
   ApiFuture<long[]> executeBatchUpdateAsync(
-      Iterable<ParsedStatement> updates, UpdateOption... options);
+      CallType callType, Iterable<ParsedStatement> updates, UpdateOption... options);
 
   /**
    * Writes a batch of {@link Mutation}s to Spanner. For {@link ReadWriteTransaction}s, this means
@@ -218,9 +234,10 @@ interface UnitOfWork {
    * {@link UnitOfWork#commit()}. For {@link SingleUseTransaction}s, the {@link Mutation}s will be
    * sent directly to Spanner.
    *
+   * @param callType Indicates whether the top-level call is a sync or async call.
    * @param mutations The mutations to write.
    * @return an {@link ApiFuture} that is done when the {@link Mutation}s have been successfully
    *     buffered or written to Cloud Spanner.
    */
-  ApiFuture<Void> writeAsync(Iterable<Mutation> mutations);
+  ApiFuture<Void> writeAsync(CallType callType, Iterable<Mutation> mutations);
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionImplTest.java
@@ -68,6 +68,7 @@ import com.google.cloud.spanner.connection.ConnectionImpl.UnitOfWorkType;
 import com.google.cloud.spanner.connection.ConnectionStatementExecutorImpl.StatementTimeoutGetter;
 import com.google.cloud.spanner.connection.ReadOnlyStalenessUtil.GetExactStaleness;
 import com.google.cloud.spanner.connection.StatementResult.ResultType;
+import com.google.cloud.spanner.connection.UnitOfWork.CallType;
 import com.google.cloud.spanner.connection.UnitOfWork.UnitOfWorkState;
 import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
 import com.google.spanner.v1.ExecuteSqlRequest.QueryOptions;
@@ -1373,7 +1374,7 @@ public class ConnectionImplTest {
     when(dbClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
     final UnitOfWork unitOfWork = mock(UnitOfWork.class);
     when(unitOfWork.executeQueryAsync(
-            any(ParsedStatement.class), any(AnalyzeMode.class), Mockito.<QueryOption>any()))
+            any(), any(ParsedStatement.class), any(AnalyzeMode.class), Mockito.<QueryOption>any()))
         .thenReturn(ApiFutures.immediateFuture(mock(ResultSet.class)));
     try (ConnectionImpl impl =
         new ConnectionImpl(connectionOptions, spannerPool, ddlClient, dbClient) {
@@ -1388,6 +1389,7 @@ public class ConnectionImplTest {
       impl.executeQuery(Statement.of("SELECT FOO FROM BAR"));
       verify(unitOfWork)
           .executeQueryAsync(
+              CallType.SYNC,
               AbstractStatementParser.getInstance(Dialect.GOOGLE_STANDARD_SQL)
                   .parse(
                       Statement.newBuilder("SELECT FOO FROM BAR")
@@ -1405,6 +1407,7 @@ public class ConnectionImplTest {
       impl.executeQuery(Statement.of("SELECT FOO FROM BAR"));
       verify(unitOfWork)
           .executeQueryAsync(
+              CallType.SYNC,
               AbstractStatementParser.getInstance(Dialect.GOOGLE_STANDARD_SQL)
                   .parse(
                       Statement.newBuilder("SELECT FOO FROM BAR")
@@ -1425,6 +1428,7 @@ public class ConnectionImplTest {
       impl.executeQuery(Statement.of("SELECT FOO FROM BAR"), prefetchOption);
       verify(unitOfWork)
           .executeQueryAsync(
+              CallType.SYNC,
               AbstractStatementParser.getInstance(Dialect.GOOGLE_STANDARD_SQL)
                   .parse(
                       Statement.newBuilder("SELECT FOO FROM BAR")
@@ -1453,6 +1457,7 @@ public class ConnectionImplTest {
           prefetchOption);
       verify(unitOfWork)
           .executeQueryAsync(
+              CallType.SYNC,
               AbstractStatementParser.getInstance(Dialect.GOOGLE_STANDARD_SQL)
                   .parse(
                       Statement.newBuilder("SELECT FOO FROM BAR")
@@ -1477,7 +1482,7 @@ public class ConnectionImplTest {
     when(dbClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
     final UnitOfWork unitOfWork = mock(UnitOfWork.class);
     when(unitOfWork.executeQueryAsync(
-            any(ParsedStatement.class), any(AnalyzeMode.class), Mockito.<QueryOption>any()))
+            any(), any(ParsedStatement.class), any(AnalyzeMode.class), Mockito.<QueryOption>any()))
         .thenReturn(ApiFutures.immediateFuture(mock(ResultSet.class)));
     try (ConnectionImpl connection =
         new ConnectionImpl(connectionOptions, spannerPool, ddlClient, dbClient) {
@@ -1584,9 +1589,9 @@ public class ConnectionImplTest {
     // Indicate that a transaction has been started.
     when(unitOfWork.getState()).thenReturn(UnitOfWorkState.STARTED);
     when(unitOfWork.executeQueryAsync(
-            any(ParsedStatement.class), any(AnalyzeMode.class), Mockito.<QueryOption>any()))
+            any(), any(ParsedStatement.class), any(AnalyzeMode.class), Mockito.<QueryOption>any()))
         .thenReturn(ApiFutures.immediateFuture(mock(ResultSet.class)));
-    when(unitOfWork.rollbackAsync()).thenReturn(ApiFutures.immediateFuture(null));
+    when(unitOfWork.rollbackAsync(any())).thenReturn(ApiFutures.immediateFuture(null));
     try (ConnectionImpl connection =
         new ConnectionImpl(connectionOptions, spannerPool, ddlClient, dbClient) {
           @Override

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ExceptionMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ExceptionMockServerTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.connection;
+
+import static com.google.cloud.spanner.SpannerApiFutures.get;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
+import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.SpannerException;
+import com.google.cloud.spanner.Statement;
+import io.grpc.Status;
+import java.util.Arrays;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ExceptionMockServerTest extends AbstractMockServerTest {
+
+  @After
+  public void clearRequests() {
+    mockSpanner.clearRequests();
+  }
+
+  @Test
+  public void testUpdateAsyncException() {
+    Statement update = Statement.of("update foo set bar=1 where baz=1");
+    mockSpanner.putStatementResult(
+        StatementResult.exception(
+            update,
+            Status.INVALID_ARGUMENT.withDescription("Table 'foo' not found").asRuntimeException()));
+
+    try (Connection connection = createConnection()) {
+      SpannerException exception =
+          assertThrows(SpannerException.class, () -> get(connection.executeUpdateAsync(update)));
+      assertNotNull(exception.getSuppressed());
+      assertEquals(1, exception.getSuppressed().length);
+      Throwable suppressed = exception.getSuppressed()[0];
+      String methodName = new Object() {}.getClass().getEnclosingMethod().getName();
+      assertTrue(
+          Arrays.stream(suppressed.getStackTrace())
+              .anyMatch(
+                  element ->
+                      element.getClassName().equals(ExceptionMockServerTest.class.getName())
+                          && element.getMethodName().equals(methodName)));
+    }
+  }
+
+  @Test
+  public void testUpdateException() {
+    Statement update = Statement.of("update foo set bar=1 where baz=1");
+    mockSpanner.putStatementResult(
+        StatementResult.exception(
+            update,
+            Status.INVALID_ARGUMENT.withDescription("Table 'foo' not found").asRuntimeException()));
+
+    try (Connection connection = createConnection()) {
+      SpannerException exception =
+          assertThrows(SpannerException.class, () -> connection.executeUpdate(update));
+      assertNotNull(exception.getSuppressed());
+      assertEquals(0, exception.getSuppressed().length);
+    }
+  }
+
+  @Test
+  public void testQueryAsyncException() {
+    Statement update = Statement.of("select * from foo");
+    mockSpanner.putStatementResult(
+        StatementResult.exception(
+            update,
+            Status.INVALID_ARGUMENT.withDescription("Table 'foo' not found").asRuntimeException()));
+
+    try (Connection connection = createConnection()) {
+      SpannerException exception =
+          assertThrows(
+              SpannerException.class,
+              () -> connection.executeQueryAsync(update).toList(row -> row));
+      assertNotNull(exception.getSuppressed());
+      assertEquals(1, exception.getSuppressed().length);
+      Throwable suppressed = exception.getSuppressed()[0];
+      String methodName = new Object() {}.getClass().getEnclosingMethod().getName();
+      assertTrue(
+          Arrays.stream(suppressed.getStackTrace())
+              .anyMatch(
+                  element ->
+                      element.getClassName().equals(ExceptionMockServerTest.class.getName())
+                          && element.getMethodName().equals(methodName)));
+    }
+  }
+
+  @Test
+  public void testQueryException() {
+    Statement update = Statement.of("select * from foo");
+    mockSpanner.putStatementResult(
+        StatementResult.exception(
+            update,
+            Status.INVALID_ARGUMENT.withDescription("Table 'foo' not found").asRuntimeException()));
+
+    try (Connection connection = createConnection()) {
+      SpannerException exception =
+          assertThrows(SpannerException.class, () -> connection.executeQuery(update).next());
+      assertNotNull(exception.getSuppressed());
+      assertEquals(0, exception.getSuppressed().length);
+    }
+  }
+
+  @Test
+  public void testCommitAsyncException() {
+    mockSpanner.setCommitExecutionTime(
+        SimulatedExecutionTime.ofException(
+            Status.INVALID_ARGUMENT.withDescription("Table 'foo' not found").asRuntimeException()));
+
+    try (Connection connection = createConnection()) {
+      connection.bufferedWrite(Mutation.newInsertBuilder("foo").set("id").to(1L).build());
+      SpannerException exception =
+          assertThrows(SpannerException.class, () -> get(connection.commitAsync()));
+      assertNotNull(exception.getSuppressed());
+      assertEquals(1, exception.getSuppressed().length);
+      Throwable suppressed = exception.getSuppressed()[0];
+      String methodName = new Object() {}.getClass().getEnclosingMethod().getName();
+      assertTrue(
+          Arrays.stream(suppressed.getStackTrace())
+              .anyMatch(
+                  element ->
+                      element.getClassName().equals(ExceptionMockServerTest.class.getName())
+                          && element.getMethodName().equals(methodName)));
+    }
+  }
+
+  @Test
+  public void testCommitException() {
+    mockSpanner.setCommitExecutionTime(
+        SimulatedExecutionTime.ofException(
+            Status.INVALID_ARGUMENT.withDescription("Table 'foo' not found").asRuntimeException()));
+
+    try (Connection connection = createConnection()) {
+      connection.bufferedWrite(Mutation.newInsertBuilder("foo").set("id").to(1L).build());
+      SpannerException exception = assertThrows(SpannerException.class, connection::commit);
+      assertNotNull(exception.getSuppressed());
+      assertEquals(0, exception.getSuppressed().length);
+    }
+  }
+}

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SingleUseTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SingleUseTransactionTest.java
@@ -54,6 +54,7 @@ import com.google.cloud.spanner.TransactionRunner;
 import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStatement;
 import com.google.cloud.spanner.connection.AbstractStatementParser.StatementType;
 import com.google.cloud.spanner.connection.StatementExecutor.StatementTimeout;
+import com.google.cloud.spanner.connection.UnitOfWork.CallType;
 import com.google.common.base.Preconditions;
 import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
 import com.google.spanner.v1.ResultSetStats;
@@ -489,7 +490,7 @@ public class SingleUseTransactionTest {
   public void testCommit() {
     SingleUseTransaction subject = createSubject();
     try {
-      subject.commitAsync();
+      subject.commitAsync(CallType.SYNC);
       fail("missing expected exception");
     } catch (SpannerException e) {
       assertThat(e.getErrorCode()).isEqualTo(ErrorCode.FAILED_PRECONDITION);
@@ -500,7 +501,7 @@ public class SingleUseTransactionTest {
   public void testRollback() {
     SingleUseTransaction subject = createSubject();
     try {
-      subject.rollbackAsync();
+      subject.rollbackAsync(CallType.SYNC);
       fail("missing expected exception");
     } catch (SpannerException e) {
       assertThat(e.getErrorCode()).isEqualTo(ErrorCode.FAILED_PRECONDITION);
@@ -511,7 +512,7 @@ public class SingleUseTransactionTest {
   public void testRunBatch() {
     SingleUseTransaction subject = createSubject();
     try {
-      subject.runBatchAsync();
+      subject.runBatchAsync(CallType.SYNC);
       fail("missing expected exception");
     } catch (SpannerException e) {
       assertThat(e.getErrorCode()).isEqualTo(ErrorCode.FAILED_PRECONDITION);
@@ -535,7 +536,7 @@ public class SingleUseTransactionTest {
     ParsedStatement ddl = createParsedDdl(sql);
     DdlClient ddlClient = createDefaultMockDdlClient();
     SingleUseTransaction subject = createDdlSubject(ddlClient);
-    get(subject.executeDdlAsync(ddl));
+    get(subject.executeDdlAsync(CallType.SYNC, ddl));
     verify(ddlClient).executeDdl(sql);
   }
 
@@ -548,7 +549,7 @@ public class SingleUseTransactionTest {
         .thenReturn(mock(OperationFuture.class));
 
     SingleUseTransaction singleUseTransaction = createDdlSubject(ddlClient);
-    get(singleUseTransaction.executeDdlAsync(ddl));
+    get(singleUseTransaction.executeDdlAsync(CallType.SYNC, ddl));
     verify(ddlClient).executeCreateDatabase(sql, Dialect.GOOGLE_STANDARD_SQL);
   }
 
@@ -557,7 +558,10 @@ public class SingleUseTransactionTest {
     for (TimestampBound staleness : getTestTimestampBounds()) {
       for (AnalyzeMode analyzeMode : AnalyzeMode.values()) {
         SingleUseTransaction subject = createReadOnlySubject(staleness);
-        ResultSet rs = get(subject.executeQueryAsync(createParsedQuery(VALID_QUERY), analyzeMode));
+        ResultSet rs =
+            get(
+                subject.executeQueryAsync(
+                    CallType.SYNC, createParsedQuery(VALID_QUERY), analyzeMode));
         assertThat(rs).isNotNull();
         assertThat(subject.getReadTimestamp()).isNotNull();
         assertThat(subject.getState())
@@ -575,7 +579,9 @@ public class SingleUseTransactionTest {
     for (TimestampBound staleness : getTestTimestampBounds()) {
       SingleUseTransaction subject = createReadOnlySubject(staleness);
       try {
-        get(subject.executeQueryAsync(createParsedQuery(INVALID_QUERY), AnalyzeMode.NONE));
+        get(
+            subject.executeQueryAsync(
+                CallType.SYNC, createParsedQuery(INVALID_QUERY), AnalyzeMode.NONE));
         fail("missing expected exception");
       } catch (SpannerException e) {
         assertThat(e.getErrorCode()).isEqualTo(ErrorCode.UNKNOWN);
@@ -608,7 +614,10 @@ public class SingleUseTransactionTest {
             .withStatementExecutor(executor)
             .setReadOnlyStaleness(TimestampBound.strong())
             .build();
-    assertThat(get(transaction.executeQueryAsync(parsedStatement, AnalyzeMode.NONE, option)))
+    assertThat(
+            get(
+                transaction.executeQueryAsync(
+                    CallType.SYNC, parsedStatement, AnalyzeMode.NONE, option)))
         .isNotNull();
   }
 
@@ -616,7 +625,7 @@ public class SingleUseTransactionTest {
   public void testExecuteUpdate_Transactional_Valid() {
     ParsedStatement update = createParsedUpdate(VALID_UPDATE);
     SingleUseTransaction subject = createSubject();
-    long updateCount = get(subject.executeUpdateAsync(update));
+    long updateCount = get(subject.executeUpdateAsync(CallType.SYNC, update));
     assertThat(updateCount).isEqualTo(VALID_UPDATE_COUNT);
     assertThat(subject.getCommitTimestamp()).isNotNull();
     assertThat(subject.getState())
@@ -628,7 +637,7 @@ public class SingleUseTransactionTest {
     ParsedStatement update = createParsedUpdate(INVALID_UPDATE);
     SingleUseTransaction subject = createSubject();
     try {
-      get(subject.executeUpdateAsync(update));
+      get(subject.executeUpdateAsync(CallType.SYNC, update));
       fail("missing expected exception");
     } catch (SpannerException e) {
       assertThat(e.getErrorCode()).isEqualTo(ErrorCode.UNKNOWN);
@@ -641,7 +650,7 @@ public class SingleUseTransactionTest {
     ParsedStatement update = createParsedUpdate(VALID_UPDATE);
     SingleUseTransaction subject = createSubject(CommitBehavior.FAIL);
     try {
-      get(subject.executeUpdateAsync(update));
+      get(subject.executeUpdateAsync(CallType.SYNC, update));
       fail("missing expected exception");
     } catch (SpannerException e) {
       assertThat(e.getErrorCode()).isEqualTo(ErrorCode.UNKNOWN);
@@ -653,7 +662,7 @@ public class SingleUseTransactionTest {
   public void testExecuteUpdate_Partitioned_Valid() {
     ParsedStatement update = createParsedUpdate(VALID_UPDATE);
     SingleUseTransaction subject = createSubject(AutocommitDmlMode.PARTITIONED_NON_ATOMIC);
-    long updateCount = get(subject.executeUpdateAsync(update));
+    long updateCount = get(subject.executeUpdateAsync(CallType.SYNC, update));
     assertThat(updateCount).isEqualTo(VALID_UPDATE_COUNT);
     assertThat(subject.getState())
         .isEqualTo(com.google.cloud.spanner.connection.UnitOfWork.UnitOfWorkState.COMMITTED);
@@ -664,7 +673,7 @@ public class SingleUseTransactionTest {
     ParsedStatement update = createParsedUpdate(INVALID_UPDATE);
     SingleUseTransaction subject = createSubject(AutocommitDmlMode.PARTITIONED_NON_ATOMIC);
     try {
-      get(subject.executeUpdateAsync(update));
+      get(subject.executeUpdateAsync(CallType.SYNC, update));
       fail("missing expected exception");
     } catch (SpannerException e) {
       assertThat(e.getErrorCode()).isEqualTo(ErrorCode.UNKNOWN);
@@ -676,7 +685,7 @@ public class SingleUseTransactionTest {
   public void testWriteIterable() {
     SingleUseTransaction subject = createSubject();
     Mutation mutation = Mutation.newInsertBuilder("FOO").build();
-    get(subject.writeAsync(Arrays.asList(mutation, mutation)));
+    get(subject.writeAsync(CallType.SYNC, Arrays.asList(mutation, mutation)));
     assertThat(subject.getCommitTimestamp()).isNotNull();
     assertThat(subject.getState())
         .isEqualTo(com.google.cloud.spanner.connection.UnitOfWork.UnitOfWorkState.COMMITTED);
@@ -687,7 +696,7 @@ public class SingleUseTransactionTest {
     SingleUseTransaction subject = createSubject(CommitBehavior.FAIL);
     Mutation mutation = Mutation.newInsertBuilder("FOO").build();
     try {
-      get(subject.writeAsync(Arrays.asList(mutation, mutation)));
+      get(subject.writeAsync(CallType.SYNC, Arrays.asList(mutation, mutation)));
       fail("missing expected exception");
     } catch (SpannerException e) {
       assertThat(e.getErrorCode()).isEqualTo(ErrorCode.UNKNOWN);
@@ -700,11 +709,15 @@ public class SingleUseTransactionTest {
     for (TimestampBound staleness : getTestTimestampBounds()) {
       SingleUseTransaction subject = createReadOnlySubject(staleness);
       ResultSet rs =
-          get(subject.executeQueryAsync(createParsedQuery(VALID_QUERY), AnalyzeMode.NONE));
+          get(
+              subject.executeQueryAsync(
+                  CallType.SYNC, createParsedQuery(VALID_QUERY), AnalyzeMode.NONE));
       assertThat(rs).isNotNull();
       assertThat(subject.getReadTimestamp()).isNotNull();
       try {
-        get(subject.executeQueryAsync(createParsedQuery(VALID_QUERY), AnalyzeMode.NONE));
+        get(
+            subject.executeQueryAsync(
+                CallType.SYNC, createParsedQuery(VALID_QUERY), AnalyzeMode.NONE));
         fail("missing expected exception");
       } catch (IllegalStateException e) {
         // Expected exception
@@ -715,10 +728,10 @@ public class SingleUseTransactionTest {
     ParsedStatement ddl = createParsedDdl(sql);
     DdlClient ddlClient = createDefaultMockDdlClient();
     SingleUseTransaction subject = createDdlSubject(ddlClient);
-    get(subject.executeDdlAsync(ddl));
+    get(subject.executeDdlAsync(CallType.SYNC, ddl));
     verify(ddlClient).executeDdl(sql);
     try {
-      get(subject.executeDdlAsync(ddl));
+      get(subject.executeDdlAsync(CallType.SYNC, ddl));
       fail("missing expected exception");
     } catch (IllegalStateException e) {
       // Expected exception
@@ -726,21 +739,25 @@ public class SingleUseTransactionTest {
 
     ParsedStatement update = createParsedUpdate(VALID_UPDATE);
     subject = createSubject();
-    long updateCount = get(subject.executeUpdateAsync(update));
+    long updateCount = get(subject.executeUpdateAsync(CallType.SYNC, update));
     assertThat(updateCount).isEqualTo(VALID_UPDATE_COUNT);
     assertThat(subject.getCommitTimestamp()).isNotNull();
     try {
-      get(subject.executeUpdateAsync(update));
+      get(subject.executeUpdateAsync(CallType.SYNC, update));
       fail("missing expected exception");
     } catch (IllegalStateException e) {
       // Expected exception
     }
 
     subject = createSubject();
-    get(subject.writeAsync(Collections.singleton(Mutation.newInsertBuilder("FOO").build())));
+    get(
+        subject.writeAsync(
+            CallType.SYNC, Collections.singleton(Mutation.newInsertBuilder("FOO").build())));
     assertThat(subject.getCommitTimestamp()).isNotNull();
     try {
-      get(subject.writeAsync(Collections.singleton(Mutation.newInsertBuilder("FOO").build())));
+      get(
+          subject.writeAsync(
+              CallType.SYNC, Collections.singleton(Mutation.newInsertBuilder("FOO").build())));
       fail("missing expected exception");
     } catch (IllegalStateException e) {
       // Expected exception
@@ -748,10 +765,10 @@ public class SingleUseTransactionTest {
 
     subject = createSubject();
     Mutation mutation = Mutation.newInsertBuilder("FOO").build();
-    get(subject.writeAsync(Arrays.asList(mutation, mutation)));
+    get(subject.writeAsync(CallType.SYNC, Arrays.asList(mutation, mutation)));
     assertThat(subject.getCommitTimestamp()).isNotNull();
     try {
-      get(subject.writeAsync(Arrays.asList(mutation, mutation)));
+      get(subject.writeAsync(CallType.SYNC, Arrays.asList(mutation, mutation)));
       fail("missing expected exception");
     } catch (IllegalStateException e) {
       // Expected exception
@@ -762,7 +779,7 @@ public class SingleUseTransactionTest {
   public void testGetCommitResponseAfterUpdate() {
     ParsedStatement update = createParsedUpdate(VALID_UPDATE);
     SingleUseTransaction transaction = createSubject();
-    get(transaction.executeUpdateAsync(update));
+    get(transaction.executeUpdateAsync(CallType.SYNC, update));
     assertNotNull(transaction.getCommitResponse());
     assertNotNull(transaction.getCommitResponseOrNull());
   }
@@ -771,7 +788,7 @@ public class SingleUseTransactionTest {
   public void testGetCommitResponseAfterQuery() {
     ParsedStatement query = createParsedQuery(VALID_QUERY);
     SingleUseTransaction transaction = createSubject();
-    get(transaction.executeQueryAsync(query, AnalyzeMode.NONE));
+    get(transaction.executeQueryAsync(CallType.SYNC, query, AnalyzeMode.NONE));
     try {
       transaction.getCommitResponse();
       fail("missing expected exception");
@@ -785,7 +802,7 @@ public class SingleUseTransactionTest {
   public void testGetCommitResponseAfterDdl() {
     ParsedStatement ddl = createParsedDdl(VALID_DDL);
     SingleUseTransaction transaction = createSubject();
-    get(transaction.executeDdlAsync(ddl));
+    get(transaction.executeDdlAsync(CallType.SYNC, ddl));
     try {
       transaction.getCommitResponse();
       fail("missing expected exception");


### PR DESCRIPTION
Only capture the call stack of a caller of one of the Connection API methods if the top-level call was an async call. For synchronous calls, we do not need to additionally capture the call stack, as any exception will include the current call stack of the synchronous method call.
