### PR TITLE
chore: add a system property to set session pool ordering

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -1976,6 +1976,7 @@ class SessionPool {
 
   enum Position {
     FIRST,
+    LAST,
     RANDOM
   }
 
@@ -2477,16 +2478,18 @@ class SessionPool {
           // Do not randomize if there are few other sessions checked out and this session has been
           // used. This ensures that this session will be re-used for the next transaction, which is
           // more efficient.
-          session.releaseToPosition = Position.FIRST;
+          session.releaseToPosition = options.getReleaseToPosition();
         }
         if (session.releaseToPosition == Position.RANDOM && !sessions.isEmpty()) {
           // A session should only be added at a random position the first time it is added to
           // the pool or if the pool was deemed unbalanced. All following releases into the pool
-          // should normally happen at the front of the pool (unless the pool is again deemed to be
-          // unbalanced).
-          session.releaseToPosition = Position.FIRST;
+          // should normally happen at the default release position (unless the pool is again deemed
+          // to be unbalanced and the insertion would happen at the front of the pool).
+          session.releaseToPosition = options.getReleaseToPosition();
           int pos = random.nextInt(sessions.size() + 1);
           sessions.add(pos, session);
+        } else if (session.releaseToPosition == Position.LAST) {
+          sessions.addLast(session);
         } else {
           sessions.addFirst(session);
         }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
@@ -456,7 +456,7 @@ public class SessionPoolOptions {
 
     private static Position getReleaseToPositionFromSystemProperty() {
       // NOTE: This System property is a beta feature. Support for it can be removed in the future.
-      String key = "SESSION_POOL_RELEASE_TO_POSITION";
+      String key = "com.google.cloud.spanner.session_pool_release_to_position";
       if (System.getProperties().containsKey(key)) {
         try {
           return Position.valueOf(System.getProperty(key).toUpperCase(Locale.ENGLISH));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -23,8 +23,10 @@ import static com.google.cloud.spanner.MetricRegistryConstants.NUM_WRITE_SESSION
 import static com.google.cloud.spanner.MetricRegistryConstants.SPANNER_DEFAULT_LABEL_VALUES;
 import static com.google.cloud.spanner.MetricRegistryConstants.SPANNER_LABEL_KEYS;
 import static com.google.cloud.spanner.MetricRegistryConstants.SPANNER_LABEL_KEYS_WITH_TYPE;
+import static com.google.cloud.spanner.SpannerOptionsTest.runWithSystemProperty;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -60,6 +62,7 @@ import com.google.cloud.spanner.TransactionRunnerImpl.TransactionContextImpl;
 import com.google.cloud.spanner.spi.v1.SpannerRpc;
 import com.google.cloud.spanner.spi.v1.SpannerRpc.ResultStreamConsumer;
 import com.google.cloud.spanner.v1.stub.SpannerStubSettings;
+import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.protobuf.ByteString;
@@ -82,12 +85,14 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -234,6 +239,139 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     assertThat(session4).isEqualTo(session2);
     session3.close();
     session4.close();
+  }
+
+  @Test
+  public void poolFifo() throws Exception {
+    setupMockSessionCreation();
+    runWithSystemProperty(
+        "SESSION_POOL_RELEASE_TO_POSITION",
+        "LAST",
+        () -> {
+          options =
+              options
+                  .toBuilder()
+                  .setMinSessions(2)
+                  .setWaitForMinSessions(Duration.ofSeconds(10L))
+                  .build();
+          pool = createPool();
+          pool.maybeWaitOnMinSessions();
+          Session session1 = pool.getSession().get();
+          Session session2 = pool.getSession().get();
+          assertNotEquals(session1, session2);
+
+          session2.close();
+          session1.close();
+
+          // Check the session out and back in once more to finalize their positions.
+          session1 = pool.getSession().get();
+          session2 = pool.getSession().get();
+          session2.close();
+          session1.close();
+
+          // Verify that we get the sessions in FIFO order, so in this order:
+          // 1. session2
+          // 2. session1
+          Session session3 = pool.getSession().get();
+          Session session4 = pool.getSession().get();
+          assertEquals(session2, session3);
+          assertEquals(session4, session1);
+          session3.close();
+          session4.close();
+
+          return null;
+        });
+  }
+
+  @Test
+  public void poolAllPositions() throws Exception {
+    int maxAttempts = 100;
+    setupMockSessionCreation();
+    for (Position position : Position.values()) {
+      runWithSystemProperty(
+          "SESSION_POOL_RELEASE_TO_POSITION",
+          position.name(),
+          () -> {
+            int attempt = 0;
+            while (attempt < maxAttempts) {
+              int numSessions = 5;
+              options =
+                  options
+                      .toBuilder()
+                      .setMinSessions(numSessions)
+                      .setMaxSessions(numSessions)
+                      .setWaitForMinSessions(Duration.ofSeconds(10L))
+                      .build();
+              pool = createPool();
+              pool.maybeWaitOnMinSessions();
+              // First check out and release the sessions twice to the pool, so we know that we have
+              // finalized the position of them.
+              for (int n = 0; n < 2; n++) {
+                checkoutAndReleaseAllSessions();
+              }
+
+              // Now verify that if we get all sessions twice, they will be in random order.
+              List<List<PooledSessionFuture>> allSessions = new ArrayList<>(2);
+              for (int n = 0; n < 2; n++) {
+                allSessions.add(checkoutAndReleaseAllSessions());
+              }
+              List<Session> firstTime =
+                  allSessions.get(0).stream()
+                      .map(PooledSessionFuture::get)
+                      .collect(Collectors.toList());
+              List<Session> secondTime =
+                  allSessions.get(1).stream()
+                      .map(PooledSessionFuture::get)
+                      .collect(Collectors.toList());
+              switch (position) {
+                case FIRST:
+                  // FIFO:
+                  // First check out all sessions, so we have 1, 2, 3, 4, ..., N
+                  // Then release them all back into the pool in the same order (1, 2, 3, 4, ...,
+                  // N).
+                  // That will give us the list N, ..., 4, 3, 2, 1 because each session is added at
+                  // the
+                  // front of the pool.
+                  assertEquals(firstTime, Lists.reverse(secondTime));
+                  break;
+                case LAST:
+                  // LIFO:
+                  // First check out all sessions, so we have 1, 2, 3, 4, ..., N
+                  // Then release them all back into the pool in the same order (1, 2, 3, 4, ...,
+                  // N).
+                  // That will give us the list 1, 2, 3, 4, ..., N because each session is added at
+                  // the
+                  // end of the pool.
+                  assertEquals(firstTime, secondTime);
+                  break;
+                case RANDOM:
+                  // Random means that we should not get the same order twice (unless the randomizer
+                  // got
+                  // lucky, and then we retry).
+                  if (attempt < (maxAttempts - 1)) {
+                    if (Objects.equals(firstTime, secondTime)) {
+                      attempt++;
+                      continue;
+                    }
+                  }
+                  assertNotEquals(firstTime, secondTime);
+              }
+              break;
+            }
+            return null;
+          });
+    }
+  }
+
+  private List<PooledSessionFuture> checkoutAndReleaseAllSessions() {
+    List<PooledSessionFuture> sessions = new ArrayList<>(pool.totalSessions());
+    for (int i = 0; i < pool.totalSessions(); i++) {
+      sessions.add(pool.getSession());
+    }
+    for (Session session : sessions) {
+      session.close();
+    }
+    return sessions;
   }
 
   @Test


### PR DESCRIPTION
Adds support for using a System property to set the default session pool ordering. The default ordering is LIFO. This can be changed to FIFO and RANDOM for users who need/want that.