### PR TITLE
feat: disable dynamic code loading properties by default

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
@@ -36,18 +36,19 @@ import com.google.cloud.spanner.SpannerOptions;
 import com.google.common.io.BaseEncoding;
 import com.google.common.io.Files;
 import java.io.File;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Objects;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class ConnectionOptionsTest {
   private static final String FILE_TEST_PATH =
-      ConnectionOptionsTest.class.getResource("test-key.json").getFile();
+      Objects.requireNonNull(ConnectionOptionsTest.class.getResource("test-key.json")).getFile();
   private static final String DEFAULT_HOST = "https://spanner.googleapis.com";
   private static final String TEST_PROJECT = "test-project-123";
   private static final String TEST_INSTANCE = "test-instance-123";
@@ -727,34 +728,61 @@ public class ConnectionOptionsTest {
   }
 
   @Test
-  public void testNonBase64EncodedCredentials() {
-    String uri =
-        "cloudspanner:/projects/test-project/instances/test-instance/databases/test-database?encodedCredentials=not-a-base64-string/";
-    SpannerException e =
-        assertThrows(
-            SpannerException.class, () -> ConnectionOptions.newBuilder().setUri(uri).build());
-    assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCode());
-    assertThat(e.getMessage())
-        .contains("The encoded credentials could not be decoded as a base64 string.");
+  public void testNonBase64EncodedCredentials() throws Throwable {
+    runWithSystemPropertyEnabled(
+        ConnectionOptions.ENABLE_ENCODED_CREDENTIALS_SYSTEM_PROPERTY,
+        () -> {
+          String uri =
+              "cloudspanner:/projects/test-project/instances/test-instance/databases/test-database?encodedCredentials=not-a-base64-string/";
+          SpannerException e =
+              assertThrows(
+                  SpannerException.class, () -> ConnectionOptions.newBuilder().setUri(uri).build());
+          assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCode());
+          assertThat(e.getMessage())
+              .contains("The encoded credentials could not be decoded as a base64 string.");
+        });
   }
 
   @Test
-  public void testInvalidEncodedCredentials() throws UnsupportedEncodingException {
-    String uri =
-        String.format(
-            "cloudspanner:/projects/test-project/instances/test-instance/databases/test-database?encodedCredentials=%s",
-            BaseEncoding.base64Url().encode("not-a-credentials-JSON-string".getBytes("UTF-8")));
-    SpannerException e =
-        assertThrows(
-            SpannerException.class, () -> ConnectionOptions.newBuilder().setUri(uri).build());
-    assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCode());
-    assertThat(e.getMessage())
-        .contains(
-            "The encoded credentials do not contain a valid Google Cloud credentials JSON string.");
+  public void testInvalidEncodedCredentials() throws Throwable {
+    runWithSystemPropertyEnabled(
+        ConnectionOptions.ENABLE_ENCODED_CREDENTIALS_SYSTEM_PROPERTY,
+        () -> {
+          String uri =
+              String.format(
+                  "cloudspanner:/projects/test-project/instances/test-instance/databases/test-database?encodedCredentials=%s",
+                  BaseEncoding.base64Url()
+                      .encode("not-a-credentials-JSON-string".getBytes(StandardCharsets.UTF_8)));
+          SpannerException e =
+              assertThrows(
+                  SpannerException.class, () -> ConnectionOptions.newBuilder().setUri(uri).build());
+          assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCode());
+          assertThat(e.getMessage())
+              .contains(
+                  "The encoded credentials do not contain a valid Google Cloud credentials JSON string.");
+        });
   }
 
   @Test
