### PR TITLE
test: update proto columns test

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Value.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Value.java
@@ -1749,9 +1749,15 @@ public abstract class Value implements Serializable {
       return com.google.protobuf.Value.newBuilder().setStringValue(base64EncodedString).build();
     }
 
+    @Nonnull
+    @Override
+    public String getAsString() {
+      return value == null ? NULL_STRING : value.toBase64();
+    }
+
     @Override
     void valueToString(StringBuilder b) {
-      b.append(value.toString());
+      b.append(value.toBase64());
     }
   }
 
@@ -2387,7 +2393,7 @@ public abstract class Value implements Serializable {
 
     @Override
     void appendElement(StringBuilder b, ByteArray element) {
-      b.append(element.toString());
+      b.append(element.toBase64());
     }
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -57,6 +57,8 @@ import com.google.cloud.spanner.ReadContext.QueryAnalyzeMode;
 import com.google.cloud.spanner.SessionPool.PooledSessionFuture;
 import com.google.cloud.spanner.SessionPoolOptions.ActionOnInactiveTransaction;
 import com.google.cloud.spanner.SessionPoolOptions.InactiveTransactionRemovalOptions;
+import com.google.cloud.spanner.SingerProto.Genre;
+import com.google.cloud.spanner.SingerProto.SingerInfo;
 import com.google.cloud.spanner.SpannerException.ResourceNotFoundException;
 import com.google.cloud.spanner.SpannerOptions.CallContextConfigurator;
 import com.google.cloud.spanner.SpannerOptions.SpannerCallContextTimeoutConfigurator;
@@ -3950,6 +3952,7 @@ public class DatabaseClientImplTest {
 
   @Test
   public void testGetAllTypesAsString() {
+    SingerInfo info = SingerInfo.newBuilder().setSingerId(1).build();
     for (Dialect dialect : Dialect.values()) {
       Statement statement = Statement.of("select * from all_types");
       mockSpanner.putStatementResult(
@@ -3959,205 +3962,7 @@ public class DatabaseClientImplTest {
                   .setMetadata(
                       RandomResultSetGenerator.generateAllTypesMetadata(
                           RandomResultSetGenerator.generateAllTypes(dialect)))
-                  .addRows(
-                      ListValue.newBuilder()
-                          .addValues(
-                              com.google.protobuf.Value.newBuilder().setBoolValue(true).build())
-                          .addValues(
-                              com.google.protobuf.Value.newBuilder().setStringValue("100").build())
-                          .addValues(
-                              com.google.protobuf.Value.newBuilder().setNumberValue(3.14d).build())
-                          .addValues(
-                              com.google.protobuf.Value.newBuilder()
-                                  .setStringValue("6.626")
-                                  .build())
-                          .addValues(
-                              com.google.protobuf.Value.newBuilder()
-                                  .setStringValue("test-string")
-                                  .build())
-                          .addValues(
-                              com.google.protobuf.Value.newBuilder()
-                                  .setStringValue("{\"key1\": \"value1\"}")
-                                  .build())
-                          .addValues(
-                              com.google.protobuf.Value.newBuilder()
-                                  .setStringValue(
-                                      Base64.getEncoder()
-                                          .encodeToString(
-                                              "test-bytes".getBytes(StandardCharsets.UTF_8)))
-                                  .build())
-                          .addValues(
-                              com.google.protobuf.Value.newBuilder()
-                                  .setStringValue("2023-01-11")
-                                  .build())
-                          .addValues(
-                              com.google.protobuf.Value.newBuilder()
-                                  .setStringValue("2023-01-11T11:55:18.123456789Z")
-                                  .build())
-                          .addValues(
-                              com.google.protobuf.Value.newBuilder()
-                                  .setListValue(
-                                      ListValue.newBuilder()
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setBoolValue(true)
-                                                  .build())
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setNullValue(NullValue.NULL_VALUE)
-                                                  .build())
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setBoolValue(false)
-                                                  .build())
-                                          .build()))
-                          .addValues(
-                              com.google.protobuf.Value.newBuilder()
-                                  .setListValue(
-                                      ListValue.newBuilder()
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setStringValue(String.valueOf(Long.MAX_VALUE))
-                                                  .build())
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setStringValue(String.valueOf(Long.MIN_VALUE))
-                                                  .build())
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setNullValue(NullValue.NULL_VALUE)
-                                                  .build())
-                                          .build()))
-                          .addValues(
-                              com.google.protobuf.Value.newBuilder()
-                                  .setListValue(
-                                      ListValue.newBuilder()
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setNullValue(NullValue.NULL_VALUE)
-                                                  .build())
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setNumberValue(-12345.6789d)
-                                                  .build())
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setNumberValue(3.14d)
-                                                  .build())
-                                          .build()))
-                          .addValues(
-                              com.google.protobuf.Value.newBuilder()
-                                  .setListValue(
-                                      ListValue.newBuilder()
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setStringValue("6.626")
-                                                  .build())
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setNullValue(NullValue.NULL_VALUE)
-                                                  .build())
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setStringValue("-8.9123")
-                                                  .build())
-                                          .build()))
-                          .addValues(
-                              com.google.protobuf.Value.newBuilder()
-                                  .setListValue(
-                                      ListValue.newBuilder()
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setStringValue("test-string1")
-                                                  .build())
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setNullValue(NullValue.NULL_VALUE)
-                                                  .build())
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setStringValue("test-string2")
-                                                  .build())
-                                          .build()))
-                          .addValues(
-                              com.google.protobuf.Value.newBuilder()
-                                  .setListValue(
-                                      ListValue.newBuilder()
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setStringValue("{\"key\": \"value1\"}")
-                                                  .build())
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setStringValue("{\"key\": \"value2\"}")
-                                                  .build())
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setNullValue(NullValue.NULL_VALUE)
-                                                  .build())
-                                          .build()))
-                          .addValues(
-                              com.google.protobuf.Value.newBuilder()
-                                  .setListValue(
-                                      ListValue.newBuilder()
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setStringValue(
-                                                      Base64.getEncoder()
-                                                          .encodeToString(
-                                                              "test-bytes1"
-                                                                  .getBytes(
-                                                                      StandardCharsets.UTF_8)))
-                                                  .build())
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setStringValue(
-                                                      Base64.getEncoder()
-                                                          .encodeToString(
-                                                              "test-bytes2"
-                                                                  .getBytes(
-                                                                      StandardCharsets.UTF_8)))
-                                                  .build())
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setNullValue(NullValue.NULL_VALUE)
-                                                  .build())
-                                          .build()))
-                          .addValues(
-                              com.google.protobuf.Value.newBuilder()
-                                  .setListValue(
-                                      ListValue.newBuilder()
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setStringValue("2000-02-29")
-                                                  .build())
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setNullValue(NullValue.NULL_VALUE)
-                                                  .build())
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setStringValue("2000-01-01")
-                                                  .build())
-                                          .build()))
-                          .addValues(
-                              com.google.protobuf.Value.newBuilder()
-                                  .setListValue(
-                                      ListValue.newBuilder()
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setStringValue("2023-01-11T11:55:18.123456789Z")
-                                                  .build())
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setNullValue(NullValue.NULL_VALUE)
-                                                  .build())
-                                          .addValues(
-                                              com.google.protobuf.Value.newBuilder()
-                                                  .setStringValue("2023-01-12T11:55:18Z")
-                                                  .build())
-                                          .build()))
-                          .build())
+                  .addRows(getRows(dialect))
                   .build()));
 
       DatabaseClient client =
