### PR TITLE
feat: Add support for Managed Autoscaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,20 +50,20 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.24.0')
+implementation platform('com.google.cloud:libraries-bom:26.25.0')
 
 implementation 'com.google.cloud:google-cloud-spanner'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-spanner:6.50.1'
+implementation 'com.google.cloud:google-cloud-spanner:6.51.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.50.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.51.0"
 ```
 <!-- {x-version-update-end} -->
 
@@ -432,7 +432,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-spanner/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-spanner.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.50.1
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.51.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Instance.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Instance.java
@@ -23,6 +23,7 @@ import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Options.ListOption;
 import com.google.longrunning.Operation;
 import com.google.spanner.admin.database.v1.CreateDatabaseMetadata;
+import com.google.spanner.admin.instance.v1.AutoscalingConfig;
 import com.google.spanner.admin.instance.v1.UpdateInstanceMetadata;
 import java.util.Map;
 
@@ -83,6 +84,12 @@ public class Instance extends InstanceInfo {
     @Override
     public Builder setProcessingUnits(int processingUnits) {
       infoBuilder.setProcessingUnits(processingUnits);
+      return this;
+    }
+
+    @Override
+    public Builder setAutoscalingConfig(AutoscalingConfig autoscalingConfig) {
+      infoBuilder.setAutoscalingConfig(autoscalingConfig);
       return this;
     }
 
@@ -220,6 +227,7 @@ public class Instance extends InstanceInfo {
             .setNodeCount(proto.getNodeCount())
             .setCreateTime(Timestamp.fromProto(proto.getCreateTime()))
             .setUpdateTime(Timestamp.fromProto(proto.getUpdateTime()))
+            .setAutoscalingConfig(proto.getAutoscalingConfig())
             .setProcessingUnits(proto.getProcessingUnits());
     State state;
     switch (proto.getState()) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceAdminClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceAdminClientImpl.java
@@ -193,18 +193,6 @@ class InstanceAdminClientImpl implements InstanceAdminClient {
   @Override
   public OperationFuture<Instance, CreateInstanceMetadata> createInstance(InstanceInfo instance)
       throws SpannerException {
-    boolean valid_capacity_with_autoscaling =
-        instance.getAutoscalingConfig() != null
-            && instance.getNodeCount() == 0
-            && instance.getProcessingUnits() == 0;
-    boolean valid_capacity_without_autoscaling =
-        (instance.getAutoscalingConfig() == null)
-            && (instance.getNodeCount() == 0 || instance.getProcessingUnits() == 0);
-
-    Preconditions.checkArgument(
-        valid_capacity_with_autoscaling || valid_capacity_without_autoscaling,
-        "Only one of nodeCount, processingUnits or autoscalingConfig can be set when creating a new instance");
-
     String projectName = PROJECT_NAME_TEMPLATE.instantiate("project", projectId);
     OperationFuture<com.google.spanner.admin.instance.v1.Instance, CreateInstanceMetadata>
         rawOperationFuture =

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceInfo.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceInfo.java
@@ -112,9 +112,7 @@ public class InstanceInfo {
      * instance. Exactly one of processing units, node count, or autoscaling config must be set when
      * creating a new instance.
      */
-    public Builder setAutoscalingConfig(AutoscalingConfig autoscalingConfig) {
-      throw new UnsupportedOperationException("Unimplemented");
-    }
+    public abstract Builder setAutoscalingConfig(AutoscalingConfig autoscalingConfig);
 
     public abstract Builder setState(State state);
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceInfo.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceInfo.java
@@ -112,7 +112,9 @@ public class InstanceInfo {
      * instance. Exactly one of processing units, node count, or autoscaling config must be set when
      * creating a new instance.
      */
-    public abstract Builder setAutoscalingConfig(AutoscalingConfig autoscalingConfig);
+    public Builder setAutoscalingConfig(AutoscalingConfig autoscalingConfig) {
+      throw new UnsupportedOperationException("Unimplemented");
+    }
 
     public abstract Builder setState(State state);
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceAdminClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceAdminClientImplTest.java
@@ -330,10 +330,10 @@ public class InstanceAdminClientImplTest {
                 .setAutoscalingConfig(getAutoscalingInstanceProto().getAutoscalingConfig())
                 .build());
     assertTrue(operation.isDone());
-    assertEquals(INSTANCE_NAME, operation.get().getId().getName());
+    Instance instance = operation.get();
+    assertEquals(INSTANCE_NAME, instance.getId().getName());
     assertEquals(
-        getAutoscalingInstanceProto().getAutoscalingConfig(),
-        operation.get().getAutoscalingConfig());
+        getAutoscalingInstanceProto().getAutoscalingConfig(), instance.getAutoscalingConfig());
   }
 
   @Test
@@ -398,12 +398,7 @@ public class InstanceAdminClientImplTest {
                 "updateInstance",
                 getInstanceProtoWithProcessingUnits(),
                 UpdateInstanceMetadata.getDefaultInstance());
-    when(rpc.updateInstance(
-            instance,
-            FieldMask.newBuilder()
-                .addPaths("autoscaling_config")
-                .addPaths("processing_units")
-                .build()))
+    when(rpc.updateInstance(instance, FieldMask.newBuilder().addPaths("processing_units").build()))
         .thenReturn(rawOperationFuture);
     InstanceInfo instanceInfo =
         InstanceInfo.newBuilder(InstanceId.of(INSTANCE_NAME))
@@ -411,10 +406,7 @@ public class InstanceAdminClientImplTest {
             .setProcessingUnits(10)
             .build();
     OperationFuture<Instance, UpdateInstanceMetadata> operationWithFieldMask =
-        client.updateInstance(
-            instanceInfo,
-            InstanceInfo.InstanceField.AUTOSCALING_CONFIG,
-            InstanceInfo.InstanceField.PROCESSING_UNITS);
+        client.updateInstance(instanceInfo, InstanceInfo.InstanceField.PROCESSING_UNITS);
     assertTrue(operationWithFieldMask.isDone());
     assertEquals(INSTANCE_NAME, operationWithFieldMask.get().getId().getName());
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceAdminClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceAdminClientImplTest.java
@@ -19,7 +19,6 @@ package com.google.cloud.spanner;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -315,24 +314,6 @@ public class InstanceAdminClientImplTest {
   }
 
   @Test
-  public void testCreateInstanceWithBothNodeCountAndProcessingUnits() throws Exception {
-    try {
-      client.createInstance(
-          InstanceInfo.newBuilder(InstanceId.of(PROJECT_ID, INSTANCE_ID))
-              .setInstanceConfigId(InstanceConfigId.of(PROJECT_ID, CONFIG_ID))
-              .setNodeCount(1)
-              .setProcessingUnits(100)
-              .build());
-      fail("missing expected exception");
-    } catch (IllegalArgumentException e) {
-      assertTrue(
-          e.getMessage()
-              .contains(
-                  "Only one of nodeCount, processingUnits or autoscalingConfig can be set when creating a new instance"));
-    }
-  }
-
-  @Test
   public void testCreateInstanceWithAutoscalingConfig() throws Exception {
     OperationFuture<com.google.spanner.admin.instance.v1.Instance, CreateInstanceMetadata>
         rawOperationFuture =
@@ -350,42 +331,6 @@ public class InstanceAdminClientImplTest {
                 .build());
     assertTrue(operation.isDone());
     assertEquals(INSTANCE_NAME, operation.get().getId().getName());
-  }
-
-  @Test
-  public void testCreateInstanceWithBothNodeCountAndAutoscalingConfig() throws Exception {
-    try {
-      client.createInstance(
-          InstanceInfo.newBuilder(InstanceId.of(PROJECT_ID, INSTANCE_ID))
-              .setInstanceConfigId(InstanceConfigId.of(PROJECT_ID, CONFIG_ID))
-              .setNodeCount(1)
-              .setAutoscalingConfig(getAutoscalingConfigProto())
-              .build());
-      fail("missing expected exception");
-    } catch (IllegalArgumentException e) {
-      assertTrue(
-          e.getMessage()
-              .contains(
-                  "Only one of nodeCount, processingUnits or autoscalingConfig can be set when creating a new instance"));
-    }
-  }
-
-  @Test
-  public void testCreateInstanceWithBothProcessingUnitsAndAutoscalingConfig() throws Exception {
-    try {
-      client.createInstance(
-          InstanceInfo.newBuilder(InstanceId.of(PROJECT_ID, INSTANCE_ID))
-              .setInstanceConfigId(InstanceConfigId.of(PROJECT_ID, CONFIG_ID))
-              .setProcessingUnits(1000)
-              .setAutoscalingConfig(getAutoscalingConfigProto())
-              .build());
-      fail("missing expected exception");
-    } catch (IllegalArgumentException e) {
-      assertTrue(
-          e.getMessage()
-              .contains(
-                  "Only one of nodeCount, processingUnits or autoscalingConfig can be set when creating a new instance"));
-    }
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceAdminClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceAdminClientImplTest.java
@@ -331,6 +331,9 @@ public class InstanceAdminClientImplTest {
                 .build());
     assertTrue(operation.isDone());
     assertEquals(INSTANCE_NAME, operation.get().getId().getName());
+    assertEquals(
+        getAutoscalingInstanceProto().getAutoscalingConfig(),
+        operation.get().getAutoscalingConfig());
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceInfoTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceInfoTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.Timestamp;
 import com.google.common.testing.EqualsTester;
+import com.google.spanner.admin.instance.v1.AutoscalingConfig;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -44,18 +45,32 @@ public class InstanceInfoTest {
     assertTrue(info.getLabels().isEmpty());
     assertNull(info.getUpdateTime());
     assertNull(info.getCreateTime());
+    assertNull(info.getAutoscalingConfig());
   }
 
   @Test
   public void testBuildInstanceInfo() {
     InstanceId id = new InstanceId("test-project", "test-instance");
     InstanceConfigId configId = new InstanceConfigId("test-project", "test-instance-config");
+    AutoscalingConfig autoscalingConfig =
+        AutoscalingConfig.newBuilder()
+            .setAutoscalingLimits(
+                AutoscalingConfig.AutoscalingLimits.newBuilder()
+                    .setMinProcessingUnits(1000)
+                    .setMaxProcessingUnits(5000))
+            .setAutoscalingTargets(
+                AutoscalingConfig.AutoscalingTargets.newBuilder()
+                    .setHighPriorityCpuUtilizationPercent(65)
+                    .setStorageUtilizationPercent(95))
+            .build();
+
     InstanceInfo info =
         InstanceInfo.newBuilder(id)
             .setInstanceConfigId(configId)
             .setDisplayName("test instance")
             .setNodeCount(1)
             .setProcessingUnits(2000)
+            .setAutoscalingConfig(autoscalingConfig)
             .setState(InstanceInfo.State.READY)
             .addLabel("env", "prod")
             .addLabel("region", "us")
@@ -67,17 +82,29 @@ public class InstanceInfoTest {
     assertThat(info.getDisplayName()).isEqualTo("test instance");
     assertThat(info.getNodeCount()).isEqualTo(1);
     assertThat(info.getProcessingUnits()).isEqualTo(2000);
+    assertThat(info.getAutoscalingConfig()).isEqualTo(autoscalingConfig);
     assertThat(info.getState()).isEqualTo(InstanceInfo.State.READY);
     assertThat(info.getLabels()).containsExactly("env", "prod", "region", "us");
     assertEquals(Timestamp.ofTimeMicroseconds(86000), info.getUpdateTime());
     assertEquals(Timestamp.ofTimeMicroseconds(46000), info.getCreateTime());
 
-    info = info.toBuilder().setDisplayName("new test instance").build();
+    AutoscalingConfig newAutoscalingConfig =
+        autoscalingConfig
+            .toBuilder()
+            .setAutoscalingLimits(
+                AutoscalingConfig.AutoscalingLimits.newBuilder().setMinNodes(10).setMaxNodes(100))
+            .build();
+    info =
+        info.toBuilder()
+            .setDisplayName("new test instance")
+            .setAutoscalingConfig(newAutoscalingConfig)
+            .build();
     assertThat(info.getId()).isEqualTo(id);
     assertThat(info.getInstanceConfigId()).isEqualTo(configId);
     assertThat(info.getDisplayName()).isEqualTo("new test instance");
     assertThat(info.getNodeCount()).isEqualTo(1);
     assertThat(info.getProcessingUnits()).isEqualTo(2000);
+    assertThat(info.getAutoscalingConfig()).isEqualTo(newAutoscalingConfig);
     assertThat(info.getState()).isEqualTo(InstanceInfo.State.READY);
     assertThat(info.getLabels()).containsExactly("env", "prod", "region", "us");
     assertEquals(Timestamp.ofTimeMicroseconds(86000), info.getUpdateTime());
@@ -88,12 +115,24 @@ public class InstanceInfoTest {
   public void testToBuilder() {
     InstanceId id = new InstanceId("test-project", "test-instance");
     InstanceConfigId configId = new InstanceConfigId("test-project", "test-instance-config");
+    AutoscalingConfig autoscalingConfig =
+        AutoscalingConfig.newBuilder()
+            .setAutoscalingLimits(
+                AutoscalingConfig.AutoscalingLimits.newBuilder()
+                    .setMinProcessingUnits(1000)
+                    .setMaxProcessingUnits(5000))
+            .setAutoscalingTargets(
+                AutoscalingConfig.AutoscalingTargets.newBuilder()
+                    .setHighPriorityCpuUtilizationPercent(65)
+                    .setStorageUtilizationPercent(95))
+            .build();
     InstanceInfo info =
         InstanceInfo.newBuilder(id)
             .setInstanceConfigId(configId)
             .setDisplayName("test instance")
             .setNodeCount(1)
             .setProcessingUnits(2000)
+            .setAutoscalingConfig(autoscalingConfig)
             .setState(InstanceInfo.State.READY)
             .addLabel("env", "prod")
             .addLabel("region", "us")
@@ -107,6 +146,7 @@ public class InstanceInfoTest {
     assertThat(rebuilt.getDisplayName()).isEqualTo("new test instance");
     assertThat(rebuilt.getNodeCount()).isEqualTo(1);
     assertThat(rebuilt.getProcessingUnits()).isEqualTo(2000);
+    assertThat(info.getAutoscalingConfig()).isEqualTo(autoscalingConfig);
     assertThat(rebuilt.getState()).isEqualTo(InstanceInfo.State.READY);
     assertThat(rebuilt.getLabels()).containsExactly("env", "prod", "region", "us");
     assertEquals(Timestamp.ofTimeMicroseconds(86000), rebuilt.getUpdateTime());
@@ -119,12 +159,36 @@ public class InstanceInfoTest {
     InstanceConfigId configId1 = new InstanceConfigId("test-project", "test-instance-config");
     InstanceConfigId configId2 = new InstanceConfigId("test-project", "other-test-instance-config");
 
+    AutoscalingConfig autoscalingConfig1 =
+        AutoscalingConfig.newBuilder()
+            .setAutoscalingLimits(
+                AutoscalingConfig.AutoscalingLimits.newBuilder()
+                    .setMinProcessingUnits(1000)
+                    .setMaxProcessingUnits(5000))
+            .setAutoscalingTargets(
+                AutoscalingConfig.AutoscalingTargets.newBuilder()
+                    .setHighPriorityCpuUtilizationPercent(65)
+                    .setStorageUtilizationPercent(95))
+            .build();
+
+    AutoscalingConfig autoscalingConfig2 =
+        autoscalingConfig1
+            .toBuilder()
+            .setAutoscalingLimits(
+                autoscalingConfig1
+                    .getAutoscalingLimits()
+                    .toBuilder()
+                    .setMinNodes(50)
+                    .setMaxNodes(100))
+            .build();
+
     InstanceInfo instance =
         InstanceInfo.newBuilder(id)
             .setInstanceConfigId(configId1)
             .setDisplayName("test instance")
             .setNodeCount(1)
             .setProcessingUnits(2000)
+            .setAutoscalingConfig(autoscalingConfig1)
             .setState(InstanceInfo.State.READY)
             .addLabel("env", "prod")
             .addLabel("region", "us")
@@ -137,6 +201,7 @@ public class InstanceInfoTest {
             .setDisplayName("test instance")
             .setNodeCount(1)
             .setProcessingUnits(2000)
+            .setAutoscalingConfig(autoscalingConfig1)
             .setState(InstanceInfo.State.READY)
             .addLabel("region", "us")
             .addLabel("env", "prod")
@@ -154,9 +219,22 @@ public class InstanceInfoTest {
             .setUpdateTime(Timestamp.ofTimeMicroseconds(8000))
             .setCreateTime(Timestamp.ofTimeMicroseconds(4000))
             .build();
+    InstanceInfo instance4 =
+        InstanceInfo.newBuilder(id)
+            .setInstanceConfigId(configId2)
+            .setDisplayName("other test instance")
+            .setNodeCount(1)
+            .setProcessingUnits(2000)
+            .setAutoscalingConfig(autoscalingConfig2)
+            .setState(InstanceInfo.State.READY)
+            .addLabel("env", "prod")
+            .setUpdateTime(Timestamp.ofTimeMicroseconds(8000))
+            .setCreateTime(Timestamp.ofTimeMicroseconds(4000))
+            .build();
     EqualsTester tester = new EqualsTester();
     tester.addEqualityGroup(instance, instance2);
     tester.addEqualityGroup(instance3);
+    tester.addEqualityGroup(instance4);
     tester.testEquals();
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceTest.java
@@ -113,6 +113,52 @@ public class InstanceTest {
   public void equality() {
     InstanceId id = new InstanceId("test-project", "test-instance");
     InstanceConfigId configId = new InstanceConfigId("test-project", "test-instance-config");
+
+    Instance instance =
+        new Instance.Builder(instanceClient, dbClient, id)
+            .setInstanceConfigId(configId)
+            .setDisplayName("test instance")
+            .setNodeCount(1)
+            .setProcessingUnits(2000)
+            .setState(InstanceInfo.State.READY)
+            .addLabel("env", "prod")
+            .addLabel("region", "us")
+            .setUpdateTime(Timestamp.ofTimeMicroseconds(86000))
+            .setCreateTime(Timestamp.ofTimeMicroseconds(46000))
+            .build();
+    Instance instance2 =
+        new Instance.Builder(instanceClient, dbClient, id)
+            .setInstanceConfigId(configId)
+            .setDisplayName("test instance")
+            .setNodeCount(1)
+            .setProcessingUnits(2000)
+            .setState(InstanceInfo.State.READY)
+            .addLabel("region", "us")
+            .addLabel("env", "prod")
+            .setUpdateTime(Timestamp.ofTimeMicroseconds(86000))
+            .setCreateTime(Timestamp.ofTimeMicroseconds(46000))
+            .build();
+    Instance instance3 =
+        new Instance.Builder(instanceClient, dbClient, id)
+            .setInstanceConfigId(configId)
+            .setDisplayName("test instance")
+            .setNodeCount(1)
+            .setProcessingUnits(2000)
+            .setState(InstanceInfo.State.READY)
+            .addLabel("env", "prod")
+            .setUpdateTime(Timestamp.ofTimeMicroseconds(8000))
+            .setCreateTime(Timestamp.ofTimeMicroseconds(4000))
+            .build();
+    EqualsTester tester = new EqualsTester();
+    tester.addEqualityGroup(instance, instance2);
+    tester.addEqualityGroup(instance3);
+    tester.testEquals();
+  }
+
+  @Test
+  public void equalityWithAutoscalingConfig() {
+    InstanceId id = new InstanceId("test-project", "test-instance");
+    InstanceConfigId configId = new InstanceConfigId("test-project", "test-instance-config");
     AutoscalingConfig autoscalingConfig1 =
         AutoscalingConfig.newBuilder()
             .setAutoscalingLimits(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITInstanceAdminTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITInstanceAdminTest.java
@@ -21,7 +21,13 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assume.assumeFalse;
 
 import com.google.api.gax.longrunning.OperationFuture;
-import com.google.cloud.spanner.*;
+import com.google.cloud.spanner.Instance;
+import com.google.cloud.spanner.InstanceAdminClient;
+import com.google.cloud.spanner.InstanceConfig;
+import com.google.cloud.spanner.InstanceInfo;
+import com.google.cloud.spanner.IntegrationTestEnv;
+import com.google.cloud.spanner.Options;
+import com.google.cloud.spanner.ParallelIntegrationTest;
 import com.google.common.collect.Iterators;
 import com.google.spanner.admin.instance.v1.AutoscalingConfig;
 import com.google.spanner.admin.instance.v1.UpdateInstanceMetadata;
@@ -148,6 +154,7 @@ public class ITInstanceAdminTest {
         instanceClient.getInstance(env.getTestHelper().getInstanceId().getInstance());
     assertThat(newInstanceFromGet).isEqualTo(newInstance);
 
+    // Revert back to the instance original state.
     toUpdate =
         InstanceInfo.newBuilder(instance.getId())
             .setAutoscalingConfig(null)


### PR DESCRIPTION

- Add the ability to create / update an instance with autoscaling config
  - Note that now user can only specify one of the node_count, processing_units or autoscaling_config as the compute capacity for an instance.
- Add the ability to see autoscaling config with an instance