### PR TITLE
chore: add method for getting the backend type name

### DIFF
--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -455,4 +455,10 @@
     <className>com/google/cloud/spanner/spi/v1/SpannerRpc</className>
     <method>java.util.Set getExecuteQueryRetryableCodes()</method>
   </difference>
+  <!-- Added getDefaultSchema() to Dialect enum. -->
+  <difference>
+    <differenceType>7013</differenceType>
+    <className>com/google/cloud/spanner/Dialect</className>
+    <method>java.lang.String getDefaultSchema()</method>
+  </difference>
 </differences>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Dialect.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Dialect.java
@@ -33,6 +33,11 @@ public enum Dialect {
     public DatabaseDialect toProto() {
       return DatabaseDialect.GOOGLE_STANDARD_SQL;
     }
+
+    @Override
+    public String getDefaultSchema() {
+      return "";
+    }
   },
   POSTGRESQL {
     @Override
@@ -43,6 +48,11 @@ public enum Dialect {
     @Override
     public DatabaseDialect toProto() {
       return DatabaseDialect.POSTGRESQL;
+    }
+
+    @Override
+    public String getDefaultSchema() {
+      return "public";
     }
   };
 
@@ -55,6 +65,8 @@ public enum Dialect {
   public abstract String createDatabaseStatementFor(String databaseName);
 
   public abstract DatabaseDialect toProto();
+
+  public abstract String getDefaultSchema();
 
   public static Dialect fromProto(DatabaseDialect databaseDialect) {
     final Dialect dialect = protoToDialect.get(databaseDialect);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TypeTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TypeTest.java
@@ -517,6 +517,69 @@ public class TypeTest {
     assertNotEquals(unrecognizedArray, Type.array(Type.int64()));
   }
 
+  @Test
+  public void testGoogleSQLTypeNames() {
+    assertEquals("INT64", Type.int64().getSpannerTypeName(Dialect.GOOGLE_STANDARD_SQL));
+    assertEquals("BOOL", Type.bool().getSpannerTypeName(Dialect.GOOGLE_STANDARD_SQL));
+    assertEquals("FLOAT64", Type.float64().getSpannerTypeName(Dialect.GOOGLE_STANDARD_SQL));
+    assertEquals("STRING", Type.string().getSpannerTypeName(Dialect.GOOGLE_STANDARD_SQL));
+    assertEquals("BYTES", Type.bytes().getSpannerTypeName(Dialect.GOOGLE_STANDARD_SQL));
+    assertEquals("DATE", Type.date().getSpannerTypeName(Dialect.GOOGLE_STANDARD_SQL));
+    assertEquals("TIMESTAMP", Type.timestamp().getSpannerTypeName(Dialect.GOOGLE_STANDARD_SQL));
+    assertEquals("JSON", Type.json().getSpannerTypeName(Dialect.GOOGLE_STANDARD_SQL));
+    assertEquals("NUMERIC", Type.numeric().getSpannerTypeName(Dialect.GOOGLE_STANDARD_SQL));
+
+    assertEquals(
+        "ARRAY<INT64>", Type.array(Type.int64()).getSpannerTypeName(Dialect.GOOGLE_STANDARD_SQL));
+    assertEquals(
+        "ARRAY<BOOL>", Type.array(Type.bool()).getSpannerTypeName(Dialect.GOOGLE_STANDARD_SQL));
+    assertEquals(
+        "ARRAY<FLOAT64>",
+        Type.array(Type.float64()).getSpannerTypeName(Dialect.GOOGLE_STANDARD_SQL));
+    assertEquals(
+        "ARRAY<STRING>", Type.array(Type.string()).getSpannerTypeName(Dialect.GOOGLE_STANDARD_SQL));
+    assertEquals(
+        "ARRAY<BYTES>", Type.array(Type.bytes()).getSpannerTypeName(Dialect.GOOGLE_STANDARD_SQL));
+    assertEquals(
+        "ARRAY<DATE>", Type.array(Type.date()).getSpannerTypeName(Dialect.GOOGLE_STANDARD_SQL));
+    assertEquals(
+        "ARRAY<TIMESTAMP>",
+        Type.array(Type.timestamp()).getSpannerTypeName(Dialect.GOOGLE_STANDARD_SQL));
+    assertEquals(
+        "ARRAY<JSON>", Type.array(Type.json()).getSpannerTypeName(Dialect.GOOGLE_STANDARD_SQL));
+    assertEquals(
+        "ARRAY<NUMERIC>",
+        Type.array(Type.numeric()).getSpannerTypeName(Dialect.GOOGLE_STANDARD_SQL));
+  }
+
+  @Test
+  public void testPostgreSQLTypeNames() {
+    assertEquals("bigint", Type.int64().getSpannerTypeName(Dialect.POSTGRESQL));
+    assertEquals("boolean", Type.bool().getSpannerTypeName(Dialect.POSTGRESQL));
+    assertEquals("double precision", Type.float64().getSpannerTypeName(Dialect.POSTGRESQL));
+    assertEquals("character varying", Type.string().getSpannerTypeName(Dialect.POSTGRESQL));
+    assertEquals("bytea", Type.bytes().getSpannerTypeName(Dialect.POSTGRESQL));
+    assertEquals("date", Type.date().getSpannerTypeName(Dialect.POSTGRESQL));
+    assertEquals(
+        "timestamp with time zone", Type.timestamp().getSpannerTypeName(Dialect.POSTGRESQL));
+    assertEquals("jsonb", Type.pgJsonb().getSpannerTypeName(Dialect.POSTGRESQL));
+    assertEquals("numeric", Type.pgNumeric().getSpannerTypeName(Dialect.POSTGRESQL));
+
+    assertEquals("bigint[]", Type.array(Type.int64()).getSpannerTypeName(Dialect.POSTGRESQL));
+    assertEquals("boolean[]", Type.array(Type.bool()).getSpannerTypeName(Dialect.POSTGRESQL));
+    assertEquals(
+        "double precision[]", Type.array(Type.float64()).getSpannerTypeName(Dialect.POSTGRESQL));
+    assertEquals(
+        "character varying[]", Type.array(Type.string()).getSpannerTypeName(Dialect.POSTGRESQL));
+    assertEquals("bytea[]", Type.array(Type.bytes()).getSpannerTypeName(Dialect.POSTGRESQL));
+    assertEquals("date[]", Type.array(Type.date()).getSpannerTypeName(Dialect.POSTGRESQL));
+    assertEquals(
+        "timestamp with time zone[]",
+        Type.array(Type.timestamp()).getSpannerTypeName(Dialect.POSTGRESQL));
+    assertEquals("jsonb[]", Type.array(Type.pgJsonb()).getSpannerTypeName(Dialect.POSTGRESQL));
+    assertEquals("numeric[]", Type.array(Type.pgNumeric()).getSpannerTypeName(Dialect.POSTGRESQL));
+  }
+
   private static void assertProtoEquals(com.google.spanner.v1.Type proto, String expected) {
     MatcherAssert.assertThat(
         proto, SpannerMatchers.matchesProto(com.google.spanner.v1.Type.class, expected));


### PR DESCRIPTION
JDBC must be able to return the type name of a query parameter. Currently, that is done with a custom implementation in the JDBC driver. This adds a method to the Spanner client for the same, so the feature is in a more logical place.
