### PR TITLE
feat: Enable leader aware routing by default

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -700,7 +700,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     private CloseableExecutorProvider asyncExecutorProvider;
     private String compressorName;
     private String emulatorHost = System.getenv("SPANNER_EMULATOR_HOST");
-    private boolean leaderAwareRoutingEnabled = false;
+    private boolean leaderAwareRoutingEnabled = true;
 
     private Builder() {
       // Manually set retry and polling settings that work.

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
@@ -680,8 +680,7 @@ public class SpannerOptionsTest {
 
   @Test
   public void testLeaderAwareRoutingEnablement() {
-    assertFalse(
-        SpannerOptions.newBuilder().setProjectId("p").build().isLeaderAwareRoutingEnabled());
+    assertTrue(SpannerOptions.newBuilder().setProjectId("p").build().isLeaderAwareRoutingEnabled());
     assertTrue(
         SpannerOptions.newBuilder()
             .setProjectId("p")


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat: Enable leader aware routing by default. This update contains performance optimisations that will reduce the latency of read/write transactions that originate from a region other than the default leader region.
END_COMMIT_OVERRIDE