### PR TITLE
fix: respect SPANNER_EMULATOR_HOST env var when autoConfigEmulator=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,20 +50,20 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.26.0')
+implementation platform('com.google.cloud:libraries-bom:26.27.0')
 
 implementation 'com.google.cloud:google-cloud-spanner'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-spanner:6.52.1'
+implementation 'com.google.cloud:google-cloud-spanner:6.53.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.52.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.53.0"
 ```
 <!-- {x-version-update-end} -->
 
@@ -432,7 +432,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-spanner/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-spanner.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.52.1
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.53.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.spanner.connection;
 
+import static com.google.cloud.spanner.connection.ConnectionOptions.Builder.SPANNER_URI_PATTERN;
+import static com.google.cloud.spanner.connection.ConnectionOptions.determineHost;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -33,6 +35,7 @@ import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerOptions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.BaseEncoding;
 import com.google.common.io.Files;
 import java.io.File;
@@ -40,6 +43,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.regex.Matcher;
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
@@ -151,6 +155,105 @@ public class ConnectionOptionsTest {
     assertEquals("test-database-123", options.getDatabaseName());
     assertEquals(NoCredentials.getInstance(), options.getCredentials());
     assertTrue(options.isUsePlainText());
+  }
+
+  @Test
+  public void testDetermineHost() {
+    final String uriWithoutHost =
+        "cloudspanner:/projects/test-project-123/instances/test-instance-123/databases/test-database-123";
+    Matcher matcherWithoutHost = SPANNER_URI_PATTERN.matcher(uriWithoutHost);
+    assertTrue(matcherWithoutHost.find());
+    final String uriWithHost =
+        "cloudspanner://custom.host.domain:1234/projects/test-project-123/instances/test-instance-123/databases/test-database-123";
+    Matcher matcherWithHost = SPANNER_URI_PATTERN.matcher(uriWithHost);
+    assertTrue(matcherWithHost.find());
+
+    assertEquals(
+        DEFAULT_HOST,
+        determineHost(
+            matcherWithoutHost,
+            /* autoConfigEmulator= */ false,
+            /* usePlainText= */ false,
+            ImmutableMap.of()));
+    assertEquals(
+        DEFAULT_HOST,
+        determineHost(
+            matcherWithoutHost,
+            /* autoConfigEmulator= */ false,
+            /* usePlainText= */ false,
+            ImmutableMap.of("FOO", "bar")));
+    assertEquals(
+        "http://localhost:9010",
+        determineHost(
+            matcherWithoutHost,
+            /* autoConfigEmulator= */ true,
+            /* usePlainText= */ false,
+            ImmutableMap.of()));
+    assertEquals(
+        "http://localhost:9011",
+        determineHost(
+            matcherWithoutHost,
+            /* autoConfigEmulator= */ true,
+            /* usePlainText= */ false,
+            ImmutableMap.of("SPANNER_EMULATOR_HOST", "localhost:9011")));
+    assertEquals(
+        "http://localhost:9010",
+        determineHost(
+            matcherWithoutHost,
+            /* autoConfigEmulator= */ true,
+            /* usePlainText= */ true,
+            ImmutableMap.of()));
+    assertEquals(
+        "http://localhost:9011",
+        determineHost(
+            matcherWithoutHost,
+            /* autoConfigEmulator= */ true,
+            /* usePlainText= */ true,
+            ImmutableMap.of("SPANNER_EMULATOR_HOST", "localhost:9011")));
+
+    // A host in the connection string has precedence over all other options.
+    assertEquals(
+        "https://custom.host.domain:1234",
+        determineHost(
+            matcherWithHost,
+            /* autoConfigEmulator= */ false,
+            /* usePlainText= */ false,
+            ImmutableMap.of()));
+    assertEquals(
+        "http://custom.host.domain:1234",
+        determineHost(
+            matcherWithHost,
+            /* autoConfigEmulator= */ false,
+            /* usePlainText= */ true,
+            ImmutableMap.of()));
+    assertEquals(
+        "http://custom.host.domain:1234",
+        determineHost(
+            matcherWithHost,
+            /* autoConfigEmulator= */ false,
+            /* usePlainText= */ true,
+            ImmutableMap.of()));
+    assertEquals(
+        "https://custom.host.domain:1234",
+        determineHost(
+            matcherWithHost,
+            /* autoConfigEmulator= */ true,
+            /* usePlainText= */ false,
+            ImmutableMap.of()));
+    assertEquals(
+        "http://custom.host.domain:1234",
+        determineHost(
+            matcherWithHost,
+            /* autoConfigEmulator= */ false,
+            /* usePlainText= */ true,
+            ImmutableMap.of("SPANNER_EMULATOR_HOST", "localhost:9011")));
+    assertEquals(
+        "https://custom.host.domain:1234",
+        determineHost(
+            matcherWithHost,
+            /* autoConfigEmulator= */ true,
+            /* usePlainText= */ false,
+            ImmutableMap.of("SPANNER_EMULATOR_HOST", "localhost:9011")));
   }
 
   @Test


### PR DESCRIPTION
The Connection API would always use the default emulator host when autoConfigEmulator=true was set in the connection string. This makes it harder to override the host name for the emulator when you also want the emulator to automatically create the instance and database that you connect to, as the only way to set it is to add it to the connection string.