-  public void testValidEncodedCredentials() throws Exception {
+  public void testValidEncodedCredentials() throws Throwable {
+    runWithSystemPropertyEnabled(
+        ConnectionOptions.ENABLE_ENCODED_CREDENTIALS_SYSTEM_PROPERTY,
+        () -> {
+          String encoded =
+              BaseEncoding.base64Url().encode(Files.asByteSource(new File(FILE_TEST_PATH)).read());
+          String uri =
+              String.format(
+                  "cloudspanner:/projects/test-project/instances/test-instance/databases/test-database?encodedCredentials=%s",
+                  encoded);
+
+          ConnectionOptions options = ConnectionOptions.newBuilder().setUri(uri).build();
+          assertEquals(
+              new CredentialsService().createCredentials(FILE_TEST_PATH), options.getCredentials());
+        });
+  }
+
+  @Test
+  public void testValidEncodedCredentials_WithoutEnablingProperty() throws Throwable {
     String encoded =
         BaseEncoding.base64Url().encode(Files.asByteSource(new File(FILE_TEST_PATH)).read());
     String uri =
@@ -762,81 +790,146 @@ public class ConnectionOptionsTest {
             "cloudspanner:/projects/test-project/instances/test-instance/databases/test-database?encodedCredentials=%s",
             encoded);
 
-    ConnectionOptions options = ConnectionOptions.newBuilder().setUri(uri).build();
-    assertEquals(
-        new CredentialsService().createCredentials(FILE_TEST_PATH), options.getCredentials());
+    SpannerException exception =
+        assertThrows(
+            SpannerException.class, () -> ConnectionOptions.newBuilder().setUri(uri).build());
+    assertEquals(ErrorCode.FAILED_PRECONDITION, exception.getErrorCode());
   }
 
   @Test
-  public void testSetCredentialsAndEncodedCredentials() throws Exception {
-    String encoded =
-        BaseEncoding.base64Url().encode(Files.asByteSource(new File(FILE_TEST_PATH)).read());
-    String uri =
-        String.format(
-            "cloudspanner:/projects/test-project/instances/test-instance/databases/test-database?credentials=%s;encodedCredentials=%s",
-            FILE_TEST_PATH, encoded);
+  public void testSetCredentialsAndEncodedCredentials() throws Throwable {
+    runWithSystemPropertyEnabled(
+        ConnectionOptions.ENABLE_ENCODED_CREDENTIALS_SYSTEM_PROPERTY,
+        () -> {
+          String encoded =
+              BaseEncoding.base64Url().encode(Files.asByteSource(new File(FILE_TEST_PATH)).read());
+          String uri =
+              String.format(
+                  "cloudspanner:/projects/test-project/instances/test-instance/databases/test-database?credentials=%s;encodedCredentials=%s",
+                  FILE_TEST_PATH, encoded);
 
-    IllegalArgumentException e =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> ConnectionOptions.newBuilder().setUri(uri).build());
-    assertTrue(
-        e.getMessage(),
-        e.getMessage()
-            .contains(
-                "Specify only one of credentialsUrl, encodedCredentials, credentialsProvider and OAuth token"));
+          IllegalArgumentException e =
+              assertThrows(
+                  IllegalArgumentException.class,
+                  () -> ConnectionOptions.newBuilder().setUri(uri).build());
+          assertTrue(
+              e.getMessage(),
+              e.getMessage()
+                  .contains(
+                      "Specify only one of credentialsUrl, encodedCredentials, credentialsProvider and OAuth token"));
+        });
   }
 
   public static class TestCredentialsProvider implements CredentialsProvider {
     @Override
-    public Credentials getCredentials() throws IOException {
+    public Credentials getCredentials() {
       return NoCredentials.getInstance();
     }
   }
 
+  static void runWithSystemPropertyEnabled(String systemPropertyName, ThrowingRunnable runnable)
+      throws Throwable {
+    String originalValue = System.getProperty(systemPropertyName);
+    System.setProperty(systemPropertyName, "true");
+    try {
+      runnable.run();
+    } finally {
+      if (originalValue == null) {
+        System.clearProperty(systemPropertyName);
+      } else {
+        System.setProperty(systemPropertyName, originalValue);
+      }
+    }
+  }
+
   @Test
-  public void testValidCredentialsProvider() {
+  public void testValidCredentialsProvider() throws Throwable {
+    runWithSystemPropertyEnabled(
+        ConnectionOptions.ENABLE_CREDENTIALS_PROVIDER_SYSTEM_PROPERTY,
+        () -> {
+          String uri =
+              String.format(
+                  "cloudspanner:/projects/test-project/instances/test-instance/databases/test-database?credentialsProvider=%s",
+                  TestCredentialsProvider.class.getName());
+
+          ConnectionOptions options = ConnectionOptions.newBuilder().setUri(uri).build();
+          assertEquals(NoCredentials.getInstance(), options.getCredentials());
+        });
+  }
+
+  @Test
+  public void testValidCredentialsProvider_WithoutEnablingSystemProperty() {
     String uri =
         String.format(
             "cloudspanner:/projects/test-project/instances/test-instance/databases/test-database?credentialsProvider=%s",
             TestCredentialsProvider.class.getName());
-
-    ConnectionOptions options = ConnectionOptions.newBuilder().setUri(uri).build();
-    assertEquals(NoCredentials.getInstance(), options.getCredentials());
-  }
-
-  @Test
-  public void testSetCredentialsAndCredentialsProvider() {
-    String uri =
-        String.format(
-            "cloudspanner:/projects/test-project/instances/test-instance/databases/test-database?credentials=%s;credentialsProvider=%s",
-            FILE_TEST_PATH, NoCredentialsProvider.class.getName());
-
-    IllegalArgumentException e =
+    SpannerException exception =
         assertThrows(
-            IllegalArgumentException.class,
-            () -> ConnectionOptions.newBuilder().setUri(uri).build());
-    assertTrue(
-        e.getMessage(),
-        e.getMessage()
-            .contains(
-                "Specify only one of credentialsUrl, encodedCredentials, credentialsProvider and OAuth token"));
+            SpannerException.class, () -> ConnectionOptions.newBuilder().setUri(uri).build());
+    assertEquals(ErrorCode.FAILED_PRECONDITION, exception.getErrorCode());
+    assertEquals(
+        "FAILED_PRECONDITION: credentialsProvider can only be used if the system property ENABLE_CREDENTIALS_PROVIDER has been set to true. "
+            + "Start the application with the JVM command line option -DENABLE_CREDENTIALS_PROVIDER=true",
+        exception.getMessage());
   }
 
   @Test
-  public void testExternalChannelProvider() {
+  public void testSetCredentialsAndCredentialsProvider() throws Throwable {
+    runWithSystemPropertyEnabled(
+        ConnectionOptions.ENABLE_CREDENTIALS_PROVIDER_SYSTEM_PROPERTY,
+        () -> {
+          String uri =
+              String.format(
+                  "cloudspanner:/projects/test-project/instances/test-instance/databases/test-database?credentials=%s;credentialsProvider=%s",
+                  FILE_TEST_PATH, NoCredentialsProvider.class.getName());
+
+          IllegalArgumentException e =
+              assertThrows(
+                  IllegalArgumentException.class,
+                  () -> ConnectionOptions.newBuilder().setUri(uri).build());
+          assertTrue(
+              e.getMessage(),
+              e.getMessage()
+                  .contains(
+                      "Specify only one of credentialsUrl, encodedCredentials, credentialsProvider and OAuth token"));
+        });
+  }
+
+  @Test
+  public void testExternalChannelProvider() throws Throwable {
+    runWithSystemPropertyEnabled(
+        ConnectionOptions.ENABLE_CHANNEL_PROVIDER_SYSTEM_PROPERTY,
+        () -> {
+          String baseUri =
+              "cloudspanner:/projects/test-project-123/instances/test-instance/databases/test-database";
+
+          ConnectionOptions options =
+              ConnectionOptions.newBuilder()
+                  .setUri(
+                      baseUri
+                          + "?channelProvider=com.google.cloud.spanner.connection.TestChannelProvider")
+                  .setCredentials(NoCredentials.getInstance())
+                  .build();
+
+          TransportChannelProvider provider = options.getChannelProvider();
+          assertTrue(provider instanceof InstantiatingGrpcChannelProvider);
+        });
+  }
+
+  @Test
+  public void testExternalChannelProvider_WithoutEnablingProperty() throws Throwable {
     String baseUri =
         "cloudspanner:/projects/test-project-123/instances/test-instance/databases/test-database";
-
-    ConnectionOptions options =
-        ConnectionOptions.newBuilder()
-            .setUri(
-                baseUri
-                    + "?channelProvider=com.google.cloud.spanner.connection.TestChannelProvider")
-            .setCredentials(NoCredentials.getInstance())
-            .build();
-
-    TransportChannelProvider provider = options.getChannelProvider();
-    assertTrue(provider instanceof InstantiatingGrpcChannelProvider);
+    SpannerException exception =
+        assertThrows(
+            SpannerException.class,
+            () ->
+                ConnectionOptions.newBuilder()
+                    .setUri(
+                        baseUri
+                            + "?channelProvider=com.google.cloud.spanner.connection.TestChannelProvider")
+                    .setCredentials(NoCredentials.getInstance())
+                    .build());
+    assertEquals(ErrorCode.FAILED_PRECONDITION, exception.getErrorCode());
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/CredentialsProviderTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/CredentialsProviderTest.java
@@ -16,13 +16,13 @@
 
 package com.google.cloud.spanner.connection;
 
+import static com.google.cloud.spanner.connection.ConnectionOptionsTest.runWithSystemPropertyEnabled;
 import static org.junit.Assert.assertEquals;
 
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.OAuth2Credentials;
 import io.grpc.ManagedChannelBuilder;
-import java.io.IOException;
 import java.io.ObjectStreamException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.BeforeClass;
@@ -64,63 +64,81 @@ public class CredentialsProviderTest extends AbstractMockServerTest {
 
   static final class TestCredentialsProvider implements CredentialsProvider {
     @Override
-    public Credentials getCredentials() throws IOException {
+    public Credentials getCredentials() {
       return new TestCredentials(COUNTER.incrementAndGet());
     }
   }
 
   @Test
-  public void testCredentialsProvider() {
-    ConnectionOptions options =
-        ConnectionOptions.newBuilder()
-            .setUri(
-                String.format(
-                    "cloudspanner://localhost:%d/projects/proj/instances/inst/databases/db?credentialsProvider=%s",
-                    getPort(), TestCredentialsProvider.class.getName()))
-            .setConfigurator(
-                spannerOptions ->
-                    spannerOptions.setChannelConfigurator(ManagedChannelBuilder::usePlaintext))
-            .build();
+  public void testCredentialsProvider() throws Throwable {
+    runWithSystemPropertyEnabled(
+        ConnectionOptions.ENABLE_CREDENTIALS_PROVIDER_SYSTEM_PROPERTY,
+        () -> {
+          ConnectionOptions options =
+              ConnectionOptions.newBuilder()
+                  .setUri(
+                      String.format(
+                          "cloudspanner://localhost:%d/projects/proj/instances/inst/databases/db?credentialsProvider=%s",
+                          getPort(), TestCredentialsProvider.class.getName()))
+                  .setConfigurator(
+                      spannerOptions ->
+                          spannerOptions.setChannelConfigurator(
+                              ManagedChannelBuilder::usePlaintext))
+                  .build();
 
-    try (Connection connection = options.getConnection()) {
-      assertEquals(
-          TestCredentials.class,
-          ((ConnectionImpl) connection).getSpanner().getOptions().getCredentials().getClass());
-      TestCredentials credentials =
-          (TestCredentials)
-              ((ConnectionImpl) connection).getSpanner().getOptions().getCredentials();
-      assertEquals(1, credentials.id);
-    }
-    // The second connection should get the same credentials from the provider.
-    try (Connection connection = options.getConnection()) {
-      assertEquals(
-          TestCredentials.class,
-          ((ConnectionImpl) connection).getSpanner().getOptions().getCredentials().getClass());
-      TestCredentials credentials =
-          (TestCredentials)
-              ((ConnectionImpl) connection).getSpanner().getOptions().getCredentials();
-      assertEquals(1, credentials.id);
-    }
+          try (Connection connection = options.getConnection()) {
+            assertEquals(
+                TestCredentials.class,
+                ((ConnectionImpl) connection)
+                    .getSpanner()
+                    .getOptions()
+                    .getCredentials()
+                    .getClass());
+            TestCredentials credentials =
+                (TestCredentials)
+                    ((ConnectionImpl) connection).getSpanner().getOptions().getCredentials();
+            assertEquals(1, credentials.id);
+          }
+          // The second connection should get the same credentials from the provider.
+          try (Connection connection = options.getConnection()) {
+            assertEquals(
+                TestCredentials.class,
+                ((ConnectionImpl) connection)
+                    .getSpanner()
+                    .getOptions()
+                    .getCredentials()
+                    .getClass());
+            TestCredentials credentials =
+                (TestCredentials)
+                    ((ConnectionImpl) connection).getSpanner().getOptions().getCredentials();
+            assertEquals(1, credentials.id);
+          }
 
-    // Creating new ConnectionOptions should refresh the credentials.
-    options =
-        ConnectionOptions.newBuilder()
-            .setUri(
-                String.format(
-                    "cloudspanner://localhost:%d/projects/proj/instances/inst/databases/db?credentialsProvider=%s",
-                    getPort(), TestCredentialsProvider.class.getName()))
-            .setConfigurator(
-                spannerOptions ->
-                    spannerOptions.setChannelConfigurator(ManagedChannelBuilder::usePlaintext))
-            .build();
-    try (Connection connection = options.getConnection()) {
-      assertEquals(
-          TestCredentials.class,
-          ((ConnectionImpl) connection).getSpanner().getOptions().getCredentials().getClass());
-      TestCredentials credentials =
-          (TestCredentials)
-              ((ConnectionImpl) connection).getSpanner().getOptions().getCredentials();
-      assertEquals(2, credentials.id);
-    }
+          // Creating new ConnectionOptions should refresh the credentials.
+          options =
+              ConnectionOptions.newBuilder()
+                  .setUri(
+                      String.format(
+                          "cloudspanner://localhost:%d/projects/proj/instances/inst/databases/db?credentialsProvider=%s",
+                          getPort(), TestCredentialsProvider.class.getName()))
+                  .setConfigurator(
+                      spannerOptions ->
+                          spannerOptions.setChannelConfigurator(
+                              ManagedChannelBuilder::usePlaintext))
+                  .build();
+          try (Connection connection = options.getConnection()) {
+            assertEquals(
+                TestCredentials.class,
+                ((ConnectionImpl) connection)
+                    .getSpanner()
+                    .getOptions()
+                    .getCredentials()
+                    .getClass());
+            TestCredentials credentials =
+                (TestCredentials)
+                    ((ConnectionImpl) connection).getSpanner().getOptions().getCredentials();
+            assertEquals(2, credentials.id);
+          }
+        });
   }
 }


### PR DESCRIPTION
Disable Connection URL properties that dynamically invoke code by default. These properties can now only be used if the corresponding System property has been enabled. This gives users control over whether they want to enable these properties in their applications or not.

You should only enable the use of these properties as long as untrusted end users cannot dynamically set these. That is; If your application is a public service that allows end users to set a Connection URL, then you should not enable the use of these properties, as it would allow a user to try to specify a credentials or channel provider class that is not a valid provider. The constructor of the selected class would in that case still be invoked.
