### PR TITLE
test: reduce test log spam

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
@@ -250,13 +250,13 @@ class SpannerImpl extends BaseService<SpannerOptions> implements Spanner {
     synchronized (this) {
       checkClosed();
       closedException = new ClosedException();
+    }
+    try {
       closureFutures = new ArrayList<>();
       for (DatabaseClientImpl dbClient : dbClients.values()) {
         closureFutures.add(dbClient.closeAsync(closedException));
       }
       dbClients.clear();
-    }
-    try {
       Futures.successfulAsList(closureFutures).get(timeout, unit);
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
       throw SpannerExceptionFactory.newSpannerException(e);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BaseSessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BaseSessionPoolTest.java
@@ -124,7 +124,7 @@ abstract class BaseSessionPoolTest {
   void runMaintenanceLoop(FakeClock clock, SessionPool pool, long numCycles) {
     for (int i = 0; i < numCycles; i++) {
       pool.poolMaintainer.maintainPool();
-      clock.currentTimeMillis += pool.poolMaintainer.loopFrequency;
+      clock.currentTimeMillis.addAndGet(pool.poolMaintainer.loopFrequency);
     }
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ChannelUsageTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ChannelUsageTest.java
@@ -52,6 +52,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -111,6 +113,8 @@ public class ChannelUsageTest {
       ConcurrentHashMap.newKeySet();
   private static final Set<InetSocketAddress> executeSqlLocalIps = ConcurrentHashMap.newKeySet();
 
+  private static Level originalLogLevel;
+
   @BeforeClass
   public static void startServer() throws IOException {
     mockSpanner = new MockSpannerServiceImpl();
@@ -165,6 +169,19 @@ public class ChannelUsageTest {
   public static void stopServer() throws InterruptedException {
     server.shutdown();
     server.awaitTermination();
+  }
+
+  @BeforeClass
+  public static void disableLogging() {
+    Logger logger = Logger.getLogger("");
+    originalLogLevel = logger.getLevel();
+    logger.setLevel(Level.OFF);
+  }
+
+  @AfterClass
+  public static void resetLogging() {
+    Logger logger = Logger.getLogger("");
+    logger.setLevel(originalLogLevel);
   }
 
   @After

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -277,7 +277,7 @@ public class DatabaseClientImplTest {
             .setLoopFrequency(1000L) // main thread runs every 1s
             .setPoolMaintainerClock(poolMaintainerClock)
             .build();
-    spanner =
+    try (Spanner spanner =
         SpannerOptions.newBuilder()
             .setProjectId(TEST_PROJECT)
             .setDatabaseRole(TEST_DATABASE_ROLE)
@@ -285,52 +285,53 @@ public class DatabaseClientImplTest {
             .setCredentials(NoCredentials.getInstance())
             .setSessionPoolOption(sessionPoolOptions)
             .build()
-            .getService();
-    DatabaseClientImpl client =
-        (DatabaseClientImpl)
-            spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+            .getService()) {
+      DatabaseClientImpl client =
+          (DatabaseClientImpl)
+              spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+      Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    poolMaintainerClock.currentTimeMillis += Duration.ofMinutes(3).toMillis();
+      poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMinutes(3).toMillis());
 
-    try (TransactionManager manager = client.transactionManager()) {
-      TransactionContext transaction = manager.begin();
-      mockSpanner.setCommitExecutionTime(
-          SimulatedExecutionTime.ofException(
-              mockSpanner.createSessionNotFoundException("TEST_SESSION_NAME")));
-      while (true) {
-        try {
-          transaction.executeUpdate(UPDATE_STATEMENT);
+      try (TransactionManager manager = client.transactionManager()) {
+        TransactionContext transaction = manager.begin();
+        mockSpanner.setCommitExecutionTime(
+            SimulatedExecutionTime.ofException(
+                mockSpanner.createSessionNotFoundException("TEST_SESSION_NAME")));
+        while (true) {
+          try {
+            transaction.executeUpdate(UPDATE_STATEMENT);
 
-          // Simulate a delay of 3 minutes to ensure that the below transaction is a long-running
-          // one.
-          // As per this test, anything which takes more than 2s is long-running
-          poolMaintainerClock.currentTimeMillis += Duration.ofMinutes(3).toMillis();
-          // force trigger pool maintainer to check for long-running sessions
-          client.pool.poolMaintainer.maintainPool();
+            // Simulate a delay of 3 minutes to ensure that the below transaction is a long-running
+            // one.
+            // As per this test, anything which takes more than 2s is long-running
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMinutes(3).toMillis());
+            // force trigger pool maintainer to check for long-running sessions
+            client.pool.poolMaintainer.maintainPool();
 
-          manager.commit();
-          assertNotNull(manager.getCommitTimestamp());
-          break;
-        } catch (AbortedException e) {
-          transaction = manager.resetForRetry();
+            manager.commit();
+            assertNotNull(manager.getCommitTimestamp());
+            break;
+          } catch (AbortedException e) {
+            transaction = manager.resetForRetry();
+          }
+          mockSpanner.setCommitExecutionTime(SimulatedExecutionTime.ofMinimumAndRandomTime(0, 0));
         }
-        mockSpanner.setCommitExecutionTime(SimulatedExecutionTime.ofMinimumAndRandomTime(0, 0));
       }
+      Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+
+      // first session executed update, session found to be long-running and cleaned up.
+      // During commit, SessionNotFound exception from backend caused replacement of session and
+      // transaction needs to be retried.
+      // On retry, session again found to be long-running and cleaned up.
+      // During commit, there was no exception from backend.
+
+      assertNotEquals(
+          endExecutionTime,
+          initialExecutionTime); // if session clean up task runs then these timings won't match
+      assertEquals(2, client.pool.numLeakedSessionsRemoved());
+      assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
     }
-    Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
-
-    // first session executed update, session found to be long-running and cleaned up.
-    // During commit, SessionNotFound exception from backend caused replacement of session and
-    // transaction needs to be retried.
-    // On retry, session again found to be long-running and cleaned up.
-    // During commit, there was no exception from backend.
-
-    assertNotEquals(
-        endExecutionTime,
-        initialExecutionTime); // if session clean up task runs then these timings won't match
-    assertEquals(2, client.pool.numLeakedSessionsRemoved());
-    assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
   }
 
   @Test
@@ -353,7 +354,7 @@ public class DatabaseClientImplTest {
             .setLoopFrequency(1000L) // main thread runs every 1s
             .setPoolMaintainerClock(poolMaintainerClock)
             .build();
-    spanner =
+    try (Spanner spanner =
         SpannerOptions.newBuilder()
             .setProjectId(TEST_PROJECT)
             .setDatabaseRole(TEST_DATABASE_ROLE)
@@ -361,47 +362,48 @@ public class DatabaseClientImplTest {
             .setCredentials(NoCredentials.getInstance())
             .setSessionPoolOption(sessionPoolOptions)
             .build()
-            .getService();
-    DatabaseClientImpl client =
-        (DatabaseClientImpl)
-            spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+            .getService()) {
+      DatabaseClientImpl client =
+          (DatabaseClientImpl)
+              spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+      Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    poolMaintainerClock.currentTimeMillis += Duration.ofMinutes(3).toMillis();
+      poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMinutes(3).toMillis());
 
-    try (TransactionManager manager = client.transactionManager()) {
-      TransactionContext transaction = manager.begin();
-      while (true) {
-        try {
-          transaction.executeUpdate(UPDATE_STATEMENT);
+      try (TransactionManager manager = client.transactionManager()) {
+        TransactionContext transaction = manager.begin();
+        while (true) {
+          try {
+            transaction.executeUpdate(UPDATE_STATEMENT);
 
-          // Simulate a delay of 3 minutes to ensure that the below transaction is a long-running
-          // one.
-          // As per this test, anything which takes more than 2s is long-running
-          poolMaintainerClock.currentTimeMillis += Duration.ofMinutes(3).toMillis();
-          // force trigger pool maintainer to check for long-running sessions
-          client.pool.poolMaintainer.maintainPool();
+            // Simulate a delay of 3 minutes to ensure that the below transaction is a long-running
+            // one.
+            // As per this test, anything which takes more than 2s is long-running
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMinutes(3).toMillis());
+            // force trigger pool maintainer to check for long-running sessions
+            client.pool.poolMaintainer.maintainPool();
 
-          manager.commit();
-          assertNotNull(manager.getCommitTimestamp());
-          break;
-        } catch (AbortedException e) {
-          transaction = manager.resetForRetry();
+            manager.commit();
+            assertNotNull(manager.getCommitTimestamp());
+            break;
+          } catch (AbortedException e) {
+            transaction = manager.resetForRetry();
+          }
         }
       }
-    }
-    Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+      Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    // first session executed update, session found to be long-running and cleaned up.
-    // During commit, SessionNotFound exception from backend caused replacement of session and
-    // transaction needs to be retried.
-    // On retry, session again found to be long-running and cleaned up.
-    // During commit, there was no exception from backend.
-    assertNotEquals(
-        endExecutionTime,
-        initialExecutionTime); // if session clean up task runs then these timings won't match
-    assertEquals(1, client.pool.numLeakedSessionsRemoved());
-    assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+      // first session executed update, session found to be long-running and cleaned up.
+      // During commit, SessionNotFound exception from backend caused replacement of session and
+      // transaction needs to be retried.
+      // On retry, session again found to be long-running and cleaned up.
+      // During commit, there was no exception from backend.
+      assertNotEquals(
+          endExecutionTime,
+          initialExecutionTime); // if session clean up task runs then these timings won't match
+      assertEquals(1, client.pool.numLeakedSessionsRemoved());
+      assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+    }
   }
 
   @Test
@@ -424,7 +426,7 @@ public class DatabaseClientImplTest {
             .setPoolMaintainerClock(poolMaintainerClock)
             .build();
 
-    spanner =
+    try (Spanner spanner =
         SpannerOptions.newBuilder()
             .setProjectId(TEST_PROJECT)
             .setDatabaseRole(TEST_DATABASE_ROLE)
@@ -432,29 +434,30 @@ public class DatabaseClientImplTest {
             .setCredentials(NoCredentials.getInstance())
             .setSessionPoolOption(sessionPoolOptions)
             .build()
-            .getService();
-    DatabaseClientImpl client =
-        (DatabaseClientImpl)
-            spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
-    poolMaintainerClock.currentTimeMillis += Duration.ofMinutes(3).toMillis();
+            .getService()) {
+      DatabaseClientImpl client =
+          (DatabaseClientImpl)
+              spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+      Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+      poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMinutes(3).toMillis());
 
-    client.executePartitionedUpdate(UPDATE_STATEMENT);
+      client.executePartitionedUpdate(UPDATE_STATEMENT);
 
-    // Simulate a delay of 3 minutes to ensure that the below transaction is a long-running one.
-    // As per this test, anything which takes more than 2s is long-running
-    poolMaintainerClock.currentTimeMillis += Duration.ofMinutes(3).toMillis();
+      // Simulate a delay of 3 minutes to ensure that the below transaction is a long-running one.
+      // As per this test, anything which takes more than 2s is long-running
+      poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMinutes(3).toMillis());
 
-    // force trigger pool maintainer to check for long-running sessions
-    client.pool.poolMaintainer.maintainPool();
+      // force trigger pool maintainer to check for long-running sessions
+      client.pool.poolMaintainer.maintainPool();
 
-    Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+      Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    assertNotEquals(
-        endExecutionTime,
-        initialExecutionTime); // if session clean up task runs then these timings won't match
-    assertEquals(0, client.pool.numLeakedSessionsRemoved());
-    assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+      assertNotEquals(
+          endExecutionTime,
+          initialExecutionTime); // if session clean up task runs then these timings won't match
+      assertEquals(0, client.pool.numLeakedSessionsRemoved());
+      assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+    }
   }
 
   /**
@@ -486,7 +489,7 @@ public class DatabaseClientImplTest {
             .setLoopFrequency(1000L) // main thread runs every 1s
             .setPoolMaintainerClock(poolMaintainerClock)
             .build();
-    spanner =
+    try (Spanner spanner =
         SpannerOptions.newBuilder()
             .setProjectId(TEST_PROJECT)
             .setDatabaseRole(TEST_DATABASE_ROLE)
@@ -494,66 +497,67 @@ public class DatabaseClientImplTest {
             .setCredentials(NoCredentials.getInstance())
             .setSessionPoolOption(sessionPoolOptions)
             .build()
-            .getService();
-    DatabaseClientImpl client =
-        (DatabaseClientImpl)
-            spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+            .getService()) {
+      DatabaseClientImpl client =
+          (DatabaseClientImpl)
+              spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+      Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    poolMaintainerClock.currentTimeMillis += Duration.ofMinutes(3).toMillis();
+      poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMinutes(3).toMillis());
 
-    client.executePartitionedUpdate(UPDATE_STATEMENT);
+      client.executePartitionedUpdate(UPDATE_STATEMENT);
 
-    // Simulate a delay of 3 minutes to ensure that the below transaction is a long-running one.
-    // As per this test, anything which takes more than 2s is long-running
-    poolMaintainerClock.currentTimeMillis += Duration.ofMinutes(3).toMillis();
+      // Simulate a delay of 3 minutes to ensure that the below transaction is a long-running one.
+      // As per this test, anything which takes more than 2s is long-running
+      poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMinutes(3).toMillis());
 
-    // force trigger pool maintainer to check for long-running sessions
-    client.pool.poolMaintainer.maintainPool();
+      // force trigger pool maintainer to check for long-running sessions
+      client.pool.poolMaintainer.maintainPool();
 
-    Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+      Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    assertNotEquals(
-        endExecutionTime,
-        initialExecutionTime); // if session clean up task runs then these timings won't match
-    assertEquals(0, client.pool.numLeakedSessionsRemoved());
-    assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+      assertNotEquals(
+          endExecutionTime,
+          initialExecutionTime); // if session clean up task runs then these timings won't match
+      assertEquals(0, client.pool.numLeakedSessionsRemoved());
+      assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
 
-    poolMaintainerClock.currentTimeMillis += Duration.ofMinutes(3).toMillis();
+      poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMinutes(3).toMillis());
 
-    try (TransactionManager manager = client.transactionManager()) {
-      TransactionContext transaction = manager.begin();
-      while (true) {
-        try {
-          transaction.executeUpdate(UPDATE_STATEMENT);
+      try (TransactionManager manager = client.transactionManager()) {
+        TransactionContext transaction = manager.begin();
+        while (true) {
+          try {
+            transaction.executeUpdate(UPDATE_STATEMENT);
 
-          // Simulate a delay of 3 minutes to ensure that the below transaction is a long-running
-          // one.
-          // As per this test, anything which takes more than 2s is long-running
-          poolMaintainerClock.currentTimeMillis += Duration.ofMinutes(3).toMillis();
-          // force trigger pool maintainer to check for long-running sessions
-          client.pool.poolMaintainer.maintainPool();
+            // Simulate a delay of 3 minutes to ensure that the below transaction is a long-running
+            // one.
+            // As per this test, anything which takes more than 2s is long-running
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMinutes(3).toMillis());
+            // force trigger pool maintainer to check for long-running sessions
+            client.pool.poolMaintainer.maintainPool();
 
-          manager.commit();
-          assertNotNull(manager.getCommitTimestamp());
-          break;
-        } catch (AbortedException e) {
-          transaction = manager.resetForRetry();
+            manager.commit();
+            assertNotNull(manager.getCommitTimestamp());
+            break;
+          } catch (AbortedException e) {
+            transaction = manager.resetForRetry();
+          }
         }
       }
-    }
-    endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+      endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    // first session executed update, session found to be long-running and cleaned up.
-    // During commit, SessionNotFound exception from backend caused replacement of session and
-    // transaction needs to be retried.
-    // On retry, session again found to be long-running and cleaned up.
-    // During commit, there was no exception from backend.
-    assertNotEquals(
-        endExecutionTime,
-        initialExecutionTime); // if session clean up task runs then these timings won't match
-    assertEquals(1, client.pool.numLeakedSessionsRemoved());
-    assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+      // first session executed update, session found to be long-running and cleaned up.
+      // During commit, SessionNotFound exception from backend caused replacement of session and
+      // transaction needs to be retried.
+      // On retry, session again found to be long-running and cleaned up.
+      // During commit, there was no exception from backend.
+      assertNotEquals(
+          endExecutionTime,
+          initialExecutionTime); // if session clean up task runs then these timings won't match
+      assertEquals(1, client.pool.numLeakedSessionsRemoved());
+      assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+    }
   }
 
   @Test
@@ -577,7 +581,7 @@ public class DatabaseClientImplTest {
             .setLoopFrequency(1000L) // main thread runs every 1s
             .setPoolMaintainerClock(poolMaintainerClock)
             .build();
-    spanner =
+    try (Spanner spanner =
         SpannerOptions.newBuilder()
             .setProjectId(TEST_PROJECT)
             .setDatabaseRole(TEST_DATABASE_ROLE)
@@ -585,53 +589,53 @@ public class DatabaseClientImplTest {
             .setCredentials(NoCredentials.getInstance())
             .setSessionPoolOption(sessionPoolOptions)
             .build()
-            .getService();
-    DatabaseClientImpl client =
-        (DatabaseClientImpl)
-            spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+            .getService()) {
+      DatabaseClientImpl client =
+          (DatabaseClientImpl)
+              spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+      Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    TransactionRunner runner = client.readWriteTransaction();
-    runner.run(
-        transaction -> {
-          try (ResultSet resultSet =
-              transaction.read(
-                  READ_TABLE_NAME,
-                  KeySet.singleKey(Key.of(1L)),
-                  READ_COLUMN_NAMES,
-                  Options.priority(RpcPriority.HIGH))) {
-            while (resultSet.next()) {}
-          }
-          poolMaintainerClock.currentTimeMillis += Duration.ofMillis(1050).toMillis();
+      TransactionRunner runner = client.readWriteTransaction();
+      runner.run(
+          transaction -> {
+            try (ResultSet resultSet =
+                transaction.read(
+                    READ_TABLE_NAME,
+                    KeySet.singleKey(Key.of(1L)),
+                    READ_COLUMN_NAMES,
+                    Options.priority(RpcPriority.HIGH))) {
+              consumeResults(resultSet);
+            }
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMillis(1050).toMillis());
 
-          try (ResultSet resultSet =
-              transaction.read(
-                  READ_TABLE_NAME,
-                  KeySet.singleKey(Key.of(1L)),
-                  READ_COLUMN_NAMES,
-                  Options.priority(RpcPriority.HIGH))) {
-            while (resultSet.next()) {}
-          }
-          poolMaintainerClock.currentTimeMillis += Duration.ofMillis(2050).toMillis();
+            try (ResultSet resultSet =
+                transaction.read(
+                    READ_TABLE_NAME,
+                    KeySet.singleKey(Key.of(1L)),
+                    READ_COLUMN_NAMES,
+                    Options.priority(RpcPriority.HIGH))) {
+              consumeResults(resultSet);
+            }
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMillis(2050).toMillis());
 
-          // force trigger pool maintainer to check for long-running sessions
-          client.pool.poolMaintainer.maintainPool();
+            // force trigger pool maintainer to check for long-running sessions
+            client.pool.poolMaintainer.maintainPool();
 
-          return null;
-        });
+            return null;
+          });
 
-    Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+      Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    assertNotEquals(
-        endExecutionTime,
-        initialExecutionTime); // if session clean up task runs then these timings won't match
-    assertEquals(0, client.pool.numLeakedSessionsRemoved());
+      assertNotEquals(
+          endExecutionTime,
+          initialExecutionTime); // if session clean up task runs then these timings won't match
+      assertEquals(0, client.pool.numLeakedSessionsRemoved());
+    }
   }
 
   @Test
   public void
-      testPoolMaintainer_whenLongRunningQueriesUsingTransactionRunner_retainSessionForTransaction()
-          throws Exception {
+      testPoolMaintainer_whenLongRunningQueriesUsingTransactionRunner_retainSessionForTransaction() {
     FakeClock poolMaintainerClock = new FakeClock();
     InactiveTransactionRemovalOptions inactiveTransactionRemovalOptions =
         InactiveTransactionRemovalOptions.newBuilder()
@@ -649,7 +653,7 @@ public class DatabaseClientImplTest {
             .setLoopFrequency(1000L) // main thread runs every 1s
             .setPoolMaintainerClock(poolMaintainerClock)
             .build();
-    spanner =
+    try (Spanner spanner =
         SpannerOptions.newBuilder()
             .setProjectId(TEST_PROJECT)
             .setDatabaseRole(TEST_DATABASE_ROLE)
@@ -657,43 +661,43 @@ public class DatabaseClientImplTest {
             .setCredentials(NoCredentials.getInstance())
             .setSessionPoolOption(sessionPoolOptions)
             .build()
-            .getService();
-    DatabaseClientImpl client =
-        (DatabaseClientImpl)
-            spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+            .getService()) {
+      DatabaseClientImpl client =
+          (DatabaseClientImpl)
+              spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+      Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    TransactionRunner runner = client.readWriteTransaction();
-    runner.run(
-        transaction -> {
-          try (ResultSet resultSet = transaction.executeQuery(SELECT1)) {
-            while (resultSet.next()) {}
-          }
-          poolMaintainerClock.currentTimeMillis += Duration.ofMillis(1050).toMillis();
+      TransactionRunner runner = client.readWriteTransaction();
+      runner.run(
+          transaction -> {
+            try (ResultSet resultSet = transaction.executeQuery(SELECT1)) {
+              consumeResults(resultSet);
+            }
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMillis(1050).toMillis());
 
-          try (ResultSet resultSet = transaction.executeQuery(SELECT1)) {
-            while (resultSet.next()) {}
-          }
-          poolMaintainerClock.currentTimeMillis += Duration.ofMillis(2050).toMillis();
+            try (ResultSet resultSet = transaction.executeQuery(SELECT1)) {
+              consumeResults(resultSet);
+            }
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMillis(2050).toMillis());
 
-          // force trigger pool maintainer to check for long-running sessions
-          client.pool.poolMaintainer.maintainPool();
+            // force trigger pool maintainer to check for long-running sessions
+            client.pool.poolMaintainer.maintainPool();
 
-          return null;
-        });
+            return null;
+          });
 
-    Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+      Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    assertNotEquals(
-        endExecutionTime,
-        initialExecutionTime); // if session clean up task runs then these timings won't match
-    assertEquals(0, client.pool.numLeakedSessionsRemoved());
+      assertNotEquals(
+          endExecutionTime,
+          initialExecutionTime); // if session clean up task runs then these timings won't match
+      assertEquals(0, client.pool.numLeakedSessionsRemoved());
+    }
   }
 
   @Test
   public void
-      testPoolMaintainer_whenLongRunningUpdatesUsingTransactionManager_retainSessionForTransaction()
-          throws Exception {
+      testPoolMaintainer_whenLongRunningUpdatesUsingTransactionManager_retainSessionForTransaction() {
     FakeClock poolMaintainerClock = new FakeClock();
     InactiveTransactionRemovalOptions inactiveTransactionRemovalOptions =
         InactiveTransactionRemovalOptions.newBuilder()
@@ -711,7 +715,7 @@ public class DatabaseClientImplTest {
             .setLoopFrequency(1000L) // main thread runs every 1s
             .setPoolMaintainerClock(poolMaintainerClock)
             .build();
-    spanner =
+    try (Spanner spanner =
         SpannerOptions.newBuilder()
             .setProjectId(TEST_PROJECT)
             .setDatabaseRole(TEST_DATABASE_ROLE)
@@ -719,40 +723,41 @@ public class DatabaseClientImplTest {
             .setCredentials(NoCredentials.getInstance())
             .setSessionPoolOption(sessionPoolOptions)
             .build()
-            .getService();
-    DatabaseClientImpl client =
-        (DatabaseClientImpl)
-            spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+            .getService()) {
+      DatabaseClientImpl client =
+          (DatabaseClientImpl)
+              spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+      Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    try (TransactionManager manager = client.transactionManager()) {
-      TransactionContext transaction = manager.begin();
-      while (true) {
-        try {
-          transaction.executeUpdate(UPDATE_STATEMENT);
-          poolMaintainerClock.currentTimeMillis += Duration.ofMillis(1050).toMillis();
+      try (TransactionManager manager = client.transactionManager()) {
+        TransactionContext transaction = manager.begin();
+        while (true) {
+          try {
+            transaction.executeUpdate(UPDATE_STATEMENT);
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMillis(1050).toMillis());
 
-          transaction.executeUpdate(UPDATE_STATEMENT);
-          poolMaintainerClock.currentTimeMillis += Duration.ofMillis(2050).toMillis();
+            transaction.executeUpdate(UPDATE_STATEMENT);
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMillis(2050).toMillis());
 
-          // force trigger pool maintainer to check for long-running sessions
-          client.pool.poolMaintainer.maintainPool();
+            // force trigger pool maintainer to check for long-running sessions
+            client.pool.poolMaintainer.maintainPool();
 
-          manager.commit();
-          assertNotNull(manager.getCommitTimestamp());
-          break;
-        } catch (AbortedException e) {
-          transaction = manager.resetForRetry();
+            manager.commit();
+            assertNotNull(manager.getCommitTimestamp());
+            break;
+          } catch (AbortedException e) {
+            transaction = manager.resetForRetry();
+          }
         }
       }
-    }
-    Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+      Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    assertNotEquals(
-        endExecutionTime,
-        initialExecutionTime); // if session clean up task runs then these timings won't match
-    assertEquals(0, client.pool.numLeakedSessionsRemoved());
-    assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+      assertNotEquals(
+          endExecutionTime,
+          initialExecutionTime); // if session clean up task runs then these timings won't match
+      assertEquals(0, client.pool.numLeakedSessionsRemoved());
+      assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+    }
   }
 
   @Test
@@ -775,7 +780,7 @@ public class DatabaseClientImplTest {
             .setLoopFrequency(1000L) // main thread runs every 1s
             .setPoolMaintainerClock(poolMaintainerClock)
             .build();
-    spanner =
+    try (Spanner spanner =
         SpannerOptions.newBuilder()
             .setProjectId(TEST_PROJECT)
             .setDatabaseRole(TEST_DATABASE_ROLE)
@@ -783,56 +788,55 @@ public class DatabaseClientImplTest {
             .setCredentials(NoCredentials.getInstance())
             .setSessionPoolOption(sessionPoolOptions)
             .build()
-            .getService();
-    DatabaseClientImpl client =
-        (DatabaseClientImpl)
-            spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+            .getService()) {
+      DatabaseClientImpl client =
+          (DatabaseClientImpl)
+              spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+      Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    try (TransactionManager manager = client.transactionManager()) {
-      TransactionContext transaction = manager.begin();
-      while (true) {
-        try {
-          try (ResultSet resultSet =
-              transaction.read(
-                  READ_TABLE_NAME,
-                  KeySet.singleKey(Key.of(1L)),
-                  READ_COLUMN_NAMES,
-                  Options.priority(RpcPriority.HIGH))) {
+      try (TransactionManager manager = client.transactionManager()) {
+        TransactionContext transaction = manager.begin();
+        while (true) {
+          try {
+            try (ResultSet resultSet =
+                transaction.read(
+                    READ_TABLE_NAME,
+                    KeySet.singleKey(Key.of(1L)),
+                    READ_COLUMN_NAMES,
+                    Options.priority(RpcPriority.HIGH))) {
+              consumeResults(resultSet);
+            }
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMillis(1050).toMillis());
 
-            while (resultSet.next()) {}
+            try (ResultSet resultSet =
+                transaction.read(
+                    READ_TABLE_NAME,
+                    KeySet.singleKey(Key.of(1L)),
+                    READ_COLUMN_NAMES,
+                    Options.priority(RpcPriority.HIGH))) {
+              consumeResults(resultSet);
+            }
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMillis(2050).toMillis());
+
+            // force trigger pool maintainer to check for long-running sessions
+            client.pool.poolMaintainer.maintainPool();
+
+            manager.commit();
+            assertNotNull(manager.getCommitTimestamp());
+            break;
+          } catch (AbortedException e) {
+            transaction = manager.resetForRetry();
           }
-          poolMaintainerClock.currentTimeMillis += Duration.ofMillis(1050).toMillis();
-
-          try (ResultSet resultSet =
-              transaction.read(
-                  READ_TABLE_NAME,
-                  KeySet.singleKey(Key.of(1L)),
-                  READ_COLUMN_NAMES,
-                  Options.priority(RpcPriority.HIGH))) {
-
-            while (resultSet.next()) {}
-          }
-          poolMaintainerClock.currentTimeMillis += Duration.ofMillis(2050).toMillis();
-
-          // force trigger pool maintainer to check for long-running sessions
-          client.pool.poolMaintainer.maintainPool();
-
-          manager.commit();
-          assertNotNull(manager.getCommitTimestamp());
-          break;
-        } catch (AbortedException e) {
-          transaction = manager.resetForRetry();
         }
       }
-    }
-    Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+      Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    assertNotEquals(
-        endExecutionTime,
-        initialExecutionTime); // if session clean up task runs then these timings won't match
-    assertEquals(0, client.pool.numLeakedSessionsRemoved());
-    assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+      assertNotEquals(
+          endExecutionTime,
+          initialExecutionTime); // if session clean up task runs then these timings won't match
+      assertEquals(0, client.pool.numLeakedSessionsRemoved());
+      assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+    }
   }
 
   @Test
@@ -855,7 +859,7 @@ public class DatabaseClientImplTest {
             .setLoopFrequency(1000L) // main thread runs every 1s
             .setPoolMaintainerClock(poolMaintainerClock)
             .build();
-    spanner =
+    try (Spanner spanner =
         SpannerOptions.newBuilder()
             .setProjectId(TEST_PROJECT)
             .setDatabaseRole(TEST_DATABASE_ROLE)
@@ -863,42 +867,43 @@ public class DatabaseClientImplTest {
             .setCredentials(NoCredentials.getInstance())
             .setSessionPoolOption(sessionPoolOptions)
             .build()
-            .getService();
-    DatabaseClientImpl client =
-        (DatabaseClientImpl)
-            spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+            .getService()) {
+      DatabaseClientImpl client =
+          (DatabaseClientImpl)
+              spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+      Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    try (TransactionManager manager = client.transactionManager()) {
-      TransactionContext transaction = manager.begin();
-      while (true) {
-        try {
-          transaction.readRow(READ_TABLE_NAME, Key.of(1L), READ_COLUMN_NAMES);
+      try (TransactionManager manager = client.transactionManager()) {
+        TransactionContext transaction = manager.begin();
+        while (true) {
+          try {
+            transaction.readRow(READ_TABLE_NAME, Key.of(1L), READ_COLUMN_NAMES);
 
-          poolMaintainerClock.currentTimeMillis += Duration.ofMillis(1050).toMillis();
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMillis(1050).toMillis());
 
-          transaction.readRow(READ_TABLE_NAME, Key.of(1L), READ_COLUMN_NAMES);
+            transaction.readRow(READ_TABLE_NAME, Key.of(1L), READ_COLUMN_NAMES);
 
-          poolMaintainerClock.currentTimeMillis += Duration.ofMillis(2050).toMillis();
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMillis(2050).toMillis());
 
-          // force trigger pool maintainer to check for long-running sessions
-          client.pool.poolMaintainer.maintainPool();
+            // force trigger pool maintainer to check for long-running sessions
+            client.pool.poolMaintainer.maintainPool();
 
-          manager.commit();
-          assertNotNull(manager.getCommitTimestamp());
-          break;
-        } catch (AbortedException e) {
-          transaction = manager.resetForRetry();
+            manager.commit();
+            assertNotNull(manager.getCommitTimestamp());
+            break;
+          } catch (AbortedException e) {
+            transaction = manager.resetForRetry();
+          }
         }
       }
-    }
-    Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+      Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    assertNotEquals(
-        endExecutionTime,
-        initialExecutionTime); // if session clean up task runs then these timings won't match
-    assertEquals(0, client.pool.numLeakedSessionsRemoved());
-    assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+      assertNotEquals(
+          endExecutionTime,
+          initialExecutionTime); // if session clean up task runs then these timings won't match
+      assertEquals(0, client.pool.numLeakedSessionsRemoved());
+      assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+    }
   }
 
   @Test
@@ -921,7 +926,7 @@ public class DatabaseClientImplTest {
             .setLoopFrequency(1000L) // main thread runs every 1s
             .setPoolMaintainerClock(poolMaintainerClock)
             .build();
-    spanner =
+    try (Spanner spanner =
         SpannerOptions.newBuilder()
             .setProjectId(TEST_PROJECT)
             .setDatabaseRole(TEST_DATABASE_ROLE)
@@ -929,46 +934,47 @@ public class DatabaseClientImplTest {
             .setCredentials(NoCredentials.getInstance())
             .setSessionPoolOption(sessionPoolOptions)
             .build()
-            .getService();
-    DatabaseClientImpl client =
-        (DatabaseClientImpl)
-            spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+            .getService()) {
+      DatabaseClientImpl client =
+          (DatabaseClientImpl)
+              spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+      Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    try (TransactionManager manager = client.transactionManager()) {
-      TransactionContext transaction = manager.begin();
-      while (true) {
-        try {
-          try (ResultSet resultSet =
-              transaction.analyzeUpdateStatement(UPDATE_STATEMENT, QueryAnalyzeMode.PROFILE); ) {
-            while (resultSet.next()) {}
+      try (TransactionManager manager = client.transactionManager()) {
+        TransactionContext transaction = manager.begin();
+        while (true) {
+          try {
+            try (ResultSet resultSet =
+                transaction.analyzeUpdateStatement(UPDATE_STATEMENT, QueryAnalyzeMode.PROFILE)) {
+              consumeResults(resultSet);
+            }
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMillis(1050).toMillis());
+
+            try (ResultSet resultSet =
+                transaction.analyzeUpdateStatement(UPDATE_STATEMENT, QueryAnalyzeMode.PROFILE)) {
+              consumeResults(resultSet);
+            }
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMillis(2050).toMillis());
+
+            // force trigger pool maintainer to check for long-running sessions
+            client.pool.poolMaintainer.maintainPool();
+
+            manager.commit();
+            assertNotNull(manager.getCommitTimestamp());
+            break;
+          } catch (AbortedException e) {
+            transaction = manager.resetForRetry();
           }
-          poolMaintainerClock.currentTimeMillis += Duration.ofMillis(1050).toMillis();
-
-          try (ResultSet resultSet =
-              transaction.analyzeUpdateStatement(UPDATE_STATEMENT, QueryAnalyzeMode.PROFILE); ) {
-            while (resultSet.next()) {}
-          }
-          poolMaintainerClock.currentTimeMillis += Duration.ofMillis(2050).toMillis();
-
-          // force trigger pool maintainer to check for long-running sessions
-          client.pool.poolMaintainer.maintainPool();
-
-          manager.commit();
-          assertNotNull(manager.getCommitTimestamp());
-          break;
-        } catch (AbortedException e) {
-          transaction = manager.resetForRetry();
         }
       }
-    }
-    Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+      Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    assertNotEquals(
-        endExecutionTime,
-        initialExecutionTime); // if session clean up task runs then these timings won't match
-    assertEquals(0, client.pool.numLeakedSessionsRemoved());
-    assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+      assertNotEquals(
+          endExecutionTime,
+          initialExecutionTime); // if session clean up task runs then these timings won't match
+      assertEquals(0, client.pool.numLeakedSessionsRemoved());
+      assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+    }
   }
 
   @Test
@@ -991,7 +997,7 @@ public class DatabaseClientImplTest {
             .setLoopFrequency(1000L) // main thread runs every 1s
             .setPoolMaintainerClock(poolMaintainerClock)
             .build();
-    spanner =
+    try (Spanner spanner =
         SpannerOptions.newBuilder()
             .setProjectId(TEST_PROJECT)
             .setDatabaseRole(TEST_DATABASE_ROLE)
@@ -999,42 +1005,43 @@ public class DatabaseClientImplTest {
             .setCredentials(NoCredentials.getInstance())
             .setSessionPoolOption(sessionPoolOptions)
             .build()
-            .getService();
-    DatabaseClientImpl client =
-        (DatabaseClientImpl)
-            spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+            .getService()) {
+      DatabaseClientImpl client =
+          (DatabaseClientImpl)
+              spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+      Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    try (TransactionManager manager = client.transactionManager()) {
-      TransactionContext transaction = manager.begin();
-      while (true) {
-        try {
-          transaction.batchUpdate(Lists.newArrayList(UPDATE_STATEMENT));
+      try (TransactionManager manager = client.transactionManager()) {
+        TransactionContext transaction = manager.begin();
+        while (true) {
+          try {
+            transaction.batchUpdate(Lists.newArrayList(UPDATE_STATEMENT));
 
-          poolMaintainerClock.currentTimeMillis += Duration.ofMillis(1050).toMillis();
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMillis(1050).toMillis());
 
-          transaction.batchUpdate(Lists.newArrayList(UPDATE_STATEMENT));
+            transaction.batchUpdate(Lists.newArrayList(UPDATE_STATEMENT));
 
-          poolMaintainerClock.currentTimeMillis += Duration.ofMillis(2050).toMillis();
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMillis(2050).toMillis());
 
-          // force trigger pool maintainer to check for long-running sessions
-          client.pool.poolMaintainer.maintainPool();
+            // force trigger pool maintainer to check for long-running sessions
+            client.pool.poolMaintainer.maintainPool();
 
-          manager.commit();
-          assertNotNull(manager.getCommitTimestamp());
-          break;
-        } catch (AbortedException e) {
-          transaction = manager.resetForRetry();
+            manager.commit();
+            assertNotNull(manager.getCommitTimestamp());
+            break;
+          } catch (AbortedException e) {
+            transaction = manager.resetForRetry();
+          }
         }
       }
-    }
-    Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+      Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    assertNotEquals(
-        endExecutionTime,
-        initialExecutionTime); // if session clean up task runs then these timings won't match
-    assertEquals(0, client.pool.numLeakedSessionsRemoved());
-    assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+      assertNotEquals(
+          endExecutionTime,
+          initialExecutionTime); // if session clean up task runs then these timings won't match
+      assertEquals(0, client.pool.numLeakedSessionsRemoved());
+      assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+    }
   }
 
   @Test
@@ -1057,7 +1064,7 @@ public class DatabaseClientImplTest {
             .setLoopFrequency(1000L) // main thread runs every 1s
             .setPoolMaintainerClock(poolMaintainerClock)
             .build();
-    spanner =
+    try (Spanner spanner =
         SpannerOptions.newBuilder()
             .setProjectId(TEST_PROJECT)
             .setDatabaseRole(TEST_DATABASE_ROLE)
@@ -1065,42 +1072,43 @@ public class DatabaseClientImplTest {
             .setCredentials(NoCredentials.getInstance())
             .setSessionPoolOption(sessionPoolOptions)
             .build()
-            .getService();
-    DatabaseClientImpl client =
-        (DatabaseClientImpl)
-            spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+            .getService()) {
+      DatabaseClientImpl client =
+          (DatabaseClientImpl)
+              spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+      Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    try (TransactionManager manager = client.transactionManager()) {
-      TransactionContext transaction = manager.begin();
-      while (true) {
-        try {
-          transaction.batchUpdateAsync(Lists.newArrayList(UPDATE_STATEMENT));
+      try (TransactionManager manager = client.transactionManager()) {
+        TransactionContext transaction = manager.begin();
+        while (true) {
+          try {
+            transaction.batchUpdateAsync(Lists.newArrayList(UPDATE_STATEMENT));
 
-          poolMaintainerClock.currentTimeMillis += Duration.ofMillis(1050).toMillis();
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMillis(1050).toMillis());
 
-          transaction.batchUpdateAsync(Lists.newArrayList(UPDATE_STATEMENT));
+            transaction.batchUpdateAsync(Lists.newArrayList(UPDATE_STATEMENT));
 
-          poolMaintainerClock.currentTimeMillis += Duration.ofMillis(2050).toMillis();
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMillis(2050).toMillis());
 
-          // force trigger pool maintainer to check for long-running sessions
-          client.pool.poolMaintainer.maintainPool();
+            // force trigger pool maintainer to check for long-running sessions
+            client.pool.poolMaintainer.maintainPool();
 
-          manager.commit();
-          assertNotNull(manager.getCommitTimestamp());
-          break;
-        } catch (AbortedException e) {
-          transaction = manager.resetForRetry();
+            manager.commit();
+            assertNotNull(manager.getCommitTimestamp());
+            break;
+          } catch (AbortedException e) {
+            transaction = manager.resetForRetry();
+          }
         }
       }
-    }
-    Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+      Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    assertNotEquals(
-        endExecutionTime,
-        initialExecutionTime); // if session clean up task runs then these timings won't match
-    assertEquals(0, client.pool.numLeakedSessionsRemoved());
-    assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+      assertNotEquals(
+          endExecutionTime,
+          initialExecutionTime); // if session clean up task runs then these timings won't match
+      assertEquals(0, client.pool.numLeakedSessionsRemoved());
+      assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+    }
   }
 
   @Test
@@ -1123,7 +1131,7 @@ public class DatabaseClientImplTest {
             .setLoopFrequency(1000L) // main thread runs every 1s
             .setPoolMaintainerClock(poolMaintainerClock)
             .build();
-    spanner =
+    try (Spanner spanner =
         SpannerOptions.newBuilder()
             .setProjectId(TEST_PROJECT)
             .setDatabaseRole(TEST_DATABASE_ROLE)
@@ -1131,44 +1139,45 @@ public class DatabaseClientImplTest {
             .setCredentials(NoCredentials.getInstance())
             .setSessionPoolOption(sessionPoolOptions)
             .build()
-            .getService();
-    DatabaseClientImpl client =
-        (DatabaseClientImpl)
-            spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+            .getService()) {
+      DatabaseClientImpl client =
+          (DatabaseClientImpl)
+              spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+      Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    try (TransactionManager manager = client.transactionManager()) {
-      TransactionContext transaction = manager.begin();
-      while (true) {
-        try {
-          try (ResultSet resultSet = transaction.executeQuery(SELECT1)) {
-            while (resultSet.next()) {}
+      try (TransactionManager manager = client.transactionManager()) {
+        TransactionContext transaction = manager.begin();
+        while (true) {
+          try {
+            try (ResultSet resultSet = transaction.executeQuery(SELECT1)) {
+              consumeResults(resultSet);
+            }
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMillis(1050).toMillis());
+
+            try (ResultSet resultSet = transaction.executeQuery(SELECT1)) {
+              consumeResults(resultSet);
+            }
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMillis(2050).toMillis());
+
+            // force trigger pool maintainer to check for long-running sessions
+            client.pool.poolMaintainer.maintainPool();
+
+            manager.commit();
+            assertNotNull(manager.getCommitTimestamp());
+            break;
+          } catch (AbortedException e) {
+            transaction = manager.resetForRetry();
           }
-          poolMaintainerClock.currentTimeMillis += Duration.ofMillis(1050).toMillis();
-
-          try (ResultSet resultSet = transaction.executeQuery(SELECT1)) {
-            while (resultSet.next()) {}
-          }
-          poolMaintainerClock.currentTimeMillis += Duration.ofMillis(2050).toMillis();
-
-          // force trigger pool maintainer to check for long-running sessions
-          client.pool.poolMaintainer.maintainPool();
-
-          manager.commit();
-          assertNotNull(manager.getCommitTimestamp());
-          break;
-        } catch (AbortedException e) {
-          transaction = manager.resetForRetry();
         }
       }
-    }
-    Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+      Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    assertNotEquals(
-        endExecutionTime,
-        initialExecutionTime); // if session clean up task runs then these timings won't match
-    assertEquals(0, client.pool.numLeakedSessionsRemoved());
-    assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+      assertNotEquals(
+          endExecutionTime,
+          initialExecutionTime); // if session clean up task runs then these timings won't match
+      assertEquals(0, client.pool.numLeakedSessionsRemoved());
+      assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+    }
   }
 
   @Test
@@ -1191,7 +1200,7 @@ public class DatabaseClientImplTest {
             .setLoopFrequency(1000L) // main thread runs every 1s
             .setPoolMaintainerClock(poolMaintainerClock)
             .build();
-    spanner =
+    try (Spanner spanner =
         SpannerOptions.newBuilder()
             .setProjectId(TEST_PROJECT)
             .setDatabaseRole(TEST_DATABASE_ROLE)
@@ -1199,44 +1208,45 @@ public class DatabaseClientImplTest {
             .setCredentials(NoCredentials.getInstance())
             .setSessionPoolOption(sessionPoolOptions)
             .build()
-            .getService();
-    DatabaseClientImpl client =
-        (DatabaseClientImpl)
-            spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+            .getService()) {
+      DatabaseClientImpl client =
+          (DatabaseClientImpl)
+              spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+      Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    try (TransactionManager manager = client.transactionManager()) {
-      TransactionContext transaction = manager.begin();
-      while (true) {
-        try {
-          try (ResultSet resultSet = transaction.executeQueryAsync(SELECT1)) {
-            while (resultSet.next()) {}
+      try (TransactionManager manager = client.transactionManager()) {
+        TransactionContext transaction = manager.begin();
+        while (true) {
+          try {
+            try (ResultSet resultSet = transaction.executeQueryAsync(SELECT1)) {
+              consumeResults(resultSet);
+            }
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMillis(1050).toMillis());
+
+            try (ResultSet resultSet = transaction.executeQueryAsync(SELECT1)) {
+              consumeResults(resultSet);
+            }
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMillis(2050).toMillis());
+
+            // force trigger pool maintainer to check for long-running sessions
+            client.pool.poolMaintainer.maintainPool();
+
+            manager.commit();
+            assertNotNull(manager.getCommitTimestamp());
+            break;
+          } catch (AbortedException e) {
+            transaction = manager.resetForRetry();
           }
-          poolMaintainerClock.currentTimeMillis += Duration.ofMillis(1050).toMillis();
-
-          try (ResultSet resultSet = transaction.executeQueryAsync(SELECT1)) {
-            while (resultSet.next()) {}
-          }
-          poolMaintainerClock.currentTimeMillis += Duration.ofMillis(2050).toMillis();
-
-          // force trigger pool maintainer to check for long-running sessions
-          client.pool.poolMaintainer.maintainPool();
-
-          manager.commit();
-          assertNotNull(manager.getCommitTimestamp());
-          break;
-        } catch (AbortedException e) {
-          transaction = manager.resetForRetry();
         }
       }
-    }
-    Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+      Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    assertNotEquals(
-        endExecutionTime,
-        initialExecutionTime); // if session clean up task runs then these timings won't match
-    assertEquals(0, client.pool.numLeakedSessionsRemoved());
-    assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+      assertNotEquals(
+          endExecutionTime,
+          initialExecutionTime); // if session clean up task runs then these timings won't match
+      assertEquals(0, client.pool.numLeakedSessionsRemoved());
+      assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+    }
   }
 
   @Test
@@ -1259,7 +1269,7 @@ public class DatabaseClientImplTest {
             .setLoopFrequency(1000L) // main thread runs every 1s
             .setPoolMaintainerClock(poolMaintainerClock)
             .build();
-    spanner =
+    try (Spanner spanner =
         SpannerOptions.newBuilder()
             .setProjectId(TEST_PROJECT)
             .setDatabaseRole(TEST_DATABASE_ROLE)
@@ -1267,44 +1277,47 @@ public class DatabaseClientImplTest {
             .setCredentials(NoCredentials.getInstance())
             .setSessionPoolOption(sessionPoolOptions)
             .build()
-            .getService();
-    DatabaseClientImpl client =
-        (DatabaseClientImpl)
-            spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+            .getService()) {
+      DatabaseClientImpl client =
+          (DatabaseClientImpl)
+              spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+      Instant initialExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    try (TransactionManager manager = client.transactionManager()) {
-      TransactionContext transaction = manager.begin();
-      while (true) {
-        try {
-          try (ResultSet resultSet = transaction.analyzeQuery(SELECT1, QueryAnalyzeMode.PROFILE)) {
-            while (resultSet.next()) {}
+      try (TransactionManager manager = client.transactionManager()) {
+        TransactionContext transaction = manager.begin();
+        while (true) {
+          try {
+            try (ResultSet resultSet =
+                transaction.analyzeQuery(SELECT1, QueryAnalyzeMode.PROFILE)) {
+              consumeResults(resultSet);
+            }
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMillis(1050).toMillis());
+
+            try (ResultSet resultSet =
+                transaction.analyzeQuery(SELECT1, QueryAnalyzeMode.PROFILE)) {
+              consumeResults(resultSet);
+            }
+            poolMaintainerClock.currentTimeMillis.addAndGet(Duration.ofMillis(2050).toMillis());
+
+            // force trigger pool maintainer to check for long-running sessions
+            client.pool.poolMaintainer.maintainPool();
+
+            manager.commit();
+            assertNotNull(manager.getCommitTimestamp());
+            break;
+          } catch (AbortedException e) {
+            transaction = manager.resetForRetry();
           }
-          poolMaintainerClock.currentTimeMillis += Duration.ofMillis(1050).toMillis();
-
-          try (ResultSet resultSet = transaction.analyzeQuery(SELECT1, QueryAnalyzeMode.PROFILE)) {
-            while (resultSet.next()) {}
-          }
-          poolMaintainerClock.currentTimeMillis += Duration.ofMillis(2050).toMillis();
-
-          // force trigger pool maintainer to check for long-running sessions
-          client.pool.poolMaintainer.maintainPool();
-
-          manager.commit();
-          assertNotNull(manager.getCommitTimestamp());
-          break;
-        } catch (AbortedException e) {
-          transaction = manager.resetForRetry();
         }
       }
-    }
-    Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
+      Instant endExecutionTime = client.pool.poolMaintainer.lastExecutionTime;
 
-    assertNotEquals(
-        endExecutionTime,
-        initialExecutionTime); // if session clean up task runs then these timings won't match
-    assertEquals(0, client.pool.numLeakedSessionsRemoved());
-    assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+      assertNotEquals(
+          endExecutionTime,
+          initialExecutionTime); // if session clean up task runs then these timings won't match
+      assertEquals(0, client.pool.numLeakedSessionsRemoved());
+      assertTrue(client.pool.getNumberOfSessionsInPool() <= client.pool.totalSessions());
+    }
   }
 
   @Test
@@ -1489,11 +1502,9 @@ public class DatabaseClientImplTest {
   public void testBatchWriteAtLeastOnceWithOptions() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    ServerStream<BatchWriteResponse> responseStream =
-        client.batchWriteAtLeastOnce(MUTATION_GROUPS, Options.priority(RpcPriority.LOW));
-    for (BatchWriteResponse response : responseStream) {}
+    consumeBatchWriteStream(
+        client.batchWriteAtLeastOnce(MUTATION_GROUPS, Options.priority(RpcPriority.LOW)));
 
-    assertNotNull(responseStream);
     List<BatchWriteRequest> requests = mockSpanner.getRequestsOfType(BatchWriteRequest.class);
     assertEquals(requests.size(), 1);
     BatchWriteRequest request = requests.get(0);
@@ -1505,11 +1516,9 @@ public class DatabaseClientImplTest {
   public void testBatchWriteAtLeastOnceWithTagOptions() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    ServerStream<BatchWriteResponse> responseStream =
-        client.batchWriteAtLeastOnce(MUTATION_GROUPS, Options.tag("app=spanner,env=test"));
-    for (BatchWriteResponse response : responseStream) {}
+    consumeBatchWriteStream(
+        client.batchWriteAtLeastOnce(MUTATION_GROUPS, Options.tag("app=spanner,env=test")));
 
-    assertNotNull(responseStream);
     List<BatchWriteRequest> requests = mockSpanner.getRequestsOfType(BatchWriteRequest.class);
     assertEquals(requests.size(), 1);
     BatchWriteRequest request = requests.get(0);
@@ -1526,7 +1535,7 @@ public class DatabaseClientImplTest {
         client
             .singleUse()
             .executeQuery(SELECT1, Options.tag("app=spanner,env=test,action=query"))) {
-      while (resultSet.next()) {}
+      consumeResults(resultSet);
     }
 
     List<ExecuteSqlRequest> requests = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class);
@@ -1544,7 +1553,7 @@ public class DatabaseClientImplTest {
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
     try (ResultSet resultSet =
         client.singleUse().executeQuery(SELECT1, Options.directedRead(DIRECTED_READ_OPTIONS1))) {
-      while (resultSet.next()) {}
+      consumeResults(resultSet);
     }
 
     List<ExecuteSqlRequest> requests = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class);
@@ -1567,7 +1576,7 @@ public class DatabaseClientImplTest {
         spannerWithDirectedReadOptions.getDatabaseClient(
             DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
     try (ResultSet resultSet = client.singleUse().executeQuery(SELECT1)) {
-      while (resultSet.next()) {}
+      consumeResults(resultSet);
     }
 
     List<ExecuteSqlRequest> requests = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class);
@@ -1591,7 +1600,7 @@ public class DatabaseClientImplTest {
             DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
     try (ResultSet resultSet =
         client.singleUse().executeQuery(SELECT1, Options.directedRead(DIRECTED_READ_OPTIONS1))) {
-      while (resultSet.next()) {}
+      consumeResults(resultSet);
     }
 
     List<ExecuteSqlRequest> requests = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class);
@@ -1613,7 +1622,7 @@ public class DatabaseClientImplTest {
                 KeySet.singleKey(Key.of(1L)),
                 READ_COLUMN_NAMES,
                 Options.tag("app=spanner,env=test,action=read"))) {
-      while (resultSet.next()) {}
+      consumeResults(resultSet);
     }
 
     List<ReadRequest> requests = mockSpanner.getRequestsOfType(ReadRequest.class);
@@ -1637,7 +1646,7 @@ public class DatabaseClientImplTest {
                 KeySet.singleKey(Key.of(1L)),
                 READ_COLUMN_NAMES,
                 Options.directedRead(DIRECTED_READ_OPTIONS1))) {
-      while (resultSet.next()) {}
+      consumeResults(resultSet);
     }
 
     List<ReadRequest> requests = mockSpanner.getRequestsOfType(ReadRequest.class);
@@ -1661,7 +1670,7 @@ public class DatabaseClientImplTest {
             DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
     try (ResultSet resultSet =
         client.singleUse().read(READ_TABLE_NAME, KeySet.singleKey(Key.of(1L)), READ_COLUMN_NAMES)) {
-      while (resultSet.next()) {}
+      consumeResults(resultSet);
     }
 
     List<ReadRequest> requests = mockSpanner.getRequestsOfType(ReadRequest.class);
@@ -1687,7 +1696,7 @@ public class DatabaseClientImplTest {
     runner.run(
         transaction -> {
           try (ResultSet resultSet = transaction.executeQuery(SELECT1)) {
-            while (resultSet.next()) {}
+            consumeResults(resultSet);
           }
           return null;
         });
@@ -1708,7 +1717,7 @@ public class DatabaseClientImplTest {
         transaction -> {
           try (ResultSet resultSet =
               transaction.executeQuery(SELECT1, Options.tag("app=spanner,env=test,action=query"))) {
-            while (resultSet.next()) {}
+            consumeResults(resultSet);
           }
           return null;
         });
@@ -1737,7 +1746,7 @@ public class DatabaseClientImplTest {
                   KeySet.singleKey(Key.of(1L)),
                   READ_COLUMN_NAMES,
                   Options.tag("app=spanner,env=test,action=read"))) {
-            while (resultSet.next()) {}
+            consumeResults(resultSet);
           }
           return null;
         });
@@ -1835,11 +1844,12 @@ public class DatabaseClientImplTest {
   public void testTransactionManagerCommitWithTag() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    TransactionManager manager =
-        client.transactionManager(Options.tag("app=spanner,env=test,action=manager"));
-    TransactionContext transaction = manager.begin();
-    transaction.buffer(Mutation.delete("TEST", KeySet.all()));
-    manager.commit();
+    try (TransactionManager manager =
+        client.transactionManager(Options.tag("app=spanner,env=test,action=manager"))) {
+      TransactionContext transaction = manager.begin();
+      transaction.buffer(Mutation.delete("TEST", KeySet.all()));
+      manager.commit();
+    }
 
     List<CommitRequest> requests = mockSpanner.getRequestsOfType(CommitRequest.class);
     assertThat(requests).hasSize(1);
@@ -2257,7 +2267,7 @@ public class DatabaseClientImplTest {
             txn -> ApiFutures.immediateFuture(txn.executeUpdate(INVALID_UPDATE_STATEMENT)),
             executor);
 
-    ExecutionException e = assertThrows(ExecutionException.class, () -> fut.get());
+    ExecutionException e = assertThrows(ExecutionException.class, fut::get);
     assertThat(e.getCause()).isInstanceOf(SpannerException.class);
     SpannerException se = (SpannerException) e.getCause();
     assertThat(se.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
@@ -2265,7 +2275,6 @@ public class DatabaseClientImplTest {
     executor.shutdown();
   }
 
-  @SuppressWarnings("resource")
   @Test
   public void testTransactionManager() {
     DatabaseClient client =
@@ -2285,7 +2294,6 @@ public class DatabaseClientImplTest {
     }
   }
 
-  @SuppressWarnings("resource")
   @Test
   public void testTransactionManager_returnsCommitStats() {
     DatabaseClient client =
@@ -2307,7 +2315,6 @@ public class DatabaseClientImplTest {
     }
   }
 
-  @SuppressWarnings("resource")
   @Test
   public void transactionManagerIsNonBlocking() throws Exception {
     mockSpanner.freeze();
@@ -2323,6 +2330,7 @@ public class DatabaseClientImplTest {
           txManager.commit();
           break;
         } catch (AbortedException e) {
+          //noinspection BusyWait
           Thread.sleep(e.getRetryDelayInMillis());
           transaction = txManager.resetForRetry();
         }
@@ -2330,9 +2338,8 @@ public class DatabaseClientImplTest {
     }
   }
 
-  @SuppressWarnings("resource")
   @Test
-  public void transactionManagerExecuteQueryAsync() throws Exception {
+  public void transactionManagerExecuteQueryAsync() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
     final AtomicInteger rowCount = new AtomicInteger();
@@ -2470,7 +2477,7 @@ public class DatabaseClientImplTest {
       DatabaseClient client =
           spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
       assertThat(spanner.getOptions().getPartitionedDmlTimeout()).isEqualTo(Duration.ofMillis(10L));
-      // PDML should timeout with these settings.
+      // PDML should time out with these settings.
       mockSpanner.setExecuteSqlExecutionTime(
           SimulatedExecutionTime.ofMinimumAndRandomTime(1000, 0));
       SpannerException e =
@@ -2478,9 +2485,9 @@ public class DatabaseClientImplTest {
               SpannerException.class, () -> client.executePartitionedUpdate(UPDATE_STATEMENT));
       assertEquals(ErrorCode.DEADLINE_EXCEEDED, e.getErrorCode());
 
-      // Normal DML should not timeout.
+      // Normal DML should not time out.
       mockSpanner.setExecuteSqlExecutionTime(SimulatedExecutionTime.ofMinimumAndRandomTime(10, 0));
-      long updateCount =
+      Long updateCount =
           client
               .readWriteTransaction()
               .run(transaction -> transaction.executeUpdate(UPDATE_STATEMENT));
@@ -2580,6 +2587,7 @@ public class DatabaseClientImplTest {
         Stopwatch watch = Stopwatch.createStarted();
         while (watch.elapsed(TimeUnit.SECONDS) < 5
             && dbClient.pool.getNumberOfSessionsBeingCreated() > 0) {
+          //noinspection BusyWait
           Thread.sleep(1L);
         }
         // All session creation should fail and stop trying.
@@ -2618,11 +2626,11 @@ public class DatabaseClientImplTest {
                     DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
         // The create session failure should propagate to the client and not retry.
         try (ResultSet rs = dbClient.singleUse().executeQuery(SELECT1)) {
-          assertThrows(ResourceNotFoundException.class, () -> rs.next());
+          assertThrows(ResourceNotFoundException.class, rs::next);
           // The server should only receive one BatchCreateSessions request.
           assertThat(mockSpanner.getRequests()).hasSize(1);
         }
-        assertThrows(ResourceNotFoundException.class, () -> dbClient.readWriteTransaction());
+        assertThrows(ResourceNotFoundException.class, dbClient::readWriteTransaction);
         // No additional requests should have been sent by the client.
         assertThat(mockSpanner.getRequests()).hasSize(1);
       }
@@ -2658,6 +2666,7 @@ public class DatabaseClientImplTest {
         Stopwatch watch = Stopwatch.createStarted();
         while (watch.elapsed(TimeUnit.SECONDS) < 5
             && dbClient.pool.getNumberOfSessionsBeingCreated() > 0) {
+          //noinspection BusyWait
           Thread.sleep(1L);
         }
         // All session creation should fail and stop trying.
@@ -2666,9 +2675,10 @@ public class DatabaseClientImplTest {
         // Force a maintainer run. This should schedule new session creation.
         dbClient.pool.poolMaintainer.maintainPool();
         // Wait until the replenish has finished.
-        watch = watch.reset().start();
+        watch.reset().start();
         while (watch.elapsed(TimeUnit.SECONDS) < 5
             && dbClient.pool.getNumberOfSessionsBeingCreated() > 0) {
+          //noinspection BusyWait
           Thread.sleep(1L);
         }
         // All session creation from replenishPool should fail and stop trying.
@@ -2710,6 +2720,7 @@ public class DatabaseClientImplTest {
         Stopwatch watch = Stopwatch.createStarted();
         while (watch.elapsed(TimeUnit.SECONDS) < 5
             && (dbClient.pool.getNumberOfSessionsBeingCreated() > 0)) {
+          //noinspection BusyWait
           Thread.sleep(1L);
         }
         // Simulate that the database or instance has been deleted.
@@ -2718,7 +2729,7 @@ public class DatabaseClientImplTest {
 
         // All subsequent calls should fail with a DatabaseNotFoundException.
         try (ResultSet rs = dbClient.singleUse().executeQuery(SELECT1)) {
-          assertThrows(ResourceNotFoundException.class, () -> rs.next());
+          assertThrows(ResourceNotFoundException.class, rs::next);
         }
         assertThrows(
             ResourceNotFoundException.class,
@@ -2745,7 +2756,7 @@ public class DatabaseClientImplTest {
         assertThat(newClient).isNotSameInstanceAs(dbClient);
         // Executing a query should now work without problems.
         try (ResultSet rs = newClient.singleUse().executeQuery(SELECT1)) {
-          while (rs.next()) {}
+          consumeResults(rs);
         }
         assertThat(mockSpanner.getRequests()).isNotEmpty();
       }
@@ -2807,6 +2818,7 @@ public class DatabaseClientImplTest {
     Stopwatch watch = Stopwatch.createStarted();
     while (watch.elapsed(TimeUnit.SECONDS) < 5
         && client.pool.getNumberOfSessionsInPool() < minSessions) {
+      //noinspection BusyWait
       Thread.sleep(1L);
     }
     assertThat(client.pool.getNumberOfSessionsInPool()).isEqualTo(minSessions);
@@ -2838,6 +2850,7 @@ public class DatabaseClientImplTest {
     while (watch.elapsed(TimeUnit.SECONDS) < 5
         && (client1.pool.getNumberOfSessionsInPool() < minSessions
             || client2.pool.getNumberOfSessionsInPool() < minSessions)) {
+      //noinspection BusyWait
       Thread.sleep(1L);
     }
     assertThat(client1.pool.getNumberOfSessionsInPool()).isEqualTo(minSessions);
@@ -2869,6 +2882,7 @@ public class DatabaseClientImplTest {
                                   return 0L;
                                 }
                               });
+                  assertNotNull(add);
                   try (ResultSet rs = transaction.executeQuery(SELECT1)) {
                     if (rs.next()) {
                       return add + rs.getLong(0);
@@ -2908,7 +2922,7 @@ public class DatabaseClientImplTest {
                               .build())
                       .build())) {
         // Just iterate over the results to execute the query.
-        while (rs.next()) {}
+        consumeResults(rs);
       }
       // Check that the last query was executed using a custom optimizer version and statistics
       // package.
@@ -2949,7 +2963,7 @@ public class DatabaseClientImplTest {
                     .build(),
                 QueryAnalyzeMode.PROFILE)) {
           // Just iterate over the results to execute the query.
-          while (rs.next()) {}
+          consumeResults(rs);
         }
       }
       // Check that the last query was executed using a custom optimizer version and statistics
@@ -2996,7 +3010,7 @@ public class DatabaseClientImplTest {
               Options.directedRead(DIRECTED_READ_OPTIONS1));
       try (ResultSet rs = transaction.execute(partitions.get(0))) {
         // Just iterate over the results to execute the query.
-        while (rs.next()) {}
+        consumeResults(rs);
       } finally {
         transaction.cleanup();
       }
@@ -3046,7 +3060,7 @@ public class DatabaseClientImplTest {
                   .build());
       try (ResultSet rs = transaction.execute(partitions.get(0))) {
         // Just iterate over the results to execute the query.
-        while (rs.next()) {}
+        consumeResults(rs);
       } finally {
         transaction.cleanup();
       }
@@ -3092,7 +3106,7 @@ public class DatabaseClientImplTest {
               Options.directedRead(DIRECTED_READ_OPTIONS1));
       try (ResultSet rs = transaction.execute(partitions.get(0))) {
         // Just iterate over the results to execute the query.
-        while (rs.next()) {}
+        consumeResults(rs);
       } finally {
         transaction.cleanup();
       }
@@ -3134,6 +3148,7 @@ public class DatabaseClientImplTest {
               Lists.newArrayList("1"));
       try (ResultSet rs = transaction.execute(partitions.get(0))) {
         // Just iterate over the results to execute the query.
+        //noinspection StatementWithEmptyBody
         while (rs.next()) {}
       } finally {
         transaction.cleanup();
@@ -3245,7 +3260,7 @@ public class DatabaseClientImplTest {
       // The following call is non-blocking and will not generate an exception.
       ResultSet rs = client.singleUse().executeQuery(SELECT1);
       // Actually trying to get any results will cause an exception.
-      SpannerException e = assertThrows(SpannerException.class, () -> rs.next());
+      SpannerException e = assertThrows(SpannerException.class, rs::next);
       assertEquals(ErrorCode.PERMISSION_DENIED, e.getErrorCode());
     }
   }
@@ -3262,7 +3277,7 @@ public class DatabaseClientImplTest {
             .singleUse()
             .executeQuery(
                 Statement.newBuilder("SELECT * FROM FOO WHERE ID=@id").bind("id").to(1L).build())) {
-      SpannerException e = assertThrows(SpannerException.class, () -> rs.next());
+      SpannerException e = assertThrows(SpannerException.class, rs::next);
       assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
       assertThat(e.getMessage()).contains("Statement: 'SELECT * FROM FOO WHERE ID=@id'");
       // The error message should normally not include the parameter values to prevent sensitive
@@ -3281,7 +3296,7 @@ public class DatabaseClientImplTest {
             .executeQuery(
                 Statement.newBuilder("SELECT * FROM FOO WHERE ID=@id").bind("id").to(1L).build())) {
       logger.setLevel(Level.FINEST);
-      SpannerException e = assertThrows(SpannerException.class, () -> rs.next());
+      SpannerException e = assertThrows(SpannerException.class, rs::next);
       // With log level set to FINEST the error should also include the parameter values.
       assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
       assertThat(e.getMessage()).contains("Statement: 'SELECT * FROM FOO WHERE ID=@id {id: 1}'");
@@ -3299,7 +3314,7 @@ public class DatabaseClientImplTest {
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
     try (ResultSet rs =
         client.singleUse().read("FOO", KeySet.singleKey(Key.of(1L)), ImmutableList.of("BAR"))) {
-      SpannerException e = assertThrows(SpannerException.class, () -> rs.next());
+      SpannerException e = assertThrows(SpannerException.class, rs::next);
       assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
       assertThat(e.getMessage()).doesNotContain("Statement:");
     }
@@ -3320,7 +3335,7 @@ public class DatabaseClientImplTest {
             () -> {
               // Query should fail with a timeout.
               try (ResultSet rs = client.singleUse().executeQuery(SELECT1)) {
-                SpannerException e = assertThrows(SpannerException.class, () -> rs.next());
+                SpannerException e = assertThrows(SpannerException.class, rs::next);
                 assertThat(e.getErrorCode()).isEqualTo(ErrorCode.DEADLINE_EXCEEDED);
               }
               // Update should succeed.
@@ -3342,7 +3357,7 @@ public class DatabaseClientImplTest {
       // This will not cause any failure as getting a session from the pool is guaranteed to be
       // non-blocking, and any exceptions will be delayed until actual query execution.
       try (ResultSet rs = client.singleUse().executeQuery(SELECT1)) {
-        SpannerException e = assertThrows(SpannerException.class, () -> rs.next());
+        SpannerException e = assertThrows(SpannerException.class, rs::next);
         assertThat(e.getErrorCode()).isEqualTo(ErrorCode.RESOURCE_EXHAUSTED);
       }
     } finally {
@@ -3371,9 +3386,9 @@ public class DatabaseClientImplTest {
     TransactionOption option = mock(TransactionOption.class);
 
     DatabaseClientImpl client = new DatabaseClientImpl(pool);
-    client.transactionManager(option);
-
-    verify(session).transactionManager(option);
+    try (TransactionManager ignore = client.transactionManager(option)) {
+      verify(session).transactionManager(option);
+    }
   }
 
   @Test
@@ -3397,9 +3412,9 @@ public class DatabaseClientImplTest {
     TransactionOption option = mock(TransactionOption.class);
 
     DatabaseClientImpl client = new DatabaseClientImpl(pool);
-    client.transactionManagerAsync(option);
-
-    verify(session).transactionManagerAsync(option);
+    try (AsyncTransactionManager ignore = client.transactionManagerAsync(option)) {
+      verify(session).transactionManagerAsync(option);
+    }
   }
 
   @Test
@@ -3408,6 +3423,7 @@ public class DatabaseClientImplTest {
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
     try (ResultSet resultSet =
         client.singleUse().executeQuery(SELECT1, Options.priority(RpcPriority.HIGH))) {
+      //noinspection StatementWithEmptyBody
       while (resultSet.next()) {}
     }
 
@@ -3430,6 +3446,7 @@ public class DatabaseClientImplTest {
                 KeySet.singleKey(Key.of(1L)),
                 READ_COLUMN_NAMES,
                 Options.priority(RpcPriority.HIGH))) {
+      //noinspection StatementWithEmptyBody
       while (resultSet.next()) {}
     }
 
@@ -3449,6 +3466,7 @@ public class DatabaseClientImplTest {
         transaction -> {
           try (ResultSet resultSet =
               transaction.executeQuery(SELECT1, Options.priority(RpcPriority.HIGH))) {
+            //noinspection StatementWithEmptyBody
             while (resultSet.next()) {}
           }
           return null;
@@ -3474,6 +3492,7 @@ public class DatabaseClientImplTest {
                   KeySet.singleKey(Key.of(1L)),
                   READ_COLUMN_NAMES,
                   Options.priority(RpcPriority.HIGH))) {
+            //noinspection StatementWithEmptyBody
             while (resultSet.next()) {}
           }
           return null;
@@ -3555,10 +3574,12 @@ public class DatabaseClientImplTest {
   public void testTransactionManagerCommitWithPriority() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    TransactionManager manager = client.transactionManager(Options.priority(RpcPriority.HIGH));
-    TransactionContext transaction = manager.begin();
-    transaction.buffer(Mutation.delete("TEST", KeySet.all()));
-    manager.commit();
+    try (TransactionManager manager =
+        client.transactionManager(Options.priority(RpcPriority.HIGH))) {
+      TransactionContext transaction = manager.begin();
+      transaction.buffer(Mutation.delete("TEST", KeySet.all()));
+      manager.commit();
+    }
 
     List<CommitRequest> requests = mockSpanner.getRequestsOfType(CommitRequest.class);
     assertThat(requests).hasSize(1);
@@ -3694,16 +3715,16 @@ public class DatabaseClientImplTest {
               ctx = transactionContext;
             }
             try (ResultSet rs = ctx.executeQuery(SELECT1)) {
+              //noinspection StatementWithEmptyBody
               while (rs.next()) {}
             }
             return 1L;
           }
         };
-    assertEquals(Long.valueOf(1L), client.readWriteTransaction().run(tx -> function.apply(tx)));
+    assertEquals(Long.valueOf(1L), client.readWriteTransaction().run(function::apply));
     SpannerException exception =
         assertThrows(
-            SpannerException.class,
-            () -> client.readWriteTransaction().run(tx -> function.apply(tx)));
+            SpannerException.class, () -> client.readWriteTransaction().run(function::apply));
     assertTrue(exception.getMessage().contains("Context has been closed"));
   }
 
@@ -4595,5 +4616,15 @@ public class DatabaseClientImplTest {
     assertEquals(
         expected.stream().collect(Collectors.joining(",", "[", "]")),
         resultSet.getValue(col).getAsString());
+  }
+
+  private void consumeResults(ResultSet resultSet) {
+    //noinspection StatementWithEmptyBody
+    while (resultSet.next()) {}
+  }
+
+  private void consumeBatchWriteStream(ServerStream<BatchWriteResponse> stream) {
+    //noinspection StatementWithEmptyBody
+    for (BatchWriteResponse ignore : stream) {}
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/FakeClock.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/FakeClock.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.spanner;
 
+import java.util.concurrent.atomic.AtomicLong;
 import org.threeten.bp.Instant;
 
 /**
@@ -22,10 +23,10 @@ import org.threeten.bp.Instant;
  * tests.
  */
 class FakeClock extends Clock {
-  volatile long currentTimeMillis;
+  final AtomicLong currentTimeMillis = new AtomicLong();
 
   @Override
   public Instant instant() {
-    return Instant.ofEpochMilli(currentTimeMillis);
+    return Instant.ofEpochMilli(currentTimeMillis.get());
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolLeakTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolLeakTest.java
@@ -148,6 +148,7 @@ public class SessionPoolLeakTest {
       // This will cause a session leak.
       ReadOnlyTransaction transaction = client.readOnlyTransaction();
       try (ResultSet resultSet = transaction.executeQuery(Statement.of("SELECT 1"))) {
+        //noinspection StatementWithEmptyBody
         while (resultSet.next()) {
           // ignore
         }
@@ -218,7 +219,7 @@ public class SessionPoolLeakTest {
     assertEquals(0, pool.getNumberOfSessionsInPool());
     setup.run();
     try (TransactionManager txManager = client.transactionManager()) {
-      SpannerException e = assertThrows(SpannerException.class, () -> txManager.begin());
+      SpannerException e = assertThrows(SpannerException.class, txManager::begin);
       assertEquals(ErrorCode.FAILED_PRECONDITION, e.getErrorCode());
     }
     assertEquals(expectedNumberOfSessionsAfterExecution, pool.getNumberOfSessionsInPool());

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerTest.java
@@ -154,7 +154,8 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
     // Now advance the time enough for both sessions in the pool to be idled. Then do one
     // maintenance loop. This should cause the last session to have been checked back into the pool
     // to get a ping, but not the second session.
-    clock.currentTimeMillis += TimeUnit.MINUTES.toMillis(options.getKeepAliveIntervalMinutes()) + 1;
+    clock.currentTimeMillis.addAndGet(
+        TimeUnit.MINUTES.toMillis(options.getKeepAliveIntervalMinutes()) + 1);
     runMaintenanceLoop(clock, pool, 1);
     assertThat(pingedSessions).containsExactly(session1.getName(), 1);
     // Do another maintenance loop. This should cause the other session to also get a ping.
@@ -174,13 +175,15 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
     session4.close();
     session3.close();
     // Advance the clock to force pings for the sessions in the pool and do three maintenance loops.
-    clock.currentTimeMillis += TimeUnit.MINUTES.toMillis(options.getKeepAliveIntervalMinutes()) + 1;
+    clock.currentTimeMillis.addAndGet(
+        TimeUnit.MINUTES.toMillis(options.getKeepAliveIntervalMinutes()) + 1);
     runMaintenanceLoop(clock, pool, 3);
     assertThat(pingedSessions).containsExactly(session1.getName(), 2, session2.getName(), 2);
 
     // Advance the clock to idle all sessions in the pool again and then check out one session. This
     // should cause only one session to get a ping.
-    clock.currentTimeMillis += TimeUnit.MINUTES.toMillis(options.getKeepAliveIntervalMinutes()) + 1;
+    clock.currentTimeMillis.addAndGet(
+        TimeUnit.MINUTES.toMillis(options.getKeepAliveIntervalMinutes()) + 1);
     // We are now checking out session2 because
     Session session6 = pool.getSession();
     // The session that was first in the pool now is equal to the initial first session as each full
@@ -210,7 +213,8 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
     session8.close();
     session9.close();
 
-    clock.currentTimeMillis += TimeUnit.MINUTES.toMillis(options.getKeepAliveIntervalMinutes()) + 1;
+    clock.currentTimeMillis.addAndGet(
+        TimeUnit.MINUTES.toMillis(options.getKeepAliveIntervalMinutes()) + 1);
     runMaintenanceLoop(clock, pool, 3);
     // session1 will not get a ping this time, as it was checked in first and is now the last
     // session in the pool.

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
@@ -68,7 +68,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nonnull;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -78,6 +82,20 @@ import org.threeten.bp.Duration;
 /** Unit tests for {@link com.google.cloud.spanner.SpannerOptions}. */
 @RunWith(JUnit4.class)
 public class SpannerOptionsTest {
+  private static Level originalLogLevel;
+
+  @BeforeClass
+  public static void disableLogging() {
+    Logger logger = Logger.getLogger("");
+    originalLogLevel = logger.getLevel();
+    logger.setLevel(Level.OFF);
+  }
+
+  @AfterClass
+  public static void resetLogging() {
+    Logger logger = Logger.getLogger("");
+    logger.setLevel(originalLogLevel);
+  }
 
   @Test
   public void defaultBuilder() {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementTimeoutTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementTimeoutTest.java
@@ -88,7 +88,7 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
   ITConnection createConnection() {
     ConnectionOptions options =
         ConnectionOptions.newBuilder()
-            .setUri(getBaseUrl())
+            .setUri(getBaseUrl() + ";trackSessionLeaks=false")
             .setConfigurator(
                 optionsConfigurator ->
                     optionsConfigurator
@@ -508,13 +508,14 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
 
                   thread.set(Thread.currentThread());
                   latch.countDown();
-                  try (ResultSet rs = connection.executeQuery(SELECT_RANDOM_STATEMENT)) {}
+                  //noinspection EmptyTryBlock
+                  try (ResultSet ignore = connection.executeQuery(SELECT_RANDOM_STATEMENT)) {}
                   return false;
                 } catch (SpannerException e) {
                   return e.getErrorCode() == ErrorCode.CANCELLED;
                 }
               });
-      latch.await(10L, TimeUnit.SECONDS);
+      assertTrue(latch.await(10L, TimeUnit.SECONDS));
       waitForRequestsToContain(ExecuteSqlRequest.class);
       thread.get().interrupt();
       assertTrue(future.get());


### PR DESCRIPTION
Several tests spammed the build log with various warnings and other log items that were irrelevant for the test output. This change removes as much as possible of that.