### PR TITLE
feat: disable affinity for grpc-gcp when there is no channel hint.

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -57,6 +57,7 @@ import com.google.api.pathtemplate.PathTemplate;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.RetryHelper;
 import com.google.cloud.RetryHelper.RetryHelperException;
+import com.google.cloud.grpc.GcpManagedChannel;
 import com.google.cloud.grpc.GcpManagedChannelBuilder;
 import com.google.cloud.grpc.GcpManagedChannelOptions;
 import com.google.cloud.grpc.GcpManagedChannelOptions.GcpMetricsOptions;
@@ -181,6 +182,7 @@ import com.google.spanner.v1.Session;
 import com.google.spanner.v1.SpannerGrpc;
 import com.google.spanner.v1.Transaction;
 import io.grpc.CallCredentials;
+import io.grpc.CallOptions;
 import io.grpc.Context;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.MethodDescriptor;
@@ -1956,6 +1958,12 @@ public class GapicSpannerRpc implements SpannerRpc {
     GrpcCallContext context = GrpcCallContext.createDefault();
     if (options != null) {
       context = context.withChannelAffinity(Option.CHANNEL_HINT.getLong(options).intValue());
+    } else {
+      // No channel hint == no affinity needed. Disabling affinity for gRPC-GCP.
+      // This is a no-op for GAX.
+      context =
+          context.withCallOptions(
+              CallOptions.DEFAULT.withOption(GcpManagedChannel.DISABLE_AFFINITY_KEY, true));
     }
     if (compressorName != null) {
       // This sets the compressor for Client -> Server.


### PR DESCRIPTION
SpannerOptions#enableGrpcGcpExtension enabled GRPC GCP extension which is a separate library that handles channel management. By default this assumes session to channel affinity. 

With multiplexed session we no longer maintain any channel hint with the session. However, grpc-gcp would still assume session to channel affinity and that may cause higher latencies. This change disables affinity whenever there is no channel hint associated with the session. Effectively this will disable affinity when multiplexed sessions are launched.