### PR TITLE
docs: fixing errors 

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -10,6 +10,7 @@ branchProtectionRules:
     requiredStatusCheckContexts:
       - dependencies (17)
       - lint
+      - javadoc
       - units (8)
       - units (11)
       - 'Kokoro - Test: Integration'
@@ -28,6 +29,7 @@ branchProtectionRules:
     requiredStatusCheckContexts:
       - dependencies (11)
       - lint
+      - javadoc
       - units (7)
       - units (8)
       - units (11)
@@ -42,6 +44,7 @@ branchProtectionRules:
     requiredStatusCheckContexts:
       - dependencies (11)
       - lint
+      - javadoc
       - units (7)
       - units (8)
       - units (11)
@@ -56,6 +59,7 @@ branchProtectionRules:
     requiredStatusCheckContexts:
       - dependencies (11)
       - lint
+      - javadoc
       - units (7)
       - units (8)
       - units (11)
@@ -69,6 +73,7 @@ branchProtectionRules:
     requiresStrictStatusChecks: false
     requiredStatusCheckContexts:
       - lint
+      - javadoc
       - units (8)
       - units (11)
       - 'Kokoro - Test: Integration'
@@ -81,6 +86,7 @@ branchProtectionRules:
     requiresStrictStatusChecks: false
     requiredStatusCheckContexts:
       - lint
+      - javadoc
       - units (8)
       - units (11)
       - 'Kokoro - Test: Integration'
@@ -95,6 +101,7 @@ branchProtectionRules:
     requiresStrictStatusChecks: false
     requiredStatusCheckContexts:
       - lint
+      - javadoc
       - units (8)
       - units (11)
       - 'Kokoro - Test: Integration'
@@ -109,6 +116,7 @@ branchProtectionRules:
     requiresStrictStatusChecks: false
     requiredStatusCheckContexts:
       - lint
