### PR TITLE
chore: add execute method with allowed return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ implementation 'com.google.cloud:google-cloud-spanner'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-spanner:6.45.1'
+implementation 'com.google.cloud:google-cloud-spanner:6.45.2'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.45.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.45.2"
 ```
 <!-- {x-version-update-end} -->
 
@@ -430,7 +430,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-spanner/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-spanner.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.45.1
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.45.2
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -422,4 +422,16 @@
     <className>com/google/cloud/spanner/spi/v1/SpannerRpc$StreamingCall</className>
     <method>com.google.api.gax.rpc.ApiCallContext getCallContext()</method>
   </difference>
+  <!-- Add an execute method that allows the driver to state what types should be allowed or not. 
+       This fixes the gap between what JDBC allows, and what is currently allowed in the Connection
+       API:
+       1. JDBC allows executeUpdate to be used for everything that does not return a ResultSet.
+       2. Connection API requires executeUpdate to be used with something that returns an update
+          count (i.e. no DDL and no client-side statements. -->
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/connection/Connection</className>
+    <method>com.google.cloud.spanner.connection.StatementResult execute(com.google.cloud.spanner.Statement, java.util.Set)</method>
+  </difference>
+  
 </differences>

--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -416,14 +416,7 @@
     <className>com/google/cloud/spanner/connection/Connection</className>
     <method>void setMaxPartitions(int)</method>
   </difference>
-  <!-- (Internal change, use stream timeout) -->
-  <difference>
-    <differenceType>7012</differenceType>
-    <className>com/google/cloud/spanner/spi/v1/SpannerRpc$StreamingCall</className>
-    <method>com.google.api.gax.rpc.ApiCallContext getCallContext()</method>
-  </difference>
-<<<<<<< HEAD
-  <!-- Add an execute method that allows the driver to state what types should be allowed or not. 
+  <!-- Add an execute method that allows the driver to state what types should be allowed or not.
        This fixes the gap between what JDBC allows, and what is currently allowed in the Connection
        API:
        1. JDBC allows executeUpdate to be used for everything that does not return a ResultSet.
@@ -434,8 +427,13 @@
     <className>com/google/cloud/spanner/connection/Connection</className>
     <method>com.google.cloud.spanner.connection.StatementResult execute(com.google.cloud.spanner.Statement, java.util.Set)</method>
   </difference>
-  
-=======
+
+  <!-- (Internal change, use stream timeout) -->
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/spi/v1/SpannerRpc$StreamingCall</className>
+    <method>com.google.api.gax.rpc.ApiCallContext getCallContext()</method>
+  </difference>
   <!-- (Internal change, propagate streaming retry settings) -->
   <difference>
     <differenceType>7012</differenceType>
@@ -457,5 +455,4 @@
     <className>com/google/cloud/spanner/spi/v1/SpannerRpc</className>
     <method>java.util.Set getExecuteQueryRetryableCodes()</method>
   </difference>
->>>>>>> main
 </differences>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
@@ -41,6 +41,7 @@ import com.google.cloud.spanner.connection.StatementResult.ResultType;
 import com.google.spanner.v1.ExecuteBatchDmlRequest;
 import com.google.spanner.v1.ResultSetStats;
 import java.util.Iterator;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -948,6 +949,35 @@ public interface Connection extends AutoCloseable {
    * @return the result of the statement
    */
   StatementResult execute(Statement statement);
+
+  /**
+   * Executes the given statement if allowed in the current {@link TransactionMode} and connection
+   * state, and if the result that would be returned is in the set of allowed result types. The
+   * statement will not be sent to Cloud Spanner if the result type would not be allowed. This
+   * method can be used by drivers that must limit the type of statements that are allowed for a
+   * given method, e.g. for the {@link java.sql.Statement#executeQuery(String)} and {@link
+   * java.sql.Statement#executeUpdate(String)} methods.
+   *
+   * <p>The returned value depends on the type of statement:
+   *
+   * <ul>
+   *   <li>Queries and DML statements with returning clause will return a {@link ResultSet}.
+   *   <li>Simple DML statements will return an update count
+   *   <li>DDL statements will return a {@link ResultType#NO_RESULT}
+   *   <li>Connection and transaction statements (SET AUTOCOMMIT=TRUE|FALSE, SHOW AUTOCOMMIT, SET
+   *       TRANSACTION READ ONLY, etc) will return either a {@link ResultSet} or {@link
+   *       ResultType#NO_RESULT}, depending on the type of statement (SHOW or SET)
+   * </ul>
+   *
+   * @param statement The statement to execute
+   * @param allowedResultTypes The result types that this method may return. The statement will not
+   *     be sent to Cloud Spanner if the statement would return a result that is not one of the
+   *     types in this set.
+   * @return the result of the statement
+   */
+  default StatementResult execute(Statement statement, Set<ResultType> allowedResultTypes) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
 
   /**
    * Executes the given statement if allowed in the current {@link TransactionMode} and connection

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
@@ -47,6 +47,7 @@ import com.google.cloud.spanner.TimestampBound.Mode;
 import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStatement;
 import com.google.cloud.spanner.connection.AbstractStatementParser.StatementType;
 import com.google.cloud.spanner.connection.StatementExecutor.StatementTimeout;
+import com.google.cloud.spanner.connection.StatementResult.ResultType;
 import com.google.cloud.spanner.connection.UnitOfWork.CallType;
 import com.google.cloud.spanner.connection.UnitOfWork.UnitOfWorkState;
 import com.google.common.annotations.VisibleForTesting;
@@ -60,12 +61,15 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import java.util.Stack;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.threeten.bp.Instant;
 
 /** Implementation for {@link Connection}, the generic Spanner connection API (not JDBC). */
@@ -939,9 +943,20 @@ class ConnectionImpl implements Connection {
 
   @Override
   public StatementResult execute(Statement statement) {
-    Preconditions.checkNotNull(statement);
+    return internalExecute(Preconditions.checkNotNull(statement), null);
+  }
+
+  @Override
+  public StatementResult execute(Statement statement, Set<ResultType> allowedResultTypes) {
+    return internalExecute(
+        Preconditions.checkNotNull(statement), Preconditions.checkNotNull(allowedResultTypes));
+  }
+
+  private StatementResult internalExecute(
+      Statement statement, @Nullable Set<ResultType> allowedResultTypes) {
     ConnectionPreconditions.checkState(!isClosed(), CLOSED_ERROR_MSG);
     ParsedStatement parsedStatement = getStatementParser().parse(statement, this.queryOptions);
+    checkResultTypeAllowed(parsedStatement, allowedResultTypes);
     switch (parsedStatement.getType()) {
       case CLIENT_SIDE:
         return parsedStatement
@@ -966,6 +981,53 @@ class ConnectionImpl implements Connection {
     throw SpannerExceptionFactory.newSpannerException(
         ErrorCode.INVALID_ARGUMENT,
         "Unknown statement: " + parsedStatement.getSqlWithoutComments());
+  }
+
+  @VisibleForTesting
+  static void checkResultTypeAllowed(
+      ParsedStatement parsedStatement, @Nullable Set<ResultType> allowedResultTypes) {
+    if (allowedResultTypes == null) {
+      return;
+    }
+    ResultType resultType = getResultType(parsedStatement);
+    if (!allowedResultTypes.contains(resultType)) {
+      throw SpannerExceptionFactory.newSpannerException(
+          ErrorCode.INVALID_ARGUMENT,
+          "This statement returns a result of type "
+              + resultType
+              + ". Only statements that return a result of one of the following types are allowed: "
+              + allowedResultTypes.stream()
+                  .map(ResultType::toString)
+                  .collect(Collectors.joining(", ")));
+    }
+  }
+
+  private static ResultType getResultType(ParsedStatement parsedStatement) {
+    switch (parsedStatement.getType()) {
+      case CLIENT_SIDE:
+        if (parsedStatement.getClientSideStatement().isQuery()) {
+          return ResultType.RESULT_SET;
+        } else if (parsedStatement.getClientSideStatement().isUpdate()) {
+          return ResultType.UPDATE_COUNT;
+        } else {
+          return ResultType.NO_RESULT;
+        }
+      case QUERY:
+        return ResultType.RESULT_SET;
+      case UPDATE:
+        if (parsedStatement.hasReturningClause()) {
+          return ResultType.RESULT_SET;
+        } else {
+          return ResultType.UPDATE_COUNT;
+        }
+      case DDL:
+        return ResultType.NO_RESULT;
+      case UNKNOWN:
+      default:
+        throw SpannerExceptionFactory.newSpannerException(
+            ErrorCode.INVALID_ARGUMENT,
+            "Unknown statement: " + parsedStatement.getSqlWithoutComments());
+    }
   }
 
   @Override


### PR DESCRIPTION
Adds an execute method to the Connection API that allows the caller to specify the allowed result types. This can be used by driver implementations, such as JDBC, to use a single execute method in the Connection API, while still making sure that the method only executes statements that it should.
The current executeUpdate method in the Connection API does not overlap completely with semantics of executeUpdate in JDBC, as JDBC allows any statement type that does not return a ResultSet to be executed with that method. The Connection API only allows statements that return an update count.
Instead of modifying the executeUpdate method in the Connection API to match the semantics of JDBC (which would be a breaking change), this method can be used generically for all execute*** methods in the JDBC driver, which again can be used to clean up some code there.