### PR TITLE
chore: fix float32 NaN comparison + deprecate generator

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Value.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Value.java
@@ -1628,6 +1628,10 @@ public abstract class Value implements Serializable {
 
     @Override
     boolean valueEquals(Value v) {
+      // NaN == NaN always returns false, so we need a custom check.
+      if (Float.isNaN(this.value)) {
+        return Float.isNaN(((Float32Impl) v).value);
+      }
       return ((Float32Impl) v).value == value;
     }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplTest.java
@@ -193,9 +193,9 @@ public class AsyncResultSetImplTest {
           });
     }
     finishedLatch.await();
-    // There should be between 1 and 4 callbacks, depending on the timing of the threads.
+    // There should be between 1 and 5 callbacks, depending on the timing of the threads.
     // Normally, there should be just 1 callback.
-    assertThat(callbackCounter.get()).isIn(Range.closed(1, 4));
+    assertThat(callbackCounter.get()).isIn(Range.closed(1, 5));
     assertThat(rowCounter.get()).isEqualTo(3);
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -4083,6 +4083,7 @@ public class DatabaseClientImplTest {
         int col = 0;
         assertAsString("true", resultSet, col++);
         assertAsString("100", resultSet, col++);
+        assertAsString("-3.14", resultSet, col++);
         assertAsString("3.14", resultSet, col++);
         assertAsString("6.626", resultSet, col++);
         assertAsString("test-string", resultSet, col++);
@@ -4098,6 +4099,15 @@ public class DatabaseClientImplTest {
         assertAsString(
             ImmutableList.of(
                 String.format("%d", Long.MAX_VALUE), String.format("%d", Long.MIN_VALUE), "NULL"),
+            resultSet,
+            col++);
+        assertAsString(
+            ImmutableList.of(
+                "NULL",
+                Float.valueOf(Float.MAX_VALUE).toString(),
+                Float.valueOf(Float.MIN_VALUE).toString(),
+                "NaN",
+                "3.14"),
             resultSet,
             col++);
         assertAsString(ImmutableList.of("NULL", "-12345.6789", "3.14"), resultSet, col++);
@@ -4561,6 +4571,7 @@ public class DatabaseClientImplTest {
         ListValue.newBuilder()
             .addValues(com.google.protobuf.Value.newBuilder().setBoolValue(true).build())
             .addValues(com.google.protobuf.Value.newBuilder().setStringValue("100").build())
+            .addValues(com.google.protobuf.Value.newBuilder().setNumberValue(-3.14f).build())
             .addValues(com.google.protobuf.Value.newBuilder().setNumberValue(3.14d).build())
             .addValues(com.google.protobuf.Value.newBuilder().setStringValue("6.626").build())
             .addValues(com.google.protobuf.Value.newBuilder().setStringValue("test-string").build())
@@ -4607,6 +4618,31 @@ public class DatabaseClientImplTest {
                             .addValues(
                                 com.google.protobuf.Value.newBuilder()
                                     .setNullValue(NullValue.NULL_VALUE)
+                                    .build())
+                            .build()))
+            .addValues(
+                com.google.protobuf.Value.newBuilder()
+                    .setListValue(
+                        ListValue.newBuilder()
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setNullValue(NullValue.NULL_VALUE)
+                                    .build())
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setNumberValue(Float.MAX_VALUE)
+                                    .build())
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setNumberValue(Float.MIN_VALUE)
+                                    .build())
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setStringValue("NaN")
+                                    .build())
+                            .addValues(
+                                com.google.protobuf.Value.newBuilder()
+                                    .setNumberValue(3.14f)
                                     .build())
                             .build()))
             .addValues(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
@@ -37,6 +37,7 @@ import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
 import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import com.google.cloud.spanner.TransactionRunnerImpl.TransactionContextImpl;
+import com.google.cloud.spanner.connection.RandomResultSetGenerator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.AbstractMessage;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RandomResultSetGenerator.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RandomResultSetGenerator.java
@@ -31,6 +31,8 @@ import com.google.spanner.v1.Type;
 import com.google.spanner.v1.TypeCode;
 import java.util.Random;
 
+/** @deprecated Use {@link com.google.cloud.spanner.connection.RandomResultSetGenerator} instead. */
+@Deprecated
 public class RandomResultSetGenerator {
   private static final Type[] TYPES =
       new Type[] {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueTest.java
@@ -193,6 +193,7 @@ public class ValueTest {
     assertThat(v.getFloat32()).isWithin(0.0001f).of(1.23f);
     assertThat(v.toString()).isEqualTo("1.23");
     assertEquals("1.23", v.getAsString());
+    assertEquals(Value.float32(Float.NaN), Value.float32(Float.NaN));
   }
 
   @Test
@@ -224,6 +225,7 @@ public class ValueTest {
     assertThat(v.getFloat64()).isWithin(0.0001).of(1.23);
     assertThat(v.toString()).isEqualTo("1.23");
     assertEquals("1.23", v.getAsString());
+    assertEquals(Value.float64(Double.NaN), Value.float64(Double.NaN));
   }
 
   @Test
@@ -267,6 +269,7 @@ public class ValueTest {
     assertEquals(1234.5678D, value.getFloat64(), 0.00001);
     assertEquals("1234.5678", value.toString());
     assertEquals("1234.5678", value.getAsString());
+    assertEquals(Value.pgNumeric("NaN"), Value.pgNumeric("NaN"));
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractMockServerTest.java
@@ -19,7 +19,6 @@ package com.google.cloud.spanner.connection;
 import com.google.cloud.spanner.ForceCloseSpannerFunction;
 import com.google.cloud.spanner.MockSpannerServiceImpl;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
-import com.google.cloud.spanner.RandomResultSetGenerator;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.admin.database.v1.MockDatabaseAdminImpl;
 import com.google.cloud.spanner.admin.instance.v1.MockInstanceAdminImpl;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/MergedResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/MergedResultSetTest.java
@@ -150,7 +150,7 @@ public class MergedResultSetTest {
       if (numPartitions == 0) {
         assertEquals(0, resultSet.getColumnCount());
       } else {
-        assertEquals(22, resultSet.getColumnCount());
+        assertEquals(24, resultSet.getColumnCount());
         assertEquals(Type.bool(), resultSet.getColumnType(0));
         assertEquals(Type.bool(), resultSet.getColumnType("COL0"));
         assertEquals(10, resultSet.getColumnIndex("COL10"));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/PartitionedQueryMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/PartitionedQueryMockServerTest.java
@@ -58,15 +58,20 @@ public class PartitionedQueryMockServerTest extends AbstractMockServerTest {
 
   @Parameter public Dialect dialect;
 
+  private Dialect currentDialect;
+
   @Before
   public void setupDialect() {
-    mockSpanner.putStatementResult(StatementResult.detectDialectResult(dialect));
+    if (currentDialect != dialect) {
+      mockSpanner.putStatementResult(StatementResult.detectDialectResult(dialect));
+      SpannerPool.closeSpannerPool();
+      currentDialect = dialect;
+    }
   }
 
   @After
   public void clearRequests() {
     mockSpanner.clearRequests();
-    SpannerPool.closeSpannerPool();
   }
 
   @Test
@@ -349,9 +354,9 @@ public class PartitionedQueryMockServerTest extends AbstractMockServerTest {
               statement, PartitionOptions.newBuilder().setMaxPartitions(maxPartitions).build())) {
         assertFalse(resultSet.next());
         assertNotNull(resultSet.getMetadata());
-        assertEquals(22, resultSet.getMetadata().getRowType().getFieldsCount());
+        assertEquals(24, resultSet.getMetadata().getRowType().getFieldsCount());
         assertNotNull(resultSet.getType());
-        assertEquals(22, resultSet.getType().getStructFields().size());
+        assertEquals(24, resultSet.getType().getStructFields().size());
       }
     }
     assertEquals(1, mockSpanner.countRequestsOfType(CreateSessionRequest.class));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/RandomResultSetGenerator.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/RandomResultSetGenerator.java
@@ -51,6 +51,7 @@ public class RandomResultSetGenerator {
             Arrays.asList(
                 Type.newBuilder().setCode(TypeCode.BOOL).build(),
                 Type.newBuilder().setCode(TypeCode.INT64).build(),
+                Type.newBuilder().setCode(TypeCode.FLOAT32).build(),
                 Type.newBuilder().setCode(TypeCode.FLOAT64).build(),
                 dialect == Dialect.POSTGRESQL
                     ? Type.newBuilder()
@@ -75,6 +76,10 @@ public class RandomResultSetGenerator {
                 Type.newBuilder()
                     .setCode(TypeCode.ARRAY)
                     .setArrayElementType(Type.newBuilder().setCode(TypeCode.INT64))
+                    .build(),
+                Type.newBuilder()
+                    .setCode(TypeCode.ARRAY)
+                    .setArrayElementType(Type.newBuilder().setCode(TypeCode.FLOAT32))
                     .build(),
                 Type.newBuilder()
                     .setCode(TypeCode.ARRAY)
@@ -228,6 +233,13 @@ public class RandomResultSetGenerator {
               Date.fromYearMonthDay(
                   random.nextInt(2019) + 1, random.nextInt(11) + 1, random.nextInt(28) + 1);
           builder.setStringValue(date.toString());
+          break;
+        case FLOAT32:
+          if (randomNaN()) {
+            builder.setNumberValue(Float.NaN);
+          } else {
+            builder.setNumberValue(random.nextFloat());
+          }
           break;
         case FLOAT64:
           if (randomNaN()) {


### PR DESCRIPTION
The FLOAT32 type was only added to the com.google.cloud.spanner.RandomResultSetGenerator, but that generator misses multiple other types. The one in the .connection package should be used instead. This PR therefore deprecates the one that should not be used, and updates all tests that used the old one.

It also adds FLOAT32 to the .connection.RandomResultSetGenerator, which is used by a larger number of tests. This discovered a bug in the FLOAT32 NaN comparison, which is also fixed in this PR.

Note: The commit is not marked with 'fix:', as the feature has not yet been released.
