### PR TITLE
chore: make getSpanner a public method

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.36.0')
+implementation platform('com.google.cloud:libraries-bom:26.37.0')
 
 implementation 'com.google.cloud:google-cloud-spanner'
 ```

--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -643,4 +643,12 @@
     <className>com/google/cloud/spanner/connection/Connection</className>
     <method>void setMaxCommitDelay(java.time.Duration)</method>
   </difference>
+
+  <!-- Make getSpanner() public -->
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/connection/Connection</className>
+    <method>com.google.cloud.spanner.Spanner getSpanner()</method>
+  </difference>
+
 </differences>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
@@ -33,6 +33,7 @@ import com.google.cloud.spanner.Options.UpdateOption;
 import com.google.cloud.spanner.PartitionOptions;
 import com.google.cloud.spanner.ReadContext.QueryAnalyzeMode;
 import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerBatchUpdateException;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.Statement;
@@ -1367,6 +1368,12 @@ public interface Connection extends AutoCloseable {
   /** The {@link DatabaseClient} that is used by this {@link Connection}. */
   @InternalApi
   default DatabaseClient getDatabaseClient() {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  /** The {@link Spanner} instance that is used by this {@link Connection}. */
+  @InternalApi
+  default Spanner getSpanner() {
     throw new UnsupportedOperationException("Not implemented");
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
@@ -305,8 +305,8 @@ class ConnectionImpl implements Connection {
     setDefaultTransactionOptions();
   }
 
-  @VisibleForTesting
-  Spanner getSpanner() {
+  @Override
+  public Spanner getSpanner() {
     return this.spanner;
   }
 


### PR DESCRIPTION
The underlying Spanner instance is often needed by the libraries that use the Connection API, and should therefore be made public.
