### PR TITLE
feat: add endpoint connection URL property

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spanner.connection;
 
 import static com.google.cloud.spanner.connection.ConnectionOptions.Builder.SPANNER_URI_PATTERN;
+import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_ENDPOINT;
 import static com.google.cloud.spanner.connection.ConnectionOptions.determineHost;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -172,6 +173,7 @@ public class ConnectionOptionsTest {
         DEFAULT_HOST,
         determineHost(
             matcherWithoutHost,
+            DEFAULT_ENDPOINT,
             /* autoConfigEmulator= */ false,
             /* usePlainText= */ false,
             ImmutableMap.of()));
@@ -179,6 +181,7 @@ public class ConnectionOptionsTest {
         DEFAULT_HOST,
         determineHost(
             matcherWithoutHost,
+            DEFAULT_ENDPOINT,
             /* autoConfigEmulator= */ false,
             /* usePlainText= */ false,
             ImmutableMap.of("FOO", "bar")));
@@ -186,6 +189,7 @@ public class ConnectionOptionsTest {
         "http://localhost:9010",
         determineHost(
             matcherWithoutHost,
+            DEFAULT_ENDPOINT,
             /* autoConfigEmulator= */ true,
             /* usePlainText= */ false,
             ImmutableMap.of()));
@@ -193,6 +197,7 @@ public class ConnectionOptionsTest {
         "http://localhost:9011",
         determineHost(
             matcherWithoutHost,
+            DEFAULT_ENDPOINT,
             /* autoConfigEmulator= */ true,
             /* usePlainText= */ false,
             ImmutableMap.of("SPANNER_EMULATOR_HOST", "localhost:9011")));
@@ -200,6 +205,7 @@ public class ConnectionOptionsTest {
         "http://localhost:9010",
         determineHost(
             matcherWithoutHost,
+            DEFAULT_ENDPOINT,
             /* autoConfigEmulator= */ true,
             /* usePlainText= */ true,
             ImmutableMap.of()));
@@ -207,6 +213,7 @@ public class ConnectionOptionsTest {
         "http://localhost:9011",
         determineHost(
             matcherWithoutHost,
+            DEFAULT_ENDPOINT,
             /* autoConfigEmulator= */ true,
             /* usePlainText= */ true,
             ImmutableMap.of("SPANNER_EMULATOR_HOST", "localhost:9011")));
@@ -216,6 +223,7 @@ public class ConnectionOptionsTest {
         "https://custom.host.domain:1234",
         determineHost(
             matcherWithHost,
+            DEFAULT_ENDPOINT,
             /* autoConfigEmulator= */ false,
             /* usePlainText= */ false,
             ImmutableMap.of()));
@@ -223,6 +231,7 @@ public class ConnectionOptionsTest {
         "http://custom.host.domain:1234",
         determineHost(
             matcherWithHost,
+            DEFAULT_ENDPOINT,
             /* autoConfigEmulator= */ false,
             /* usePlainText= */ true,
             ImmutableMap.of()));
@@ -230,6 +239,7 @@ public class ConnectionOptionsTest {
         "http://custom.host.domain:1234",
         determineHost(
             matcherWithHost,
+            DEFAULT_ENDPOINT,
             /* autoConfigEmulator= */ false,
             /* usePlainText= */ true,
             ImmutableMap.of()));
@@ -237,6 +247,7 @@ public class ConnectionOptionsTest {
         "https://custom.host.domain:1234",
         determineHost(
             matcherWithHost,
+            DEFAULT_ENDPOINT,
             /* autoConfigEmulator= */ true,
             /* usePlainText= */ false,
             ImmutableMap.of()));
@@ -244,6 +255,7 @@ public class ConnectionOptionsTest {
         "http://custom.host.domain:1234",
         determineHost(
             matcherWithHost,
+            DEFAULT_ENDPOINT,
             /* autoConfigEmulator= */ false,
             /* usePlainText= */ true,
             ImmutableMap.of("SPANNER_EMULATOR_HOST", "localhost:9011")));
@@ -251,9 +263,40 @@ public class ConnectionOptionsTest {
         "https://custom.host.domain:1234",
         determineHost(
             matcherWithHost,
+            DEFAULT_ENDPOINT,
             /* autoConfigEmulator= */ true,
             /* usePlainText= */ false,
             ImmutableMap.of("SPANNER_EMULATOR_HOST", "localhost:9011")));
+
+    // The 'endpoint' connection URL property can also be used to connect to the emulator.
+    // Using this property is sometimes easier than adding the URL to the host part of the
+    // connection string, for example because it can be added to the Properties object that
+    // is used by JDBC.
+    assertEquals(
+        "http://localhost:9010",
+        determineHost(
+            matcherWithoutHost,
+            "localhost:9010",
+            /* autoConfigEmulator= */ false,
+            /* usePlainText= */ true,
+            ImmutableMap.of()));
+    // A value for the 'endpoint' connection property overrides any value in the host group.
+    assertEquals(
+        "https://my.endpoint:1234",
+        determineHost(
+            matcherWithHost,
+            "my.endpoint:1234",
+            /* autoConfigEmulator= */ false,
+            /* usePlainText= */ false,
+            ImmutableMap.of("SPANNER_EMULATOR_HOST", "localhost:9011")));
+    assertEquals(
+        "http://my.endpoint.local:1234",
+        determineHost(
+            matcherWithHost,
+            "my.endpoint.local:1234",
+            /* autoConfigEmulator= */ false,
+            /* usePlainText= */ true,
+            ImmutableMap.of()));
   }
 
   @Test
@@ -282,6 +325,20 @@ public class ConnectionOptionsTest {
     ConnectionOptions.Builder builder = ConnectionOptions.newBuilder();
     builder.setUri(
         "cloudspanner://central-emulator.local:8080/projects/test-project-123/instances/test-instance-123/databases/test-database-123?autoConfigEmulator=true");
+    ConnectionOptions options = builder.build();
+    assertEquals("http://central-emulator.local:8080", options.getHost());
+    assertEquals("test-project-123", options.getProjectId());
+    assertEquals("test-instance-123", options.getInstanceId());
+    assertEquals("test-database-123", options.getDatabaseName());
+    assertEquals(NoCredentials.getInstance(), options.getCredentials());
+    assertTrue(options.isUsePlainText());
+  }
+
+  @Test
+  public void testBuildWithAutoConfigEmulatorAndEndpoint() {
+    ConnectionOptions.Builder builder = ConnectionOptions.newBuilder();
+    builder.setUri(
+        "cloudspanner:/projects/test-project-123/instances/test-instance-123/databases/test-database-123?autoConfigEmulator=true;endpoint=central-emulator.local:8080");
     ConnectionOptions options = builder.build();
     assertEquals("http://central-emulator.local:8080", options.getHost());
     assertEquals("test-project-123", options.getProjectId());


### PR DESCRIPTION
Adds an 'endpoint' connection URL property for the Connection API. This property can be used instead of adding the endpoint to the host group part of the Connection URL, which again removes the need to actually change the connection URL when connecting to for example the emulator from the JDBC driver. The latter can instead just add the endpoint to the Properties set that is given to the JDBC driver.
