### PR TITLE
fix: ignore UnsupportedOperationException for virtual threads

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ThreadFactoryUtil.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ThreadFactoryUtil.java
@@ -69,6 +69,11 @@ public class ThreadFactoryUtil {
     } catch (ClassNotFoundException | NoSuchMethodException ignore) {
       return null;
     } catch (InvocationTargetException | IllegalAccessException e) {
+      // Java 20 supports virtual threads as an experimental feature. It will throw an
+      // UnsupportedOperationException if experimental features have not been enabled.
+      if (e.getCause() instanceof UnsupportedOperationException) {
+        return null;
+      }
       throw new RuntimeException(e);
     }
   }
@@ -91,6 +96,11 @@ public class ThreadFactoryUtil {
       } catch (NoSuchMethodException ignore) {
         return null;
       } catch (InvocationTargetException | IllegalAccessException e) {
+        // Java 20 supports virtual threads as an experimental feature. It will throw an
+        // UnsupportedOperationException if experimental features have not been enabled.
+        if (e.getCause() instanceof UnsupportedOperationException) {
+          return null;
+        }
         throw new RuntimeException(e);
       }
     }


### PR DESCRIPTION
The virtual threads util that tries to create a virtual thread factory on JVMs that support this would fail on Java 20, because:
1. Java 20 supports virtual threads as an experimental feature. This means that the code is present.
2. The feature is by default disabled, and throws an UnsupportedOperationException.

This fix takes the above into account and returns null if a user tries to create a virtual threads factory on Java 20 with experimental features disabled.
