### PR TITLE
fix: add ensureDecoded to proto type

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/GrpcStruct.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/GrpcStruct.java
@@ -373,6 +373,7 @@ class GrpcStruct extends Struct implements Serializable {
     Preconditions.checkNotNull(
         message,
         "Proto message may not be null. Use MyProtoClass.getDefaultInstance() as a parameter value.");
+    ensureDecoded(columnIndex);
     try {
       return (T)
           message

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITProtoColumnTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITProtoColumnTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 import com.google.cloud.ByteArray;
 import com.google.cloud.spanner.Database;
@@ -69,17 +70,17 @@ public class ITProtoColumnTest {
   private static DatabaseAdminClient dbAdminClient;
   private static DatabaseClient databaseClient;
 
-  public static boolean isNotUsingAllowlistedProject() {
+  public static boolean isUsingAllowlistedProject() {
     String projectId = System.getProperty("spanner.gce.config.project_id", "");
-    return !(projectId.equalsIgnoreCase("gcloud-devel")
-        || projectId.equalsIgnoreCase("span-cloud-testing"));
+    return projectId.equalsIgnoreCase("gcloud-devel")
+        || projectId.equalsIgnoreCase("span-cloud-testing");
   }
 
   @BeforeClass
   public static void setUpDatabase() throws Exception {
     assumeFalse(
         "Proto Column is not supported in the emulator", EmulatorSpannerHelper.isUsingEmulator());
-    assumeFalse("Proto Column is not yet enabled in production", isNotUsingAllowlistedProject());
+    assumeTrue("Proto Column is not yet enabled in production", isUsingAllowlistedProject());
     RemoteSpannerHelper testHelper = env.getTestHelper();
     databaseID = DatabaseId.of(testHelper.getInstanceId(), testHelper.getUniqueDatabaseId());
     dbAdminClient = testHelper.getClient().getDatabaseAdminClient();
@@ -138,7 +139,7 @@ public class ITProtoColumnTest {
   @AfterClass
   public static void afterClass() throws Exception {
     try {
-      if (!isUsingEmulator() && !isNotUsingAllowlistedProject()) {
+      if (!isUsingEmulator() && isUsingAllowlistedProject()) {
         dbAdminClient.dropDatabase(
             databaseID.getInstanceId().getInstance(), databaseID.getDatabase());
       }
@@ -168,7 +169,7 @@ public class ITProtoColumnTest {
   public void testProtoColumnsUpdateAndRead() {
     assumeFalse(
         "Proto Column is not supported in the emulator", EmulatorSpannerHelper.isUsingEmulator());
-    assumeFalse("Proto Column is not yet enabled in production", isNotUsingAllowlistedProject());
+    assumeTrue("Proto Column is not yet enabled in production", isUsingAllowlistedProject());
     SingerInfo singerInfo =
         SingerInfo.newBuilder().setSingerId(1).setNationality("Country1").build();
     ByteArray singerInfoBytes = ByteArray.copyFrom(singerInfo.toByteArray());
@@ -276,7 +277,7 @@ public class ITProtoColumnTest {
   public void testProtoColumnsDMLParameterizedQueriesPKAndIndexes() {
     assumeFalse(
         "Proto Column is not supported in the emulator", EmulatorSpannerHelper.isUsingEmulator());
-    assumeFalse("Proto Column is not yet enabled in production", isNotUsingAllowlistedProject());
+    assumeTrue("Proto Column is not yet enabled in production", isUsingAllowlistedProject());
 
     SingerInfo singerInfo1 =
         SingerInfo.newBuilder().setSingerId(1).setNationality("Country1").build();
@@ -383,7 +384,7 @@ public class ITProtoColumnTest {
   public void testProtoMessageDeserializationError() {
     assumeFalse(
         "Proto Column is not supported in the emulator", EmulatorSpannerHelper.isUsingEmulator());
-    assumeFalse("Proto Column is not yet enabled in production", isNotUsingAllowlistedProject());
+    assumeTrue("Proto Column is not yet enabled in production", isUsingAllowlistedProject());
 
     SingerInfo singerInfo =
         SingerInfo.newBuilder().setSingerId(1).setNationality("Country1").build();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITProtoColumnTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITProtoColumnTest.java
@@ -54,14 +54,12 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 // Integration Tests to test DDL, DML and DQL for Proto Columns and Enums
-@Ignore("Feature is not yet enabled in production")
 @Category(ParallelIntegrationTest.class)
 @RunWith(JUnit4.class)
 public class ITProtoColumnTest {
@@ -71,10 +69,17 @@ public class ITProtoColumnTest {
   private static DatabaseAdminClient dbAdminClient;
   private static DatabaseClient databaseClient;
 
+  public static boolean isNotUsingAllowlistedProject() {
+    String projectId = System.getProperty("spanner.gce.config.project_id", "");
+    return !(projectId.equalsIgnoreCase("gcloud-devel")
+        || projectId.equalsIgnoreCase("span-cloud-testing"));
+  }
+
   @BeforeClass
   public static void setUpDatabase() throws Exception {
     assumeFalse(
         "Proto Column is not supported in the emulator", EmulatorSpannerHelper.isUsingEmulator());
+    assumeFalse("Proto Column is not yet enabled in production", isNotUsingAllowlistedProject());
     RemoteSpannerHelper testHelper = env.getTestHelper();
     databaseID = DatabaseId.of(testHelper.getInstanceId(), testHelper.getUniqueDatabaseId());
     dbAdminClient = testHelper.getClient().getDatabaseAdminClient();
@@ -133,7 +138,7 @@ public class ITProtoColumnTest {
   @AfterClass
   public static void afterClass() throws Exception {
     try {
-      if (!isUsingEmulator()) {
+      if (!isUsingEmulator() && !isNotUsingAllowlistedProject()) {
         dbAdminClient.dropDatabase(
             databaseID.getInstanceId().getInstance(), databaseID.getDatabase());
       }
@@ -163,6 +168,7 @@ public class ITProtoColumnTest {
   public void testProtoColumnsUpdateAndRead() {
     assumeFalse(
         "Proto Column is not supported in the emulator", EmulatorSpannerHelper.isUsingEmulator());
+    assumeFalse("Proto Column is not yet enabled in production", isNotUsingAllowlistedProject());
     SingerInfo singerInfo =
         SingerInfo.newBuilder().setSingerId(1).setNationality("Country1").build();
     ByteArray singerInfoBytes = ByteArray.copyFrom(singerInfo.toByteArray());
@@ -270,6 +276,7 @@ public class ITProtoColumnTest {
   public void testProtoColumnsDMLParameterizedQueriesPKAndIndexes() {
     assumeFalse(
         "Proto Column is not supported in the emulator", EmulatorSpannerHelper.isUsingEmulator());
+    assumeFalse("Proto Column is not yet enabled in production", isNotUsingAllowlistedProject());
 
     SingerInfo singerInfo1 =
         SingerInfo.newBuilder().setSingerId(1).setNationality("Country1").build();
@@ -376,6 +383,7 @@ public class ITProtoColumnTest {
   public void testProtoMessageDeserializationError() {
     assumeFalse(
         "Proto Column is not supported in the emulator", EmulatorSpannerHelper.isUsingEmulator());
+    assumeFalse("Proto Column is not yet enabled in production", isNotUsingAllowlistedProject());
 
     SingerInfo singerInfo =
         SingerInfo.newBuilder().setSingerId(1).setNationality("Country1").build();


### PR DESCRIPTION
**Issue**: When running `ITProtocolumnTest` locally
```
java.lang.ClassCastException: class com.google.protobuf.Value cannot be cast to class com.google.cloud.spanner.AbstractResultSet$LazyByteArray (com.google.protobuf.Value and com.google.cloud.spanner.AbstractResultSet$LazyByteArray are in unnamed module of loader 'app')

	at com.google.cloud.spanner.GrpcStruct.getProtoMessageInternal(GrpcStruct.java:385)
	at com.google.cloud.spanner.AbstractResultSet.getProtoMessageInternal(AbstractResultSet.java:326)
	at com.google.cloud.spanner.AbstractStructReader.getProtoMessage(AbstractStructReader.java:301)
	at com.google.cloud.spanner.ForwardingStructReader.getProtoMessage(ForwardingStructReader.java:423)
	at com.google.cloud.spanner.it.ITProtoColumnTest.testProtoColumnsUpdateAndRead(ITProtoColumnTest.java:247)

```

**Reason** - #2846 refactored code for easy maintenance and decoded data only when called. This change was not added to proto type and it was throwing the exception.

**Why Presubmits failed to catch** - We disabled the Proto tests in #2857 (Look PR description for the reason). This PR made changes to test file to skip only on non allowlisted projects so that these issues can be caught in presubmits.