### PR TITLE
chore: support concurrent transactions on a multiplexed session.

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -479,20 +479,17 @@ class SessionImpl implements Session {
 
   <T extends SessionTransaction> T setActive(@Nullable T ctx) {
     throwIfTransactionsPending();
-
-    if (activeTransaction != null) {
-      activeTransaction.invalidate();
-    }
-    activeTransaction = ctx;
-    readyTransactionId = null;
-    if (activeTransaction != null) {
-      activeTransaction.setSpan(currentSpan);
+    if (!this.isMultiplexed) {
+      if (activeTransaction != null) {
+        activeTransaction.invalidate();
+      }
+      activeTransaction = ctx;
+      readyTransactionId = null;
+      if (activeTransaction != null) {
+        activeTransaction.setSpan(currentSpan);
+      }
     }
     return ctx;
-  }
-
-  boolean hasReadyTransaction() {
-    return readyTransactionId != null;
   }
 
   TraceWrapper getTracer() {


### PR DESCRIPTION
setActive() method within SessionImpl does the below things

1. Handles nested transaction use-case
2. Invalidates active transactions - Disabling this will allow multiple transactions per session.
3. Resets readyTransactionId - The value for readyTransactionId is only set in the prepareReadWriteTransaction method. Otherwise the value anyway remains null.
4. Sets the span per active transaction - A session no longer can maintain a single span. Hence, we will require to change the way spans are added for multiplexed session. This is doable since for each new RPC, a new span object is created and stored in the local thread context. Instead of storing the span state in SessionImpl, we can fetch the span from context and set it.

For multiplexed session we are disabling #2, #3 and #4 for launching read-only transactions. The functionality of spans/traces for multiplexed session will be tested and added in a separate PR.