### PR TITLE
chore: use a singleton session pool clock

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -73,7 +73,7 @@ abstract class AbstractReadContext
     private DecodeMode defaultDecodeMode = SpannerOptions.Builder.DEFAULT_DECODE_MODE;
     private DirectedReadOptions defaultDirectedReadOption;
     private ExecutorProvider executorProvider;
-    private Clock clock = new Clock();
+    private Clock clock = Clock.INSTANCE;
 
     Builder() {}
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Clock.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Clock.java
@@ -23,6 +23,10 @@ import org.threeten.bp.Instant;
  * Clock.
  */
 class Clock {
+  static final Clock INSTANCE = new Clock();
+
+  Clock() {}
+
   Instant instant() {
     return Instant.now();
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -2952,6 +2952,13 @@ class SessionPool {
   }
 
   @VisibleForTesting
+  int getTotalSessionsPlusNumSessionsBeingCreated() {
+    synchronized (lock) {
+      return numSessionsBeingCreated + allSessions.size();
+    }
+  }
+
+  @VisibleForTesting
   long getNumWaiterTimeouts() {
     return numWaiterTimeouts.get();
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -2349,8 +2349,13 @@ class SessionPool {
                           + acquireSessionTimeout.toMillis()
                           + "ms for acquiring session. To mitigate error SessionPoolOptions#setAcquireSessionTimeout(Duration) to set a higher timeout"
                           + " or increase the number of sessions in the session pool.");
-              waiter.setException(exception);
-              throw exception;
+              if (waiter.setException(exception)) {
+                // Only throw the exception if setting it on the waiter was successful. The
+                // waiter.setException(..) method returns false if some other thread in the meantime
+                // called waiter.set(..), which means that a session became available between the
+                // time that the TimeoutException was thrown and now.
+                throw exception;
+              }
             }
             return null;
           } catch (ExecutionException e) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
@@ -491,7 +491,7 @@ public class SessionPoolOptions {
     private boolean useMultiplexedSession = getUseMultiplexedSessionFromEnvVariable();
 
     private Duration multiplexedSessionMaintenanceDuration = Duration.ofDays(7);
-    private Clock poolMaintainerClock;
+    private Clock poolMaintainerClock = Clock.INSTANCE;
 
     private static Position getReleaseToPositionFromSystemProperty() {
       // NOTE: This System property is a beta feature. Support for it can be removed in the future.
@@ -701,7 +701,7 @@ public class SessionPoolOptions {
 
     @VisibleForTesting
     Builder setPoolMaintainerClock(Clock poolMaintainerClock) {
-      this.poolMaintainerClock = poolMaintainerClock;
+      this.poolMaintainerClock = Preconditions.checkNotNull(poolMaintainerClock);
       return this;
     }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractMockServerTest.java
@@ -31,7 +31,7 @@ abstract class AbstractMockServerTest {
   protected static Server server;
   protected static LocalChannelProvider channelProvider;
 
-  private Spanner spanner;
+  protected Spanner spanner;
 
   @BeforeClass
   public static void startMockServer() throws IOException {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BaseSessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BaseSessionPoolTest.java
@@ -85,8 +85,7 @@ abstract class BaseSessionPoolTest {
     return session;
   }
 
-  SessionImpl buildMockSession(ReadContext context) {
-    SpannerImpl spanner = mock(SpannerImpl.class);
+  SessionImpl buildMockSession(SpannerImpl spanner, ReadContext context) {
     Map options = new HashMap<>();
     options.put(Option.CHANNEL_HINT, channelHint.getAndIncrement());
     final SessionImpl session =
@@ -123,8 +122,8 @@ abstract class BaseSessionPoolTest {
     return session;
   }
 
-  SessionImpl buildMockMultiplexedSession(ReadContext context, Timestamp creationTime) {
-    SpannerImpl spanner = mock(SpannerImpl.class);
+  SessionImpl buildMockMultiplexedSession(
+      SpannerImpl spanner, ReadContext context, Timestamp creationTime) {
     Map options = new HashMap<>();
     final SessionImpl session =
         new SessionImpl(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BatchClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BatchClientImplTest.java
@@ -86,6 +86,9 @@ public final class BatchClientImplTest {
     GrpcTransportOptions transportOptions = mock(GrpcTransportOptions.class);
     when(transportOptions.getExecutorFactory()).thenReturn(mock(ExecutorFactory.class));
     when(spannerOptions.getTransportOptions()).thenReturn(transportOptions);
+    SessionPoolOptions sessionPoolOptions = mock(SessionPoolOptions.class);
+    when(sessionPoolOptions.getPoolMaintainerClock()).thenReturn(Clock.INSTANCE);
+    when(spannerOptions.getSessionPoolOptions()).thenReturn(sessionPoolOptions);
     @SuppressWarnings("resource")
     SpannerImpl spanner = new SpannerImpl(gapicRpc, spannerOptions);
     client = new BatchClientImpl(spanner.getSessionClient(db));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/FailOnOverkillTraceComponentImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/FailOnOverkillTraceComponentImpl.java
@@ -45,6 +45,7 @@ import io.opencensus.trace.propagation.BinaryFormat;
 import io.opencensus.trace.propagation.PropagationComponent;
 import io.opencensus.trace.propagation.TextFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -62,7 +63,8 @@ public class FailOnOverkillTraceComponentImpl extends TraceComponent {
   private final Clock clock = ZeroTimeClock.getInstance();
   private final ExportComponent exportComponent = new TestExportComponent();
   private final TraceConfig traceConfig = new TestTraceConfig();
-  private static final Map<String, Boolean> spans = new LinkedHashMap<>();
+  private static final Map<String, Boolean> spans =
+      Collections.synchronizedMap(new LinkedHashMap<>());
 
   private static final List<String> annotations = new ArrayList<>();
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -2133,6 +2133,10 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
     return numSessionsCreated.get();
   }
 
+  public Map<String, Session> getSessions() {
+    return sessions;
+  }
+
   @Override
   public List<AbstractMessage> getRequests() {
     return new ArrayList<>(this.requests);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MultiplexedSessionMaintainerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MultiplexedSessionMaintainerTest.java
@@ -76,7 +76,9 @@ public class MultiplexedSessionMaintainerTest extends BaseSessionPoolTest {
             .setIncStep(1)
             .setKeepAliveIntervalMinutes(2)
             .setUseMultiplexedSession(true)
+            .setPoolMaintainerClock(clock)
             .build();
+    when(spannerOptions.getSessionPoolOptions()).thenReturn(options);
     multiplexedSessionsRemoved.clear();
   }
 
@@ -93,7 +95,8 @@ public class MultiplexedSessionMaintainerTest extends BaseSessionPoolTest {
                       Instant.ofEpochMilli(clock.currentTimeMillis.get()).getEpochSecond(), 0);
               consumer.onSessionReady(
                   setupMockSession(
-                      buildMockMultiplexedSession(mockContext, timestamp.toProto()), mockContext));
+                      buildMockMultiplexedSession(client, mockContext, timestamp.toProto()),
+                      mockContext));
               return null;
             })
         .when(sessionClient)
@@ -108,7 +111,8 @@ public class MultiplexedSessionMaintainerTest extends BaseSessionPoolTest {
                       Instant.ofEpochMilli(clock.currentTimeMillis.get()).getEpochSecond(), 0);
               consumer.onSessionReady(
                   setupMockSession(
-                      buildMockMultiplexedSession(mockContext, timestamp.toProto()), mockContext));
+                      buildMockMultiplexedSession(client, mockContext, timestamp.toProto()),
+                      mockContext));
               return null;
             })
         .when(sessionClient)
@@ -158,7 +162,8 @@ public class MultiplexedSessionMaintainerTest extends BaseSessionPoolTest {
                       Instant.ofEpochMilli(clock.currentTimeMillis.get()).getEpochSecond(), 0);
               consumer.onSessionReady(
                   setupMockSession(
-                      buildMockMultiplexedSession(mockContext, timestamp.toProto()), mockContext));
+                      buildMockMultiplexedSession(client, mockContext, timestamp.toProto()),
+                      mockContext));
               return null;
             })
         .when(sessionClient)
@@ -193,7 +198,8 @@ public class MultiplexedSessionMaintainerTest extends BaseSessionPoolTest {
                       Instant.ofEpochMilli(clock.currentTimeMillis.get()).getEpochSecond(), 0);
               consumer.onSessionReady(
                   setupMockSession(
-                      buildMockMultiplexedSession(mockContext, timestamp.toProto()), mockContext));
+                      buildMockMultiplexedSession(client, mockContext, timestamp.toProto()),
+                      mockContext));
               return null;
             })
         .when(sessionClient)
