### PR TITLE
refactor: remove setSpan() method from SessionImpl class.

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -451,11 +451,6 @@ abstract class AbstractReadContext
     this.tracer = builder.tracer;
   }
 
-  @Override
-  public void setSpan(ISpan span) {
-    this.span = span;
-  }
-
   long getSeqNo() {
     return seqNo.incrementAndGet();
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncTransactionManagerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncTransactionManagerImpl.java
@@ -48,11 +48,6 @@ final class AsyncTransactionManagerImpl
   }
 
   @Override
-  public void setSpan(ISpan span) {
-    this.span = span;
-  }
-
-  @Override
   public void close() {
     closeAsync();
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
@@ -21,6 +21,7 @@ import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Options.TransactionOption;
 import com.google.cloud.spanner.Options.UpdateOption;
 import com.google.cloud.spanner.SessionPool.PooledSessionFuture;
+import com.google.cloud.spanner.SessionPool.SessionFuture;
 import com.google.cloud.spanner.SpannerImpl.ClosedException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
@@ -50,6 +51,10 @@ class DatabaseClientImpl implements DatabaseClient {
   @VisibleForTesting
   PooledSessionFuture getSession() {
     return pool.getSession();
+  }
+
+  SessionFuture getMultiplexedSession() {
+    return pool.getMultiplexedSessionWithFallback();
   }
 
   @Override
@@ -123,7 +128,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public ReadContext singleUse() {
     ISpan span = tracer.spanBuilder(READ_ONLY_TRANSACTION);
     try (IScope s = tracer.withSpan(span)) {
-      return getSession().singleUse();
+      return getMultiplexedSession().singleUse();
     } catch (RuntimeException e) {
       span.setStatus(e);
       span.end();
@@ -135,7 +140,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public ReadContext singleUse(TimestampBound bound) {
     ISpan span = tracer.spanBuilder(READ_ONLY_TRANSACTION);
     try (IScope s = tracer.withSpan(span)) {
-      return getSession().singleUse(bound);
+      return getMultiplexedSession().singleUse(bound);
     } catch (RuntimeException e) {
       span.setStatus(e);
       span.end();
@@ -147,7 +152,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public ReadOnlyTransaction singleUseReadOnlyTransaction() {
     ISpan span = tracer.spanBuilder(READ_ONLY_TRANSACTION);
     try (IScope s = tracer.withSpan(span)) {
-      return getSession().singleUseReadOnlyTransaction();
+      return getMultiplexedSession().singleUseReadOnlyTransaction();
     } catch (RuntimeException e) {
       span.setStatus(e);
       span.end();
@@ -159,7 +164,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public ReadOnlyTransaction singleUseReadOnlyTransaction(TimestampBound bound) {
     ISpan span = tracer.spanBuilder(READ_ONLY_TRANSACTION);
     try (IScope s = tracer.withSpan(span)) {
-      return getSession().singleUseReadOnlyTransaction(bound);
+      return getMultiplexedSession().singleUseReadOnlyTransaction(bound);
     } catch (RuntimeException e) {
       span.setStatus(e);
       span.end();
@@ -171,7 +176,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public ReadOnlyTransaction readOnlyTransaction() {
     ISpan span = tracer.spanBuilder(READ_ONLY_TRANSACTION);
     try (IScope s = tracer.withSpan(span)) {
-      return getSession().readOnlyTransaction();
+      return getMultiplexedSession().readOnlyTransaction();
     } catch (RuntimeException e) {
       span.setStatus(e);
       span.end();
@@ -183,7 +188,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public ReadOnlyTransaction readOnlyTransaction(TimestampBound bound) {
     ISpan span = tracer.spanBuilder(READ_ONLY_TRANSACTION);
     try (IScope s = tracer.withSpan(span)) {
-      return getSession().readOnlyTransaction(bound);
+      return getMultiplexedSession().readOnlyTransaction(bound);
     } catch (RuntimeException e) {
       span.setStatus(e);
       span.end();

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/PartitionedDmlTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/PartitionedDmlTransaction.java
@@ -138,10 +138,6 @@ public class PartitionedDmlTransaction implements SessionImpl.SessionTransaction
     isValid = false;
   }
 
-  /** No-op method needed to implement SessionTransaction interface. */
-  @Override
-  public void setSpan(ISpan span) {}
-
   private Duration tryUpdateTimeout(final Duration timeout, final Stopwatch stopwatch) {
     final Duration remainingTimeout =
         timeout.minus(stopwatch.elapsed(TimeUnit.MILLISECONDS), ChronoUnit.MILLIS);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -467,12 +467,13 @@ class SessionImpl implements Session {
 
   <T extends SessionTransaction> T setActive(@Nullable T ctx) {
     throwIfTransactionsPending();
-
-    if (activeTransaction != null) {
-      activeTransaction.invalidate();
+    if (!this.isMultiplexed) {
+      if (activeTransaction != null) {
+        activeTransaction.invalidate();
+      }
+      activeTransaction = ctx;
+      readyTransactionId = null;
     }
-    activeTransaction = ctx;
-    readyTransactionId = null;
     return ctx;
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -1908,15 +1908,11 @@ class SessionPool {
 
     private void keepAlive() {
       markUsed();
-      final ISpan previousSpan = delegate.getCurrentSpan();
-      delegate.setCurrentSpan(tracer.getBlankSpan());
       try (ResultSet resultSet =
           delegate
               .singleUse(TimestampBound.ofMaxStaleness(60, TimeUnit.SECONDS))
               .executeQuery(Statement.newBuilder("SELECT 1").build())) {
         resultSet.next();
-      } finally {
-        delegate.setCurrentSpan(previousSpan);
       }
     }
 
@@ -1955,7 +1951,6 @@ class SessionPool {
 
     @Override
     public void markBusy(ISpan span) {
-      this.delegate.setCurrentSpan(span);
       this.state = SessionState.BUSY;
     }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionManagerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionManagerImpl.java
@@ -40,15 +40,6 @@ final class TransactionManagerImpl implements TransactionManager, SessionTransac
     this.options = Options.fromTransactionOptions(options);
   }
 
-  ISpan getSpan() {
-    return span;
-  }
-
-  @Override
-  public void setSpan(ISpan span) {
-    this.span = span;
-  }
-
   @Override
   public TransactionContext begin() {
     Preconditions.checkState(txn == null, "begin can only be called once");

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -985,11 +985,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
     this.options = Options.fromTransactionOptions(options);
     this.txn = session.newTransaction(this.options);
     this.tracer = session.getTracer();
-  }
-
-  @Override
-  public void setSpan(ISpan span) {
-    this.span = span;
+    this.span = tracer.getCurrentSpan();
   }
 
   @Nullable

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
@@ -140,7 +140,6 @@ public class SessionImplTest {
     Span oTspan = mock(Span.class);
     ISpan span = new OpenTelemetrySpan(oTspan);
     when(oTspan.makeCurrent()).thenReturn(mock(Scope.class));
-    ((SessionImpl) session).setCurrentSpan(span);
     // We expect the same options, "options", on all calls on "session".
     options = optionsCaptor.getValue();
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -1455,7 +1455,6 @@ public class SessionPoolTest extends BaseSessionPoolTest {
       when(closedSession.beginTransactionAsync(any(), eq(true))).thenThrow(sessionNotFound);
       when(closedSession.getTracer()).thenReturn(tracer);
       TransactionRunnerImpl closedTransactionRunner = new TransactionRunnerImpl(closedSession);
-      closedTransactionRunner.setSpan(span);
       when(closedSession.readWriteTransaction()).thenReturn(closedTransactionRunner);
 
       final SessionImpl openSession = mock(SessionImpl.class);
@@ -1470,7 +1469,6 @@ public class SessionPoolTest extends BaseSessionPoolTest {
           .thenReturn(ApiFutures.immediateFuture(ByteString.copyFromUtf8("open-txn")));
       when(openSession.getTracer()).thenReturn(tracer);
       TransactionRunnerImpl openTransactionRunner = new TransactionRunnerImpl(openSession);
-      openTransactionRunner.setSpan(span);
       when(openSession.readWriteTransaction()).thenReturn(openTransactionRunner);
 
       ResultSet openResultSet = mock(ResultSet.class);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
@@ -146,7 +146,6 @@ public class TransactionRunnerImplTest {
     Span oTspan = mock(Span.class);
     span = new OpenTelemetrySpan(oTspan);
     when(oTspan.makeCurrent()).thenReturn(mock(Scope.class));
-    transactionRunner.setSpan(span);
   }
 
   @SuppressWarnings("unchecked")
@@ -312,9 +311,7 @@ public class TransactionRunnerImplTest {
             throw new IllegalStateException();
           }
         };
-    session.setCurrentSpan(new OpenTelemetrySpan(mock(io.opentelemetry.api.trace.Span.class)));
     TransactionRunnerImpl runner = new TransactionRunnerImpl(session);
-    runner.setSpan(span);
     assertThat(usedInlinedBegin).isFalse();
     runner.run(
         transaction -> {
@@ -347,7 +344,6 @@ public class TransactionRunnerImplTest {
             ApiFutures.immediateFuture(ByteString.copyFromUtf8(UUID.randomUUID().toString())));
     when(session.getName()).thenReturn(SessionId.of("p", "i", "d", "test").getName());
     TransactionRunnerImpl runner = new TransactionRunnerImpl(session);
-    runner.setSpan(span);
     ExecuteBatchDmlResponse response1 =
         ExecuteBatchDmlResponse.newBuilder()
             .addResultSets(


### PR DESCRIPTION
Since multiplexed sessions can run more than one transaction concurrently, it shouldn't store a single span object. A new span object is created and stored in the context of the public method which is invoked. There are two changes in this PR

* setSpan() method is removed from the `SessionTransaction` interface in `SessionImpl` class.
* Modify setActive() method within `SessionImpl` interface.

setActive() method within SessionImpl does the below things

1. Handles nested transaction use-case
2. Invalidates active transactions - Disabling this will allow multiple transactions per session.
3. Resets readyTransactionId - The value for readyTransactionId is only set in the prepareReadWriteTransaction method. Otherwise the value anyway remains null.
4. Sets the span per active transaction - A session no longer can maintain a single span. Hence, we will require to change the way spans are added for multiplexed session. This is doable since for each new RPC, a new span object is created and stored in the local thread context. Instead of storing the span state in `SessionImpl`, we can fetch the span from context and set it.

For multiplexed session we are disabling https://github.com/googleapis/java-spanner/issues/2, https://github.com/googleapis/java-spanner/pull/3 and https://github.com/googleapis/java-spanner/pull/4 for launching read-only transactions. The functionality of spans/traces for multiplexed session will be tested and added in a separate PR.