### PR TITLE
feat: support PostgreSQL for autoConfigEmulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ implementation 'com.google.cloud:google-cloud-spanner'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-spanner:6.45.2'
+implementation 'com.google.cloud:google-cloud-spanner:6.45.3'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.45.2"
+libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.45.3"
 ```
 <!-- {x-version-update-end} -->
 
@@ -430,7 +430,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-spanner/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-spanner.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.45.2
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.45.3
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
@@ -249,7 +249,8 @@ class ConnectionImpl implements Connection {
     this.options = options;
     this.spanner = spannerPool.getSpanner(options, this);
     if (options.isAutoConfigEmulator()) {
-      EmulatorUtil.maybeCreateInstanceAndDatabase(spanner, options.getDatabaseId());
+      EmulatorUtil.maybeCreateInstanceAndDatabase(
+          spanner, options.getDatabaseId(), options.getDialect());
     }
     this.dbClient = spanner.getDatabaseClient(options.getDatabaseId());
     this.batchClient = spanner.getBatchClient(options.getDatabaseId());

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/EmulatorUtil.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/EmulatorUtil.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner.connection;
 
 import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.DatabaseId;
+import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.InstanceConfigId;
 import com.google.cloud.spanner.InstanceInfo;
@@ -41,8 +42,10 @@ class EmulatorUtil {
    *
    * @param spanner a {@link Spanner} instance that connects to an emulator instance
    * @param databaseId the id of the instance and the database to create
+   * @param dialect the {@link Dialect} to use for the database to create
    */
-  static void maybeCreateInstanceAndDatabase(Spanner spanner, DatabaseId databaseId) {
+  static void maybeCreateInstanceAndDatabase(
+      Spanner spanner, DatabaseId databaseId, Dialect dialect) {
     Preconditions.checkArgument(
         NoCredentials.getInstance().equals(spanner.getOptions().getCredentials()));
     try {
@@ -70,7 +73,8 @@ class EmulatorUtil {
           .getDatabaseAdminClient()
           .createDatabase(
               databaseId.getInstanceId().getInstance(),
-              databaseId.getDatabase(),
+              dialect.createDatabaseStatementFor(databaseId.getDatabase()),
+              dialect,
               ImmutableList.of())
           .get();
     } catch (ExecutionException executionException) {


### PR DESCRIPTION
The autoConfigEmulator=true flag in the Connection API can be used to automatically connect to the emulator and automatically create the instance and database that is being referenced. This makes running a quick test on the emulator much easier, as all you need to do is to configure the correct (JDBC) connection URL, and it will automatically work. This mode would always create a GoogleSQL database. This change adds support for creating a PostgreSQL database if the user specifically sets the dialect in the connection string.