### PR TITLE
chore: loosen restrictions setRetryAbortsInternally

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
@@ -678,10 +678,6 @@ class ConnectionImpl implements Connection {
    */
   private void checkSetRetryAbortsInternallyAvailable() {
     ConnectionPreconditions.checkState(!isClosed(), CLOSED_ERROR_MSG);
-    ConnectionPreconditions.checkState(isInTransaction(), "This connection has no transaction");
-    ConnectionPreconditions.checkState(
-        getTransactionMode() == TransactionMode.READ_WRITE_TRANSACTION,
-        "RetryAbortsInternally is only available for read-write transactions");
     ConnectionPreconditions.checkState(
         !isTransactionStarted(),
         "RetryAbortsInternally cannot be set after the transaction has started");


### PR DESCRIPTION
Calling setRetryAbortsInternally(boolean) was unnecessarily strict, as there is no reason why it should be disallowed to change the value while in auto-commit mode and/or read-only mode. The fact that the flag does not have any direct impact on those modes, does not mean that it should be disallowed to set the value.

The fact that it was impossible to set the value while in auto-commit mode, also means that it is impossible to disable it using a startup command for a PostgreSQL connection to PGAdapter, as PGAdapter creates connections in auto-commit mode.
