### PR TITLE
chore: use a cache for the statement parser

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractStatementParser.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractStatementParser.java
@@ -392,12 +392,13 @@ public abstract class AbstractStatementParser {
   static final Set<String> dmlStatements = ImmutableSet.of("INSERT", "UPDATE", "DELETE");
   private final Set<ClientSideStatementImpl> statements;
 
-  public static final int DEFAULT_MAX_STATEMENT_CACHE_SIZE = 20;
+  /** The default maximum size of the statement cache in Mb. */
+  public static final int DEFAULT_MAX_STATEMENT_CACHE_SIZE_MB = 20;
 
   private static int getMaxStatementCacheSize() {
     String stringValue = System.getProperty("spanner.statement_cache_size");
     if (stringValue == null) {
-      return DEFAULT_MAX_STATEMENT_CACHE_SIZE;
+      return DEFAULT_MAX_STATEMENT_CACHE_SIZE_MB;
     }
     int value = 0;
     try {
@@ -414,7 +415,7 @@ public abstract class AbstractStatementParser {
 
   /**
    * Cache for parsed statements. This prevents statements that are executed multiple times by the
-   * application to be parsed over and over again. The maximum size is set to 5,000.
+   * application to be parsed over and over again. The default maximum size is 20Mb.
    */
   private final Cache<String, ParsedStatement> statementCache;
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractStatementParser.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractStatementParser.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.spanner.connection;
 
-import com.apple.laf.AquaTreeUI.MacPropertyChangeHandler;
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.ErrorCode;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractStatementParser.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractStatementParser.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spanner.connection;
 
+import com.apple.laf.AquaTreeUI.MacPropertyChangeHandler;
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.ErrorCode;
@@ -426,7 +427,7 @@ public abstract class AbstractStatementParser {
       CacheBuilder<String, ParsedStatement> cacheBuilder =
           CacheBuilder.newBuilder()
               // Set the max size to (approx) 5MB (by default).
-              .maximumWeight(getMaxStatementCacheSize() * 1024L * 1024L)
+              .maximumWeight(maxCacheSize * 1024L * 1024L)
               // We do length*2 because Java uses 2 bytes for each char.
               .weigher(
                   (Weigher<String, ParsedStatement>)

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractStatementParser.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractStatementParser.java
@@ -393,10 +393,10 @@ public abstract class AbstractStatementParser {
   private final Set<ClientSideStatementImpl> statements;
 
   /** The default maximum size of the statement cache in Mb. */
-  public static final int DEFAULT_MAX_STATEMENT_CACHE_SIZE_MB = 20;
+  public static final int DEFAULT_MAX_STATEMENT_CACHE_SIZE_MB = 5;
 
   private static int getMaxStatementCacheSize() {
-    String stringValue = System.getProperty("spanner.statement_cache_size");
+    String stringValue = System.getProperty("spanner.statement_cache_size_mb");
     if (stringValue == null) {
       return DEFAULT_MAX_STATEMENT_CACHE_SIZE_MB;
     }
@@ -415,7 +415,7 @@ public abstract class AbstractStatementParser {
 
   /**
    * Cache for parsed statements. This prevents statements that are executed multiple times by the
-   * application to be parsed over and over again. The default maximum size is 20Mb.
+   * application to be parsed over and over again. The default maximum size is 5Mb.
    */
   private final Cache<String, ParsedStatement> statementCache;
 
@@ -425,7 +425,7 @@ public abstract class AbstractStatementParser {
     if (maxCacheSize > 0) {
       CacheBuilder<String, ParsedStatement> cacheBuilder =
           CacheBuilder.newBuilder()
-              // Set the max size to (approx) 20MB (by default).
+              // Set the max size to (approx) 5MB (by default).
               .maximumWeight(getMaxStatementCacheSize() * 1024L * 1024L)
               // We do length*2 because Java uses 2 bytes for each char.
               .weigher(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolStressTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolStressTest.java
@@ -294,6 +294,7 @@ public class SessionPoolStressTest extends BaseSessionPoolTest {
             () -> {
               while (!stopMaintenance.get()) {
                 runMaintenanceLoop(clock, pool, 1);
+                Uninterruptibles.sleepUninterruptibly(1L, TimeUnit.MILLISECONDS);
               }
             })
         .start();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementParserTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementParserTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
@@ -34,6 +35,7 @@ import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStateme
 import com.google.cloud.spanner.connection.AbstractStatementParser.StatementType;
 import com.google.cloud.spanner.connection.ClientSideStatementImpl.CompileException;
 import com.google.cloud.spanner.connection.StatementResult.ClientSideStatementType;
+import com.google.common.cache.CacheStats;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.truth.Truth;
@@ -43,9 +45,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 import java.util.Set;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -80,6 +85,17 @@ public class StatementParserTest {
   }
 
   private AbstractStatementParser parser;
+
+  @BeforeClass
+  public static void enableStatementCacheStats() {
+    AbstractStatementParser.resetParsers();
+    System.setProperty("spanner.record_statement_cache_stats", "true");
+  }
+
+  @AfterClass
+  public static void disableStatementCacheStats() {
+    System.clearProperty("spanner.record_statement_cache_stats");
+  }
 
   @Before
   public void setupParser() {
@@ -1607,6 +1623,63 @@ public class StatementParserTest {
     assertEquals(
         "/* foo /* inner comment */ not in inner comment */".length(),
         skipMultiLineComment("/* foo /* inner comment */ not in inner comment */ bar", 0));
+  }
+
+  @Test
+  public void testStatementCache_NonParameterizedStatement() {
+    CacheStats statsBefore = parser.getStatementCacheStats();
+
+    String sql = "select foo from bar where id=" + UUID.randomUUID();
+    ParsedStatement parsedStatement1 = parser.parse(Statement.of(sql));
+    assertEquals(StatementType.QUERY, parsedStatement1.getType());
+
+    ParsedStatement parsedStatement2 = parser.parse(Statement.of(sql));
+    assertEquals(StatementType.QUERY, parsedStatement2.getType());
+
+    // Even though the parsed statements are cached, the returned instances are not the same.
+    // This makes sure that statements with the same SQL string and different parameter values
+    // can use the cache.
+    assertNotSame(parsedStatement1, parsedStatement2);
+
+    CacheStats statsAfter = parser.getStatementCacheStats();
+    CacheStats stats = statsAfter.minus(statsBefore);
+
+    // The first query had a cache miss. The second a cache hit.
+    assertEquals(1, stats.missCount());
+    assertEquals(1, stats.hitCount());
+  }
+
+  @Test
+  public void testStatementCache_ParameterizedStatement() {
+    CacheStats statsBefore = parser.getStatementCacheStats();
+
+    String sql =
+        "select "
+            + UUID.randomUUID()
+            + " from bar where id="
+            + (dialect == Dialect.POSTGRESQL ? "$1" : "@p1");
+    Statement statement1 = Statement.newBuilder(sql).bind("p1").to(1L).build();
+    Statement statement2 = Statement.newBuilder(sql).bind("p1").to(2L).build();
+
+    ParsedStatement parsedStatement1 = parser.parse(statement1);
+    assertEquals(StatementType.QUERY, parsedStatement1.getType());
+    assertEquals(parsedStatement1.getStatement(), statement1);
+
+    ParsedStatement parsedStatement2 = parser.parse(statement2);
+    assertEquals(StatementType.QUERY, parsedStatement2.getType());
+    assertEquals(parsedStatement2.getStatement(), statement2);
+
+    // Even though the parsed statements are cached, the returned instances are not the same.
+    // This makes sure that statements with the same SQL string and different parameter values
+    // can use the cache.
+    assertNotSame(parsedStatement1, parsedStatement2);
+
+    CacheStats statsAfter = parser.getStatementCacheStats();
+    CacheStats stats = statsAfter.minus(statsBefore);
+
+    // The first query had a cache miss. The second a cache hit.
+    assertEquals(1, stats.missCount());
+    assertEquals(1, stats.hitCount());
   }
 
   private void assertUnclosedLiteral(String sql) {


### PR DESCRIPTION
Add a cache for the statement parser that is used in the Connection API. This will reduce the number of times that a SQL string needs to be parsed by the JDBC driver and PGAdapter.