### PR TITLE
fix: cast for Proto type

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
@@ -820,7 +820,8 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
         case INT64:
           return Value.int64(isNull ? null : getLongInternal(columnIndex));
         case ENUM:
-          return Value.protoEnum(getLongInternal(columnIndex), columnType.getProtoTypeFqn());
+          return Value.protoEnum(
+              isNull ? null : getLongInternal(columnIndex), columnType.getProtoTypeFqn());
         case NUMERIC:
           return Value.numeric(isNull ? null : getBigDecimalInternal(columnIndex));
         case PG_NUMERIC:
@@ -836,7 +837,8 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
         case BYTES:
           return Value.internalBytes(isNull ? null : getLazyBytesInternal(columnIndex));
         case PROTO:
-          return Value.protoMessage(getBytesInternal(columnIndex), columnType.getProtoTypeFqn());
+          return Value.protoMessage(
+              isNull ? null : getBytesInternal(columnIndex), columnType.getProtoTypeFqn());
         case TIMESTAMP:
           return Value.timestamp(isNull ? null : getTimestampInternal(columnIndex));
         case DATE:

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
@@ -485,7 +485,7 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
           case PROTO:
             builder
                 .set(fieldName)
-                .to(Value.protoMessage((ByteArray) value, fieldType.getProtoTypeFqn()));
+                .to(Value.protoMessage(((LazyByteArray) value).getByteArray(), fieldType.getProtoTypeFqn()));
             break;
           case ENUM:
             builder.set(fieldName).to(Value.protoEnum((Long) value, fieldType.getProtoTypeFqn()));

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
@@ -485,7 +485,10 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
           case PROTO:
             builder
                 .set(fieldName)
-                .to(Value.protoMessage(((LazyByteArray) value).getByteArray(), fieldType.getProtoTypeFqn()));
+                .to(
+                    Value.protoMessage(
+                        value == null ? null : ((LazyByteArray) value).getByteArray(),
+                        fieldType.getProtoTypeFqn()));
             break;
           case ENUM:
             builder.set(fieldName).to(Value.protoEnum((Long) value, fieldType.getProtoTypeFqn()));

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractStructReader.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractStructReader.java
@@ -348,8 +348,8 @@ public abstract class AbstractStructReader implements StructReader {
   @Override
   public long[] getLongArray(String columnName) {
     int columnIndex = getColumnIndex(columnName);
-    checkNonNullOfCodes(columnIndex, Collections.singletonList(Code.ARRAY), columnIndex);
-    checkArrayElementType(columnIndex, Arrays.asList(Code.ENUM, Code.INT64), columnIndex);
+    checkNonNullOfCodes(columnIndex, Collections.singletonList(Code.ARRAY), columnName);
+    checkArrayElementType(columnIndex, Arrays.asList(Code.ENUM, Code.INT64), columnName);
     return getLongArrayInternal(columnIndex);
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractStructReader.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractStructReader.java
@@ -340,14 +340,16 @@ public abstract class AbstractStructReader implements StructReader {
 
   @Override
   public long[] getLongArray(int columnIndex) {
-    checkNonNullOfType(columnIndex, Type.array(Type.int64()), columnIndex);
+    checkNonNullOfCodes(columnIndex, Collections.singletonList(Code.ARRAY), columnIndex);
+    checkArrayElementType(columnIndex, Arrays.asList(Code.ENUM, Code.INT64), columnIndex);
     return getLongArrayInternal(columnIndex);
   }
 
   @Override
   public long[] getLongArray(String columnName) {
     int columnIndex = getColumnIndex(columnName);
-    checkNonNullOfType(columnIndex, Type.array(Type.int64()), columnName);
+    checkNonNullOfCodes(columnIndex, Collections.singletonList(Code.ARRAY), columnIndex);
+    checkArrayElementType(columnIndex, Arrays.asList(Code.ENUM, Code.INT64), columnIndex);
     return getLongArrayInternal(columnIndex);
   }
 


### PR DESCRIPTION
This PR fixes the following issues,
1. When export was done on `PROTO` type it was throwing a cast exception as follows,
```
Caused by: java.lang.ClassCastException: class com.google.cloud.spanner.AbstractResultSet$LazyByteArray cannot be cast to class com.google.cloud.ByteArray (com.google.cloud.spanner.AbstractResultSet$LazyByteArray and com.google.cloud.ByteArray are in unnamed module of loader 'app')

```
2. Add `ENUM` compatibility for `getLongArray` method.
3. `null` check for `PROTO` and `ENUM`