+      - javadoc
       - units (8)
       - units (11)
       - 'Kokoro - Test: Integration'

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractLazyInitializer.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractLazyInitializer.java
@@ -19,6 +19,8 @@ package com.google.cloud.spanner;
 /**
  * Generic {@link AbstractLazyInitializer} for any heavy-weight object that might throw an exception
  * during initialization. The underlying object is initialized at most once.
+ *
+ * @param <T> Object which is to be initialized lazily
  */
 public abstract class AbstractLazyInitializer<T> {
   private final Object lock = new Object();

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSet.java
@@ -115,7 +115,7 @@ public interface AsyncResultSet extends ResultSet {
    *       CursorState#NOT_READY}.
    * </ul>
    *
-   * <h3>Flow Control</h3>
+   * <h2>Flow Control</h2>
    *
    * If no flow control is needed (say because result sizes are known in advance to be finite in
    * size) then async processing is simple. The following is a code example that transfers work from

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSet.java
@@ -117,7 +117,7 @@ public interface AsyncResultSet extends ResultSet {
    *       CursorState#NOT_READY}.
    * </ul>
    *
-   * <h2>Flow Control</h2>
+   * <h4>Flow Control</h4>
    *
    * If no flow control is needed (say because result sizes are known in advance to be finite in
    * size) then async processing is simple. The following is a code example that transfers work from

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSet.java
@@ -60,7 +60,8 @@ public interface AsyncResultSet extends ResultSet {
     CONTINUE,
 
     /**
-     * Tell the cursor to suspend all callbacks until application calls {@link RowCursor#resume()}.
+     * Tell the cursor to suspend all callbacks until application calls {@link
+     * ForwardingAsyncResultSet#resume()}.
      */
     PAUSE,
 
@@ -68,8 +69,8 @@ public interface AsyncResultSet extends ResultSet {
      * Tell the cursor you are done receiving results, even if there are more results sitting in the
      * buffer. Once you return DONE, you will receive no further callbacks.
      *
-     * <p>Approximately equivalent to calling {@link RowCursor#cancel()}, and then returning {@code
-     * PAUSE}, but more clear, immediate, and idiomatic.
+     * <p>Approximately equivalent to calling {@link ForwardingAsyncResultSet#cancel()}, and then
+     * returning {@code PAUSE}, but more clear, immediate, and idiomatic.
      *
      * <p>It is legal to commit a transaction that owns this read before actually returning {@code
      * DONE}.
@@ -105,11 +106,12 @@ public interface AsyncResultSet extends ResultSet {
    *   <li>Callback will stop being called once any of the following occurs:
    *       <ol>
    *         <li>Callback returns {@link CallbackResponse#DONE}.
-   *         <li>{@link ResultSet#tryNext()} returns {@link CursorState#DONE}.
-   *         <li>{@link ResultSet#tryNext()} throws an exception.
+   *         <li>{@link ForwardingAsyncResultSet#tryNext()} returns {@link CursorState#DONE}.
+   *         <li>{@link ForwardingAsyncResultSet#tryNext()} throws an exception.
    *       </ol>
-   *   <li>Callback may possibly be invoked after a call to {@link ResultSet#cancel()} call, but the
-   *       subsequent call to {@link #tryNext()} will yield a SpannerException.
+   *   <li>Callback may possibly be invoked after a call to {@link
+   *       ForwardingAsyncResultSet#cancel()} call, but the subsequent call to {@link #tryNext()}
+   *       will yield a SpannerException.
    *   <li>Spurious callbacks are possible where cursors are not actually ready. Typically callback
    *       should return {@link CallbackResponse#CONTINUE} any time it sees {@link
    *       CursorState#NOT_READY}.

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncRunner.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncRunner.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner;
 
 import com.google.api.core.ApiFuture;
 import com.google.cloud.Timestamp;
+import io.grpc.Status.Code;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 
@@ -40,8 +41,8 @@ public interface AsyncRunner {
      * <p>In most cases, the implementation will not need to catch {@code SpannerException}s from
      * Spanner operations, instead letting these propagate to the framework. The transaction runner
      * will take appropriate action based on the type of exception. In particular, implementations
-     * should never catch an exception of type {@link SpannerErrors#isAborted}: these indicate that
-     * some reads may have returned inconsistent data and the transaction attempt must be aborted.
+     * should never catch an exception of type {@link Code#ABORTED}: these indicate that some reads
+     * may have returned inconsistent data and the transaction attempt must be aborted.
      *
      * @param txn the transaction
      * @return future over the result of the work

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncTransactionManager.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncTransactionManager.java
@@ -115,6 +115,9 @@ public interface AsyncTransactionManager extends AutoCloseable {
    *     executor)
    *   .commitAsync();
    * }</pre>
+   *
+   * @param <I>
+   * @param <O>
    */
   interface AsyncTransactionStep<I, O> extends ApiFuture<O> {
     /**
@@ -140,6 +143,9 @@ public interface AsyncTransactionManager extends AutoCloseable {
    * a {@link TransactionContext} and the output value of the previous transaction step as its input
    * parameters. The method should return an {@link ApiFuture} that will return the result of this
    * step.
+   *
+   * @param <I>
+   * @param <O>
    */
   interface AsyncTransactionFunction<I, O> {
     /**

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncTransactionManager.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncTransactionManager.java
@@ -18,7 +18,7 @@ package com.google.cloud.spanner;
 
 import com.google.api.core.ApiFuture;
 import com.google.cloud.Timestamp;
-import com.google.cloud.spanner.AsyncTransactionManager.TransactionContextFuture;
+import com.google.cloud.spanner.Options.TransactionOption;
 import com.google.cloud.spanner.TransactionManager.TransactionState;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeoutException;
  * so can cause resources to be leaked and deadlocks. Easiest way to guarantee this is by calling
  * {@link #close()} in a finally block.
  *
- * @see DatabaseClient#transactionManagerAsync()
+ * @see DatabaseClient#transactionManagerAsync(TransactionOption...)
  */
 public interface AsyncTransactionManager extends AutoCloseable {
   /**
@@ -91,10 +91,10 @@ public interface AsyncTransactionManager extends AutoCloseable {
 
   /**
    * {@link AsyncTransactionStep} is returned by {@link
-   * TransactionContextFuture#then(AsyncTransactionFunction)} and {@link
-   * AsyncTransactionStep#then(AsyncTransactionFunction)} and allows transaction steps that should
-   * be executed serially to be chained together. Each step can contain one or more statements that
-   * may execute in parallel.
+   * TransactionContextFuture#then(AsyncTransactionFunction, Executor)} and {@link
+   * AsyncTransactionStep#then(AsyncTransactionFunction, Executor)} and allows transaction steps
+   * that should be executed serially to be chained together. Each step can contain one or more
+   * statements that may execute in parallel.
    *
    * <p>Example usage:
    *
@@ -151,8 +151,8 @@ public interface AsyncTransactionManager extends AutoCloseable {
      * @param input the result of the previous transaction step.
      * @return an {@link ApiFuture} that will return the result of this step, and that will be the
      *     input of the next transaction step. This method should never return <code>null</code>.
-     *     Instead, if the method does not have a return value, the method should return {@link
-     *     ApiFutures#immediateFuture(null)}.
+     *     Instead, if the method does not have a return value, the method should return
+     *     ApiFutures#immediateFuture(null).
      */
     ApiFuture<O> apply(TransactionContext txn, I input) throws Exception;
   }
@@ -160,7 +160,7 @@ public interface AsyncTransactionManager extends AutoCloseable {
   /**
    * Creates a new read write transaction. This must be called before doing any other operation and
    * can only be called once. To create a new transaction for subsequent retries, see {@link
-   * #resetForRetry()}.
+   * #resetForRetryAsync()}.
    */
   TransactionContextFuture beginAsync();
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseAdminClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseAdminClient.java
@@ -137,7 +137,7 @@ public interface DatabaseAdminClient {
    * Database db = op.waitFor().getResult();
    * }</pre>
    *
-   * @see also #createDatabase(String, String, Iterable)
+   * @see #createDatabase(String, String, Iterable)
    */
   OperationFuture<Database, CreateDatabaseMetadata> createDatabase(
       Database database, Iterable<String> statements) throws SpannerException;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClient.java
@@ -368,8 +368,8 @@ public interface DatabaseClient {
 
   /**
    * Returns a transaction manager which allows manual management of transaction lifecycle. This API
-   * is meant for advanced users. Most users should instead use the {@link #readWriteTransaction()}
-   * API instead.
+   * is meant for advanced users. Most users should instead use the {@link
+   * #readWriteTransaction(TransactionOption...)} API instead.
    *
    * <p>Example of using {@link TransactionManager}.
    *
@@ -449,7 +449,7 @@ public interface DatabaseClient {
   /**
    * Returns an asynchronous transaction manager which allows manual management of transaction
    * lifecycle. This API is meant for advanced users. Most users should instead use the {@link
-   * #runAsync()} API instead.
+   * #runAsync(TransactionOption...)} API instead.
    *
    * <p>Example of using {@link AsyncTransactionManager}.
    *
@@ -514,12 +514,13 @@ public interface DatabaseClient {
    *
    * <p>Partitioned DML updates are used to execute a single DML statement with a different
    * execution strategy that provides different, and often better, scalability properties for large,
-   * table-wide operations than DML in a {@link #readWriteTransaction()} transaction. Smaller scoped
-   * statements, such as an OLTP workload, should prefer using {@link
-   * TransactionContext#executeUpdate(Statement)} with {@link #readWriteTransaction()}.
+   * table-wide operations than DML in a {@link #readWriteTransaction(TransactionOption...)}
+   * transaction. Smaller scoped statements, such as an OLTP workload, should prefer using {@link
+   * TransactionContext#executeUpdate(Statement,UpdateOption...)} with {@link
+   * #readWriteTransaction(TransactionOption...)}.
    *
    * <p>That said, Partitioned DML is not a drop-in replacement for standard DML used in {@link
-   * #readWriteTransaction()}.
+   * #readWriteTransaction(TransactionOption...)}.
    *
    * <ul>
    *   <li>The DML statement must be fully-partitionable. Specifically, the statement must be

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClient.java
@@ -412,7 +412,7 @@ public interface DatabaseClient {
    *
    * <p>Example of a read write transaction.
    *
-   * <pre> <code>
+   * <pre>{@code
    * Executor executor = Executors.newSingleThreadExecutor();
    * final long singerId = my_singer_id;
    * AsyncRunner runner = client.runAsync();
@@ -432,7 +432,7 @@ public interface DatabaseClient {
    *                   .build());
    *         },
    *         executor);
-   * </code></pre>
+   * }</pre>
    *
    * Options for a transaction can include:
    *

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceConfigInfo.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceConfigInfo.java
@@ -117,9 +117,9 @@ public class InstanceConfigInfo {
   }
 
   /**
-   * Base configuration, e.g. projects/<project_name>/instanceConfigs/nam3, based on which this
-   * configuration is created. Only set for user managed configurations. The base config must refer
-   * to a configuration of type GOOGLE_MANAGED.
+   * Base configuration, e.g. {@code projects/<project_name>/instanceConfigs/nam3}, based on which
+   * this configuration is created. Only set for user managed configurations. The base config must
+   * refer to a configuration of type GOOGLE_MANAGED.
    */
   public InstanceConfigInfo getBaseConfig() {
     return baseConfig;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Operation.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Operation.java
@@ -32,7 +32,12 @@ import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
-/** Represents a long running operation. */
+/**
+ * Represents a long-running operation.
+ *
+ * @param <R>
+ * @param <M>
+ */
 // TODO(user): Implement other operations on Operation.
 public class Operation<R, M> {
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
@@ -156,9 +156,9 @@ public final class Options implements Serializable {
   }
 
   /**
-   * If this is for a partitioned read & query and this field is set to `true`, the request will be
-   * executed via Spanner independent compute resources. The method is available in Beta mode (and
-   * is not generally available now).
+   * If this is for a partitioned read and query and this field is set to `true`, the request will
+   * be executed via Spanner independent compute resources. The method is available in Beta mode
+   * (and is not generally available now).
    */
   @BetaApi
   public static DataBoostQueryOption dataBoostEnabled(Boolean dataBoostEnabled) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Session.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Session.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.InternalApi;
+import com.google.cloud.spanner.Options.TransactionOption;
 import com.google.protobuf.Empty;
 
 /**
@@ -48,11 +49,12 @@ public interface Session extends DatabaseClient, AutoCloseable {
   String getName();
 
   /**
-   * Prepares a transaction for use by a subsequent {@link #readWriteTransaction()} or {@link
-   * #write(Iterable)} call. It is not necessary to call this method before running a transaction or
-   * performing a write, but doing so may allow one round trip of the protocol to be performed in
-   * advance; calling this method on an idle session that is expected to execute a transaction or
-   * write in the near future may reduce the latency of the subsequent transaction/write.
+   * Prepares a transaction for use by a subsequent {@link
+   * DatabaseClient#readWriteTransaction(TransactionOption...)} or {@link #write(Iterable)} call. It
+   * is not necessary to call this method before running a transaction or performing a write, but
+   * doing so may allow one round trip of the protocol to be performed in advance; calling this
+   * method on an idle session that is expected to execute a transaction or write in the near future
+   * may reduce the latency of the subsequent transaction/write.
    */
   void prepareReadWriteTransaction();
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -32,6 +32,7 @@ import com.google.cloud.TransportOptions;
 import com.google.cloud.grpc.GcpManagedChannelOptions;
 import com.google.cloud.grpc.GrpcTransportOptions;
 import com.google.cloud.spanner.Options.QueryOption;
+import com.google.cloud.spanner.Options.UpdateOption;
 import com.google.cloud.spanner.admin.database.v1.DatabaseAdminSettings;
 import com.google.cloud.spanner.admin.database.v1.stub.DatabaseAdminStubSettings;
 import com.google.cloud.spanner.admin.instance.v1.InstanceAdminSettings;
@@ -134,10 +135,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
   private final String compressorName;
   private final boolean leaderAwareRoutingEnabled;
 
-  /**
-   * Interface that can be used to provide {@link CallCredentials} instead of {@link Credentials} to
-   * {@link SpannerOptions}.
-   */
+  /** Interface that can be used to provide {@link CallCredentials} to {@link SpannerOptions}. */
   public interface CallCredentialsProvider {
     /** Return the {@link CallCredentials} to use for a gRPC call. */
     CallCredentials getCallCredentials();
@@ -970,7 +968,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
 
     /**
      * Sets a timeout specifically for Partitioned DML statements executed through {@link
-     * DatabaseClient#executePartitionedUpdate(Statement)}. The default is 2 hours.
+     * DatabaseClient#executePartitionedUpdate(Statement, UpdateOption...)}. The default is 2 hours.
      */
     public Builder setPartitionedDmlTimeout(Duration timeout) {
       this.partitionedDmlTimeout = timeout;
@@ -1065,9 +1063,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
 
     /**
      * Sets a {@link CallCredentialsProvider} that can deliver {@link CallCredentials} to use on a
-     * per-gRPC basis. Any credentials returned by this {@link CallCredentialsProvider} will have
-     * preference above any {@link Credentials} that may have been set on the {@link SpannerOptions}
-     * instance.
+     * per-gRPC basis.
      */
     public Builder setCallCredentialsProvider(CallCredentialsProvider callCredentialsProvider) {
       this.callCredentialsProvider = callCredentialsProvider;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/StructReader.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/StructReader.java
@@ -72,87 +72,164 @@ public interface StructReader {
    */
   int getColumnIndex(String columnName);
 
-  /** Returns the type of a column. */
+  /**
+   * @param columnIndex
+   * @return the type of a column.
+   */
   Type getColumnType(int columnIndex);
 
-  /** Returns the type of a column. */
+  /**
+   * @param columnName
+   * @return the type of a column.
+   */
   Type getColumnType(String columnName);
 
-  /** Returns {@code true} if a column contains a {@code NULL} value. */
+  /**
+   * @param columnIndex
+   * @return {@code true} if a column contains a {@code NULL} value.
+   */
   boolean isNull(int columnIndex);
 
-  /** Returns {@code true} if a column contains a {@code NULL} value. */
+  /**
+   * @param columnName
+   * @return {@code true} if a column contains a {@code NULL} value.
+   */
   boolean isNull(String columnName);
 
-  /** Returns the value of a non-{@code NULL} column with type {@link Type#bool()}. */
+  /**
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@link Type#bool()}.
+   */
   boolean getBoolean(int columnIndex);
 
-  /** Returns the value of a non-{@code NULL} column with type {@link Type#bool()}. */
+  /**
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@link Type#bool()}.
+   */
   boolean getBoolean(String columnName);
 
-  /** Returns the value of a non-{@code NULL} column with type {@link Type#int64()}. */
+  /**
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@link Type#int64()}.
+   */
   long getLong(int columnIndex);
 
-  /** Returns the value of a non-{@code NULL} column with type {@link Type#int64()}. */
+  /**
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@link Type#int64()}.
+   */
   long getLong(String columnName);
 
-  /** Returns the value of a non-{@code NULL} column with type {@link Type#float64()}. */
+  /**
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@link Type#float64()}.
+   */
   double getDouble(int columnIndex);
 
-  /** Returns the value of a non-{@code NULL} column with type {@link Type#float64()}. */
+  /**
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@link Type#float64()}.
+   */
   double getDouble(String columnName);
 
-  /** Returns the value of a non-{@code NULL} column with type {@link Type#numeric()}. */
+  /**
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@link Type#numeric()}.
+   */
   BigDecimal getBigDecimal(int columnIndex);
 
-  /** Returns the value of a non-{@code NULL} column with type {@link Type#numeric()}. */
+  /**
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@link Type#numeric()}.
+   */
   BigDecimal getBigDecimal(String columnName);
 
-  /** Returns the value of a non-{@code NULL} column with type {@link Type#string()}. */
+  /**
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@link Type#string()}.
+   */
   String getString(int columnIndex);
 
-  /** Returns the value of a non-{@code NULL} column with type {@link Type#string()}. */
+  /**
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@link Type#string()}.
+   */
   String getString(String columnName);
 
-  /** Returns the value of a non-{@code NULL} column with type {@link Type#json()}. */
+  /**
+   *
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@link Type#json()}.
+   */
   default String getJson(int columnIndex) {
     throw new UnsupportedOperationException("method should be overwritten");
   }
 
-  /** Returns the value of a non-{@code NULL} column with type {@link Type#json()}. */
+  /**
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@link Type#json()}.
+   */
   default String getJson(String columnName) {
     throw new UnsupportedOperationException("method should be overwritten");
   }
 
-  /** Returns the value of a non-{@code NULL} column with type {@link Type#pgJsonb()}. */
+  /**
+   *
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@link Type#pgJsonb()}.
+   */
   default String getPgJsonb(int columnIndex) {
     throw new UnsupportedOperationException("method should be overwritten");
   }
 
-  /** Returns the value of a non-{@code NULL} column with type {@link Type#pgJsonb()}. */
+  /**
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@link Type#pgJsonb()}.
+   */
   default String getPgJsonb(String columnName) {
     throw new UnsupportedOperationException("method should be overwritten");
   }
 
-  /** Returns the value of a non-{@code NULL} column with type {@link Type#bytes()}. */
+  /**
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@link Type#bytes()}.
+   */
   ByteArray getBytes(int columnIndex);
 
-  /** Returns the value of a non-{@code NULL} column with type {@link Type#bytes()}. */
+  /**
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@link Type#bytes()}.
+   */
   ByteArray getBytes(String columnName);
 
-  /** Returns the value of a non-{@code NULL} column with type {@link Type#timestamp()}. */
+  /**
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@link Type#timestamp()}.
+   */
   Timestamp getTimestamp(int columnIndex);
 
-  /** Returns the value of a non-{@code NULL} column with type {@link Type#timestamp()}. */
+  /**
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@link Type#timestamp()}.
+   */
   Timestamp getTimestamp(String columnName);
 
-  /** Returns the value of a non-{@code NULL} column with type {@link Type#date()}. */
+  /**
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@link Type#date()}.
+   */
   Date getDate(int columnIndex);
 
-  /** Returns the value of a non-{@code NULL} column with type {@link Type#date()}. */
+  /**
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@link Type#date()}.
+   */
   Date getDate(String columnName);
 
-  /** Returns the value of a nullable column as a {@link Value}. */
+  /**
+   * @param columnIndex
+   * @return the value of a nullable column as a {@link Value}.
+   */
   default Value getValue(int columnIndex) {
     throw new UnsupportedOperationException("method should be overwritten");
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/StructReader.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/StructReader.java
@@ -65,7 +65,7 @@ public interface StructReader {
   int getColumnCount();
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the index of the column named {@code columnName}.
    * @throws IllegalArgumentException if there is not exactly one element of {@code
    *     type().structFields()} with {@link Type.StructField#getName()} equal to {@code columnName}
@@ -73,92 +73,92 @@ public interface StructReader {
   int getColumnIndex(String columnName);
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the type of a column.
    */
   Type getColumnType(int columnIndex);
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the type of a column.
    */
   Type getColumnType(String columnName);
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return {@code true} if a column contains a {@code NULL} value.
    */
   boolean isNull(int columnIndex);
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return {@code true} if a column contains a {@code NULL} value.
    */
   boolean isNull(String columnName);
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@link Type#bool()}.
    */
   boolean getBoolean(int columnIndex);
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@link Type#bool()}.
    */
   boolean getBoolean(String columnName);
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@link Type#int64()}.
    */
   long getLong(int columnIndex);
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@link Type#int64()}.
    */
   long getLong(String columnName);
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@link Type#float64()}.
    */
   double getDouble(int columnIndex);
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@link Type#float64()}.
    */
   double getDouble(String columnName);
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@link Type#numeric()}.
    */
   BigDecimal getBigDecimal(int columnIndex);
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@link Type#numeric()}.
    */
   BigDecimal getBigDecimal(String columnName);
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@link Type#string()}.
    */
   String getString(int columnIndex);
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@link Type#string()}.
    */
   String getString(String columnName);
 
   /**
    *
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@link Type#json()}.
    */
   default String getJson(int columnIndex) {
@@ -166,7 +166,7 @@ public interface StructReader {
   }
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@link Type#json()}.
    */
   default String getJson(String columnName) {
@@ -175,7 +175,7 @@ public interface StructReader {
 
   /**
    *
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@link Type#pgJsonb()}.
    */
   default String getPgJsonb(int columnIndex) {
@@ -183,7 +183,7 @@ public interface StructReader {
   }
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@link Type#pgJsonb()}.
    */
   default String getPgJsonb(String columnName) {
@@ -191,43 +191,43 @@ public interface StructReader {
   }
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@link Type#bytes()}.
    */
   ByteArray getBytes(int columnIndex);
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@link Type#bytes()}.
    */
   ByteArray getBytes(String columnName);
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@link Type#timestamp()}.
    */
   Timestamp getTimestamp(int columnIndex);
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@link Type#timestamp()}.
    */
   Timestamp getTimestamp(String columnName);
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@link Type#date()}.
    */
   Date getDate(int columnIndex);
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@link Type#date()}.
    */
   Date getDate(String columnName);
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a nullable column as a {@link Value}.
    */
   default Value getValue(int columnIndex) {
@@ -235,7 +235,7 @@ public interface StructReader {
   }
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a nullable column as a {@link Value}.
    */
   default Value getValue(String columnName) {
@@ -243,7 +243,7 @@ public interface StructReader {
   }
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.bool())}.
    *
    * @throws NullPointerException if any element of the array value is {@code NULL}. If the array
@@ -252,7 +252,7 @@ public interface StructReader {
   boolean[] getBooleanArray(int columnIndex);
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.bool())}.
    *
    * @throws NullPointerException if any element of the array value is {@code NULL}. If the array
@@ -261,7 +261,7 @@ public interface StructReader {
   boolean[] getBooleanArray(String columnName);
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.bool())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
@@ -269,7 +269,7 @@ public interface StructReader {
   List<Boolean> getBooleanList(int columnIndex);
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.bool())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
@@ -277,7 +277,7 @@ public interface StructReader {
   List<Boolean> getBooleanList(String columnName);
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.int64())}.
    *
    * @throws NullPointerException if any element of the array value is {@code NULL}. If the array
@@ -286,7 +286,7 @@ public interface StructReader {
   long[] getLongArray(int columnIndex);
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.int64())}.
    *
    * @throws NullPointerException if any element of the array value is {@code NULL}. If the array
@@ -295,7 +295,7 @@ public interface StructReader {
   long[] getLongArray(String columnName);
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.int64())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
@@ -311,7 +311,7 @@ public interface StructReader {
   List<Long> getLongList(String columnName);
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.float64())}.
    *
    * @throws NullPointerException if any element of the array value is {@code NULL}. If the array
@@ -320,7 +320,7 @@ public interface StructReader {
   double[] getDoubleArray(int columnIndex);
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.float64())}.
    *
    * @throws NullPointerException if any element of the array value is {@code NULL}. If the array
@@ -329,7 +329,7 @@ public interface StructReader {
   double[] getDoubleArray(String columnName);
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.float64())} The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
@@ -337,7 +337,7 @@ public interface StructReader {
   List<Double> getDoubleList(int columnIndex);
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.float64())} The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
@@ -345,7 +345,7 @@ public interface StructReader {
   List<Double> getDoubleList(String columnName);
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.numeric())} The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
@@ -353,7 +353,7 @@ public interface StructReader {
   List<BigDecimal> getBigDecimalList(int columnIndex);
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.numeric())} The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
@@ -361,7 +361,7 @@ public interface StructReader {
   List<BigDecimal> getBigDecimalList(String columnName);
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.string())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
@@ -369,7 +369,7 @@ public interface StructReader {
   List<String> getStringList(int columnIndex);
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.string())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
@@ -377,7 +377,7 @@ public interface StructReader {
   List<String> getStringList(String columnName);
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.json())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
@@ -387,7 +387,7 @@ public interface StructReader {
   };
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.json())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
@@ -397,7 +397,7 @@ public interface StructReader {
   };
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.pgJsonb())} The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
@@ -407,7 +407,7 @@ public interface StructReader {
   };
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.pgJsonb())} The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
@@ -417,7 +417,7 @@ public interface StructReader {
   };
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.bytes())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
@@ -425,7 +425,7 @@ public interface StructReader {
   List<ByteArray> getBytesList(int columnIndex);
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.bytes())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
@@ -433,7 +433,7 @@ public interface StructReader {
   List<ByteArray> getBytesList(String columnName);
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.timestamp())}
    * The list returned by this method is lazily constructed. Create a copy of it if you intend to
    * access each element in the list multiple times.
@@ -441,7 +441,7 @@ public interface StructReader {
   List<Timestamp> getTimestampList(int columnIndex);
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.timestamp())}
    * The list returned by this method is lazily constructed. Create a copy of it if you intend to
    * access each element in the list multiple times.
@@ -449,7 +449,7 @@ public interface StructReader {
   List<Timestamp> getTimestampList(String columnName);
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.date())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
@@ -457,7 +457,7 @@ public interface StructReader {
   List<Date> getDateList(int columnIndex);
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.date())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
@@ -465,7 +465,7 @@ public interface StructReader {
   List<Date> getDateList(String columnName);
 
   /**
-   * @param columnIndex
+   * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.struct(...))}
    * The list returned by this method is lazily constructed. Create a copy of it if you intend to
    * access each element in the list multiple times.
@@ -473,7 +473,7 @@ public interface StructReader {
   List<Struct> getStructList(int columnIndex);
 
   /**
-   * @param columnName
+   * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.struct(...))}
    * The list returned by this method is lazily constructed. Create a copy of it if you intend to
    * access each element in the list multiple times.

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/StructReader.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/StructReader.java
@@ -52,21 +52,21 @@ import java.util.List;
  */
 public interface StructReader {
   /**
-   * Returns the type of the underlying data. This will always be a {@code STRUCT} type, with fields
+   * @return the type of the underlying data. This will always be a {@code STRUCT} type, with fields
    * corresponding to the data's columns. For the result of a read or query, this will always match
    * the columns passed to the {@code read()} call or named in the query text, in order.
    */
   Type getType();
 
   /**
-   * Returns the number of columns in the underlying data. This includes any columns with {@code
+   * @return the number of columns in the underlying data. This includes any columns with {@code
    * NULL} values.
    */
   int getColumnCount();
 
   /**
-   * Returns the index of the column named {@code columnName}.
-   *
+   * @param columnName
+   * @return the index of the column named {@code columnName}.
    * @throws IllegalArgumentException if there is not exactly one element of {@code
    *     type().structFields()} with {@link Type.StructField#getName()} equal to {@code columnName}
    */
@@ -157,13 +157,17 @@ public interface StructReader {
     throw new UnsupportedOperationException("method should be overwritten");
   }
 
-  /** Returns the value of a nullable column as a {@link Value}. */
+  /**
+   * @param columnName
+   * @return the value of a nullable column as a {@link Value}.
+   */
   default Value getValue(String columnName) {
     throw new UnsupportedOperationException("method should be overwritten");
   }
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.bool())}.
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.bool())}.
    *
    * @throws NullPointerException if any element of the array value is {@code NULL}. If the array
    *     may contain {@code NULL} values, use {@link #getBooleanList(int)} instead.
@@ -171,7 +175,8 @@ public interface StructReader {
   boolean[] getBooleanArray(int columnIndex);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.bool())}.
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.bool())}.
    *
    * @throws NullPointerException if any element of the array value is {@code NULL}. If the array
    *     may contain {@code NULL} values, use {@link #getBooleanList(String)} instead.
@@ -179,21 +184,24 @@ public interface StructReader {
   boolean[] getBooleanArray(String columnName);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.bool())}. The
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.bool())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
    */
   List<Boolean> getBooleanList(int columnIndex);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.bool())}. The
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.bool())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
    */
   List<Boolean> getBooleanList(String columnName);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.int64())}.
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.int64())}.
    *
    * @throws NullPointerException if any element of the array value is {@code NULL}. If the array
    *     may contain {@code NULL} values, use {@link #getLongList(int)} instead.
@@ -201,7 +209,8 @@ public interface StructReader {
   long[] getLongArray(int columnIndex);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.int64())}.
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.int64())}.
    *
    * @throws NullPointerException if any element of the array value is {@code NULL}. If the array
    *     may contain {@code NULL} values, use {@link #getLongList(String)} instead.
@@ -209,21 +218,24 @@ public interface StructReader {
   long[] getLongArray(String columnName);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.int64())}. The
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.int64())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
    */
   List<Long> getLongList(int columnIndex);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.int64())}. The
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.int64())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
    */
   List<Long> getLongList(String columnName);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.float64())}.
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.float64())}.
    *
    * @throws NullPointerException if any element of the array value is {@code NULL}. If the array
    *     may contain {@code NULL} values, use {@link #getDoubleList(int)} instead.
@@ -231,7 +243,8 @@ public interface StructReader {
   double[] getDoubleArray(int columnIndex);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.float64())}.
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.float64())}.
    *
    * @throws NullPointerException if any element of the array value is {@code NULL}. If the array
    *     may contain {@code NULL} values, use {@link #getDoubleList(String)} instead.
@@ -239,49 +252,56 @@ public interface StructReader {
   double[] getDoubleArray(String columnName);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.float64())} The
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.float64())} The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
    */
   List<Double> getDoubleList(int columnIndex);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.float64())} The
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.float64())} The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
    */
   List<Double> getDoubleList(String columnName);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.numeric())} The
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.numeric())} The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
    */
   List<BigDecimal> getBigDecimalList(int columnIndex);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.numeric())} The
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.numeric())} The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
    */
   List<BigDecimal> getBigDecimalList(String columnName);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.string())}. The
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.string())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
    */
   List<String> getStringList(int columnIndex);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.string())}. The
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.string())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
    */
   List<String> getStringList(String columnName);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.json())}. The
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.json())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
    */
