### PR TITLE
test: swap expected and actual values in DML returning tests.

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDmlReturningTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDmlReturningTest.java
@@ -232,7 +232,8 @@ public final class ITDmlReturningTest {
   @Test
   public void dmlReturningWithExecuteQuery() {
     List<Struct> rows = executeQuery(DML_COUNT, insertDmlReturning());
-    assertEquals(1,
+    assertEquals(
+        1,
         getClient()
             .singleUse()
             .readRow("T", Key.of(String.format("%d-boo1", id)), Collections.singletonList("V"))
@@ -244,7 +245,8 @@ public final class ITDmlReturningTest {
       assertEquals(String.format("%d-boo%d", id, idx + 1), rows.get(idx).getString("K"));
     }
     rows = executeQuery(DML_COUNT, updateDmlReturning());
-    assertEquals(100,
+    assertEquals(
+        100,
         getClient()
             .singleUse()
             .readRow("T", Key.of(String.format("%d-boo1", id)), Collections.singletonList("V"))
@@ -293,7 +295,8 @@ public final class ITDmlReturningTest {
   @Test
   public void dmlReturningWithExecuteQueryAsync() {
     List<Struct> rows = executeQueryAsync(DML_COUNT, insertDmlReturning());
-    assertEquals(1,
+    assertEquals(
+        1,
         getClient()
             .singleUse()
             .readRow("T", Key.of(String.format("%d-boo1", id)), Collections.singletonList("V"))
@@ -305,7 +308,8 @@ public final class ITDmlReturningTest {
       assertEquals(String.format("%d-boo%d", id, idx + 1), rows.get(idx).getString("K"));
     }
     rows = executeQueryAsync(DML_COUNT, updateDmlReturning());
-    assertEquals(100,
+    assertEquals(
+        100,
         getClient()
             .singleUse()
             .readRow("T", Key.of(String.format("%d-boo1", id)), Collections.singletonList("V"))

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDmlReturningTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITDmlReturningTest.java
@@ -196,7 +196,7 @@ public final class ITDmlReturningTest {
         };
     TransactionRunner runner = getClient().readWriteTransaction();
     Long rowCount = runner.run(callable);
-    assertEquals(rowCount, (Long) expectedCount);
+    assertEquals((Long) expectedCount, rowCount);
   }
 
   @Test
@@ -217,7 +217,7 @@ public final class ITDmlReturningTest {
         };
     TransactionRunner runner = getClient().readWriteTransaction();
     Long rowCount = runner.run(callable);
-    assertEquals(rowCount, (Long) expectedCount);
+    assertEquals((Long) expectedCount, rowCount);
   }
 
   @Test
@@ -226,36 +226,34 @@ public final class ITDmlReturningTest {
         assertThrows(
             SpannerException.class,
             () -> getClient().executePartitionedUpdate(Statement.of(updateDmlReturning())));
-    assertEquals(e.getErrorCode(), ErrorCode.UNIMPLEMENTED);
+    assertEquals(ErrorCode.UNIMPLEMENTED, e.getErrorCode());
   }
 
   @Test
   public void dmlReturningWithExecuteQuery() {
     List<Struct> rows = executeQuery(DML_COUNT, insertDmlReturning());
-    assertEquals(
+    assertEquals(1,
         getClient()
             .singleUse()
             .readRow("T", Key.of(String.format("%d-boo1", id)), Collections.singletonList("V"))
-            .getLong(0),
-        1);
+            .getLong(0));
 
     // Check if keys(K) and V have expected values.
     for (int idx = 0; idx < rows.size(); idx++) {
-      assertEquals(rows.get(idx).getLong("V"), idx + 1);
-      assertEquals(rows.get(idx).getString("K"), String.format("%d-boo%d", id, idx + 1));
+      assertEquals(idx + 1, rows.get(idx).getLong("V"));
+      assertEquals(String.format("%d-boo%d", id, idx + 1), rows.get(idx).getString("K"));
     }
     rows = executeQuery(DML_COUNT, updateDmlReturning());
-    assertEquals(
+    assertEquals(100,
         getClient()
             .singleUse()
             .readRow("T", Key.of(String.format("%d-boo1", id)), Collections.singletonList("V"))
-            .getLong(0),
-        100);
+            .getLong(0));
 
     // Check if keys(K) and V have expected values.
     for (int idx = 0; idx < rows.size(); idx++) {
-      assertEquals(rows.get(idx).getLong("V"), 100);
-      assertEquals(rows.get(idx).getString("K"), String.format("%d-boo%d", id, idx + 1));
+      assertEquals(100, rows.get(idx).getLong("V"));
+      assertEquals(String.format("%d-boo%d", id, idx + 1), rows.get(idx).getString("K"));
     }
     rows = executeQuery(DML_COUNT, deleteDmlReturning());
     assertNull(
@@ -265,8 +263,8 @@ public final class ITDmlReturningTest {
 
     // Check if keys(K) and V have expected values.
     for (int idx = 0; idx < rows.size(); idx++) {
-      assertEquals(rows.get(idx).getLong("V"), 100);
-      assertEquals(rows.get(idx).getString("K"), String.format("%d-boo%d", id, idx + 1));
+      assertEquals(100, rows.get(idx).getLong("V"));
+      assertEquals(String.format("%d-boo%d", id, idx + 1), rows.get(idx).getString("K"));
     }
   }
 
@@ -295,30 +293,28 @@ public final class ITDmlReturningTest {
   @Test
   public void dmlReturningWithExecuteQueryAsync() {
     List<Struct> rows = executeQueryAsync(DML_COUNT, insertDmlReturning());
-    assertEquals(
+    assertEquals(1,
         getClient()
             .singleUse()
             .readRow("T", Key.of(String.format("%d-boo1", id)), Collections.singletonList("V"))
-            .getLong(0),
-        1);
+            .getLong(0));
 
     // Check if keys(K) and V have expected values.
     for (int idx = 0; idx < rows.size(); idx++) {
-      assertEquals(rows.get(idx).getLong("V"), idx + 1);
-      assertEquals(rows.get(idx).getString("K"), String.format("%d-boo%d", id, idx + 1));
+      assertEquals(idx + 1, rows.get(idx).getLong("V"));
+      assertEquals(String.format("%d-boo%d", id, idx + 1), rows.get(idx).getString("K"));
     }
     rows = executeQueryAsync(DML_COUNT, updateDmlReturning());
-    assertEquals(
+    assertEquals(100,
         getClient()
             .singleUse()
             .readRow("T", Key.of(String.format("%d-boo1", id)), Collections.singletonList("V"))
-            .getLong(0),
-        100);
+            .getLong(0));
 
     // Check if keys(K) and V have expected values.
     for (int idx = 0; idx < rows.size(); idx++) {
-      assertEquals(rows.get(idx).getLong("V"), 100);
-      assertEquals(rows.get(idx).getString("K"), String.format("%d-boo%d", id, idx + 1));
+      assertEquals(100, rows.get(idx).getLong("V"));
+      assertEquals(String.format("%d-boo%d", id, idx + 1), rows.get(idx).getString("K"));
     }
     rows = executeQueryAsync(DML_COUNT, deleteDmlReturning());
     assertNull(
@@ -328,8 +324,8 @@ public final class ITDmlReturningTest {
 
     // Check if keys(K) and V have expected values.
     for (int idx = 0; idx < rows.size(); idx++) {
-      assertEquals(rows.get(idx).getLong("V"), 100);
-      assertEquals(rows.get(idx).getString("K"), String.format("%d-boo%d", id, idx + 1));
+      assertEquals(100, rows.get(idx).getLong("V"));
+      assertEquals(String.format("%d-boo%d", id, idx + 1), rows.get(idx).getString("K"));
     }
   }
 
@@ -373,10 +369,10 @@ public final class ITDmlReturningTest {
   public void dmlReturningWithBatchUpdate() {
     // Check if batchUpdate works well with a mix of Simple DML and DML Returning statements.
     long[] rowCounts = batchUpdate(insertDmlReturning(), updateDmlReturning(), deleteDml());
-    assertEquals(rowCounts.length, 3);
-    assertEquals(rowCounts[0], DML_COUNT);
-    assertEquals(rowCounts[1], DML_COUNT);
-    assertEquals(rowCounts[2], DML_COUNT);
+    assertEquals(3, rowCounts.length);
+    assertEquals(DML_COUNT, rowCounts[0]);
+    assertEquals(DML_COUNT, rowCounts[1]);
+    assertEquals(DML_COUNT, rowCounts[2]);
   }
 
   private long[] batchUpdate(final String... stmts) {
@@ -392,10 +388,10 @@ public final class ITDmlReturningTest {
   public void dmlReturningWithBatchUpdateAsync() {
     // Check if batchUpdateAsync works well with a mix of Simple DML and DML Returning statements.
     long[] rowCounts = batchUpdateAsync(insertDmlReturning(), updateDmlReturning(), deleteDml());
-    assertEquals(rowCounts.length, 3);
-    assertEquals(rowCounts[0], DML_COUNT);
-    assertEquals(rowCounts[1], DML_COUNT);
-    assertEquals(rowCounts[2], DML_COUNT);
+    assertEquals(3, rowCounts.length);
+    assertEquals(DML_COUNT, rowCounts[0]);
+    assertEquals(DML_COUNT, rowCounts[1]);
+    assertEquals(DML_COUNT, rowCounts[2]);
   }
 
   private long[] batchUpdateAsync(final String... stmts) {


### PR DESCRIPTION
While debugging flaky issue - https://github.com/googleapis/java-spanner/issues/2629 , it was noticed that `ITDmlReturningTest` is not using the right convention for `assertEquals` method. This PR swaps the value so that debugging readability is improved.

For ex - The following error message in the above issue is confusing due to this swap between expected/actual values.
```
java.lang.AssertionError: expected:<1> but was:<2>
```