@@ -4209,7 +4014,18 @@ public class DatabaseClientImplTest {
             ImmutableList.of("2023-01-11T11:55:18.123456789Z", "NULL", "2023-01-12T11:55:18Z"),
             resultSet,
             col++);
-
+        if (dialect == Dialect.GOOGLE_STANDARD_SQL) {
+          assertAsString(Base64.getEncoder().encodeToString(info.toByteArray()), resultSet, col++);
+          assertAsString(String.valueOf(Genre.JAZZ_VALUE), resultSet, col++);
+          assertAsString(
+              ImmutableList.of(
+                  String.format("%s", Base64.getEncoder().encodeToString(info.toByteArray())),
+                  "NULL"),
+              resultSet,
+              col++);
+          assertAsString(
+              ImmutableList.of(String.format("%d", Genre.JAZZ_VALUE), "NULL"), resultSet, col++);
+        }
         assertFalse(resultSet.next());
       }
     }
@@ -4626,5 +4442,226 @@ public class DatabaseClientImplTest {
   private void consumeBatchWriteStream(ServerStream<BatchWriteResponse> stream) {
     //noinspection StatementWithEmptyBody
     for (BatchWriteResponse ignore : stream) {}
+  }
+
+  private ListValue getRows(Dialect dialect) {
+    SingerInfo info = SingerInfo.newBuilder().setSingerId(1).build();
+    ListValue.Builder valuesBuilder =
+        ListValue.newBuilder()
+            .addValues(com.google.protobuf.Value.newBuilder().setBoolValue(true).build())
+            .addValues(com.google.protobuf.Value.newBuilder().setStringValue("100").build())
+            .addValues(com.google.protobuf.Value.newBuilder().setNumberValue(3.14d).build())
+            .addValues(com.google.protobuf.Value.newBuilder().setStringValue("6.626").build())
+            .addValues(com.google.protobuf.Value.newBuilder().setStringValue("test-string").build())
+            .addValues(
+                com.google.protobuf.Value.newBuilder()
+                    .setStringValue("{\"key1\": \"value1\"}")
+                    .build())
+            .addValues(
+                com.google.protobuf.Value.newBuilder()
+                    .setStringValue(
+                        Base64.getEncoder()
+                            .encodeToString("test-bytes".getBytes(StandardCharsets.UTF_8)))
+                    .build())
+            .addValues(com.google.protobuf.Value.newBuilder().setStringValue("2023-01-11").build())
+            .addValues(
+                com.google.protobuf.Value.newBuilder()
+                    .setStringValue("2023-01-11T11:55:18.123456789Z")
+                    .build())
+            .addValues(
+                com.google.protobuf.Value.newBuilder()
+                    .setListValue(
+                        ListValue.newBuilder()
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder().setBoolValue(true).build())
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setNullValue(NullValue.NULL_VALUE)
+                                    .build())
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder().setBoolValue(false).build())
+                            .build()))
+            .addValues(
+                com.google.protobuf.Value.newBuilder()
+                    .setListValue(
+                        ListValue.newBuilder()
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setStringValue(String.valueOf(Long.MAX_VALUE))
+                                    .build())
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setStringValue(String.valueOf(Long.MIN_VALUE))
+                                    .build())
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setNullValue(NullValue.NULL_VALUE)
+                                    .build())
+                            .build()))
+            .addValues(
+                com.google.protobuf.Value.newBuilder()
+                    .setListValue(
+                        ListValue.newBuilder()
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setNullValue(NullValue.NULL_VALUE)
+                                    .build())
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setNumberValue(-12345.6789d)
+                                    .build())
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setNumberValue(3.14d)
+                                    .build())
+                            .build()))
+            .addValues(
+                com.google.protobuf.Value.newBuilder()
+                    .setListValue(
+                        ListValue.newBuilder()
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setStringValue("6.626")
+                                    .build())
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setNullValue(NullValue.NULL_VALUE)
+                                    .build())
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setStringValue("-8.9123")
+                                    .build())
+                            .build()))
+            .addValues(
+                com.google.protobuf.Value.newBuilder()
+                    .setListValue(
+                        ListValue.newBuilder()
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setStringValue("test-string1")
+                                    .build())
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setNullValue(NullValue.NULL_VALUE)
+                                    .build())
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setStringValue("test-string2")
+                                    .build())
+                            .build()))
+            .addValues(
+                com.google.protobuf.Value.newBuilder()
+                    .setListValue(
+                        ListValue.newBuilder()
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setStringValue("{\"key\": \"value1\"}")
+                                    .build())
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setStringValue("{\"key\": \"value2\"}")
+                                    .build())
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setNullValue(NullValue.NULL_VALUE)
+                                    .build())
+                            .build()))
+            .addValues(
+                com.google.protobuf.Value.newBuilder()
+                    .setListValue(
+                        ListValue.newBuilder()
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setStringValue(
+                                        Base64.getEncoder()
+                                            .encodeToString(
+                                                "test-bytes1".getBytes(StandardCharsets.UTF_8)))
+                                    .build())
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setStringValue(
+                                        Base64.getEncoder()
+                                            .encodeToString(
+                                                "test-bytes2".getBytes(StandardCharsets.UTF_8)))
+                                    .build())
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setNullValue(NullValue.NULL_VALUE)
+                                    .build())
+                            .build()))
+            .addValues(
+                com.google.protobuf.Value.newBuilder()
+                    .setListValue(
+                        ListValue.newBuilder()
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setStringValue("2000-02-29")
+                                    .build())
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setNullValue(NullValue.NULL_VALUE)
+                                    .build())
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setStringValue("2000-01-01")
+                                    .build())
+                            .build()))
+            .addValues(
+                com.google.protobuf.Value.newBuilder()
+                    .setListValue(
+                        ListValue.newBuilder()
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setStringValue("2023-01-11T11:55:18.123456789Z")
+                                    .build())
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setNullValue(NullValue.NULL_VALUE)
+                                    .build())
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setStringValue("2023-01-12T11:55:18Z")
+                                    .build())
+                            .build()));
+    if (dialect == Dialect.GOOGLE_STANDARD_SQL) {
+      // Proto columns is supported only for GOOGLE_STANDARD_SQL
+      valuesBuilder
+          .addValues(
+              com.google.protobuf.Value.newBuilder()
+                  .setStringValue(Base64.getEncoder().encodeToString(info.toByteArray()))
+                  .build())
+          .addValues(
+              com.google.protobuf.Value.newBuilder()
+                  .setStringValue(String.valueOf(Genre.JAZZ_VALUE))
+                  .build())
+          .addValues(
+              com.google.protobuf.Value.newBuilder()
+                  .setListValue(
+                      ListValue.newBuilder()
+                          .addValues(
+                              com.google.protobuf.Value.newBuilder()
+                                  .setStringValue(
+                                      Base64.getEncoder().encodeToString(info.toByteArray()))
+                                  .build())
+                          .addValues(
+                              com.google.protobuf.Value.newBuilder()
+                                  .setNullValue(NullValue.NULL_VALUE)
+                                  .build())
+                          .build()))
+          .addValues(
+              com.google.protobuf.Value.newBuilder()
+                  .setListValue(
+                      ListValue.newBuilder()
+                          .addValues(
+                              com.google.protobuf.Value.newBuilder()
+                                  .setStringValue(String.valueOf(Genre.JAZZ_VALUE))
+                                  .build())
+                          .addValues(
+                              com.google.protobuf.Value.newBuilder()
+                                  .setNullValue(NullValue.NULL_VALUE)
+                                  .build())
+                          .build()));
+    }
+    return valuesBuilder.build();
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/MergedResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/MergedResultSetTest.java
@@ -150,7 +150,7 @@ public class MergedResultSetTest {
       if (numPartitions == 0) {
         assertEquals(0, resultSet.getColumnCount());
       } else {
-        assertEquals(18, resultSet.getColumnCount());
+        assertEquals(22, resultSet.getColumnCount());
         assertEquals(Type.bool(), resultSet.getColumnType(0));
         assertEquals(Type.bool(), resultSet.getColumnType("COL0"));
         assertEquals(10, resultSet.getColumnIndex("COL10"));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/PartitionedQueryMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/PartitionedQueryMockServerTest.java
@@ -349,9 +349,9 @@ public class PartitionedQueryMockServerTest extends AbstractMockServerTest {
               statement, PartitionOptions.newBuilder().setMaxPartitions(maxPartitions).build())) {
         assertFalse(resultSet.next());
         assertNotNull(resultSet.getMetadata());
-        assertEquals(18, resultSet.getMetadata().getRowType().getFieldsCount());
+        assertEquals(22, resultSet.getMetadata().getRowType().getFieldsCount());
         assertNotNull(resultSet.getType());
-        assertEquals(18, resultSet.getType().getStructFields().size());
+        assertEquals(22, resultSet.getType().getStructFields().size());
       }
     }
     assertEquals(1, mockSpanner.countRequestsOfType(CreateSessionRequest.class));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/RandomResultSetGenerator.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/RandomResultSetGenerator.java
