### PR TITLE
chore: add a CI target to run emulator integration tests using multip…

### DIFF
--- a/.github/workflows/integration-tests-against-emulator-with-multiplexed-session.yaml
+++ b/.github/workflows/integration-tests-against-emulator-with-multiplexed-session.yaml
@@ -1,0 +1,42 @@
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+name: integration-tests-against-emulator-with-multiplexed-session
+jobs:
+  units:
+    runs-on: ubuntu-latest
+
+    services:
+      emulator:
+        image: gcr.io/cloud-spanner-emulator/emulator:latest
+        ports:
+        - 9010:9010
+        - 9020:9020
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: stCarolas/setup-maven@v5
+      with:
+        maven-version: 3.8.1
+    # Build with JDK 11 and run tests with JDK 8
+    - uses: actions/setup-java@v4
+      with:
+        java-version: 11
+        distribution: temurin
+    - name: Compiling main library
+      run: .kokoro/build.sh
+    - uses: actions/setup-java@v4
+      with:
+        java-version: 8
+        distribution: temurin
+    - name: Running tests
+      run: |
+        mvn -V -B -Dspanner.testenv.instance="" -Penable-integration-tests \
+            -DtrimStackTrace=false -Dclirr.skip=true -Denforcer.skip=true \
+            -Dmaven.main.skip=true -fae verify
+      env:
+        JOB_TYPE: test
+        SPANNER_EMULATOR_HOST: localhost:9010
+        GOOGLE_CLOUD_SPANNER_ENABLE_MULTIPLEXED_SESSIONS: true


### PR DESCRIPTION
- Creating a new target through which we can obtain test coverage using multiplexed sessions. The target uses an additional env variable `GOOGLE_CLOUD_SPANNER_ENABLE_MULTIPLEXED_SESSIONS: true` using which multiplexed sessions will get enabled in the tests.
- This CI runner will be no-op initially till we merge - https://github.com/googleapis/java-spanner/pull/3027 . Post that it may error out and we would require to fix the errors.