### PR TITLE
fix: fix write replace in grpcStruct

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/GrpcStruct.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/GrpcStruct.java
@@ -70,6 +70,7 @@ class GrpcStruct extends Struct implements Serializable {
     for (int i = 0; i < structFields.size(); i++) {
       Type.StructField field = structFields.get(i);
       String fieldName = field.getName();
+      ensureDecoded(i);
       Object value = rowData.get(i);
       Type fieldType = field.getType();
       switch (fieldType.getCode()) {


### PR DESCRIPTION
#2846 has refactored the result set class. However the `writeReplace` method was not updated. This PR fixes it.
**Impact**: This will break the import export functionality in Pantheon and dataflow templates.

The error is as follows
```
Caused by: java.lang.IllegalArgumentException: Unable to encode element '[string_value: "Singers5"
, string_value: "1"
, string_value: "CgFB"
, null_value: NULL_VALUE
]' with coder 'SerializableCoder(com.google.cloud.spanner.Struct)'.
    org.apache.beam.sdk.coders.Coder.getEncodedElementByteSize(Coder.java:300)
    org.apache.beam.sdk.coders.Coder.registerByteSizeObserver(Coder.java:291)
    org.apache.beam.fn.harness.data.PCollectionConsumerRegistry$SampleByteSizeDistribution.tryUpdate(PCollectionConsumerRegistry.java:509)
    org.apache.beam.fn.harness.data.PCollectionConsumerRegistry$MetricTrackingFnDataReceiver.accept(PCollectionConsumerRegistry.java:336)
    org.apache.beam.fn.harness.data.PCollectionConsumerRegistry$MetricTrackingFnDataReceiver.accept(PCollectionConsumerRegistry.java:275)
Caused by: java.lang.ClassCastException: class com.google.protobuf.Value cannot be cast to class java.lang.String (com.google.protobuf.Value is in unnamed module of loader 'app'; java.lang.String is in module java.base of loader 'bootstrap')
    com.google.cloud.spanner.GrpcStruct.writeReplace(GrpcStruct.java:92)

```

Job link: https://pantheon.corp.google.com/dataflow/jobs/us-central1/2024-02-21_00_14_12-8497790410952556713;bottomTab=JOB_LOGS;logsSeverity=ERROR;graphView=0?project=span-cloud-testing&pageState=(%22dfTime%22:(%22l%22:%22dfJobMaxTime%22))&mods=logs_tg_staging