### PR TITLE
feat: add session pool option for modelling a timeout around session acquisition.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ implementation 'com.google.cloud:google-cloud-spanner'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-spanner:6.47.0'
+implementation 'com.google.cloud:google-cloud-spanner:6.48.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.47.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.48.0"
 ```
 <!-- {x-version-update-end} -->
 
@@ -431,7 +431,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-spanner/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-spanner.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.47.0
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.48.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -1665,8 +1665,6 @@ class SessionPool {
         try (Scope waitScope = tracer.withSpan(span)) {
           PooledSession s =
               pollUninterruptiblyWithTimeout(currentTimeout, options.getAcquireSessionTimeout());
-          // TODO clean up this code since acquireSessionTimeout will never be null and hence
-          // we won't have a use-case when s == null
           if (s == null) {
             // Set the status to DEADLINE_EXCEEDED and retry.
             numWaiterTimeouts.incrementAndGet();
@@ -1695,8 +1693,6 @@ class SessionPool {
       try {
         while (true) {
           try {
-            // TODO refactor this code since eventually acquireSessionTimeout will always have a
-            // default value and won't be null
             return acquireSessionTimeout == null
                 ? waiter.get(timeoutMillis, TimeUnit.MILLISECONDS)
                 : waiter.get(acquireSessionTimeout.toMillis(), TimeUnit.MILLISECONDS);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -1708,7 +1708,9 @@ class SessionPool {
                   ErrorCode.RESOURCE_EXHAUSTED,
                   "Timed out after waiting "
                       + acquireSessionTimeout.toMillis()
-                      + "ms for acquiring session.");
+                      + "ms for acquiring session. To mitigate error increase the timeout duration at"
+                      + " session pool option `acquireSessionTimeout` or increase the "
+                      + "number of sessions in the session pool.");
             }
             return null;
           } catch (ExecutionException e) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -1704,9 +1704,8 @@ class SessionPool {
                   ErrorCode.RESOURCE_EXHAUSTED,
                   "Timed out after waiting "
                       + acquireSessionTimeout.toMillis()
-                      + "ms for acquiring session. To mitigate error increase the timeout duration at"
-                      + " session pool option `acquireSessionTimeout` or increase the "
-                      + "number of sessions in the session pool.");
+                      + "ms for acquiring session. To mitigate error SessionPoolOptions#setAcquireSessionTimeout(Duration) to set a higher timeout"
+                      + " or increase the number of sessions in the session pool.");
             }
             return null;
           } catch (ExecutionException e) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
@@ -723,9 +723,11 @@ public class SessionPoolOptions {
      */
     public Builder setAcquireSessionTimeout(Duration acquireSessionTimeout) {
       try {
-        Preconditions.checkArgument(
-            acquireSessionTimeout.toMillis() > 0,
-            "acquireSessionTimeout should be greater than 0 ns");
+        if (acquireSessionTimeout != null) {
+          Preconditions.checkArgument(
+              acquireSessionTimeout.toMillis() > 0,
+              "acquireSessionTimeout should be greater than 0 ns");
+        }
       } catch (ArithmeticException ex) {
         throw new IllegalArgumentException(
             "acquireSessionTimeout in millis should be lesser than Long.MAX_VALUE");

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
@@ -52,7 +52,13 @@ public class SessionPoolOptions {
   private final ActionOnSessionLeak actionOnSessionLeak;
   private final boolean trackStackTraceOfSessionCheckout;
   private final InactiveTransactionRemovalOptions inactiveTransactionRemovalOptions;
-  private final long initialWaitForSessionTimeoutMillis;
+
+  /**
+   * Use {@link #acquireSessionTimeout} instead to specify the total duration to wait while
+   * acquiring session for a transaction.
+   */
+  @Deprecated private final long initialWaitForSessionTimeoutMillis;
+
   private final boolean autoDetectDialect;
   private final Duration waitForMinSessions;
   private final Duration acquireSessionTimeout;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
@@ -718,8 +718,7 @@ public class SessionPoolOptions {
 
     /**
      * If greater than zero, we wait for said duration when no sessions are available in the {@link
-     * SessionPool}. When no configuration is passed, the default is a 60s timeout. To avoid setting
-     * a default value, set the value as null.
+     * SessionPool}. The default is a 60s timeout. Set the value to null to disable the timeout.
      */
     public Builder setAcquireSessionTimeout(Duration acquireSessionTimeout) {
       try {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
@@ -550,8 +550,9 @@ public class SessionPoolOptions {
      * If all sessions are in use and there is no more room for creating new sessions, block for a
      * session to become available. Default behavior is same.
      *
-     * <p>By default the requests are blocked for 60s and will fail with a `SpannerException` with error code `ResourceExhausted` if this timeout is exceeded. If you wish to block for a different period
-     * use the option {@link Builder#setAcquireSessionTimeout(Duration)} ()}
+     * <p>By default the requests are blocked for 60s and will fail with a `SpannerException` with
+     * error code `ResourceExhausted` if this timeout is exceeded. If you wish to block for a
+     * different period use the option {@link Builder#setAcquireSessionTimeout(Duration)} ()}
      */
     public Builder setBlockIfPoolExhausted() {
       this.actionOnExhaustion = ActionOnExhaustion.BLOCK;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
@@ -549,6 +549,9 @@ public class SessionPoolOptions {
     /**
      * If all sessions are in use and there is no more room for creating new sessions, block for a
      * session to become available. Default behavior is same.
+     *
+     * <p>By default the requests are blocked for 60s. If we wish to block for a different period
+     * use the option {@link Builder#setAcquireSessionTimeout(Duration)} ()}
      */
     public Builder setBlockIfPoolExhausted() {
       this.actionOnExhaustion = ActionOnExhaustion.BLOCK;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
@@ -711,7 +711,7 @@ public class SessionPoolOptions {
 
     /**
      * If greater than zero, we wait for said duration when no sessions are available in the {@link
-     * SessionPool}. When no configuration is passed, we default to 60s to acquire a session.
+     * SessionPool}. When no configuration is passed, the default is a 60s timeout.
      */
     public Builder setAcquireSessionTimeout(Duration acquireSessionTimeout) {
       this.acquireSessionTimeout = acquireSessionTimeout;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
@@ -550,7 +550,7 @@ public class SessionPoolOptions {
      * If all sessions are in use and there is no more room for creating new sessions, block for a
      * session to become available. Default behavior is same.
      *
-     * <p>By default the requests are blocked for 60s. If we wish to block for a different period
+     * <p>By default the requests are blocked for 60s and will fail with a `SpannerException` with error code `ResourceExhausted` if this timeout is exceeded. If you wish to block for a different period
      * use the option {@link Builder#setAcquireSessionTimeout(Duration)} ()}
      */
     public Builder setBlockIfPoolExhausted() {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
@@ -55,6 +55,7 @@ public class SessionPoolOptions {
   private final long initialWaitForSessionTimeoutMillis;
   private final boolean autoDetectDialect;
   private final Duration waitForMinSessions;
+  private final Duration acquireSessionTimeout;
 
   /** Property for allowing mocking of session maintenance clock. */
   private final Clock poolMaintainerClock;
@@ -78,6 +79,7 @@ public class SessionPoolOptions {
     this.removeInactiveSessionAfter = builder.removeInactiveSessionAfter;
     this.autoDetectDialect = builder.autoDetectDialect;
     this.waitForMinSessions = builder.waitForMinSessions;
+    this.acquireSessionTimeout = builder.acquireSessionTimeout;
     this.inactiveTransactionRemovalOptions = builder.inactiveTransactionRemovalOptions;
     this.poolMaintainerClock = builder.poolMaintainerClock;
   }
@@ -105,6 +107,7 @@ public class SessionPoolOptions {
         && Objects.equals(this.removeInactiveSessionAfter, other.removeInactiveSessionAfter)
         && Objects.equals(this.autoDetectDialect, other.autoDetectDialect)
         && Objects.equals(this.waitForMinSessions, other.waitForMinSessions)
+        && Objects.equals(this.acquireSessionTimeout, other.acquireSessionTimeout)
         && Objects.equals(
             this.inactiveTransactionRemovalOptions, other.inactiveTransactionRemovalOptions)
         && Objects.equals(this.poolMaintainerClock, other.poolMaintainerClock);
@@ -128,6 +131,7 @@ public class SessionPoolOptions {
         this.removeInactiveSessionAfter,
         this.autoDetectDialect,
         this.waitForMinSessions,
+        this.acquireSessionTimeout,
         this.inactiveTransactionRemovalOptions,
         this.poolMaintainerClock);
   }
@@ -237,6 +241,11 @@ public class SessionPoolOptions {
 
   Duration getWaitForMinSessions() {
     return waitForMinSessions;
+  }
+
+  @VisibleForTesting
+  Duration getAcquireSessionTimeout() {
+    return acquireSessionTimeout;
   }
 
   public static Builder newBuilder() {
@@ -424,6 +433,7 @@ public class SessionPoolOptions {
     private Duration removeInactiveSessionAfter = Duration.ofMinutes(55L);
     private boolean autoDetectDialect = false;
     private Duration waitForMinSessions = Duration.ZERO;
+    private Duration acquireSessionTimeout = Duration.ofSeconds(60);
 
     private Clock poolMaintainerClock;
 
@@ -446,6 +456,7 @@ public class SessionPoolOptions {
       this.removeInactiveSessionAfter = options.removeInactiveSessionAfter;
       this.autoDetectDialect = options.autoDetectDialect;
       this.waitForMinSessions = options.waitForMinSessions;
+      this.acquireSessionTimeout = options.acquireSessionTimeout;
       this.inactiveTransactionRemovalOptions = options.inactiveTransactionRemovalOptions;
       this.poolMaintainerClock = options.poolMaintainerClock;
     }
@@ -692,6 +703,15 @@ public class SessionPoolOptions {
      */
     public Builder setWaitForMinSessions(Duration waitForMinSessions) {
       this.waitForMinSessions = waitForMinSessions;
+      return this;
+    }
+
+    /**
+     * If greater than zero, we wait for said duration when no sessions are available in the {@link
+     * SessionPool}. When no configuration is passed, we default to 60s to acquire a session.
+     */
+    public Builder setAcquireSessionTimeout(Duration acquireSessionTimeout) {
+      this.acquireSessionTimeout = acquireSessionTimeout;
       return this;
     }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
@@ -718,9 +718,18 @@ public class SessionPoolOptions {
 
     /**
      * If greater than zero, we wait for said duration when no sessions are available in the {@link
-     * SessionPool}. When no configuration is passed, the default is a 60s timeout.
+     * SessionPool}. When no configuration is passed, the default is a 60s timeout. To avoid setting
+     * a default value, set the value as null.
      */
     public Builder setAcquireSessionTimeout(Duration acquireSessionTimeout) {
+      try {
+        Preconditions.checkArgument(
+            acquireSessionTimeout.toMillis() > 0,
+            "acquireSessionTimeout should be greater than 0 ns");
+      } catch (ArithmeticException ex) {
+        throw new IllegalArgumentException(
+            "acquireSessionTimeout in millis should be lesser than Long.MAX_VALUE");
+      }
       this.acquireSessionTimeout = acquireSessionTimeout;
       return this;
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BatchCreateSessionsSlowTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BatchCreateSessionsSlowTest.java
@@ -41,17 +41,14 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.junit.runners.MethodSorters;
 import org.threeten.bp.Duration;
 
 @Category(SlowTest.class)
 @RunWith(JUnit4.class)
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class BatchCreateSessionsSlowTest {
   private static final String TEST_PROJECT = "my-project";
   private static final String TEST_DATABASE_ROLE = "my-role";

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BatchCreateSessionsSlowTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BatchCreateSessionsSlowTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.spanner;
 
 import static com.google.cloud.spanner.MockSpannerTestUtil.READ_ONE_KEY_VALUE_RESULTSET;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BatchCreateSessionsSlowTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BatchCreateSessionsSlowTest.java
@@ -1,0 +1,195 @@
+package com.google.cloud.spanner;
+
+import static com.google.cloud.spanner.MockSpannerTestUtil.READ_ONE_KEY_VALUE_RESULTSET;
+import static com.google.cloud.spanner.MockSpannerTestUtil.READ_ONE_KEY_VALUE_STATEMENT;
+import static com.google.cloud.spanner.MockSpannerTestUtil.SELECT1;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.google.api.gax.grpc.testing.LocalChannelProvider;
+import com.google.cloud.NoCredentials;
+import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
+import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import io.grpc.Server;
+import io.grpc.inprocess.InProcessServerBuilder;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.junit.runners.MethodSorters;
+import org.threeten.bp.Duration;
+
+@Category(SlowTest.class)
+@RunWith(JUnit4.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class BatchCreateSessionsSlowTest {
+  private static final String TEST_PROJECT = "my-project";
+  private static final String TEST_DATABASE_ROLE = "my-role";
+  private static MockSpannerServiceImpl mockSpanner;
+  private static Server server;
+  private static LocalChannelProvider channelProvider;
+  private Spanner spanner;
+
+  @BeforeClass
+  public static void startStaticServer() throws IOException {
+    mockSpanner = new MockSpannerServiceImpl();
+    mockSpanner.setAbortProbability(0.0D); // We don't want any unpredictable aborted transactions.
+    mockSpanner.putStatementResult(
+        StatementResult.query(SELECT1, MockSpannerTestUtil.SELECT1_RESULTSET));
+    mockSpanner.putStatementResult(
+        StatementResult.query(READ_ONE_KEY_VALUE_STATEMENT, READ_ONE_KEY_VALUE_RESULTSET));
+
+    String uniqueName = InProcessServerBuilder.generateName();
+    server =
+        InProcessServerBuilder.forName(uniqueName)
+            // We need to use a real executor for timeouts to occur.
+            .scheduledExecutorService(new ScheduledThreadPoolExecutor(1))
+            .addService(mockSpanner)
+            .build()
+            .start();
+    channelProvider = LocalChannelProvider.create(uniqueName);
+  }
+
+  @AfterClass
+  public static void stopServer() throws InterruptedException {
+    server.shutdown();
+    server.awaitTermination();
+  }
+
+  @Before
+  public void setUp() {
+    spanner =
+        SpannerOptions.newBuilder()
+            .setProjectId(TEST_PROJECT)
+            .setDatabaseRole(TEST_DATABASE_ROLE)
+            .setChannelProvider(channelProvider)
+            .setCredentials(NoCredentials.getInstance())
+            .setSessionPoolOption(SessionPoolOptions.newBuilder().setFailOnSessionLeak().build())
+            .build()
+            .getService();
+  }
+
+  @After
+  public void tearDown() {
+    mockSpanner.unfreeze();
+    spanner.close();
+    mockSpanner.reset();
+    mockSpanner.removeAllExecutionTimes();
+  }
+
+  @Test
+  public void testBatchCreateSessionsTimesOut_whenDeadlineExceeded() throws Exception {
+    // Simulate a minimum execution time of 1000 milliseconds for the BatchCreateSessions RPC.
+    mockSpanner.setBatchCreateSessionsExecutionTime(
+        SimulatedExecutionTime.ofMinimumAndRandomTime(1000, 0));
+    SpannerOptions.Builder builder =
+        SpannerOptions.newBuilder()
+            .setProjectId("my-project")
+            .setChannelProvider(channelProvider)
+            .setCredentials(NoCredentials.getInstance());
+    // Set the timeout and retry settings for BatchCreateSessions to a simple
+    // single-attempt-and-timeout after 100ms.
+    builder
+        .getSpannerStubSettingsBuilder()
+        .batchCreateSessionsSettings()
+        .setSimpleTimeoutNoRetries(Duration.ofMillis(100));
+
+    try (Spanner spanner = builder.build().getService()) {
+      DatabaseId databaseId = DatabaseId.of("my-project", "my-instance", "my-database");
+      DatabaseClient client = spanner.getDatabaseClient(databaseId);
+
+      ListeningExecutorService service =
+          MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(1000));
+      List<ListenableFuture<Void>> futures = new ArrayList<>(5000);
+      AtomicInteger counter = new AtomicInteger();
+      for (int i = 0; i < 5000; i++) {
+        final int index = i;
+        futures.add(
+            service.submit(
+                () -> {
+                  // The following call is non-blocking and will not generate an exception.
+                  ResultSet rs = client.singleUse().executeQuery(SELECT1);
+                  // Actually trying to get any results will cause an exception.
+                  // The DEADLINE_EXCEEDED error of the BatchCreateSessions RPC is in this case
+                  // propagated to
+                  // the application.
+                  SpannerException e = assertThrows(SpannerException.class, rs::next);
+                  assertEquals(ErrorCode.DEADLINE_EXCEEDED, e.getErrorCode());
+                  System.out.printf("finished test %d\n", counter.incrementAndGet());
+
+                  return null;
+                }));
+      }
+      service.shutdown();
+      assertEquals(5000, Futures.allAsList(futures).get().size());
+    }
+  }
+
+  @Test
+  public void testBatchCreateSessionsTimesOut_whenResourceExhausted() throws Exception {
+    // Simulate a minimum execution time of 2000 milliseconds for the BatchCreateSessions RPC.
+    mockSpanner.setBatchCreateSessionsExecutionTime(
+        SimulatedExecutionTime.ofMinimumAndRandomTime(2000, 0));
+    // Add a timeout for the max amount of time (60ms) that a request waits when a session is
+    // unavailable.
+    SessionPoolOptions sessionPoolOptions =
+        SessionPoolOptions.newBuilder().setAcquireSessionTimeout(Duration.ofMillis(60)).build();
+    SpannerOptions.Builder builder =
+        SpannerOptions.newBuilder()
+            .setProjectId("my-project")
+            .setChannelProvider(channelProvider)
+            .setCredentials(NoCredentials.getInstance())
+            .setSessionPoolOption(sessionPoolOptions);
+    // Set the timeout and retry settings for BatchCreateSessions to a simple
+    // single-attempt-and-timeout after 1000ms. This will ensure that session acquisition timeout of
+    // 60ms will kick for all requests before the overall request RPC timeout is breached.
+    builder
+        .getSpannerStubSettingsBuilder()
+        .batchCreateSessionsSettings()
+        .setSimpleTimeoutNoRetries(Duration.ofMillis(1000));
+
+    try (Spanner spanner = builder.build().getService()) {
+      DatabaseId databaseId = DatabaseId.of("my-project", "my-instance", "my-database");
+      DatabaseClient client = spanner.getDatabaseClient(databaseId);
+
+      ListeningExecutorService service =
+          MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(1000));
+      List<ListenableFuture<Void>> futures = new ArrayList<>(5000);
+      AtomicInteger counter = new AtomicInteger();
+      for (int i = 0; i < 5000; i++) {
+        final int index = i;
+        futures.add(
+            service.submit(
+                () -> {
+                  // The following call is non-blocking and will not generate an exception.
+                  ResultSet rs = client.singleUse().executeQuery(SELECT1);
+                  // Actually trying to get any results will cause an exception.
+                  // When number of requests > MAX_SESSIONS, post setAcquireSessionTimeout
+                  // a few requests will timeout with RESOURCE_EXHAUSTED error.
+                  SpannerException e = assertThrows(SpannerException.class, rs::next);
+                  assertEquals(ErrorCode.RESOURCE_EXHAUSTED, e.getErrorCode());
+                  System.out.printf("finished test %d\n", counter.incrementAndGet());
+
+                  return null;
+                }));
+      }
+      service.shutdown();
+      assertEquals(5000, Futures.allAsList(futures).get().size());
+    }
+  }
+}

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -2261,7 +2261,7 @@ public class DatabaseClientImplTest {
 
   @Test
   public void testBatchCreateSessionsTimesOut_whenResourceExhausted() throws Exception {
-    // Simulate a minimum execution time of 1000 milliseconds for the BatchCreateSessions RPC.
+    // Simulate a minimum execution time of 2000 milliseconds for the BatchCreateSessions RPC.
     mockSpanner.setBatchCreateSessionsExecutionTime(
         SimulatedExecutionTime.ofMinimumAndRandomTime(2000, 0));
     // Add a timeout for the max amount of time (60ms) that a request waits when a session is

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -48,7 +48,6 @@ import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.AbstractResultSet.GrpcStreamIterator;
 import com.google.cloud.spanner.AsyncResultSet.CallbackResponse;
 import com.google.cloud.spanner.AsyncTransactionManager.TransactionContextFuture;
-import com.google.cloud.spanner.BaseSessionPoolTest.FakeClock;
 import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
 import com.google.cloud.spanner.Options.RpcPriority;
@@ -66,10 +65,6 @@ import com.google.cloud.spanner.connection.RandomResultSetGenerator;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.BaseEncoding;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListeningExecutorService;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.protobuf.AbstractMessage;
 import com.google.protobuf.ByteString;
@@ -2208,107 +2203,6 @@ public class DatabaseClientImplTest {
       // Actually trying to get any results will cause an exception.
       SpannerException e = assertThrows(SpannerException.class, () -> rs.next());
       assertEquals(ErrorCode.PERMISSION_DENIED, e.getErrorCode());
-    }
-  }
-
-  @Test
-  public void testBatchCreateSessionsTimesOut_whenDeadlineExceeded() throws Exception {
-    // Simulate a minimum execution time of 1000 milliseconds for the BatchCreateSessions RPC.
-    mockSpanner.setBatchCreateSessionsExecutionTime(
-        SimulatedExecutionTime.ofMinimumAndRandomTime(1000, 0));
-    SpannerOptions.Builder builder =
-        SpannerOptions.newBuilder()
-            .setProjectId("my-project")
-            .setChannelProvider(channelProvider)
-            .setCredentials(NoCredentials.getInstance());
-    // Set the timeout and retry settings for BatchCreateSessions to a simple
-    // single-attempt-and-timeout after 100ms.
-    builder
-        .getSpannerStubSettingsBuilder()
-        .batchCreateSessionsSettings()
-        .setSimpleTimeoutNoRetries(Duration.ofMillis(100));
-
-    try (Spanner spanner = builder.build().getService()) {
-      DatabaseId databaseId = DatabaseId.of("my-project", "my-instance", "my-database");
-      DatabaseClient client = spanner.getDatabaseClient(databaseId);
-
-      ListeningExecutorService service =
-          MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(1000));
-      List<ListenableFuture<Void>> futures = new ArrayList<>(5000);
-      AtomicInteger counter = new AtomicInteger();
-      for (int i = 0; i < 5000; i++) {
-        final int index = i;
-        futures.add(
-            service.submit(
-                () -> {
-                  // The following call is non-blocking and will not generate an exception.
-                  ResultSet rs = client.singleUse().executeQuery(SELECT1);
-                  // Actually trying to get any results will cause an exception.
-                  // The DEADLINE_EXCEEDED error of the BatchCreateSessions RPC is in this case
-                  // propagated to
-                  // the application.
-                  SpannerException e = assertThrows(SpannerException.class, rs::next);
-                  assertEquals(ErrorCode.DEADLINE_EXCEEDED, e.getErrorCode());
-                  System.out.printf("finished test %d\n", counter.incrementAndGet());
-
-                  return null;
-                }));
-      }
-      service.shutdown();
-      assertEquals(5000, Futures.allAsList(futures).get().size());
-    }
-  }
-
-  @Test
-  public void testBatchCreateSessionsTimesOut_whenResourceExhausted() throws Exception {
-    // Simulate a minimum execution time of 2000 milliseconds for the BatchCreateSessions RPC.
-    mockSpanner.setBatchCreateSessionsExecutionTime(
-        SimulatedExecutionTime.ofMinimumAndRandomTime(2000, 0));
-    // Add a timeout for the max amount of time (60ms) that a request waits when a session is
-    // unavailable.
-    SessionPoolOptions sessionPoolOptions =
-        SessionPoolOptions.newBuilder().setAcquireSessionTimeout(Duration.ofMillis(60)).build();
-    SpannerOptions.Builder builder =
-        SpannerOptions.newBuilder()
-            .setProjectId("my-project")
-            .setChannelProvider(channelProvider)
-            .setCredentials(NoCredentials.getInstance())
-            .setSessionPoolOption(sessionPoolOptions);
-    // Set the timeout and retry settings for BatchCreateSessions to a simple
-    // single-attempt-and-timeout after 1000ms. This will ensure that session acquisition timeout of
-    // 60ms will kick for all requests before the overall request RPC timeout is breached.
-    builder
-        .getSpannerStubSettingsBuilder()
-        .batchCreateSessionsSettings()
-        .setSimpleTimeoutNoRetries(Duration.ofMillis(1000));
-
-    try (Spanner spanner = builder.build().getService()) {
-      DatabaseId databaseId = DatabaseId.of("my-project", "my-instance", "my-database");
-      DatabaseClient client = spanner.getDatabaseClient(databaseId);
-
-      ListeningExecutorService service =
-          MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(1000));
-      List<ListenableFuture<Void>> futures = new ArrayList<>(5000);
-      AtomicInteger counter = new AtomicInteger();
-      for (int i = 0; i < 5000; i++) {
-        final int index = i;
-        futures.add(
-            service.submit(
-                () -> {
-                  // The following call is non-blocking and will not generate an exception.
-                  ResultSet rs = client.singleUse().executeQuery(SELECT1);
-                  // Actually trying to get any results will cause an exception.
-                  // When number of requests > MAX_SESSIONS, post setAcquireSessionTimeout
-                  // a few requests will timeout with RESOURCE_EXHAUSTED error.
-                  SpannerException e = assertThrows(SpannerException.class, rs::next);
-                  assertEquals(ErrorCode.RESOURCE_EXHAUSTED, e.getErrorCode());
-                  System.out.printf("finished test %d\n", counter.incrementAndGet());
-
-                  return null;
-                }));
-      }
-      service.shutdown();
-      assertEquals(5000, Futures.allAsList(futures).get().size());
     }
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolOptionsTest.java
@@ -186,4 +186,19 @@ public class SessionPoolOptionsTest {
     SessionPoolOptions.newBuilder()
         .setInactiveTransactionRemovalOptions(inactiveTransactionRemovalOptions);
   }
+
+  @Test
+  public void setAcquireSessionTimeout() {
+    SessionPoolOptions sessionPoolOptions =
+        SessionPoolOptions.newBuilder().setAcquireSessionTimeout(Duration.ofSeconds(20)).build();
+
+    assertEquals(Duration.ofSeconds(20), sessionPoolOptions.getAcquireSessionTimeout());
+  }
+
+  @Test
+  public void verifyDefaultAcquireSessionTimeout() {
+    SessionPoolOptions sessionPoolOptions = SessionPoolOptions.newBuilder().build();
+
+    assertEquals(Duration.ofSeconds(60), sessionPoolOptions.getAcquireSessionTimeout());
+  }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolOptionsTest.java
@@ -189,10 +189,27 @@ public class SessionPoolOptionsTest {
 
   @Test
   public void setAcquireSessionTimeout() {
-    SessionPoolOptions sessionPoolOptions =
+    SessionPoolOptions sessionPoolOptions1 =
         SessionPoolOptions.newBuilder().setAcquireSessionTimeout(Duration.ofSeconds(20)).build();
+    SessionPoolOptions sessionPoolOptions2 =
+        SessionPoolOptions.newBuilder()
+            .setAcquireSessionTimeout(Duration.ofMillis(Long.MAX_VALUE))
+            .build();
 
-    assertEquals(Duration.ofSeconds(20), sessionPoolOptions.getAcquireSessionTimeout());
+    assertEquals(Duration.ofSeconds(20), sessionPoolOptions1.getAcquireSessionTimeout());
+    assertEquals(Duration.ofMillis(Long.MAX_VALUE), sessionPoolOptions2.getAcquireSessionTimeout());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void setAcquireSessionTimeout_valueLessThanLowerBound() {
+    SessionPoolOptions.newBuilder().setAcquireSessionTimeout(Duration.ofMillis(0)).build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void setAcquireSessionTimeout_valueMoreThanUpperBound() {
+    SessionPoolOptions.newBuilder()
+        .setAcquireSessionTimeout(Duration.ofSeconds(Long.MAX_VALUE))
+        .build();
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -1021,6 +1021,54 @@ public class SessionPoolTest extends BaseSessionPoolTest {
   }
 
   @Test
+  public void blockAndTimeoutOnPoolExhaustion_withAcquireSessionTimeout() throws Exception {
+    // Create a session pool with max 1 session and a low timeout for waiting for a session.
+    options =
+        SessionPoolOptions.newBuilder()
+            .setMinSessions(minSessions)
+            .setMaxSessions(1)
+            .setInitialWaitForSessionTimeoutMillis(20L)
+            .setAcquireSessionTimeout(Duration.ofMillis(20L))
+            .build();
+    setupMockSessionCreation();
+    pool = createPool();
+    // Take the only session that can be in the pool.
+    PooledSessionFuture checkedOutSession = pool.getSession();
+    checkedOutSession.get();
+    ExecutorService executor = Executors.newFixedThreadPool(1);
+    final CountDownLatch latch = new CountDownLatch(1);
+    // Then try asynchronously to take another session. This attempt should time out.
+    Future<Void> fut =
+        executor.submit(
+            () -> {
+              latch.countDown();
+              PooledSessionFuture session = pool.getSession();
+              session.close();
+              return null;
+            });
+    // Wait until the background thread is actually waiting for a session.
+    latch.await();
+    // Wait until the request has timed out.
+    int waitCount = 0;
+    while (pool.getNumWaiterTimeouts() == 0L && waitCount < 1000) {
+      Thread.sleep(5L);
+      waitCount++;
+    }
+    // Return the checked out session to the pool so the async request will get a session and
+    // finish.
+    checkedOutSession.close();
+    // Verify that the async request also succeeds.
+    fut.get(10L, TimeUnit.SECONDS);
+    executor.shutdown();
+
+    // Verify that the session was returned to the pool and that we can get it again.
+    Session session = pool.getSession();
+    assertThat(session).isNotNull();
+    session.close();
+    assertThat(pool.getNumWaiterTimeouts()).isAtLeast(1L);
+  }
+
+  @Test
   public void testSessionNotFoundSingleUse() {
     Statement statement = Statement.of("SELECT 1");
     final SessionImpl closedSession = mockSession();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -980,6 +980,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
             .setMinSessions(minSessions)
             .setMaxSessions(1)
             .setInitialWaitForSessionTimeoutMillis(20L)
+            .setAcquireSessionTimeout(null)
             .build();
     setupMockSessionCreation();
     pool = createPool();


### PR DESCRIPTION
Requests are made to wait till a session is available. We are introducing a session pool option `acquireSessionTimeout` and a public method `setAcquireSessionTimeout` in the `SessionPoolOptions` class that will allow to specify a timeout value for requests. Post this timeout application will receive a `RESOURCE_EXHAUSTED` error. If this option is not passed, the client library will wait for 60s by default.

* Sample Usage
```
SessionPoolOptions sessionPoolOptions =
        SessionPoolOptions.newBuilder().setAcquireSessionTimeout(Duration.ofMillis(60)).build();
SpannerOptions.Builder builder =
        SpannerOptions.newBuilder()
            .setProjectId("my-project")
            .setChannelProvider(channelProvider)
            .setCredentials(NoCredentials.getInstance())
            .setSessionPoolOption(sessionPoolOptions);
```