### PR TITLE
feat: Add maxBatchingDelayMs Option.

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
@@ -474,7 +474,7 @@ public final class Options implements Serializable {
     if (withCommitStats) {
       b.append("withCommitStats: ").append(withCommitStats).append(' ');
     }
-    if (maxBatchingDelayMs) {
+    if (maxBatchingDelayMs != null) {
       b.append("maxBatchingDelayMs: ").append(maxBatchingDelayMs).append(' ');
     }
     if (limit != null) {
@@ -555,7 +555,7 @@ public final class Options implements Serializable {
     if (withCommitStats) {
       result = 31 * result + 1231;
     }
-    if (maxBatchingDelayMs) {
+    if (maxBatchingDelayMs != null) {
       result = 31 * result + maxBatchingDelayMs.hashCode();
     }
     if (limit != null) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
@@ -242,7 +242,7 @@ public final class Options implements Serializable {
 
   static final CommitStatsOption COMMIT_STATS_OPTION = new CommitStatsOption();
 
-  static final class MaxBatchingDelayMsOption extends InernalOption implements TransactionOption {
+  static final class MaxBatchingDelayMsOption extends InternalOption implements TransactionOption {
     final int maxBatchingDelayMs;
 
     MaxBatchingDelayMsOption(int maxBatchingDelayMs) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
@@ -96,6 +96,11 @@ public final class Options implements Serializable {
     return COMMIT_STATS_OPTION;
   }
 
+  /** Specifies the maximum batching delay for the transaction. */
+  public static TransactionOption maxBatchingDelayMs(int maxBatchingDelayMs) {
+    return new MaxBatchingDelayMsOption(maxBatchingDelayMs);
+  }
+
   /**
    * Specifying this instructs the transaction to request Optimistic Lock from the backend. In this
    * concurrency mode, operations during the execution phase, i.e., reads and queries, are performed
@@ -136,7 +141,7 @@ public final class Options implements Serializable {
   }
 
   /** Specifies the priority to use for the RPC. */
-  public static ReadQueryUpdateTransactionOption priority(RpcPriority priority) {
+p  public static ReadQueryUpdateTransactionOption priority(RpcPriority priority) {
     return new PriorityOption(priority);
   }
 
@@ -237,6 +242,19 @@ public final class Options implements Serializable {
 
   static final CommitStatsOption COMMIT_STATS_OPTION = new CommitStatsOption();
 
+  static final class MaxBatchingDelayMsOption extends InernalOption implements TransactionOption {
+    final int maxBatchingDelayMs;
+
+    MaxBatchingDelayMsOption(int maxBatchingDelayMs) {
+      this.maxBatchingDelayMs = maxBatchingDelayMs;
+    }
+      
+    @Override
+    void appendToOptions(Options options) {
+      options.maxBatchingDelayMs = maxBatchingDelayMs;
+    }
+  }
+
   /** Option to request Optimistic Concurrency Control for read/write transactions. */
   static final class OptimisticLockOption extends InternalOption implements TransactionOption {
     @Override
@@ -329,6 +347,7 @@ public final class Options implements Serializable {
   }
 
   private boolean withCommitStats;
+  private Integer maxBatchingDelayMs;
   private Long limit;
   private Integer prefetchChunks;
   private Integer bufferRows;
@@ -347,6 +366,14 @@ public final class Options implements Serializable {
 
   boolean withCommitStats() {
     return withCommitStats;
+  }
+
+  boolean hasMaxBatchingDelayMs() {
+    return maxBatchingDelayMs != null;
+  }
+
+  int maxBatchingDelayMs() {
+    return maxBatchingDelayMs;
   }
 
   boolean hasLimit() {
@@ -447,6 +474,9 @@ public final class Options implements Serializable {
     if (withCommitStats) {
       b.append("withCommitStats: ").append(withCommitStats).append(' ');
     }
+    if (maxBatchingDelayMs) {
+      b.append("maxBatchingDelayMs: ").append(maxBatchingDelayMs).append(' ');
+    }
     if (limit != null) {
       b.append("limit: ").append(limit).append(' ');
     }
@@ -496,6 +526,7 @@ public final class Options implements Serializable {
 
     Options that = (Options) o;
     return Objects.equals(withCommitStats, that.withCommitStats)
+	&& Objects.equals(maxBatchingDelayMs, that.maxBatchingDelayMs)
         && (!hasLimit() && !that.hasLimit()
             || hasLimit() && that.hasLimit() && Objects.equals(limit(), that.limit()))
         && (!hasPrefetchChunks() && !that.hasPrefetchChunks()
@@ -523,6 +554,9 @@ public final class Options implements Serializable {
     int result = 31;
     if (withCommitStats) {
       result = 31 * result + 1231;
+    }
+    if (maxBatchingDelayMs) {
+      result = 31 * result + maxBatchingDelayMs.hashCode();
     }
     if (limit != null) {
       result = 31 * result + limit.hashCode();

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
@@ -141,7 +141,7 @@ public final class Options implements Serializable {
   }
 
   /** Specifies the priority to use for the RPC. */
-p  public static ReadQueryUpdateTransactionOption priority(RpcPriority priority) {
+  public static ReadQueryUpdateTransactionOption priority(RpcPriority priority) {
     return new PriorityOption(priority);
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -185,7 +185,7 @@ class SessionImpl implements Session {
     }
     if (commitRequestOptions.hasMaxBatchingDelayMs()) {
 	Duration maxBatchingDelay =
-	  Duration.newBuilder.setNanos(1000000 * commitRequestOptions.maxBatchingDelayMs());
+	    Duration.newBuilder().setNanos(1000000 * commitRequestOptions.maxBatchingDelayMs());
 	requestBuilder.setMaxBatchingDelay(maxBatchingDelay);
     }
     Span span = tracer.spanBuilder(SpannerImpl.COMMIT).startSpan();

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -34,6 +34,7 @@ import com.google.common.base.Ticker;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Duration;
 import com.google.protobuf.Empty;
 import com.google.spanner.v1.BeginTransactionRequest;
 import com.google.spanner.v1.CommitRequest;
@@ -181,6 +182,11 @@ class SessionImpl implements Session {
         requestOptionsBuilder.setTransactionTag(commitRequestOptions.tag());
       }
       requestBuilder.setRequestOptions(requestOptionsBuilder.build());
+    }
+    if (commitRequestOptions.hasMaxBatchingDelayMs()) {
+	Duration maxBatchingDelay =
+	  Duration.newBuilder.setNanos(1000000 * commitRequestOptions.maxBatchingDelayMs());
+	requestBuilder.setMaxBatchingDelay(maxBatchingDelay);
     }
     Span span = tracer.spanBuilder(SpannerImpl.COMMIT).startSpan();
     try (Scope s = tracer.withSpan(span)) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -35,6 +35,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Duration;
 import com.google.protobuf.Empty;
 import com.google.rpc.Code;
 import com.google.spanner.v1.CommitRequest;
@@ -329,6 +330,11 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
           requestOptionsBuilder.setTransactionTag(getTransactionTag());
         }
         builder.setRequestOptions(requestOptionsBuilder.build());
+      }
+      if (options.hasMaxBatchingDelayMs()) {
+	Duration maxBatchingDelay =
+	  Duration.newBuilder.setNanos(1000000 * options.maxBatchingDelayMs());
+	builder.setMaxBatchingDelay(maxBatchingDelay);
       }
       synchronized (lock) {
         if (transactionIdFuture == null && transactionId == null && runningAsyncOperations == 0) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -36,7 +36,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Duration;
-import com.google.protobuf.Duration.Builder;
 import com.google.protobuf.Empty;
 import com.google.rpc.Code;
 import com.google.spanner.v1.CommitRequest;
@@ -334,8 +333,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
       }
       if (options.hasMaxBatchingDelayMs()) {
 	Duration.Builder maxBatchingDelay =
-	    Duration.newBuilder()
-	        .setNanos(1000000 * options.maxBatchingDelayMs());
+	    Duration.newBuilder().setNanos(1000000 * options.maxBatchingDelayMs());
 	builder.setMaxBatchingDelay(maxBatchingDelay);
       }
       synchronized (lock) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Duration;
+import com.google.protobuf.Duration.Builder;
 import com.google.protobuf.Empty;
 import com.google.rpc.Code;
 import com.google.spanner.v1.CommitRequest;
@@ -332,8 +333,9 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
         builder.setRequestOptions(requestOptionsBuilder.build());
       }
       if (options.hasMaxBatchingDelayMs()) {
-	Duration maxBatchingDelay =
-	  Duration.newBuilder.setNanos(1000000 * options.maxBatchingDelayMs());
+	Duration.Builder maxBatchingDelay =
+	    Duration.newBuilder()
+	        .setNanos(1000000 * options.maxBatchingDelayMs());
 	builder.setMaxBatchingDelay(maxBatchingDelay);
       }
       synchronized (lock) {


### PR DESCRIPTION
Adds support for max batching delay option in Commit requests.

This feature allows users to express how much latency they are willing for spanner to add to attempt to batch their writes. Generally speaking, the more latency they are willing to tolerate, the more efficiently Spanner can serve the writes.