### PR TITLE
test: fix the queryAndThen method in the mock test server

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -260,7 +260,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
      */
     public static StatementResult queryAndThen(
         Statement statement, ResultSet resultSet, ResultSet next) {
-      return new StatementResult(statement, resultSet);
+      return new StatementResult(statement, resultSet, next);
     }
 
     /** Creates a {@link StatementResult} for a read request. */


### PR DESCRIPTION
The mock server that is used for testing contained a queryAndThen(..) method that did not do anything with the 'and then' part. This PR fixes that, and adds an additional test using that method. That test shows what happens with a bit-reversed sequence when a transaction is aborted.