### PR TITLE
chore: README for google-cloud-spanner-executor module

### DIFF
--- a/google-cloud-spanner-executor/README.md
+++ b/google-cloud-spanner-executor/README.md
@@ -1,0 +1,4 @@
+This module is for Google-internal use ([details](
+http://go/cloud-spanner-client-testing-design)).
+This is not for customers.
+


### PR DESCRIPTION
The google-cloud-spanner-executor module is not for Spanner library users. Adding a note to avoid confusion for those who browse this repository.