@@ -290,7 +310,8 @@ public interface StructReader {
   };
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.json())}. The
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.json())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
    */
@@ -299,7 +320,8 @@ public interface StructReader {
   };
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.pgJsonb())} The
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.pgJsonb())} The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
    */
@@ -308,7 +330,8 @@ public interface StructReader {
   };
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.pgJsonb())} The
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.pgJsonb())} The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
    */
@@ -317,56 +340,64 @@ public interface StructReader {
   };
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.bytes())}. The
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.bytes())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
    */
   List<ByteArray> getBytesList(int columnIndex);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.bytes())}. The
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.bytes())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
    */
   List<ByteArray> getBytesList(String columnName);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.timestamp())}
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.timestamp())}
    * The list returned by this method is lazily constructed. Create a copy of it if you intend to
    * access each element in the list multiple times.
    */
   List<Timestamp> getTimestampList(int columnIndex);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.timestamp())}
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.timestamp())}
    * The list returned by this method is lazily constructed. Create a copy of it if you intend to
    * access each element in the list multiple times.
    */
   List<Timestamp> getTimestampList(String columnName);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.date())}. The
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.date())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
    */
   List<Date> getDateList(int columnIndex);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.date())}. The
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.date())}. The
    * list returned by this method is lazily constructed. Create a copy of it if you intend to access
    * each element in the list multiple times.
    */
   List<Date> getDateList(String columnName);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.struct(...))}
