### PR TITLE
fix: fix kokoro windows java8 ci

### DIFF
--- a/.kokoro/build.bat
+++ b/.kokoro/build.bat
@@ -17,6 +17,6 @@
 
 set JAVA8_HOME=%JAVA_HOME:"=%
 choco install -y openjdk11
-set JAVA11_HOME=C:\Program Files\Eclipse Adoptium\jdk-11.0.18.10-hotspot\
+set JAVA11_HOME=C:\Program Files\Eclipse Adoptium\jdk-11.0.19.7-hotspot\
 
 "C:\Program Files\Git\bin\bash.exe" %~dp0build.sh

--- a/.kokoro/build.bat
+++ b/.kokoro/build.bat
@@ -15,8 +15,4 @@
 :: downstream client libraries before they are released.
 :: See documentation in type-shell-output.bat
 
-set JAVA8_HOME=%JAVA_HOME:"=%
-choco install -y openjdk11
-set JAVA11_HOME=C:\Program Files\Eclipse Adoptium\jdk-11.0.20.8-hotspot\
-
 "C:\Program Files\Git\bin\bash.exe" %~dp0build.sh

--- a/.kokoro/build.bat
+++ b/.kokoro/build.bat
@@ -17,6 +17,6 @@
 
 set JAVA8_HOME=%JAVA_HOME:"=%
 choco install -y openjdk11
-set JAVA11_HOME=C:\Program Files\Eclipse Adoptium\jdk-11.0.19.7-hotspot\
+set JAVA11_HOME=C:\Program Files\Eclipse Adoptium\jdk-11.0.20.8-hotspot\
 
 "C:\Program Files\Git\bin\bash.exe" %~dp0build.sh

--- a/README.md
+++ b/README.md
@@ -50,20 +50,20 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.21.0')
+implementation platform('com.google.cloud:libraries-bom:26.22.0')
 
 implementation 'com.google.cloud:google-cloud-spanner'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-spanner:6.44.0'
+implementation 'com.google.cloud:google-cloud-spanner:6.45.3'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.44.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.45.3"
 ```
 <!-- {x-version-update-end} -->
 
@@ -430,7 +430,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-spanner/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-spanner.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.44.0
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.45.3
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles


### PR DESCRIPTION
Windows build fails due to incorrect JAVA11_HOME env. This PR corrects it to latest version to fix the failing window builds.
<img width="863" alt="image" src="https://github.com/googleapis/java-spanner/assets/57220027/b3658fc6-a0fa-4eaa-82ad-1964e52c5161">

<img width="1020" alt="image" src="https://github.com/googleapis/java-spanner/assets/57220027/72598b71-f328-4d47-aa42-143515ac59a0">

