### PR TITLE
deps: update dependency com.google.cloud:google-cloud-shared-dependencies to v3.12.0.with temp exclusions.

### DIFF
--- a/google-cloud-spanner-executor/pom.xml
+++ b/google-cloud-spanner-executor/pom.xml
@@ -49,6 +49,14 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
+      <!--   Temp exclusion. Remove next protobuf upgrade (to 3.23.3 or higher)
+         context: https://github.com/googleapis/sdk-platform-java/pull/1791#issuecomment-1601587713-->
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.j2objc</groupId>
+          <artifactId>j2objc-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
@@ -82,6 +90,14 @@
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-spanner-executor-v1</artifactId>
       <version>1.4.0</version>
+      <!--   Temp exclusion. Remove next protobuf upgrade (to 3.23.3 or higher)
+         context: https://github.com/googleapis/sdk-platform-java/pull/1791#issuecomment-1601587713-->
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.j2objc</groupId>
+          <artifactId>j2objc-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -191,6 +191,14 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
+      <!--   Temp exclusion. Remove next protobuf upgrade (to 3.23.3 or higher)
+         context: https://github.com/googleapis/sdk-platform-java/pull/1791#issuecomment-1601587713-->
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.j2objc</groupId>
+          <artifactId>j2objc-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <github.global.server>github</github.global.server>
     <site.installationModule>google-cloud-spanner-parent</site.installationModule>
-    <google.cloud.shared-dependencies.version>3.11.0</google.cloud.shared-dependencies.version>
+    <google.cloud.shared-dependencies.version>3.12.0</google.cloud.shared-dependencies.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Temp exclusions are needed to avoid dependency version discrepancy due to 3.23.2. 
For more context: https://github.com/googleapis/sdk-platform-java/pull/1791#issuecomment-1601587713
@suztomo  Can you take a look if this temp fix looks okay?

Closes #2509
