### PR TITLE
chore: add open census metric label is_multiplexed for multiplexed se…

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ implementation 'com.google.cloud:google-cloud-spanner'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-spanner:6.63.0'
+implementation 'com.google.cloud:google-cloud-spanner:6.64.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.63.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.64.0"
 ```
 <!-- {x-version-update-end} -->
 
@@ -650,7 +650,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-spanner/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-spanner.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.63.0
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.64.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MetricRegistryConstants.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MetricRegistryConstants.java
@@ -30,6 +30,9 @@ class MetricRegistryConstants {
       LabelKey.create("instance_id", "Name of the instance");
   private static final LabelKey LIBRARY_VERSION =
       LabelKey.create("library_version", "Library version");
+  static final LabelKey IS_MULTIPLEXED_KEY =
+      LabelKey.create("is_multiplexed", "Multiplexed Session");
+
   private static final LabelKey SESSION_TYPE = LabelKey.create("Type", "Type of the Sessions");
 
   /** The label value is used to represent missing value. */
@@ -62,6 +65,9 @@ class MetricRegistryConstants {
   static final ImmutableList<LabelValue> SPANNER_DEFAULT_LABEL_VALUES =
       ImmutableList.of(UNSET_LABEL, UNSET_LABEL, UNSET_LABEL, UNSET_LABEL);
 
+  static final ImmutableList<LabelKey> SPANNER_LABEL_KEYS_WITH_MULTIPLEXED_SESSIONS =
+      ImmutableList.of(CLIENT_ID, DATABASE, INSTANCE_ID, LIBRARY_VERSION, IS_MULTIPLEXED_KEY);
+
   /** Unit to represent counts. */
   static final String COUNT = "1";
 
@@ -80,7 +86,6 @@ class MetricRegistryConstants {
   static final String NUM_SESSIONS_AVAILABLE = "spanner/num_available_sessions";
   static final String SESSIONS_TYPE = "session_type";
   static final String IS_MULTIPLEXED = "is_multiplexed";
-
   static final String MAX_IN_USE_SESSIONS_DESCRIPTION =
       "The maximum number of sessions in use during the last 10 minute interval.";
   static final String MAX_ALLOWED_SESSIONS_DESCRIPTION =


### PR DESCRIPTION
Introduced a new metric label `is_multiplexed` using which customers can see the split of data between multiplexed sessions and regular sessions. This works when customer uses open census.

Similar support was added for open telemetry here - https://github.com/googleapis/java-spanner/pull/2975