### PR TITLE
perf: optimize critical path for executeQuery

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -580,19 +580,17 @@ abstract class AbstractReadContext
   @VisibleForTesting
   QueryOptions buildQueryOptions(QueryOptions requestOptions) {
     // Shortcut for the most common return value.
-    if (defaultQueryOptions.equals(QueryOptions.getDefaultInstance()) && requestOptions == null) {
-      return QueryOptions.getDefaultInstance();
+    if (requestOptions == null) {
+      return defaultQueryOptions;
     }
-    // Create a builder based on the default query options.
-    QueryOptions.Builder builder = defaultQueryOptions.toBuilder();
-    // Then overwrite with specific options for this query.
-    if (requestOptions != null) {
-      builder.mergeFrom(requestOptions);
-    }
-    return builder.build();
+    return defaultQueryOptions.toBuilder().mergeFrom(requestOptions).build();
   }
 
   RequestOptions buildRequestOptions(Options options) {
+    if (!(options.hasPriority() || options.hasTag() || getTransactionTag() != null)) {
+      return RequestOptions.getDefaultInstance();
+    }
+
     RequestOptions.Builder builder = RequestOptions.newBuilder();
     if (options.hasPriority()) {
       builder.setPriority(options.priority());

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
@@ -1090,7 +1090,7 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
     private final RetrySettings streamingRetrySettings;
     private final Set<Code> retryableCodes;
     private static final Logger logger = Logger.getLogger(ResumableStreamIterator.class.getName());
-    private final BackOff backOff;
+    private BackOff backOff;
     private final LinkedList<PartialResultSet> buffer = new LinkedList<>();
     private final int maxBufferSize;
     private final Span span;
@@ -1115,7 +1115,6 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
       this.span = tracer.spanBuilderWithExplicitParent(streamName, parent).startSpan();
       this.streamingRetrySettings = Preconditions.checkNotNull(streamingRetrySettings);
       this.retryableCodes = Preconditions.checkNotNull(retryableCodes);
-      this.backOff = newBackOff();
     }
 
     private ExponentialBackOff newBackOff() {
@@ -1289,6 +1288,9 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
               if (delay != -1) {
                 backoffSleep(context, delay);
               } else {
+                if (backOff == null) {
+                  backOff = newBackOff();
+                }
                 backoffSleep(context, backOff);
               }
             }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ForwardingResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ForwardingResultSet.java
@@ -17,10 +17,10 @@
 package com.google.cloud.spanner;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.spanner.v1.ResultSetMetadata;
 import com.google.spanner.v1.ResultSetStats;
+import java.util.function.Supplier;
 
 /** Forwarding implementation of ResultSet that forwards all calls to a delegate. */
 public class ForwardingResultSet extends ForwardingStructReader implements ResultSet {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ForwardingStructReader.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ForwardingStructReader.java
@@ -20,10 +20,10 @@ import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.function.Supplier;
 
 /** Forwarding implements of StructReader */
 public class ForwardingStructReader implements StructReader {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -99,7 +99,7 @@ class SessionImpl implements Session {
   ByteString readyTransactionId;
   private final Map<SpannerRpc.Option, ?> options;
   private Span currentSpan;
-  private volatile Instant lastUseTime;
+  private Instant lastUseTime;
 
   SessionImpl(SpannerImpl spanner, String name, Map<SpannerRpc.Option, ?> options) {
     this.spanner = spanner;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
@@ -440,7 +440,7 @@ public class SessionPoolOptions {
      * actual session leak is detected. The stack trace of the exception will in that case not
      * contain the call stack of when the session was checked out.
      */
-    private boolean trackStackTraceOfSessionCheckout = true;
+    private boolean trackStackTraceOfSessionCheckout = false;
 
     private InactiveTransactionRemovalOptions inactiveTransactionRemovalOptions =
         InactiveTransactionRemovalOptions.newBuilder().build();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -105,10 +105,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -1904,7 +1904,7 @@ public class DatabaseClientImplTest {
     DatabaseClientImpl client =
         (DatabaseClientImpl)
             spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Set<PooledSessionFuture> checkedOut = client.pool.checkedOutSessions;
+    Collection<PooledSessionFuture> checkedOut = client.pool.checkedOutSessions;
     assertThat(checkedOut).isEmpty();
     try (ResultSet rs = client.singleUse().executeQuery(SELECT1)) {
       assertThat(rs.next()).isTrue();
@@ -3617,7 +3617,7 @@ public class DatabaseClientImplTest {
     DatabaseClientImpl client =
         (DatabaseClientImpl)
             spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Set<PooledSessionFuture> checkedOut = client.pool.checkedOutSessions;
+    Collection<PooledSessionFuture> checkedOut = client.pool.checkedOutSessions;
     assertThat(checkedOut).isEmpty();
 
     // Getting a single use read-only transaction and not using it should not cause any sessions
@@ -3632,7 +3632,7 @@ public class DatabaseClientImplTest {
     DatabaseClientImpl client =
         (DatabaseClientImpl)
             spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Set<PooledSessionFuture> checkedOut = client.pool.checkedOutSessions;
+    Collection<PooledSessionFuture> checkedOut = client.pool.checkedOutSessions;
     assertThat(checkedOut).isEmpty();
 
     client.singleUseReadOnlyTransaction().close();
@@ -3645,7 +3645,7 @@ public class DatabaseClientImplTest {
     DatabaseClientImpl client =
         (DatabaseClientImpl)
             spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Set<PooledSessionFuture> checkedOut = client.pool.checkedOutSessions;
+    Collection<PooledSessionFuture> checkedOut = client.pool.checkedOutSessions;
     assertThat(checkedOut).isEmpty();
 
     client.readWriteTransaction();
@@ -3658,7 +3658,7 @@ public class DatabaseClientImplTest {
     DatabaseClientImpl client =
         (DatabaseClientImpl)
             spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Set<PooledSessionFuture> checkedOut = client.pool.checkedOutSessions;
+    Collection<PooledSessionFuture> checkedOut = client.pool.checkedOutSessions;
     assertThat(checkedOut).isEmpty();
 
     client.readOnlyTransaction().close();
@@ -3671,7 +3671,7 @@ public class DatabaseClientImplTest {
     DatabaseClientImpl client =
         (DatabaseClientImpl)
             spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Set<PooledSessionFuture> checkedOut = client.pool.checkedOutSessions;
+    Collection<PooledSessionFuture> checkedOut = client.pool.checkedOutSessions;
     assertThat(checkedOut).isEmpty();
 
     client.transactionManager().close();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractMockServerTest.java
@@ -19,7 +19,6 @@ package com.google.cloud.spanner.connection;
 import com.google.cloud.spanner.ForceCloseSpannerFunction;
 import com.google.cloud.spanner.MockSpannerServiceImpl;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
-import com.google.cloud.spanner.RandomResultSetGenerator;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.admin.database.v1.MockDatabaseAdminImpl;
 import com.google.cloud.spanner.admin.instance.v1.MockInstanceAdminImpl;
@@ -121,7 +120,8 @@ public abstract class AbstractMockServerTest {
   public static final int RANDOM_RESULT_SET_ROW_COUNT = 100;
   public static final Statement SELECT_RANDOM_STATEMENT = Statement.of("SELECT * FROM RANDOM");
   public static final com.google.spanner.v1.ResultSet RANDOM_RESULT_SET =
-      new RandomResultSetGenerator(RANDOM_RESULT_SET_ROW_COUNT).generate();
+      SELECT_COUNT_RESULTSET_AFTER_INSERT;
+  //      new RandomResultSetGenerator(RANDOM_RESULT_SET_ROW_COUNT).generate();
 
   public static MockSpannerServiceImpl mockSpanner;
   public static MockInstanceAdminImpl mockInstanceAdmin;


### PR DESCRIPTION
Removes some unnecessary calls from the critical path for executing a query.