+   * @param columnIndex
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.struct(...))}
    * The list returned by this method is lazily constructed. Create a copy of it if you intend to
    * access each element in the list multiple times.
    */
   List<Struct> getStructList(int columnIndex);
 
   /**
-   * Returns the value of a non-{@code NULL} column with type {@code Type.array(Type.struct(...))}
+   * @param columnName
+   * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.struct(...))}
    * The list returned by this method is lazily constructed. Create a copy of it if you intend to
    * access each element in the list multiple times.
    */

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/StructReader.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/StructReader.java
@@ -53,14 +53,14 @@ import java.util.List;
 public interface StructReader {
   /**
    * @return the type of the underlying data. This will always be a {@code STRUCT} type, with fields
-   * corresponding to the data's columns. For the result of a read or query, this will always match
-   * the columns passed to the {@code read()} call or named in the query text, in order.
+   *     corresponding to the data's columns. For the result of a read or query, this will always
+   *     match the columns passed to the {@code read()} call or named in the query text, in order.
    */
   Type getType();
 
   /**
    * @return the number of columns in the underlying data. This includes any columns with {@code
-   * NULL} values.
+   *     NULL} values.
    */
   int getColumnCount();
 
@@ -157,7 +157,6 @@ public interface StructReader {
   String getString(String columnName);
 
   /**
-   *
    * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@link Type#json()}.
    */
@@ -174,7 +173,6 @@ public interface StructReader {
   }
 
   /**
-   *
    * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@link Type#pgJsonb()}.
    */
@@ -245,7 +243,6 @@ public interface StructReader {
   /**
    * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.bool())}.
-   *
    * @throws NullPointerException if any element of the array value is {@code NULL}. If the array
    *     may contain {@code NULL} values, use {@link #getBooleanList(int)} instead.
    */
@@ -254,7 +251,6 @@ public interface StructReader {
   /**
    * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.bool())}.
-   *
    * @throws NullPointerException if any element of the array value is {@code NULL}. If the array
    *     may contain {@code NULL} values, use {@link #getBooleanList(String)} instead.
    */
@@ -263,23 +259,22 @@ public interface StructReader {
   /**
    * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.bool())}. The
-   * list returned by this method is lazily constructed. Create a copy of it if you intend to access
-   * each element in the list multiple times.
+   *     list returned by this method is lazily constructed. Create a copy of it if you intend to
+   *     access each element in the list multiple times.
    */
   List<Boolean> getBooleanList(int columnIndex);
 
   /**
    * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.bool())}. The
-   * list returned by this method is lazily constructed. Create a copy of it if you intend to access
-   * each element in the list multiple times.
+   *     list returned by this method is lazily constructed. Create a copy of it if you intend to
+   *     access each element in the list multiple times.
    */
   List<Boolean> getBooleanList(String columnName);
 
   /**
    * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.int64())}.
-   *
    * @throws NullPointerException if any element of the array value is {@code NULL}. If the array
    *     may contain {@code NULL} values, use {@link #getLongList(int)} instead.
    */
@@ -288,7 +283,6 @@ public interface StructReader {
   /**
    * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.int64())}.
-   *
    * @throws NullPointerException if any element of the array value is {@code NULL}. If the array
    *     may contain {@code NULL} values, use {@link #getLongList(String)} instead.
    */
@@ -297,23 +291,22 @@ public interface StructReader {
   /**
    * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.int64())}. The
-   * list returned by this method is lazily constructed. Create a copy of it if you intend to access
-   * each element in the list multiple times.
+   *     list returned by this method is lazily constructed. Create a copy of it if you intend to
+   *     access each element in the list multiple times.
    */
   List<Long> getLongList(int columnIndex);
 
   /**
    * @param columnName
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.int64())}. The
-   * list returned by this method is lazily constructed. Create a copy of it if you intend to access
-   * each element in the list multiple times.
+   *     list returned by this method is lazily constructed. Create a copy of it if you intend to
+   *     access each element in the list multiple times.
    */
   List<Long> getLongList(String columnName);
 
   /**
    * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.float64())}.
-   *
    * @throws NullPointerException if any element of the array value is {@code NULL}. If the array
    *     may contain {@code NULL} values, use {@link #getDoubleList(int)} instead.
    */
@@ -322,7 +315,6 @@ public interface StructReader {
   /**
    * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.float64())}.
-   *
    * @throws NullPointerException if any element of the array value is {@code NULL}. If the array
    *     may contain {@code NULL} values, use {@link #getDoubleList(String)} instead.
    */
@@ -331,56 +323,56 @@ public interface StructReader {
   /**
    * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.float64())} The
-   * list returned by this method is lazily constructed. Create a copy of it if you intend to access
-   * each element in the list multiple times.
+   *     list returned by this method is lazily constructed. Create a copy of it if you intend to
+   *     access each element in the list multiple times.
    */
   List<Double> getDoubleList(int columnIndex);
 
   /**
    * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.float64())} The
-   * list returned by this method is lazily constructed. Create a copy of it if you intend to access
-   * each element in the list multiple times.
+   *     list returned by this method is lazily constructed. Create a copy of it if you intend to
+   *     access each element in the list multiple times.
    */
   List<Double> getDoubleList(String columnName);
 
   /**
    * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.numeric())} The
-   * list returned by this method is lazily constructed. Create a copy of it if you intend to access
-   * each element in the list multiple times.
+   *     list returned by this method is lazily constructed. Create a copy of it if you intend to
+   *     access each element in the list multiple times.
    */
   List<BigDecimal> getBigDecimalList(int columnIndex);
 
   /**
    * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.numeric())} The
-   * list returned by this method is lazily constructed. Create a copy of it if you intend to access
-   * each element in the list multiple times.
+   *     list returned by this method is lazily constructed. Create a copy of it if you intend to
+   *     access each element in the list multiple times.
    */
   List<BigDecimal> getBigDecimalList(String columnName);
 
   /**
    * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.string())}. The
-   * list returned by this method is lazily constructed. Create a copy of it if you intend to access
-   * each element in the list multiple times.
+   *     list returned by this method is lazily constructed. Create a copy of it if you intend to
+   *     access each element in the list multiple times.
    */
   List<String> getStringList(int columnIndex);
 
   /**
    * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.string())}. The
-   * list returned by this method is lazily constructed. Create a copy of it if you intend to access
-   * each element in the list multiple times.
+   *     list returned by this method is lazily constructed. Create a copy of it if you intend to
+   *     access each element in the list multiple times.
    */
   List<String> getStringList(String columnName);
 
   /**
    * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.json())}. The
-   * list returned by this method is lazily constructed. Create a copy of it if you intend to access
-   * each element in the list multiple times.
+   *     list returned by this method is lazily constructed. Create a copy of it if you intend to
+   *     access each element in the list multiple times.
    */
   default List<String> getJsonList(int columnIndex) {
     throw new UnsupportedOperationException("method should be overwritten");
@@ -389,8 +381,8 @@ public interface StructReader {
   /**
    * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.json())}. The
-   * list returned by this method is lazily constructed. Create a copy of it if you intend to access
-   * each element in the list multiple times.
+   *     list returned by this method is lazily constructed. Create a copy of it if you intend to
+   *     access each element in the list multiple times.
    */
   default List<String> getJsonList(String columnName) {
     throw new UnsupportedOperationException("method should be overwritten");
@@ -399,8 +391,8 @@ public interface StructReader {
   /**
    * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.pgJsonb())} The
-   * list returned by this method is lazily constructed. Create a copy of it if you intend to access
-   * each element in the list multiple times.
+   *     list returned by this method is lazily constructed. Create a copy of it if you intend to
+   *     access each element in the list multiple times.
    */
   default List<String> getPgJsonbList(int columnIndex) {
     throw new UnsupportedOperationException("method should be overwritten");
@@ -409,8 +401,8 @@ public interface StructReader {
   /**
    * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.pgJsonb())} The
-   * list returned by this method is lazily constructed. Create a copy of it if you intend to access
-   * each element in the list multiple times.
+   *     list returned by this method is lazily constructed. Create a copy of it if you intend to
+   *     access each element in the list multiple times.
    */
   default List<String> getPgJsonbList(String columnName) {
     throw new UnsupportedOperationException("method should be overwritten");
@@ -419,64 +411,64 @@ public interface StructReader {
   /**
    * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.bytes())}. The
-   * list returned by this method is lazily constructed. Create a copy of it if you intend to access
-   * each element in the list multiple times.
+   *     list returned by this method is lazily constructed. Create a copy of it if you intend to
+   *     access each element in the list multiple times.
    */
   List<ByteArray> getBytesList(int columnIndex);
 
   /**
    * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.bytes())}. The
-   * list returned by this method is lazily constructed. Create a copy of it if you intend to access
-   * each element in the list multiple times.
+   *     list returned by this method is lazily constructed. Create a copy of it if you intend to
+   *     access each element in the list multiple times.
    */
   List<ByteArray> getBytesList(String columnName);
 
   /**
    * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.timestamp())}
-   * The list returned by this method is lazily constructed. Create a copy of it if you intend to
-   * access each element in the list multiple times.
+   *     The list returned by this method is lazily constructed. Create a copy of it if you intend
+   *     to access each element in the list multiple times.
    */
   List<Timestamp> getTimestampList(int columnIndex);
 
   /**
    * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.timestamp())}
-   * The list returned by this method is lazily constructed. Create a copy of it if you intend to
-   * access each element in the list multiple times.
+   *     The list returned by this method is lazily constructed. Create a copy of it if you intend
+   *     to access each element in the list multiple times.
    */
   List<Timestamp> getTimestampList(String columnName);
 
   /**
    * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.date())}. The
-   * list returned by this method is lazily constructed. Create a copy of it if you intend to access
-   * each element in the list multiple times.
+   *     list returned by this method is lazily constructed. Create a copy of it if you intend to
+   *     access each element in the list multiple times.
    */
   List<Date> getDateList(int columnIndex);
 
   /**
    * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.date())}. The
-   * list returned by this method is lazily constructed. Create a copy of it if you intend to access
-   * each element in the list multiple times.
+   *     list returned by this method is lazily constructed. Create a copy of it if you intend to
+   *     access each element in the list multiple times.
    */
   List<Date> getDateList(String columnName);
 
   /**
    * @param columnIndex index of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.struct(...))}
-   * The list returned by this method is lazily constructed. Create a copy of it if you intend to
-   * access each element in the list multiple times.
+   *     The list returned by this method is lazily constructed. Create a copy of it if you intend
+   *     to access each element in the list multiple times.
    */
   List<Struct> getStructList(int columnIndex);
 
   /**
    * @param columnName name of the column
    * @return the value of a non-{@code NULL} column with type {@code Type.array(Type.struct(...))}
-   * The list returned by this method is lazily constructed. Create a copy of it if you intend to
-   * access each element in the list multiple times.
+   *     The list returned by this method is lazily constructed. Create a copy of it if you intend
+   *     to access each element in the list multiple times.
    */
   List<Struct> getStructList(String columnName);
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TimestampBound.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TimestampBound.java
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>Each type of timestamp bound is discussed in detail below.
  *
- * <h3>Strong reads</h3>
+ * <h2>Strong reads</h2>
  *
  * <p>Strong reads are guaranteed to see the effects of all transactions that have committed before
  * the start of the read. Furthermore, all rows yielded by a single read are consistent with each
@@ -59,7 +59,7 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>Use {@link #strong()} to create a bound of this type.
  *
- * <h3>Exact Staleness</h3>
+ * <h2>Exact Staleness</h2>
  *
  * <p>These timestamp bounds execute reads at a user-specified timestamp. Reads at a timestamp are
  * guaranteed to see a consistent prefix of the global transaction history: they observe
@@ -78,7 +78,7 @@ import java.util.concurrent.TimeUnit;
  * <p>Use {@link #ofReadTimestamp(Timestamp)} and {@link #ofExactStaleness(long, TimeUnit)} to
  * create a bound of this type.
  *
- * <h3>Bounded Staleness</h3>
+ * <h2>Bounded Staleness</h2>
  *
  * <p>Bounded staleness modes allow Cloud Spanner to pick the read timestamp, subject to a
  * user-provided staleness bound. Cloud Spanner chooses the newest timestamp within the staleness
@@ -103,7 +103,7 @@ import java.util.concurrent.TimeUnit;
  * <p>Use {@link #ofMinReadTimestamp(Timestamp)} and {@link #ofMaxStaleness(long, TimeUnit)} to
  * create a bound of this type.
  *
- * <h3>Old Read Timestamps and Garbage Collection</h3>
+ * <h2>Old Read Timestamps and Garbage Collection</h2>
  *
  * <p>Cloud Spanner continuously garbage collects deleted and overwritten data in the background to
  * reclaim storage space. This process is known as "version GC". By default, version GC reclaims

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContext.java
@@ -118,13 +118,13 @@ public interface TransactionContext extends ReadContext {
   long executeUpdate(Statement statement, UpdateOption... options);
 
   /**
-   * Same as {@link #executeUpdate(Statement)}, but is guaranteed to be non-blocking. If multiple
-   * asynchronous update statements are submitted to the same read/write transaction, the statements
-   * are guaranteed to be submitted to Cloud Spanner in the order that they were submitted in the
-   * client. This does however not guarantee that an asynchronous update statement will see the
-   * results of all previously submitted statements, as the execution of the statements can be
-   * parallel. If you rely on the results of a previous statement, you should block until the result
-   * of that statement is known and has been returned to the client.
+   * Same as {@link #executeUpdate(Statement,UpdateOption...)}, but is guaranteed to be
+   * non-blocking. If multiple asynchronous update statements are submitted to the same read/write
+   * transaction, the statements are guaranteed to be submitted to Cloud Spanner in the order that
+   * they were submitted in the client. This does however not guarantee that an asynchronous update
+   * statement will see the results of all previously submitted statements, as the execution of the
+   * statements can be parallel. If you rely on the results of a previous statement, you should
+   * block until the result of that statement is known and has been returned to the client.
    */
   ApiFuture<Long> executeUpdateAsync(Statement statement, UpdateOption... options);
 
@@ -179,13 +179,13 @@ public interface TransactionContext extends ReadContext {
   long[] batchUpdate(Iterable<Statement> statements, UpdateOption... options);
 
   /**
-   * Same as {@link #batchUpdate(Iterable)}, but is guaranteed to be non-blocking. If multiple
-   * asynchronous update statements are submitted to the same read/write transaction, the statements
-   * are guaranteed to be submitted to Cloud Spanner in the order that they were submitted in the
-   * client. This does however not guarantee that an asynchronous update statement will see the
-   * results of all previously submitted statements, as the execution of the statements can be
-   * parallel. If you rely on the results of a previous statement, you should block until the result
-   * of that statement is known and has been returned to the client.
+   * Same as {@link #batchUpdate(Iterable, UpdateOption...)}, but is guaranteed to be non-blocking.
+   * If multiple asynchronous update statements are submitted to the same read/write transaction,
+   * the statements are guaranteed to be submitted to Cloud Spanner in the order that they were
+   * submitted in the client. This does however not guarantee that an asynchronous update statement
+   * will see the results of all previously submitted statements, as the execution of the statements
+   * can be parallel. If you rely on the results of a previous statement, you should block until the
+   * result of that statement is known and has been returned to the client.
    */
   ApiFuture<long[]> batchUpdateAsync(Iterable<Statement> statements, UpdateOption... options);
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContext.java
@@ -44,7 +44,7 @@ import com.google.spanner.v1.ResultSetStats;
  * <p>Conceptually, a read-write transaction consists of zero or more reads or SQL queries followed
  * by a commit.
  *
- * <h3>Semantics</h3>
+ * <h2>Semantics</h2>
  *
  * <p>Cloud Spanner can commit the transaction if all read locks it acquired are still valid at
  * commit time, and it is able to acquire write locks for all writes. Cloud Spanner can abort the
@@ -55,7 +55,7 @@ import com.google.spanner.v1.ResultSetStats;
  * transaction's locks were held for. It is an error to use Cloud Spanner locks for any sort of
  * mutual exclusion other than between Cloud Spanner transactions themselves.
  *
- * <h3>Retrying Aborted Transactions</h3>
+ * <h2>Retrying Aborted Transactions</h2>
  *
  * <p>When a transaction aborts, the application can choose to retry the whole transaction again. To
  * maximize the chances of successfully committing the retry, the client should execute the retry in
@@ -71,7 +71,7 @@ import com.google.spanner.v1.ResultSetStats;
  * <p>Application code does not need to retry explicitly; {@link TransactionRunner} will
  * automatically retry a transaction if an attempt results in an abort.
  *
- * <h3>Idle Transactions</h3>
+ * <h2>Idle Transactions</h2>
  *
  * <p>A transaction is considered idle if it has no outstanding reads or SQL queries and has not
  * started a read or SQL query within the last 10 seconds. Idle transactions can be aborted by Cloud

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContext.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spanner;
 
 import com.google.api.core.ApiFuture;
+import com.google.cloud.spanner.Options.TransactionOption;
 import com.google.cloud.spanner.Options.UpdateOption;
 import com.google.spanner.v1.ResultSetStats;
 
@@ -81,7 +82,7 @@ import com.google.spanner.v1.ResultSetStats;
  * <p>If this behavior is undesirable, periodically executing a simple SQL query in the transaction
  * (e.g., {@code SELECT 1}) prevents the transaction from becoming idle.
  *
- * @see Session#readWriteTransaction()
+ * @see DatabaseClient#readWriteTransaction(TransactionOption...)
  * @see TransactionRunner
  */
 public interface TransactionContext extends ReadContext {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionManager.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionManager.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spanner;
 
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Options.TransactionOption;
 
 /**
  * An interface for managing the life cycle of a read write transaction including all its retries.
@@ -33,7 +34,7 @@ import com.google.cloud.Timestamp;
  * can cause resources to be leaked and deadlocks. Easiest way to guarantee this is by calling
  * {@link #close()} in a finally block.
  *
- * @see DatabaseClient#transactionManager()
+ * @see DatabaseClient#transactionManager(TransactionOption...)
  */
 public interface TransactionManager extends AutoCloseable {
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunner.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunner.java
@@ -17,13 +17,14 @@
 package com.google.cloud.spanner;
 
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Options.TransactionOption;
 import javax.annotation.Nullable;
 
 /**
  * An interface for executing a body of work in the context of a read-write transaction, with
  * retries for transaction aborts. See {@link TransactionContext} for a description of transaction
  * semantics. {@code TransactionRunner} instances are obtained by calling {@link
- * Session#readWriteTransaction()}.
+ * DatabaseClient#readWriteTransaction(TransactionOption...)}.
  *
  * <p>A {@code TransactionRunner} instance can only be used for a single invocation of {@link
  * #run(TransactionCallable)}.

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ValueBinder.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ValueBinder.java
@@ -31,6 +31,8 @@ import javax.annotation.Nullable;
  *
  * <p>{@code ValueBinder} subclasses typically carry state and are therefore not thread-safe,
  * although the core implementation itself is thread-safe.
+ *
+ * @param <R> The context which is used to bind the {@link Value}.
  */
 public abstract class ValueBinder<R> {
   /**

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractStatementParser.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractStatementParser.java
@@ -57,7 +57,11 @@ public abstract class AbstractStatementParser {
               Dialect.POSTGRESQL,
               PostgreSQLStatementParser.class);
 
-  /** Get an instance of {@link AbstractStatementParser} for the specified dialect. */
+  /**
+   * Get an instance of {@link AbstractStatementParser} for the specified dialect.
+   * @param dialect
+   * @return
+   */
   public static AbstractStatementParser getInstance(Dialect dialect) {
     synchronized (lock) {
       if (!INSTANCES.containsKey(dialect)) {
@@ -227,20 +231,24 @@ public abstract class AbstractStatementParser {
           && Objects.equals(this.sqlWithoutComments, o.sqlWithoutComments);
     }
 
-    /** Returns the type of statement that was recognized by the parser. */
+    /**
+     * @return the type of statement that was recognized by the parser.
+     */
     @InternalApi
     public StatementType getType() {
       return type;
     }
 
-    /** Returns whether the statement has a returning clause or not. * */
+    /**
+     * @return whether the statement has a returning clause or not.
+     */
     @InternalApi
     public boolean hasReturningClause() {
       return this.returningClause;
     }
 
     /**
-     * Returns true if the statement is a query that will return a {@link
+     * @return true if the statement is a query that will return a {@link
      * com.google.cloud.spanner.ResultSet}.
      */
     @InternalApi
@@ -259,7 +267,7 @@ public abstract class AbstractStatementParser {
     }
 
     /**
-     * Returns true if the statement is a DML statement or a client side statement that will return
+     * @return true if the statement is a DML statement or a client side statement that will return
      * an update count.
      */
     @InternalApi
@@ -277,7 +285,9 @@ public abstract class AbstractStatementParser {
       return false;
     }
 
-    /** Returns true if the statement is a DDL statement. */
+    /**
+     * @return true if the statement is a DDL statement.
+     */
     @InternalApi
     public boolean isDdl() {
       switch (type) {
@@ -293,7 +303,7 @@ public abstract class AbstractStatementParser {
     }
 
     /**
-     * Returns the {@link ClientSideStatementType} of this statement. This method may only be called
+     * @return the {@link ClientSideStatementType} of this statement. This method may only be called
      * on statements of type {@link StatementType#CLIENT_SIDE}.
      */
     @InternalApi
@@ -326,7 +336,9 @@ public abstract class AbstractStatementParser {
           .build();
     }
 
-    /** Returns the SQL statement with all comments removed from the SQL string. */
+    /**
+     * @return the SQL statement with all comments removed from the SQL string.
+     */
     @InternalApi
     public String getSqlWithoutComments() {
       return sqlWithoutComments;
@@ -494,6 +506,12 @@ public abstract class AbstractStatementParser {
   @InternalApi
   abstract String removeCommentsAndTrimInternal(String sql);
 
+  /**
+   * Removes comments from and trims the given sql statement using the dialect of this parser.
+   *
+   * @param sql The sql statement to remove comments from and to trim.
+   * @return the sql statement without the comments and leading and trailing spaces.
+   */
   @InternalApi
   public String removeCommentsAndTrim(String sql) {
     return removeCommentsAndTrimInternal(sql);
@@ -531,6 +549,19 @@ public abstract class AbstractStatementParser {
   abstract ParametersInfo convertPositionalParametersToNamedParametersInternal(
       char paramChar, String sql);
 
+  /**
+   * Converts all positional parameters (?) in the given sql string into named parameters. The
+   * parameters are named @p1, @p2, etc. This method is used when converting a JDBC statement that
+   * uses positional parameters to a Cloud Spanner {@link Statement} instance that requires named
+   * parameters. The input SQL string may not contain any comments. There is an exception case if
+   * the statement starts with a GSQL comment which forces it to be interpreted as a GoogleSql
+   * statement.
+   *
+   * @param sql The sql string without comments that should be converted
+   * @return A {@link ParametersInfo} object containing a string with named parameters instead of
+   *     positional parameters and the number of parameters.
+   * @throws SpannerException If the input sql string contains an unclosed string/byte literal.
+   */
   @InternalApi
   public ParametersInfo convertPositionalParametersToNamedParameters(char paramChar, String sql) {
     return convertPositionalParametersToNamedParametersInternal(paramChar, sql);
@@ -557,6 +588,13 @@ public abstract class AbstractStatementParser {
   @InternalApi
   protected abstract boolean checkReturningClauseInternal(String sql);
 
+  /**
+   * Checks if the given SQL string contains a Returning clause. This method is used only in case of
+   * a DML statement.
+   *
+   * @param sql The sql string without comments that has to be evaluated.
+   * @return A boolean indicating whether the sql string has a Returning clause or not.
+   */
   @InternalApi
   public boolean checkReturningClause(String sql) {
     return checkReturningClauseInternal(sql);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractStatementParser.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractStatementParser.java
@@ -59,6 +59,7 @@ public abstract class AbstractStatementParser {
 
   /**
    * Get an instance of {@link AbstractStatementParser} for the specified dialect.
+   *
    * @param dialect
    * @return
    */
@@ -231,17 +232,13 @@ public abstract class AbstractStatementParser {
           && Objects.equals(this.sqlWithoutComments, o.sqlWithoutComments);
     }
 
-    /**
-     * @return the type of statement that was recognized by the parser.
-     */
+    /** @return the type of statement that was recognized by the parser. */
     @InternalApi
     public StatementType getType() {
       return type;
     }
 
-    /**
-     * @return whether the statement has a returning clause or not.
-     */
+    /** @return whether the statement has a returning clause or not. */
     @InternalApi
     public boolean hasReturningClause() {
       return this.returningClause;
@@ -249,7 +246,7 @@ public abstract class AbstractStatementParser {
 
     /**
      * @return true if the statement is a query that will return a {@link
-     * com.google.cloud.spanner.ResultSet}.
+     *     com.google.cloud.spanner.ResultSet}.
      */
     @InternalApi
     public boolean isQuery() {
@@ -268,7 +265,7 @@ public abstract class AbstractStatementParser {
 
     /**
      * @return true if the statement is a DML statement or a client side statement that will return
-     * an update count.
+     *     an update count.
      */
     @InternalApi
     public boolean isUpdate() {
@@ -285,9 +282,7 @@ public abstract class AbstractStatementParser {
       return false;
     }
 
-    /**
-     * @return true if the statement is a DDL statement.
-     */
+    /** @return true if the statement is a DDL statement. */
     @InternalApi
     public boolean isDdl() {
       switch (type) {
@@ -304,7 +299,7 @@ public abstract class AbstractStatementParser {
 
     /**
      * @return the {@link ClientSideStatementType} of this statement. This method may only be called
-     * on statements of type {@link StatementType#CLIENT_SIDE}.
+     *     on statements of type {@link StatementType#CLIENT_SIDE}.
      */
     @InternalApi
     public ClientSideStatementType getClientSideStatementType() {
@@ -336,9 +331,7 @@ public abstract class AbstractStatementParser {
           .build();
     }
 
-    /**
-     * @return the SQL statement with all comments removed from the SQL string.
-     */
+    /** @return the SQL statement with all comments removed from the SQL string. */
     @InternalApi
     public String getSqlWithoutComments() {
       return sqlWithoutComments;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GrpcResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GrpcResultSetTest.java
@@ -51,7 +51,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link com.google.cloud.spanner.SpannerImpl.GrpcResultSet}. */
+/** Unit tests for {@link com.google.cloud.spanner.AbstractResultSet.GrpcResultSet}. */
 @RunWith(JUnit4.class)
 public class GrpcResultSetTest {
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceAdminClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceAdminClientImplTest.java
@@ -54,7 +54,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 
-/** Unit tests for {@link com.google.cloud.spanner.SpannerImpl.InstanceAdminClientImpl}. */
+/** Unit tests for {@link com.google.cloud.spanner.InstanceAdminClientImpl}. */
 @RunWith(JUnit4.class)
 public class InstanceAdminClientImplTest {
   private static final String PROJECT_ID = "my-project";

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
@@ -73,7 +73,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-/** Unit test for {@link com.google.cloud.spanner.SpannerImpl.TransactionRunnerImpl} */
+/** Unit test for {@link com.google.cloud.spanner.TransactionRunnerImpl} */
 @RunWith(JUnit4.class)
 public class TransactionRunnerImplTest {
   private static final class TestExecutorFactory

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractSqlScriptVerifier.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractSqlScriptVerifier.java
@@ -70,9 +70,9 @@ import java.util.stream.Stream;
  *       equal. The value of a variable can be set using a @PUT statement.
  * </ul>
  *
- * The parser can set a temporary variable value using a @PUT statement: <code>
- * @PUT 'variable_name'\nSQL statement</code> The SQL statement must be a statement that returns a
- * {@link ResultSet} containing exactly one row and one column.
+ * The parser can set a temporary variable value using a @PUT statement: {@code @PUT
+ * 'variable_name'\nSQL statement} The SQL statement must be a statement that returns a {@link
+ * ResultSet} containing exactly one row and one column.
  *
  * <p>In addition the verifier can create new connections if the script contains NEW_CONNECTION;
  * statements and the verifier has been created with a {@link GenericConnectionProvider}. See {@link
@@ -130,7 +130,7 @@ public abstract class AbstractSqlScriptVerifier {
 
   /**
    * Generic wrapper around a connection to a database. The underlying connection could be a Spanner
-   * {@link com.google.cloud.spanner.jdbc.Connection} or a JDBC {@link java.sql.Connection}
+   * {@link com.google.cloud.spanner.connection.Connection} or a JDBC {@link java.sql.Connection}
    */
   public abstract static class GenericConnection implements AutoCloseable {
     protected abstract GenericStatementResult execute(String sql) throws Exception;
@@ -208,8 +208,8 @@ public abstract class AbstractSqlScriptVerifier {
    * Statements without an @EXPECT statement will be executed and its result will be ignored, unless
    * the statement throws an exception, which will fail the test case.
    *
-   * <p>The {@link com.google.cloud.spanner.jdbc.Connection}s that the statements are executed on
-   * must be created by a {@link GenericConnectionProvider}
+   * <p>The {@link com.google.cloud.spanner.connection.Connection}s that the statements are executed
+   * on must be created by a {@link GenericConnectionProvider}
    *
    * @param filename The file name containing the statements. Statements must be separated by a
    *     semicolon (;)
@@ -229,8 +229,8 @@ public abstract class AbstractSqlScriptVerifier {
    * Statements without an @EXPECT statement will be executed and its result will be ignored, unless
    * the statement throws an exception, which will fail the test case.
    *
-   * <p>The {@link com.google.cloud.spanner.jdbc.Connection}s that the statements are executed on
-   * must be created by a {@link GenericConnectionProvider}
+   * <p>The {@link com.google.cloud.spanner.connection.Connection}s that the statements are executed
+   * on must be created by a {@link GenericConnectionProvider}
    *
    * @param filename The file name containing the statements. Statements must be separated by a
    *     semicolon (;)
@@ -250,8 +250,8 @@ public abstract class AbstractSqlScriptVerifier {
    * Statements without an @EXPECT statement will be executed and its result will be ignored, unless
    * the statement throws an exception, which will fail the test case.
    *
-   * @param providedConnection The {@link com.google.cloud.spanner.jdbc.Connection} to execute the
-   *     statements against
+   * @param providedConnection The {@link com.google.cloud.spanner.connection.Connection} to execute
+   *     the statements against
    * @param filename The file name containing the statements. Statements must be separated by a
    *     semicolon (;)
    * @param resourceClass The class that defines the package where to find the input file
@@ -271,8 +271,8 @@ public abstract class AbstractSqlScriptVerifier {
    * Statements without an @EXPECT statement will be executed and its result will be ignored, unless
    * the statement throws an exception, which will fail the test case.
    *
-   * @param providedConnection The {@link com.google.cloud.spanner.jdbc.Connection} to execute the
-   *     statements against
+   * @param providedConnection The {@link com.google.cloud.spanner.connection.Connection} to execute
+   *     the statements against
    * @param filename The file name containing the statements. Statements must be separated by a
    *     semicolon (;)
    * @param resourceClass The class that defines the package where to find the input file

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SqlScriptVerifier.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SqlScriptVerifier.java
@@ -28,7 +28,8 @@ import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.connection.StatementResult.ResultType;
 
 /**
- * SQL script verifier implementation for Spanner {@link com.google.cloud.spanner.jdbc.Connection}
+ * SQL script verifier implementation for Spanner {@link
+ * com.google.cloud.spanner.connection.Connection}
  *
  * @see AbstractSqlScriptVerifier for more information
  */


### PR DESCRIPTION
Java SDK team is installing a job to compile doc errors as part of - https://github.com/googleapis/java-spanner/pull/2515 . The job won't succeed with existing errors. This PR fixes the existing errors in docs.

Command for testing - `mvn javadoc:javadoc javadoc:test-javadoc -B -ntp`