@@ -114,7 +114,7 @@ public class RandomResultSetGenerator {
                     .setArrayElementType(Type.newBuilder().setCode(TypeCode.TIMESTAMP))
                     .build()));
 
-    // appendProtoTypes(types, dialect);
+    appendProtoTypes(types, dialect);
     Type[] typeArray = new Type[types.size()];
     typeArray = types.toArray(typeArray);
     return typeArray;
@@ -123,8 +123,16 @@ public class RandomResultSetGenerator {
   /** To append Proto & Enum types * */
   private static void appendProtoTypes(List<Type> types, Dialect dialect) {
     if (dialect == Dialect.GOOGLE_STANDARD_SQL) {
-      types.add(Type.newBuilder().setCode(TypeCode.PROTO).setProtoTypeFqn("testProto").build());
-      types.add(Type.newBuilder().setCode(TypeCode.ENUM).setProtoTypeFqn("testEnum").build());
+      types.add(
+          Type.newBuilder()
+              .setCode(TypeCode.PROTO)
+              .setProtoTypeFqn(SingerInfo.getDescriptor().getFullName())
+              .build());
+      types.add(
+          Type.newBuilder()
+              .setCode(TypeCode.ENUM)
+              .setProtoTypeFqn(Genre.getDescriptor().getFullName())
+              .build());
       types.add(
           Type.newBuilder()
               .setCode(TypeCode.ARRAY)

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITProtoColumnTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITProtoColumnTest.java
@@ -304,7 +304,7 @@ public class ITProtoColumnTest {
             });
 
     // Read all rows based on Proto Message field and Proto Enum Primary key column values
-    ResultSet resultSet1 =
+    try (ResultSet resultSet1 =
         databaseClient
             .singleUse()
             .read(
@@ -313,40 +313,42 @@ public class ITProtoColumnTest {
                     .addKey(Key.of("Country1", Genre.FOLK))
                     .addKey(Key.of("Country2", Genre.JAZZ))
                     .build(),
-                Arrays.asList("SingerId", "FirstName", "LastName", "SingerInfo", "SingerGenre"));
+                Arrays.asList("SingerId", "FirstName", "LastName", "SingerInfo", "SingerGenre"))) {
+      resultSet1.next();
+      assertEquals(1, resultSet1.getLong("SingerId"));
+      assertEquals("FirstName1", resultSet1.getString("FirstName"));
+      assertEquals("LastName1", resultSet1.getString("LastName"));
+      assertEquals(
+          singerInfo1, resultSet1.getProtoMessage("SingerInfo", SingerInfo.getDefaultInstance()));
+      assertEquals(genre1, resultSet1.getProtoEnum("SingerGenre", Genre::forNumber));
 
-    resultSet1.next();
-    assertEquals(1, resultSet1.getLong("SingerId"));
-    assertEquals("FirstName1", resultSet1.getString("FirstName"));
-    assertEquals("LastName1", resultSet1.getString("LastName"));
-    assertEquals(
-        singerInfo1, resultSet1.getProtoMessage("SingerInfo", SingerInfo.getDefaultInstance()));
-    assertEquals(genre1, resultSet1.getProtoEnum("SingerGenre", Genre::forNumber));
-
-    resultSet1.next();
-    assertEquals(2, resultSet1.getLong("SingerId"));
-    assertEquals("FirstName2", resultSet1.getString("FirstName"));
-    assertEquals("LastName2", resultSet1.getString("LastName"));
-    assertEquals(
-        singerInfo2, resultSet1.getProtoMessage("SingerInfo", SingerInfo.getDefaultInstance()));
-    assertEquals(genre2, resultSet1.getProtoEnum("SingerGenre", Genre::forNumber));
+      resultSet1.next();
+      assertEquals(2, resultSet1.getLong("SingerId"));
+      assertEquals("FirstName2", resultSet1.getString("FirstName"));
+      assertEquals("LastName2", resultSet1.getString("LastName"));
+      assertEquals(
+          singerInfo2, resultSet1.getProtoMessage("SingerInfo", SingerInfo.getDefaultInstance()));
+      assertEquals(genre2, resultSet1.getProtoEnum("SingerGenre", Genre::forNumber));
+    }
 
     // Read rows using Index on Proto Message field and Proto Enum column
-    ResultSet resultSet2 =
+    try (ResultSet resultSet2 =
         databaseClient
             .singleUse()
             .readUsingIndex(
                 "Singers",
                 "SingerByNationalityAndGenre",
                 KeySet.singleKey(Key.of("Country2", Genre.JAZZ)),
-                Arrays.asList("SingerId", "FirstName", "LastName"));
-    resultSet2.next();
-    assertEquals(2, resultSet2.getLong("SingerId"));
-    assertEquals("FirstName2", resultSet2.getString("FirstName"));
-    assertEquals("LastName2", resultSet2.getString("LastName"));
+                Arrays.asList("SingerId", "FirstName", "LastName"))) {
+
+      resultSet2.next();
+      assertEquals(2, resultSet2.getLong("SingerId"));
+      assertEquals("FirstName2", resultSet2.getString("FirstName"));
+      assertEquals("LastName2", resultSet2.getString("LastName"));
+    }
 
     // Filter using Parameterized DQL
-    ResultSet resultSet3 =
+    try (ResultSet resultSet3 =
         databaseClient
             .singleUse()
             .executeQuery(
@@ -357,13 +359,13 @@ public class ITProtoColumnTest {
                     .to("Country2")
                     .bind("genre")
                     .to(Genre.JAZZ)
-                    .build());
-
-    resultSet3.next();
-    assertEquals(2, resultSet1.getLong("SingerId"));
-    assertEquals(
-        singerInfo2, resultSet1.getProtoMessage("SingerInfo", SingerInfo.getDefaultInstance()));
-    assertEquals(genre2, resultSet1.getProtoEnum("SingerGenre", Genre::forNumber));
+                    .build())) {
+      resultSet3.next();
+      assertEquals(2, resultSet3.getLong("SingerId"));
+      assertEquals(
+          singerInfo2, resultSet3.getProtoMessage("SingerInfo", SingerInfo.getDefaultInstance()));
+      assertEquals(genre2, resultSet3.getProtoEnum("SingerGenre", Genre::forNumber));
+    }
   }
 
   // Test the exception in case Invalid protocol message object is provided while deserializing the
@@ -385,18 +387,20 @@ public class ITProtoColumnTest {
                 .to(singerInfo)
                 .build()));
 
-    ResultSet resultSet =
+    try (ResultSet resultSet =
         databaseClient
             .singleUse()
-            .read("Types", KeySet.all(), Collections.singletonList("ProtoMessage"));
-    resultSet.next();
+            .read("Types", KeySet.all(), Collections.singletonList("ProtoMessage"))) {
 
-    SpannerException e =
-        assertThrows(
-            SpannerException.class,
-            () -> resultSet.getProtoMessage("ProtoMessage", Backup.getDefaultInstance()));
+      resultSet.next();
 
-    // Underlying cause is InvalidWireTypeException
-    assertEquals(InvalidWireTypeException.class, e.getCause().getClass());
+      SpannerException e =
+          assertThrows(
+              SpannerException.class,
+              () -> resultSet.getProtoMessage("ProtoMessage", Backup.getDefaultInstance()));
+
+      // Underlying cause is InvalidWireTypeException
+      assertEquals(InvalidWireTypeException.class, e.getCause().getClass());
+    }
   }
 }


### PR DESCRIPTION
This PR has the following changes in test files
1. Use `try-with-resource` block in Proto Columns integration tests to free up resources and sessions.
2. Add `PROTO` and `ENUM` types to `testGetAllTypesAsString` unit test.