### PR TITLE
docs: remove doc reference for THEN RETURN for batchUpdate

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContext.java
@@ -162,11 +162,10 @@ public interface TransactionContext extends ReadContext {
   }
 
   /**
-   * Executes a list of DML statements (which can include simple DML statements or DML statements
-   * with returning clause) in a single request. The statements will be executed in order and the
-   * semantics is the same as if each statement is executed by {@code executeUpdate} in a loop. This
-   * method returns an array of long integers, each representing the number of rows modified by each
-   * statement.
+   * Executes a list of DML statements in a single request. The statements will be executed in order
+   * and the semantics is the same as if each statement is executed by {@code executeUpdate} in a
+   * loop. This method returns an array of long integers, each representing the number of rows
+   * modified by each statement.
    *
    * <p>If an individual statement fails, execution stops and a {@code SpannerBatchUpdateException}
    * is returned, which includes the error and the number of rows affected by the statements that


### PR DESCRIPTION
Update the documentation of batch dml API to make it less confusing: calling out that you can use DML RETURNING in an API that doesn't support returning a result is weird.
