### PR TITLE
chore: remove double client lib token header

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,20 +50,20 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.24.0')
+implementation platform('com.google.cloud:libraries-bom:26.25.0')
 
 implementation 'com.google.cloud:google-cloud-spanner'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-spanner:6.50.1'
+implementation 'com.google.cloud:google-cloud-spanner:6.51.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.50.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.51.0"
 ```
 <!-- {x-version-update-end} -->
 
@@ -432,7 +432,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-spanner/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-spanner.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.50.1
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.51.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spanner;
 
 import com.google.api.core.ApiFunction;
+import com.google.api.core.InternalApi;
 import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.grpc.GrpcCallContext;
 import com.google.api.gax.grpc.GrpcInterceptorProvider;
@@ -686,10 +687,10 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     private final ImmutableSet<String> allowedClientLibTokens =
         ImmutableSet.of(
             ServiceOptions.getGoogApiClientLibName(),
-            JDBC_API_CLIENT_LIB_TOKEN,
-            HIBERNATE_API_CLIENT_LIB_TOKEN,
-            LIQUIBASE_API_CLIENT_LIB_TOKEN,
-            PG_ADAPTER_CLIENT_LIB_TOKEN);
+            createCustomClientLibToken(JDBC_API_CLIENT_LIB_TOKEN),
+            createCustomClientLibToken(HIBERNATE_API_CLIENT_LIB_TOKEN),
+            createCustomClientLibToken(LIQUIBASE_API_CLIENT_LIB_TOKEN),
+            createCustomClientLibToken(PG_ADAPTER_CLIENT_LIB_TOKEN));
     private TransportChannelProvider channelProvider;
 
     @SuppressWarnings("rawtypes")
@@ -724,6 +725,10 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     private String compressorName;
     private String emulatorHost = System.getenv("SPANNER_EMULATOR_HOST");
     private boolean leaderAwareRoutingEnabled = true;
+
+    private static String createCustomClientLibToken(String token) {
+      return token + " " + ServiceOptions.getGoogApiClientLibName();
+    }
 
     private Builder() {
       // Manually set retry and polling settings that work.
@@ -793,6 +798,13 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     @Override
     protected Set<String> getAllowedClientLibTokens() {
       return allowedClientLibTokens;
+    }
+
+    @InternalApi
+    @Override
+    public SpannerOptions.Builder setClientLibToken(String clientLibToken) {
+      return super.setClientLibToken(
+          clientLibToken + " " + ServiceOptions.getGoogApiClientLibName());
     }
 
     /**

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -55,7 +55,6 @@ import com.google.api.gax.rpc.WatchdogProvider;
 import com.google.api.pathtemplate.PathTemplate;
 import com.google.cloud.RetryHelper;
 import com.google.cloud.RetryHelper.RetryHelperException;
-import com.google.cloud.ServiceOptions;
 import com.google.cloud.grpc.GcpManagedChannelBuilder;
 import com.google.cloud.grpc.GcpManagedChannelOptions;
 import com.google.cloud.grpc.GcpManagedChannelOptions.GcpMetricsOptions;
@@ -297,8 +296,7 @@ public class GapicSpannerRpc implements SpannerRpc {
     ApiClientHeaderProvider internalHeaderProvider =
         internalHeaderProviderBuilder
             .setClientLibToken(
-                options.getClientLibToken() + " " + ServiceOptions.getGoogApiClientLibName(),
-                GaxProperties.getLibraryVersion(options.getClass()))
+                options.getClientLibToken(), GaxProperties.getLibraryVersion(options.getClass()))
             .setTransportToken(
                 GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion())
             .build();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
@@ -516,7 +516,9 @@ public class SpannerOptionsTest {
             .setCredentials(NoCredentials.getInstance())
             .setClientLibToken(jdbcToken)
             .build();
-    assertThat(options.getClientLibToken()).isEqualTo(jdbcToken);
+    // Verify that the client lib token that will actually be used contains both the JDBC token and
+    // the standard Java client library token ('gccl').
+    assertEquals("sp-jdbc gccl", options.getClientLibToken());
 
     options =
         SpannerOptions.newBuilder()
@@ -524,7 +526,7 @@ public class SpannerOptionsTest {
             .setCredentials(NoCredentials.getInstance())
             .setClientLibToken(hibernateToken)
             .build();
-    assertThat(options.getClientLibToken()).isEqualTo(hibernateToken);
+    assertEquals("sp-hib gccl", options.getClientLibToken());
 
     options =
         SpannerOptions.newBuilder()
@@ -532,7 +534,7 @@ public class SpannerOptionsTest {
             .setCredentials(NoCredentials.getInstance())
             .setClientLibToken(pgAdapterToken)
             .build();
-    assertEquals(options.getClientLibToken(), pgAdapterToken);
+    assertEquals("pg-adapter gccl", options.getClientLibToken());
 
     options =
         SpannerOptions.newBuilder()


### PR DESCRIPTION
Removes the double inclusion of the standard client lib token when no custom client lib token has been set. Also reuses more of the standard feature for setting the client lib token, instaed of appending the standard token at the moment that we are creating the gRPC stub. This should reduce the probability that anyone who might be using a custom header or custom client in some way will get it wrong.
