### PR TITLE
docs: remove reference to returning clauses for Batch DML

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionContext.java
@@ -162,11 +162,10 @@ public interface TransactionContext extends ReadContext {
   }
 
   /**
-   * Executes a list of DML statements (which can include simple DML statements or DML statements
-   * with returning clause) in a single request. The statements will be executed in order and the
-   * semantics is the same as if each statement is executed by {@code executeUpdate} in a loop. This
-   * method returns an array of long integers, each representing the number of rows modified by each
-   * statement.
+   * Executes a list of DML statements in a single request. The statements will be executed in order
+   * and the semantics is the same as if each statement is executed by {@code executeUpdate} in a
+   * loop. This method returns an array of long integers, each representing the number of rows
+   * modified by each statement.
    *
    * <p>If an individual statement fails, execution stops and a {@code SpannerBatchUpdateException}
    * is returned, which includes the error and the number of rows affected by the statements that


### PR DESCRIPTION
Remove the reference to THEN RETURN / RETURNING clauses for Batch DML requests, as these clauses are ignored for batch DML and not returned to the client.