@@ -232,7 +238,8 @@ public class MultiplexedSessionMaintainerTest extends BaseSessionPoolTest {
                       Instant.ofEpochMilli(clock.currentTimeMillis.get()).getEpochSecond(), 0);
               consumer.onSessionReady(
                   setupMockSession(
-                      buildMockMultiplexedSession(mockContext, timestamp.toProto()), mockContext));
+                      buildMockMultiplexedSession(client, mockContext, timestamp.toProto()),
+                      mockContext));
               return null;
             })
         .when(sessionClient)

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MultiplexedSessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MultiplexedSessionPoolTest.java
@@ -81,6 +81,7 @@ public class MultiplexedSessionPoolTest extends BaseSessionPoolTest {
             .setMaxSessions(2)
             .setUseMultiplexedSession(true)
             .build();
+    when(spannerOptions.getSessionPoolOptions()).thenReturn(options);
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionClientTests.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionClientTests.java
@@ -125,6 +125,9 @@ public class SessionClientTests {
     doNothing().when(span).end();
     doNothing().when(span).addAnnotation("Starting Commit");
     when(spanner.getRpc()).thenReturn(rpc);
+    SessionPoolOptions sessionPoolOptions = mock(SessionPoolOptions.class);
+    when(sessionPoolOptions.getPoolMaintainerClock()).thenReturn(Clock.INSTANCE);
+    when(spannerOptions.getSessionPoolOptions()).thenReturn(sessionPoolOptions);
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
@@ -98,7 +98,9 @@ public class SessionImplTest {
     GrpcTransportOptions transportOptions = mock(GrpcTransportOptions.class);
     when(transportOptions.getExecutorFactory()).thenReturn(mock(ExecutorFactory.class));
     when(spannerOptions.getTransportOptions()).thenReturn(transportOptions);
-    when(spannerOptions.getSessionPoolOptions()).thenReturn(mock(SessionPoolOptions.class));
+    SessionPoolOptions sessionPoolOptions = mock(SessionPoolOptions.class);
+    when(sessionPoolOptions.getPoolMaintainerClock()).thenReturn(Clock.INSTANCE);
+    when(spannerOptions.getSessionPoolOptions()).thenReturn(sessionPoolOptions);
     when(spannerOptions.getOpenTelemetry()).thenReturn(OpenTelemetry.noop());
     @SuppressWarnings("resource")
     SpannerImpl spanner = new SpannerImpl(rpc, spannerOptions);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerMockServerTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.spanner;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 
 import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
@@ -123,6 +124,10 @@ public class SessionPoolMaintainerMockServerTest extends AbstractMockServerTest 
 
   @Test
   public void testSessionNotFoundIsRetried() {
+    assumeFalse(
+        "Session not found errors are not relevant for multiplexed sessions",
+        spanner.getOptions().getSessionPoolOptions().getUseMultiplexedSession());
+
     int minSessions = spanner.getOptions().getSessionPoolOptions().getMinSessions();
     DatabaseClientImpl client =
         (DatabaseClientImpl) spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerMockServerTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.NoCredentials;
+import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.common.base.Stopwatch;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.Value;
+import com.google.spanner.v1.BatchCreateSessionsRequest;
+import com.google.spanner.v1.ExecuteSqlRequest;
+import com.google.spanner.v1.ResultSetMetadata;
+import com.google.spanner.v1.StructType;
+import com.google.spanner.v1.StructType.Field;
+import com.google.spanner.v1.Type;
+import com.google.spanner.v1.TypeCode;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.threeten.bp.Duration;
+
+@RunWith(JUnit4.class)
+public class SessionPoolMaintainerMockServerTest extends AbstractMockServerTest {
+  private final FakeClock clock = new FakeClock();
+
+  @BeforeClass
+  public static void setupResults() {
+    mockSpanner.putStatementResult(
+        StatementResult.query(
+            Statement.of("SELECT 1"),
+            com.google.spanner.v1.ResultSet.newBuilder()
+                .setMetadata(
+                    ResultSetMetadata.newBuilder()
+                        .setRowType(
+                            StructType.newBuilder()
+                                .addFields(
+                                    Field.newBuilder()
+                                        .setName("C")
+                                        .setType(Type.newBuilder().setCode(TypeCode.INT64).build())
+                                        .build())
+                                .build())
+                        .build())
+                .addRows(
+                    ListValue.newBuilder()
+                        .addValues(Value.newBuilder().setStringValue("1").build())
+                        .build())
+                .build()));
+  }
+
+  @Before
+  public void createSpannerInstance() {
+    clock.currentTimeMillis.set(System.currentTimeMillis());
+    spanner =
+        SpannerOptions.newBuilder()
+            .setProjectId("p")
+            .setChannelProvider(channelProvider)
+            .setCredentials(NoCredentials.getInstance())
+            .setSessionPoolOption(
+                SessionPoolOptions.newBuilder()
+                    .setPoolMaintainerClock(clock)
+                    .setWaitForMinSessions(Duration.ofSeconds(10L))
+                    .setFailOnSessionLeak()
+                    .build())
+            .build()
+            .getService();
+  }
+
+  @Test
+  public void testMaintain() {
+    int minSessions = spanner.getOptions().getSessionPoolOptions().getMinSessions();
+    DatabaseClientImpl client =
+        (DatabaseClientImpl) spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+    assertEquals(minSessions, mockSpanner.getSessions().size());
+    assertEquals(0, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    clock.currentTimeMillis.addAndGet(Duration.ofMinutes(35).toMillis());
+    client.pool.poolMaintainer.maintainPool();
+    assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    client.pool.poolMaintainer.maintainPool();
+    assertEquals(2, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    clock.currentTimeMillis.addAndGet(Duration.ofMinutes(21).toMillis());
+
+    // Most sessions are considered idle and are removed.
+    client.pool.poolMaintainer.maintainPool();
+    assertEquals(2, client.pool.totalSessions());
+
+    // The pool is replenished.
+    client.pool.poolMaintainer.maintainPool();
+    assertEquals(
+        minSessions, client.pool.totalSessions() + client.pool.getNumberOfSessionsBeingCreated());
+    Stopwatch watch = Stopwatch.createStarted();
+    //noinspection StatementWithEmptyBody
+    while (client.pool.totalSessions() < minSessions
+        && watch.elapsed(TimeUnit.MILLISECONDS)
+            < spanner.getOptions().getSessionPoolOptions().getWaitForMinSessions().toMillis()) {
+      // wait for the pool to be replenished.
+    }
+    assertEquals(minSessions, client.pool.totalSessions());
+  }
+
+  @Test
+  public void testSessionNotFoundIsRetried() {
+    int minSessions = spanner.getOptions().getSessionPoolOptions().getMinSessions();
+    DatabaseClientImpl client =
+        (DatabaseClientImpl) spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+    assertEquals(minSessions, mockSpanner.getSessions().size());
+
+    // Remove all sessions from the backend.
+    mockSpanner.getSessions().clear();
+
+    // Sessions have been removed from the backend, but this will still succeed, as Session not
+    // found errors are retried by the client.
+    try (ResultSet resultSet = client.singleUse().executeQuery(Statement.of("SELECT 1"))) {
+      assertTrue(resultSet.next());
+      assertEquals(1L, resultSet.getLong(0));
+      assertFalse(resultSet.next());
+    }
+
+    int numRequests = mockSpanner.countRequestsOfType(ExecuteSqlRequest.class);
+    assertTrue(
+        String.format("Number of requests should be larger than 1, but was %d", numRequests),
+        numRequests > 1);
+  }
+
+  @Test
+  public void testMaintainerReplenishesPoolIfAllAreInvalid() {
+    int minSessions = spanner.getOptions().getSessionPoolOptions().getMinSessions();
+    DatabaseClientImpl client =
+        (DatabaseClientImpl) spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+    assertEquals(minSessions, mockSpanner.getSessions().size());
+
+    // Remove all sessions from the backend.
+    mockSpanner.getSessions().clear();
+    // Advance the clock of the maintainer to mark all sessions are eligible for maintenance.
+    clock.currentTimeMillis.addAndGet(Duration.ofMinutes(35).toMillis());
+    // Run the maintainer. This will ping one session, which again will cause it to be replaced.
+    client.pool.poolMaintainer.maintainPool();
+    assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+
+    // The session will be replaced using a single BatchCreateSessions call.
+    Stopwatch watch = Stopwatch.createStarted();
+    //noinspection StatementWithEmptyBody
+    while (client.pool.totalSessions() < minSessions
+        && watch.elapsed(TimeUnit.MILLISECONDS)
+            < spanner.getOptions().getSessionPoolOptions().getWaitForMinSessions().toMillis()) {
+      // wait for the pool to be replenished.
+    }
+    assertEquals(minSessions, client.pool.totalSessions());
+    assertEquals(
+        spanner.getOptions().getNumChannels() + 1,
+        mockSpanner.countRequestsOfType(BatchCreateSessionsRequest.class));
+  }
+}

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerMockServerTest.java
@@ -100,9 +100,13 @@ public class SessionPoolMaintainerMockServerTest extends AbstractMockServerTest 
     assertEquals(2, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
     clock.currentTimeMillis.addAndGet(Duration.ofMinutes(21).toMillis());
 
-    // Most sessions are considered idle and are removed.
+    // Most sessions are considered idle and are removed. Freeze the mock Spanner server to prevent
+    // the replenish action to fill the pool again before we check the number of sessions in the
+    // pool.
+    mockSpanner.freeze();
     client.pool.poolMaintainer.maintainPool();
     assertEquals(2, client.pool.totalSessions());
+    mockSpanner.unfreeze();
 
     // The pool is replenished.
     client.pool.poolMaintainer.maintainPool();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerMockServerTest.java
@@ -108,10 +108,9 @@ public class SessionPoolMaintainerMockServerTest extends AbstractMockServerTest 
     assertEquals(2, client.pool.totalSessions());
     mockSpanner.unfreeze();
 
-    // The pool is replenished.
+    // The pool should be replenished.
     client.pool.poolMaintainer.maintainPool();
-    assertEquals(
-        minSessions, client.pool.totalSessions() + client.pool.getNumberOfSessionsBeingCreated());
+    assertEquals(minSessions, client.pool.getTotalSessionsPlusNumSessionsBeingCreated());
     Stopwatch watch = Stopwatch.createStarted();
     //noinspection StatementWithEmptyBody
     while (client.pool.totalSessions() < minSessions

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerTest.java
@@ -76,7 +76,9 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
             .setMaxSessions(5)
             .setIncStep(1)
             .setKeepAliveIntervalMinutes(2)
+            .setPoolMaintainerClock(clock)
             .build();
+    when(spannerOptions.getSessionPoolOptions()).thenReturn(options);
     idledSessions.clear();
     pingedSessions.clear();
   }
@@ -92,7 +94,7 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
                     for (int i = 0; i < sessionCount; i++) {
                       ReadContext mockContext = mock(ReadContext.class);
                       consumer.onSessionReady(
-                          setupMockSession(buildMockSession(mockContext), mockContext));
+                          setupMockSession(buildMockSession(client, mockContext), mockContext));
                     }
                   });
               return null;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolStressTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolStressTest.java
@@ -68,7 +68,6 @@ public class SessionPoolStressTest extends BaseSessionPoolTest {
 
   DatabaseId db = DatabaseId.of("projects/p/instances/i/databases/unused");
   SessionPool pool;
-  SessionPoolOptions options;
   ExecutorService createExecutor = Executors.newSingleThreadExecutor();
   final Object lock = new Object();
   Random random = new Random();
@@ -109,7 +108,7 @@ public class SessionPoolStressTest extends BaseSessionPoolTest {
                     for (int s = 0; s < sessionCount; s++) {
                       SessionImpl session;
                       synchronized (lock) {
-                        session = getMockedSession(context);
+                        session = getMockedSession(mockSpanner, context);
                         setupSession(session, context);
                         sessions.put(session.getName(), false);
                         if (sessions.size() > maxAliveSessions) {
@@ -128,8 +127,7 @@ public class SessionPoolStressTest extends BaseSessionPoolTest {
             Mockito.anyInt(), Mockito.anyBoolean(), Mockito.any(SessionConsumer.class));
   }
 
-  SessionImpl getMockedSession(ReadContext context) {
-    SpannerImpl spanner = mock(SpannerImpl.class);
+  SessionImpl getMockedSession(SpannerImpl spanner, ReadContext context) {
     Map options = new HashMap<>();
     options.put(Option.CHANNEL_HINT, channelHint.getAndIncrement());
     final SessionImpl session =
@@ -209,6 +207,7 @@ public class SessionPoolStressTest extends BaseSessionPoolTest {
     int maxSessions = concurrentThreads / 2;
     SessionPoolOptions.Builder builder =
         SessionPoolOptions.newBuilder()
+            .setPoolMaintainerClock(clock)
             .setMinSessions(minSessions)
             .setMaxSessions(maxSessions)
             .setInactiveTransactionRemovalOptions(
@@ -220,9 +219,11 @@ public class SessionPoolStressTest extends BaseSessionPoolTest {
     } else {
       builder.setFailIfPoolExhausted();
     }
+    SessionPoolOptions sessionPoolOptions = builder.build();
+    when(spannerOptions.getSessionPoolOptions()).thenReturn(sessionPoolOptions);
     pool =
         SessionPool.createPool(
-            builder.build(),
+            sessionPoolOptions,
             new TestExecutorFactory(),
             mockSpanner.getSessionClient(db),
             clock,

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpanTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpanTest.java
@@ -438,7 +438,7 @@ public class SpanTest {
     Map<String, Boolean> spans = failOnOverkillTraceComponent.getSpans();
 
     if (isMultiplexedSessionsEnabled()) {
-      assertThat(spans.size()).isEqualTo(4);
+      assertEquals(spans.toString(), 4, spans.size());
       assertThat(spans).containsEntry("CloudSpannerOperation.CreateMultiplexedSession", true);
     } else {
       assertThat(spans.size()).isEqualTo(3);


### PR DESCRIPTION
* Changes the session pool maintainer clock to a singleton.
* Adds more tests for session pool maintenance.
* Makes sure the clock that is set in the options is used for all transactions.
