### PR TITLE
chore: add a CI target to run unit tests using multiplexed sessions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,23 @@ jobs:
     - run: .kokoro/build.sh
       env:
         JOB_TYPE: test
+  units-with-multiplexed-session:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 11, 17, 21 ]
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: ${{matrix.java}}
+    - run: java -version
+    - run: .kokoro/build.sh
+      env:
+        JOB_TYPE: test
+        GOOGLE_CLOUD_SPANNER_ENABLE_MULTIPLEXED_SESSIONS: true
   units-java8:
     # Building using Java 17 and run the tests with Java 8 runtime
     name: "units (8)"


### PR DESCRIPTION
- Creating a new target through which we can obtain unit test coverage using multiplexed sessions. The target uses an additional env variable `GOOGLE_CLOUD_SPANNER_ENABLE_MULTIPLEXED_SESSIONS: true` using which multiplexed sessions will get enabled in the tests.
- Any errors will be fixed as a follow up before multiplexed sessions is enabled. Currently it is not enabled.