### PR TITLE
chore: add a new integration test runner for multiplexed sessions.

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -109,6 +109,21 @@ integration-directpath-enabled)
       verify
     RETURN_CODE=$?
     ;;
+integration-multiplexed-sessions-enabled)
+    mvn -B ${INTEGRATION_TEST_ARGS} \
+      -ntp \
+      -Penable-integration-tests \
+      -Djava.net.preferIPv4Stack=true \
+      -DtrimStackTrace=false \
+      -Dclirr.skip=true \
+      -Denforcer.skip=true \
+      -Dmaven.main.skip=true \
+      -Dspanner.gce.config.project_id=gcloud-devel \
+      -Dspanner.testenv.instance=projects/gcloud-devel/instances/java-client-integration-tests-multiplexed-sessions \
+      -fae \
+      verify
+    RETURN_CODE=$?
+    ;;
 integration-cloud-devel)
     mvn -B ${INTEGRATION_TEST_ARGS} \
       -ntp \

--- a/.kokoro/presubmit/integration-multiplexed-sessions-enabled.cfg
+++ b/.kokoro/presubmit/integration-multiplexed-sessions-enabled.cfg
@@ -1,0 +1,38 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java8"
+}
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "integration-multiplexed-sessions-enabled"
+}
+
+# TODO: remove this after we've migrated all tests and scripts
+env_vars: {
+  key: "GCLOUD_PROJECT"
+  value: "gcloud-devel"
+}
+
+env_vars: {
+  key: "GOOGLE_CLOUD_PROJECT"
+  value: "gcloud-devel"
+}
+
+env_vars: {
+  key: "GOOGLE_APPLICATION_CREDENTIALS"
+  value: "secret_manager/java-it-service-account"
+}
+
+env_vars: {
+  key: "SECRET_MANAGER_KEYS"
+  value: "java-it-service-account"
+}
+
+env_vars: {
+    key: "GOOGLE_CLOUD_SPANNER_ENABLE_MULTIPLEXED_SESSIONS"
+    value: "true"
+}

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
@@ -16,13 +16,13 @@
 
 package com.google.cloud.spanner;
 
+import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.SessionPool.Position;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.Locale;
 import java.util.Objects;
-import org.apache.http.annotation.Experimental;
 import org.threeten.bp.Duration;
 
 /** Options for the session pool used by {@code DatabaseClient}. */
@@ -520,7 +520,7 @@ public class SessionPoolOptions {
      * multiplexed sessions.
      */
     @InternalApi
-    @Experimental
+    @BetaApi
     private static boolean getUseMultiplexedSessionFromEnvVariable() {
       return Boolean.parseBoolean(
           System.getenv("GOOGLE_CLOUD_SPANNER_ENABLE_MULTIPLEXED_SESSIONS"));

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
@@ -16,11 +16,13 @@
 
 package com.google.cloud.spanner;
 
+import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.SessionPool.Position;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.Locale;
 import java.util.Objects;
+import org.apache.http.annotation.Experimental;
 import org.threeten.bp.Duration;
 
 /** Options for the session pool used by {@code DatabaseClient}. */
@@ -493,7 +495,8 @@ public class SessionPoolOptions {
      */
     private long randomizePositionQPSThreshold = 0L;
 
-    private boolean useMultiplexedSession = false;
+    private boolean useMultiplexedSession = getUseMultiplexedSessionFromEnvVariable();
+
     private Duration multiplexedSessionMaintenanceDuration = Duration.ofDays(7);
     private Duration waitForMultiplexedSession = Duration.ofSeconds(10);
     private Clock poolMaintainerClock;
@@ -509,6 +512,18 @@ public class SessionPoolOptions {
         }
       }
       return Position.FIRST;
+    }
+
+    /**
+     * This environment is only added to support internal spanner testing. Support for it can be
+     * removed in the future. Use {@link SessionPoolOptions#useMultiplexedSession} instead to use
+     * multiplexed sessions.
+     */
+    @InternalApi
+    @Experimental
+    private static boolean getUseMultiplexedSessionFromEnvVariable() {
+      return Boolean.parseBoolean(
+          System.getenv("GOOGLE_CLOUD_SPANNER_ENABLE_MULTIPLEXED_SESSIONS"));
     }
 
     public Builder() {}


### PR DESCRIPTION
* Using a different instance ID - `projects/gcloud-devel/instances/java-client-integration-tests-multiplexed-sessions` for this runner so that it does not compete for resources with other active tests.
* This runner is expected to fail since multiplexed sessions is not enabled in production. It will pass for PRs where we point to cloud-devel (just for test purposes).