### PR TITLE
fix: add imports used in sample files.

### DIFF
--- a/samples/snippets/src/test/java/com/example/spanner/UpdateDatabaseSampleIT.java
+++ b/samples/snippets/src/test/java/com/example/spanner/UpdateDatabaseSampleIT.java
@@ -20,6 +20,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.cloud.spanner.Database;
+import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.DatabaseInfo.DatabaseField;
 import com.google.spanner.admin.database.v1.UpdateDatabaseMetadata;
 import java.util.Collections;


### PR DESCRIPTION
Local compilation is failing due to missing imports. The change adds the missing imports for integration test file. We would separately be investigating why these compilation issues were not detected earlier.