### PR TITLE
chore: deduplicate code for batch updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ implementation 'com.google.cloud:google-cloud-spanner'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-spanner:6.45.1'
+implementation 'com.google.cloud:google-cloud-spanner:6.45.2'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.45.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.45.2"
 ```
 <!-- {x-version-update-end} -->
 
@@ -430,7 +430,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-spanner/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-spanner.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.45.1
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.45.2
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
@@ -1323,32 +1323,15 @@ class ConnectionImpl implements Connection {
 
   @Override
   public long[] executeBatchUpdate(Iterable<Statement> updates) {
-    Preconditions.checkNotNull(updates);
-    ConnectionPreconditions.checkState(!isClosed(), CLOSED_ERROR_MSG);
-    // Check that there are only DML statements in the input.
-    List<ParsedStatement> parsedStatements = new LinkedList<>();
-    for (Statement update : updates) {
-      ParsedStatement parsedStatement = getStatementParser().parse(update);
-      switch (parsedStatement.getType()) {
-        case UPDATE:
-          parsedStatements.add(parsedStatement);
-          break;
-        case CLIENT_SIDE:
-        case QUERY:
-        case DDL:
-        case UNKNOWN:
-        default:
-          throw SpannerExceptionFactory.newSpannerException(
-              ErrorCode.INVALID_ARGUMENT,
-              "The batch update list contains a statement that is not an update statement: "
-                  + parsedStatement.getSqlWithoutComments());
-      }
-    }
-    return get(internalExecuteBatchUpdateAsync(CallType.SYNC, parsedStatements));
+    return get(internalExecuteBatchUpdateAsync(CallType.SYNC, parseUpdateStatements(updates)));
   }
 
   @Override
   public ApiFuture<long[]> executeBatchUpdateAsync(Iterable<Statement> updates) {
+    return internalExecuteBatchUpdateAsync(CallType.ASYNC, parseUpdateStatements(updates));
+  }
+
+  private List<ParsedStatement> parseUpdateStatements(Iterable<Statement> updates) {
     Preconditions.checkNotNull(updates);
     ConnectionPreconditions.checkState(!isClosed(), CLOSED_ERROR_MSG);
     // Check that there are only DML statements in the input.
@@ -1370,7 +1353,7 @@ class ConnectionImpl implements Connection {
                   + parsedStatement.getSqlWithoutComments());
       }
     }
-    return internalExecuteBatchUpdateAsync(CallType.ASYNC, parsedStatements);
+    return parsedStatements;
   }
 
   private QueryOption[] mergeDataBoost(QueryOption... options) {


### PR DESCRIPTION
De-duplicate code that is equal for both the sync and async version of the executeBatchUpdate methods.