### PR TITLE
fix: remove google-cloud-spanner-executor from the BOM

### DIFF
--- a/google-cloud-spanner-bom/pom.xml
+++ b/google-cloud-spanner-bom/pom.xml
@@ -57,11 +57,6 @@
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-spanner-executor</artifactId>
-        <version>6.56.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-spanner-executor:current} -->
-      </dependency>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-spanner</artifactId>
         <type>test-jar</type>
         <version>6.56.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-spanner:current} -->


### PR DESCRIPTION
google-cloud-spanner-executor is for Google-internal use. No customers should use it. It has been added to the BOM accidentally. (b/320677880)

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-spanner/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
