### PR TITLE
chore: fix all unit tests  with multiplexed sessions.

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
@@ -21,6 +21,7 @@ import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Options.TransactionOption;
 import com.google.cloud.spanner.Options.UpdateOption;
 import com.google.cloud.spanner.SessionPool.PooledSessionFuture;
+import com.google.cloud.spanner.SessionPool.SessionFutureWrapper;
 import com.google.cloud.spanner.SpannerImpl.ClosedException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
@@ -50,6 +51,11 @@ class DatabaseClientImpl implements DatabaseClient {
   @VisibleForTesting
   PooledSessionFuture getSession() {
     return pool.getSession();
+  }
+
+  @VisibleForTesting
+  SessionFutureWrapper getMultiplexedSession() {
+    return pool.getMultiplexedSessionWithFallback();
   }
 
   @Override
@@ -123,7 +129,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public ReadContext singleUse() {
     ISpan span = tracer.spanBuilder(READ_ONLY_TRANSACTION);
     try (IScope s = tracer.withSpan(span)) {
-      return getSession().singleUse();
+      return getMultiplexedSession().singleUse();
     } catch (RuntimeException e) {
       span.setStatus(e);
       span.end();
@@ -135,7 +141,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public ReadContext singleUse(TimestampBound bound) {
     ISpan span = tracer.spanBuilder(READ_ONLY_TRANSACTION);
     try (IScope s = tracer.withSpan(span)) {
-      return getSession().singleUse(bound);
+      return getMultiplexedSession().singleUse(bound);
     } catch (RuntimeException e) {
       span.setStatus(e);
       span.end();
@@ -147,7 +153,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public ReadOnlyTransaction singleUseReadOnlyTransaction() {
     ISpan span = tracer.spanBuilder(READ_ONLY_TRANSACTION);
     try (IScope s = tracer.withSpan(span)) {
-      return getSession().singleUseReadOnlyTransaction();
+      return getMultiplexedSession().singleUseReadOnlyTransaction();
     } catch (RuntimeException e) {
       span.setStatus(e);
       span.end();
@@ -159,7 +165,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public ReadOnlyTransaction singleUseReadOnlyTransaction(TimestampBound bound) {
     ISpan span = tracer.spanBuilder(READ_ONLY_TRANSACTION);
     try (IScope s = tracer.withSpan(span)) {
-      return getSession().singleUseReadOnlyTransaction(bound);
+      return getMultiplexedSession().singleUseReadOnlyTransaction(bound);
     } catch (RuntimeException e) {
       span.setStatus(e);
       span.end();
@@ -171,7 +177,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public ReadOnlyTransaction readOnlyTransaction() {
     ISpan span = tracer.spanBuilder(READ_ONLY_TRANSACTION);
     try (IScope s = tracer.withSpan(span)) {
-      return getSession().readOnlyTransaction();
+      return getMultiplexedSession().readOnlyTransaction();
     } catch (RuntimeException e) {
       span.setStatus(e);
       span.end();
@@ -183,7 +189,7 @@ class DatabaseClientImpl implements DatabaseClient {
   public ReadOnlyTransaction readOnlyTransaction(TimestampBound bound) {
     ISpan span = tracer.spanBuilder(READ_ONLY_TRANSACTION);
     try (IScope s = tracer.withSpan(span)) {
-      return getSession().readOnlyTransaction(bound);
+      return getMultiplexedSession().readOnlyTransaction(bound);
     } catch (RuntimeException e) {
       span.setStatus(e);
       span.end();

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionClient.java
@@ -263,6 +263,61 @@ class SessionClient implements AutoCloseable {
   }
 
   /**
+   * Create a multiplexed session asynchronously and returns it to the given {@link
+   * SessionConsumer}. A multiplexed session is not affiliated with any GRPC channel. The given
+   * {@link SessionConsumer} is guaranteed to eventually get exactly 1 multiplexed session unless an
+   * error occurs. In case of an error on the gRPC calls, the consumer will receive one {@link
+   * SessionConsumer#onSessionCreateFailure(Throwable, int)} calls with the error.
+   *
+   * @param consumer The {@link SessionConsumer} to use for callbacks when sessions are available.
+   */
+  void asyncCreateMultiplexedSession(SessionConsumer consumer) {
+    try {
+      executor.submit(new CreateMultiplexedSessionsRunnable(consumer));
+    } catch (Throwable t) {
+      consumer.onSessionCreateFailure(t, 1);
+    }
+  }
+
+  private final class CreateMultiplexedSessionsRunnable implements Runnable {
+    private final SessionConsumer consumer;
+
+    private CreateMultiplexedSessionsRunnable(SessionConsumer consumer) {
+      Preconditions.checkNotNull(consumer);
+      this.consumer = consumer;
+    }
+
+    @Override
+    public void run() {
+      ISpan span = spanner.getTracer().spanBuilder(SpannerImpl.CREATE_MULTIPLEXED_SESSION);
+      try (IScope s = spanner.getTracer().withSpan(span)) {
+        com.google.spanner.v1.Session session =
+            spanner
+                .getRpc()
+                .createSession(
+                    db.getName(),
+                    spanner.getOptions().getDatabaseRole(),
+                    spanner.getOptions().getSessionLabels(),
+                    null,
+                    true);
+        SessionImpl sessionImpl =
+            new SessionImpl(
+                spanner,
+                new SessionReference(
+                    session.getName(), session.getCreateTime(), session.getMultiplexed(), null));
+        span.addAnnotation(
+            String.format("Request for %d multiplexed session returned %d session", 1, 1));
+        consumer.onSessionReady(sessionImpl);
+      } catch (Throwable t) {
+        span.setStatus(t);
+        consumer.onSessionCreateFailure(t, 1);
+      } finally {
+        span.end();
+      }
+    }
+  }
+
+  /**
    * Asynchronously creates a batch of sessions and returns these to the given {@link
    * SessionConsumer}. This method may split the actual session creation over several gRPC calls in
    * order to distribute the sessions evenly over all available channels and to parallelize the

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -3038,6 +3038,13 @@ class SessionPool {
   }
 
   @VisibleForTesting
+  boolean isMultiplexedSessionBeingCreated() {
+    synchronized (lock) {
+      return multiplexedSessionBeingCreated;
+    }
+  }
+
+  @VisibleForTesting
   long getNumWaiterTimeouts() {
     return numWaiterTimeouts.get();
   }
@@ -3617,7 +3624,7 @@ class SessionPool {
           logger.log(
               Level.INFO,
               String.format(
-                  "Removed Multiplexed Session => %s created at => %s and",
+                  "Removed Multiplexed Session => %s created at => %s",
                   oldSession.getName(), oldSession.getCreateTime()));
           if (multiplexedSessionRemovedListener != null) {
             multiplexedSessionRemovedListener.apply(oldSession);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
@@ -284,7 +284,7 @@ public class SessionPoolOptions {
     return randomizePositionQPSThreshold;
   }
 
-  boolean getUseMultiplexedSession() {
+  public boolean getUseMultiplexedSession() {
     return useMultiplexedSession;
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerTest.java
@@ -49,6 +49,7 @@ import com.google.protobuf.AbstractMessage;
 import com.google.spanner.v1.BatchCreateSessionsRequest;
 import com.google.spanner.v1.BeginTransactionRequest;
 import com.google.spanner.v1.CommitRequest;
+import com.google.spanner.v1.CreateSessionRequest;
 import com.google.spanner.v1.ExecuteBatchDmlRequest;
 import com.google.spanner.v1.ExecuteSqlRequest;
 import com.google.spanner.v1.RollbackRequest;
@@ -344,18 +345,34 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
         }
       }
     }
-    assertThat(mockSpanner.getRequestTypes())
-        .containsExactly(
-            BatchCreateSessionsRequest.class,
-            // The first update that fails. This will cause a transaction retry.
-            ExecuteSqlRequest.class,
-            // The retry will use an explicit BeginTransaction call.
-            BeginTransactionRequest.class,
-            // The first update will again fail, but now there is a transaction id, so the
-            // transaction can continue.
-            ExecuteSqlRequest.class,
-            ExecuteSqlRequest.class,
-            CommitRequest.class);
+    if (isMultiplexedSessionsEnabled()) {
+      assertThat(mockSpanner.getRequestTypes())
+          .containsExactly(
+              CreateSessionRequest.class,
+              BatchCreateSessionsRequest.class,
+              // The first update that fails. This will cause a transaction retry.
+              ExecuteSqlRequest.class,
+              // The retry will use an explicit BeginTransaction call.
+              BeginTransactionRequest.class,
+              // The first update will again fail, but now there is a transaction id, so the
+              // transaction can continue.
+              ExecuteSqlRequest.class,
+              ExecuteSqlRequest.class,
+              CommitRequest.class);
+    } else {
+      assertThat(mockSpanner.getRequestTypes())
+          .containsExactly(
+              BatchCreateSessionsRequest.class,
+              // The first update that fails. This will cause a transaction retry.
+              ExecuteSqlRequest.class,
+              // The retry will use an explicit BeginTransaction call.
+              BeginTransactionRequest.class,
+              // The first update will again fail, but now there is a transaction id, so the
+              // transaction can continue.
+              ExecuteSqlRequest.class,
+              ExecuteSqlRequest.class,
+              CommitRequest.class);
+    }
   }
 
   @Test
@@ -549,9 +566,18 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
                   executor)
               .commitAsync()
               .get();
-          assertThat(mockSpanner.getRequestTypes())
-              .containsExactly(
-                  BatchCreateSessionsRequest.class, ExecuteSqlRequest.class, CommitRequest.class);
+          if (isMultiplexedSessionsEnabled()) {
+            assertThat(mockSpanner.getRequestTypes())
+                .containsExactly(
+                    CreateSessionRequest.class,
+                    BatchCreateSessionsRequest.class,
+                    ExecuteSqlRequest.class,
+                    CommitRequest.class);
+          } else {
+            assertThat(mockSpanner.getRequestTypes())
+                .containsExactly(
+                    BatchCreateSessionsRequest.class, ExecuteSqlRequest.class, CommitRequest.class);
+          }
           break;
         } catch (AbortedException e) {
           txn = mgr.resetForRetryAsync();
@@ -655,12 +681,22 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
         }
       }
     }
-    assertThat(mockSpanner.getRequestTypes())
-        .containsExactly(
-            BatchCreateSessionsRequest.class,
-            ExecuteBatchDmlRequest.class,
-            ExecuteBatchDmlRequest.class,
-            CommitRequest.class);
+    if (isMultiplexedSessionsEnabled()) {
+      assertThat(mockSpanner.getRequestTypes())
+          .containsExactly(
+              CreateSessionRequest.class,
+              BatchCreateSessionsRequest.class,
+              ExecuteBatchDmlRequest.class,
+              ExecuteBatchDmlRequest.class,
+              CommitRequest.class);
+    } else {
+      assertThat(mockSpanner.getRequestTypes())
+          .containsExactly(
+              BatchCreateSessionsRequest.class,
+              ExecuteBatchDmlRequest.class,
+              ExecuteBatchDmlRequest.class,
+              CommitRequest.class);
+    }
   }
 
   @Test
@@ -693,13 +729,24 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
     assertThat(attempt.get()).isEqualTo(2);
     // There should only be 1 CommitRequest, as the first attempt should abort already after the
     // ExecuteBatchDmlRequest.
-    assertThat(mockSpanner.getRequestTypes())
-        .containsExactly(
-            BatchCreateSessionsRequest.class,
-            ExecuteBatchDmlRequest.class,
-            BeginTransactionRequest.class,
-            ExecuteBatchDmlRequest.class,
-            CommitRequest.class);
+    if (isMultiplexedSessionsEnabled()) {
+      assertThat(mockSpanner.getRequestTypes())
+          .containsExactly(
+              CreateSessionRequest.class,
+              BatchCreateSessionsRequest.class,
+              ExecuteBatchDmlRequest.class,
+              BeginTransactionRequest.class,
+              ExecuteBatchDmlRequest.class,
+              CommitRequest.class);
+    } else {
+      assertThat(mockSpanner.getRequestTypes())
+          .containsExactly(
+              BatchCreateSessionsRequest.class,
+              ExecuteBatchDmlRequest.class,
+              BeginTransactionRequest.class,
+              ExecuteBatchDmlRequest.class,
+              CommitRequest.class);
+    }
   }
 
   @Test
@@ -730,13 +777,24 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
     assertThat(attempt.get()).isEqualTo(2);
     // There should only be 1 CommitRequest, as the first attempt should abort already after the
     // ExecuteBatchDmlRequest.
-    assertThat(mockSpanner.getRequestTypes())
-        .containsExactly(
-            BatchCreateSessionsRequest.class,
-            ExecuteBatchDmlRequest.class,
-            BeginTransactionRequest.class,
-            ExecuteBatchDmlRequest.class,
-            CommitRequest.class);
+    if (isMultiplexedSessionsEnabled()) {
+      assertThat(mockSpanner.getRequestTypes())
+          .containsExactly(
+              CreateSessionRequest.class,
+              BatchCreateSessionsRequest.class,
+              ExecuteBatchDmlRequest.class,
+              BeginTransactionRequest.class,
+              ExecuteBatchDmlRequest.class,
+              CommitRequest.class);
+    } else {
+      assertThat(mockSpanner.getRequestTypes())
+          .containsExactly(
+              BatchCreateSessionsRequest.class,
+              ExecuteBatchDmlRequest.class,
+              BeginTransactionRequest.class,
+              ExecuteBatchDmlRequest.class,
+              CommitRequest.class);
+    }
   }
 
   @Test
@@ -785,14 +843,26 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
     } finally {
       mockSpanner.putStatementResult(StatementResult.update(UPDATE_STATEMENT, UPDATE_COUNT));
     }
-    assertThat(mockSpanner.getRequestTypes())
-        .containsExactly(
-            BatchCreateSessionsRequest.class,
-            ExecuteBatchDmlRequest.class,
-            CommitRequest.class,
-            BeginTransactionRequest.class,
-            ExecuteBatchDmlRequest.class,
-            CommitRequest.class);
+    if (isMultiplexedSessionsEnabled()) {
+      assertThat(mockSpanner.getRequestTypes())
+          .containsExactly(
+              CreateSessionRequest.class,
+              BatchCreateSessionsRequest.class,
+              ExecuteBatchDmlRequest.class,
+              CommitRequest.class,
+              BeginTransactionRequest.class,
+              ExecuteBatchDmlRequest.class,
+              CommitRequest.class);
+    } else {
+      assertThat(mockSpanner.getRequestTypes())
+          .containsExactly(
+              BatchCreateSessionsRequest.class,
+              ExecuteBatchDmlRequest.class,
+              CommitRequest.class,
+              BeginTransactionRequest.class,
+              ExecuteBatchDmlRequest.class,
+              CommitRequest.class);
+    }
   }
 
   @Test
@@ -831,23 +901,46 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
     Iterable<Class<? extends AbstractMessage>> requests = mockSpanner.getRequestTypes();
     int size = Iterables.size(requests);
     assertThat(size).isIn(Range.closed(5, 6));
-    if (size == 5) {
-      assertThat(requests)
-          .containsExactly(
-              BatchCreateSessionsRequest.class,
-              ExecuteBatchDmlRequest.class,
-              BeginTransactionRequest.class,
-              ExecuteBatchDmlRequest.class,
-              CommitRequest.class);
+    if (isMultiplexedSessionsEnabled()) {
+      if (size == 6) {
+        assertThat(requests)
+            .containsExactly(
+                CreateSessionRequest.class,
+                BatchCreateSessionsRequest.class,
+                ExecuteBatchDmlRequest.class,
+                BeginTransactionRequest.class,
+                ExecuteBatchDmlRequest.class,
+                CommitRequest.class);
+      } else {
+        assertThat(requests)
+            .containsExactly(
+                CreateSessionRequest.class,
+                BatchCreateSessionsRequest.class,
+                ExecuteBatchDmlRequest.class,
+                CommitRequest.class,
+                BeginTransactionRequest.class,
+                ExecuteBatchDmlRequest.class,
+                CommitRequest.class);
+      }
     } else {
-      assertThat(requests)
-          .containsExactly(
-              BatchCreateSessionsRequest.class,
-              ExecuteBatchDmlRequest.class,
-              CommitRequest.class,
-              BeginTransactionRequest.class,
-              ExecuteBatchDmlRequest.class,
-              CommitRequest.class);
+      if (size == 5) {
+        assertThat(requests)
+            .containsExactly(
+                BatchCreateSessionsRequest.class,
+                ExecuteBatchDmlRequest.class,
+                BeginTransactionRequest.class,
+                ExecuteBatchDmlRequest.class,
+                CommitRequest.class);
+      } else {
+        assertThat(requests)
+            .containsExactly(
+                BatchCreateSessionsRequest.class,
+                ExecuteBatchDmlRequest.class,
+                CommitRequest.class,
+                BeginTransactionRequest.class,
+                ExecuteBatchDmlRequest.class,
+                CommitRequest.class);
+      }
     }
   }
 
@@ -875,9 +968,18 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
       assertThat(e.getErrorCode()).isEqualTo(ErrorCode.RESOURCE_EXHAUSTED);
       assertThat(e.getMessage()).contains("mutation limit exceeded");
     }
-    assertThat(mockSpanner.getRequestTypes())
-        .containsExactly(
-            BatchCreateSessionsRequest.class, ExecuteBatchDmlRequest.class, CommitRequest.class);
+    if (isMultiplexedSessionsEnabled()) {
+      assertThat(mockSpanner.getRequestTypes())
+          .containsExactly(
+              CreateSessionRequest.class,
+              BatchCreateSessionsRequest.class,
+              ExecuteBatchDmlRequest.class,
+              CommitRequest.class);
+    } else {
+      assertThat(mockSpanner.getRequestTypes())
+          .containsExactly(
+              BatchCreateSessionsRequest.class, ExecuteBatchDmlRequest.class, CommitRequest.class);
+    }
   }
 
   @Test
@@ -901,9 +1003,18 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
         }
       }
     }
-    assertThat(mockSpanner.getRequestTypes())
-        .containsExactly(
-            BatchCreateSessionsRequest.class, ExecuteBatchDmlRequest.class, CommitRequest.class);
+    if (isMultiplexedSessionsEnabled()) {
+      assertThat(mockSpanner.getRequestTypes())
+          .containsExactly(
+              CreateSessionRequest.class,
+              BatchCreateSessionsRequest.class,
+              ExecuteBatchDmlRequest.class,
+              CommitRequest.class);
+    } else {
+      assertThat(mockSpanner.getRequestTypes())
+          .containsExactly(
+              BatchCreateSessionsRequest.class, ExecuteBatchDmlRequest.class, CommitRequest.class);
+    }
   }
 
   @Test
@@ -1033,5 +1144,12 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
 
       assertThat(res.get(10L, TimeUnit.SECONDS)).isNull();
     }
+  }
+
+  private boolean isMultiplexedSessionsEnabled() {
+    if (spanner.getOptions() == null || spanner.getOptions().getSessionPoolOptions() == null) {
+      return false;
+    }
+    return spanner.getOptions().getSessionPoolOptions().getUseMultiplexedSession();
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BaseSessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BaseSessionPoolTest.java
@@ -88,6 +88,7 @@ abstract class BaseSessionPoolTest {
   SessionImpl mockMultiplexedSession() {
     final SessionImpl session = mock(SessionImpl.class);
     Map options = new HashMap<>();
+    when(session.getIsMultiplexed()).thenReturn(true);
     when(session.getOptions()).thenReturn(options);
     when(session.getName())
         .thenReturn(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BaseSessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BaseSessionPoolTest.java
@@ -85,6 +85,22 @@ abstract class BaseSessionPoolTest {
     return session;
   }
 
+  SessionImpl mockMultiplexedSession() {
+    final SessionImpl session = mock(SessionImpl.class);
+    Map options = new HashMap<>();
+    when(session.getOptions()).thenReturn(options);
+    when(session.getName())
+        .thenReturn(
+            "projects/dummy/instances/dummy/database/dummy/sessions/session" + sessionIndex);
+    when(session.asyncClose()).thenReturn(ApiFutures.immediateFuture(Empty.getDefaultInstance()));
+    when(session.writeWithOptions(any(Iterable.class)))
+        .thenReturn(new CommitResponse(com.google.spanner.v1.CommitResponse.getDefaultInstance()));
+    when(session.writeAtLeastOnceWithOptions(any(Iterable.class)))
+        .thenReturn(new CommitResponse(com.google.spanner.v1.CommitResponse.getDefaultInstance()));
+    sessionIndex++;
+    return session;
+  }
+
   SessionImpl buildMockSession(ReadContext context) {
     SpannerImpl spanner = mock(SpannerImpl.class);
     Map options = new HashMap<>();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BatchCreateSessionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BatchCreateSessionsTest.java
@@ -178,11 +178,6 @@ public class BatchCreateSessionsTest {
     DatabaseClientImpl client;
     mockSpanner.setMaxTotalSessions(maxServerSessions);
     try (Spanner spanner = createSpanner(minSessions, maxSessions)) {
-      if (spanner.getOptions().getSessionPoolOptions().getUseMultiplexedSession()) {
-        // there will 550 regular sessions and 1 multiplexed session (when multiplexed session is
-        // enabled
-        mockSpanner.setMaxTotalSessions(maxServerSessions + 1);
-      }
       // Create a database client which will create a session pool.
       client =
           (DatabaseClientImpl)

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BatchCreateSessionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BatchCreateSessionsTest.java
@@ -178,6 +178,11 @@ public class BatchCreateSessionsTest {
     DatabaseClientImpl client;
     mockSpanner.setMaxTotalSessions(maxServerSessions);
     try (Spanner spanner = createSpanner(minSessions, maxSessions)) {
+      if (spanner.getOptions().getSessionPoolOptions().getUseMultiplexedSession()) {
+        // there will 550 regular sessions and 1 multiplexed session (when multiplexed session is
+        // enabled
+        mockSpanner.setMaxTotalSessions(maxServerSessions + 1);
+      }
       // Create a database client which will create a session pool.
       client =
           (DatabaseClientImpl)

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ChannelUsageTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ChannelUsageTest.java
@@ -221,11 +221,9 @@ public class ChannelUsageTest {
   @Test
   public void testCreatesNumChannels() {
     try (Spanner spanner = createSpannerOptions().getService()) {
-      if (enableGcpPool) {
-        assumeFalse(
-            "GRPC-GCP is currently not supported with multiplexed sessions",
-            isMultiplexedSessionsEnabled(spanner));
-      }
+      assumeFalse(
+          "GRPC-GCP is currently not supported with multiplexed sessions",
+          isMultiplexedSessionsEnabled(spanner));
       DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
       try (ResultSet resultSet = client.singleUse().executeQuery(SELECT1)) {
         while (resultSet.next()) {}
@@ -237,11 +235,9 @@ public class ChannelUsageTest {
   @Test
   public void testUsesAllChannels() throws InterruptedException, ExecutionException {
     try (Spanner spanner = createSpannerOptions().getService()) {
-      if (enableGcpPool) {
-        assumeFalse(
-            "GRPC-GCP is currently not supported with multiplexed sessions",
-            isMultiplexedSessionsEnabled(spanner));
-      }
+      assumeFalse(
+          "GRPC-GCP is currently not supported with multiplexed sessions",
+          isMultiplexedSessionsEnabled(spanner));
       DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
       ListeningExecutorService executor =
           MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(numChannels * 2));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -32,6 +32,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -2318,7 +2320,9 @@ public class DatabaseClientImplTest {
     assertThat(checkedOut).isEmpty();
     try (ResultSet rs = client.singleUse().executeQuery(SELECT1)) {
       assertThat(rs.next()).isTrue();
-      assertThat(checkedOut).hasSize(1);
+      if (!isMultiplexedSessionsEnabled()) {
+        assertThat(checkedOut).hasSize(1);
+      }
       assertThat(rs.getLong(0)).isEqualTo(1L);
       assertThat(rs.next()).isFalse();
     }
@@ -3009,6 +3013,10 @@ public class DatabaseClientImplTest {
               "Instance", SpannerExceptionFactory.INSTANCE_RESOURCE_TYPE, INSTANCE_NAME)
         };
     for (StatusRuntimeException exception : exceptions) {
+      if (isMultiplexedSessionsEnabled()) {
+        mockSpanner.setCreateSessionExecutionTime(
+            SimulatedExecutionTime.ofStickyException(exception));
+      }
       mockSpanner.setBatchCreateSessionsExecutionTime(
           SimulatedExecutionTime.ofStickyException(exception));
       // Ensure there are no sessions in the pool by default.
@@ -3175,6 +3183,10 @@ public class DatabaseClientImplTest {
               "Instance", SpannerExceptionFactory.INSTANCE_RESOURCE_TYPE, INSTANCE_NAME)
         };
     for (StatusRuntimeException exception : exceptions) {
+      if (isMultiplexedSessionsEnabled()) {
+        mockSpanner.setCreateSessionExecutionTime(
+            SimulatedExecutionTime.ofStickyException(exception));
+      }
       mockSpanner.setBatchCreateSessionsExecutionTime(
           SimulatedExecutionTime.ofStickyException(exception));
       try (Spanner spanner =
@@ -3645,6 +3657,9 @@ public class DatabaseClientImplTest {
 
   @Test
   public void testBatchCreateSessionsPermissionDenied() {
+    assumeFalse(
+        "BatchCreateSessions RPC is not invoked for multiplexed sessions",
+        isMultiplexedSessionsEnabled());
     mockSpanner.setBatchCreateSessionsExecutionTime(
         SimulatedExecutionTime.ofStickyException(
             Status.PERMISSION_DENIED.withDescription("Not permitted").asRuntimeException()));
@@ -3662,6 +3677,34 @@ public class DatabaseClientImplTest {
       // Actually trying to get any results will cause an exception.
       SpannerException e = assertThrows(SpannerException.class, rs::next);
       assertEquals(ErrorCode.PERMISSION_DENIED, e.getErrorCode());
+    } finally {
+      mockSpanner.setBatchCreateSessionsExecutionTime(SimulatedExecutionTime.none());
+    }
+  }
+
+  @Test
+  public void testCreateSessionsPermissionDenied() {
+    assumeTrue(
+        "CreateSessions RPC is not invoked for regular sessions", isMultiplexedSessionsEnabled());
+    mockSpanner.setCreateSessionExecutionTime(
+        SimulatedExecutionTime.ofStickyException(
+            Status.PERMISSION_DENIED.withDescription("Not permitted").asRuntimeException()));
+    try (Spanner spanner =
+        SpannerOptions.newBuilder()
+            .setProjectId("my-project")
+            .setChannelProvider(channelProvider)
+            .setCredentials(NoCredentials.getInstance())
+            .build()
+            .getService()) {
+      DatabaseId databaseId = DatabaseId.of("my-project", "my-instance", "my-database");
+      DatabaseClient client = spanner.getDatabaseClient(databaseId);
+      // The following call is non-blocking and will not generate an exception.
+      ResultSet rs = client.singleUse().executeQuery(SELECT1);
+      // Actually trying to get any results will cause an exception.
+      SpannerException e = assertThrows(SpannerException.class, rs::next);
+      assertEquals(ErrorCode.PERMISSION_DENIED, e.getErrorCode());
+    } finally {
+      mockSpanner.setCreateSessionExecutionTime(SimulatedExecutionTime.none());
     }
   }
 
@@ -3747,6 +3790,9 @@ public class DatabaseClientImplTest {
 
   @Test
   public void testBatchCreateSessionsFailure_shouldNotPropagateToCloseMethod() {
+    assumeFalse(
+        "BatchCreateSessions RPC is not invoked for multiplexed sessions",
+        isMultiplexedSessionsEnabled());
     try {
       // Simulate session creation failures on the backend.
       mockSpanner.setBatchCreateSessionsExecutionTime(
@@ -3762,6 +3808,28 @@ public class DatabaseClientImplTest {
       }
     } finally {
       mockSpanner.setBatchCreateSessionsExecutionTime(SimulatedExecutionTime.none());
+    }
+  }
+
+  @Test
+  public void testCreateSessionsFailure_shouldNotPropagateToCloseMethod() {
+    assumeTrue(
+        "CreateSessions is not invoked for regular sessions", isMultiplexedSessionsEnabled());
+    try {
+      // Simulate session creation failures on the backend.
+      mockSpanner.setCreateSessionExecutionTime(
+          SimulatedExecutionTime.ofStickyException(Status.RESOURCE_EXHAUSTED.asRuntimeException()));
+      DatabaseClient client =
+          spannerWithEmptySessionPool.getDatabaseClient(
+              DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+      // This will not cause any failure as getting a session from the pool is guaranteed to be
+      // non-blocking, and any exceptions will be delayed until actual query execution.
+      try (ResultSet rs = client.singleUse().executeQuery(SELECT1)) {
+        SpannerException e = assertThrows(SpannerException.class, rs::next);
+        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.RESOURCE_EXHAUSTED);
+      }
+    } finally {
+      mockSpanner.setCreateSessionExecutionTime(SimulatedExecutionTime.none());
     }
   }
 
@@ -5236,5 +5304,12 @@ public class DatabaseClientImplTest {
     }
 
     return valuesBuilder.build();
+  }
+
+  private boolean isMultiplexedSessionsEnabled() {
+    if (spanner.getOptions() == null || spanner.getOptions().getSessionPoolOptions() == null) {
+      return false;
+    }
+    return spanner.getOptions().getSessionPoolOptions().getUseMultiplexedSession();
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestWithClosedSessionsEnv.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestWithClosedSessionsEnv.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner;
 
 import com.google.cloud.spanner.SessionPool.PooledSession;
 import com.google.cloud.spanner.SessionPool.PooledSessionFuture;
+import com.google.cloud.spanner.SessionPool.SessionFutureWrapper;
 import com.google.cloud.spanner.testing.RemoteSpannerHelper;
 
 /**
@@ -83,6 +84,20 @@ public class IntegrationTestWithClosedSessionsEnv extends IntegrationTestEnv {
         invalidateNextSession = false;
       }
       session.get().setAllowReplacing(allowReplacing);
+      return session;
+    }
+
+    @Override
+    SessionFutureWrapper getMultiplexedSession() {
+      SessionFutureWrapper session = super.getMultiplexedSession();
+      if (invalidateNextSession) {
+        session.get().get().getDelegate().close();
+        session.get().get().setAllowReplacing(false);
+        awaitDeleted(session.get().get().getDelegate());
+        session.get().get().setAllowReplacing(allowReplacing);
+        invalidateNextSession = false;
+      }
+      session.get().get().setAllowReplacing(allowReplacing);
       return session;
     }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -585,6 +585,8 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
   private ConcurrentMap<String, StatementResult> partialStatementResults =
       new ConcurrentHashMap<>();
   private ConcurrentMap<String, Session> sessions = new ConcurrentHashMap<>();
+  private ConcurrentMap<String, Session> multiplexedSessions = new ConcurrentHashMap<>();
+
   private ConcurrentMap<String, Instant> sessionLastUsed = new ConcurrentHashMap<>();
   private ConcurrentMap<ByteString, Transaction> transactions = new ConcurrentHashMap<>();
   private final Queue<ByteString> transactionsStarted = new ConcurrentLinkedQueue<>();
@@ -828,7 +830,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
             response.addSession(session);
             numSessionsCreated.incrementAndGet();
           } else {
-            sessions.remove(name);
+            removeSession(name);
           }
         } else {
           // Someone else tried to create a session with the same id. This should not be possible
@@ -839,12 +841,12 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
       responseObserver.onCompleted();
     } catch (StatusRuntimeException e) {
       if (name != null) {
-        sessions.remove(name);
+        removeSession(name);
       }
       responseObserver.onError(e);
     } catch (Throwable e) {
       if (name != null) {
-        sessions.remove(name);
+        removeSession(name);
       }
       responseObserver.onError(
           Status.INTERNAL
@@ -872,7 +874,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
               .setApproximateLastUseTime(now)
               .setMultiplexed(requestSession.getMultiplexed())
               .build();
-      Session prev = sessions.putIfAbsent(name, session);
+      Session prev = addSession(session);
       if (prev == null) {
         sessionLastUsed.put(name, Instant.now());
         numSessionsCreated.incrementAndGet();
@@ -883,10 +885,10 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
         responseObserver.onError(Status.ALREADY_EXISTS.asRuntimeException());
       }
     } catch (StatusRuntimeException e) {
-      sessions.remove(name);
+      removeSession(name);
       responseObserver.onError(e);
     } catch (Throwable e) {
-      sessions.remove(name);
+      removeSession(name);
       responseObserver.onError(
           Status.INTERNAL
               .withDescription("Create session failed: " + e.getMessage())
@@ -900,7 +902,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
     Preconditions.checkNotNull(request.getName());
     try {
       getSessionExecutionTime.simulateExecutionTime(exceptions, stickyGlobalExceptions, freezeLock);
-      Session session = sessions.get(request.getName());
+      Session session = getSession(request.getName());
       if (session == null) {
         setSessionNotFound(request.getName(), responseObserver);
       } else {
@@ -969,7 +971,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
     try {
       deleteSessionExecutionTime.simulateExecutionTime(
           exceptions, stickyGlobalExceptions, freezeLock);
-      Session session = sessions.get(request.getName());
+      Session session = getSession(request.getName());
       if (session != null) {
         try {
           doDeleteSession(session);
@@ -986,7 +988,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
   }
 
   void doDeleteSession(Session session) {
-    sessions.remove(session.getName());
+    removeSession(session.getName());
     transactionCounters.remove(session.getName());
     sessionLastUsed.remove(session.getName());
   }
@@ -995,7 +997,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
   public void executeSql(ExecuteSqlRequest request, StreamObserver<ResultSet> responseObserver) {
     requests.add(request);
     Preconditions.checkNotNull(request.getSession());
-    Session session = sessions.get(request.getSession());
+    Session session = getSession(request.getSession());
     if (session == null) {
       setSessionNotFound(request.getSession(), responseObserver);
       return;
@@ -1081,7 +1083,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
       ExecuteBatchDmlRequest request, StreamObserver<ExecuteBatchDmlResponse> responseObserver) {
     requests.add(request);
     Preconditions.checkNotNull(request.getSession());
-    Session session = sessions.get(request.getSession());
+    Session session = getSession(request.getSession());
     if (session == null) {
       setSessionNotFound(request.getSession(), responseObserver);
       return;
@@ -1184,7 +1186,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
       requests.add(request);
     }
     Preconditions.checkNotNull(request.getSession());
-    Session session = sessions.get(request.getSession());
+    Session session = getSession(request.getSession());
     if (session == null) {
       setSessionNotFound(request.getSession(), responseObserver);
       return;
@@ -1586,7 +1588,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
   public void read(final ReadRequest request, StreamObserver<ResultSet> responseObserver) {
     requests.add(request);
     Preconditions.checkNotNull(request.getSession());
-    Session session = sessions.get(request.getSession());
+    Session session = getSession(request.getSession());
     if (session == null) {
       setSessionNotFound(request.getSession(), responseObserver);
       return;
@@ -1619,7 +1621,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
       final ReadRequest request, StreamObserver<PartialResultSet> responseObserver) {
     requests.add(request);
     Preconditions.checkNotNull(request.getSession());
-    Session session = sessions.get(request.getSession());
+    Session session = getSession(request.getSession());
     if (session == null) {
       setSessionNotFound(request.getSession(), responseObserver);
       return;
@@ -1822,7 +1824,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
       BeginTransactionRequest request, StreamObserver<Transaction> responseObserver) {
     requests.add(request);
     Preconditions.checkNotNull(request.getSession());
-    Session session = sessions.get(request.getSession());
+    Session session = getSession(request.getSession());
     if (session == null) {
       setSessionNotFound(request.getSession(), responseObserver);
       return;
@@ -1936,7 +1938,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
   public void commit(CommitRequest request, StreamObserver<CommitResponse> responseObserver) {
     requests.add(request);
     Preconditions.checkNotNull(request.getSession());
-    Session session = sessions.get(request.getSession());
+    Session session = getSession(request.getSession());
     if (session == null) {
       setSessionNotFound(request.getSession(), responseObserver);
       return;
@@ -1998,7 +2000,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
       BatchWriteRequest request, StreamObserver<BatchWriteResponse> responseObserver) {
     requests.add(request);
     Preconditions.checkNotNull(request.getSession());
-    Session session = sessions.get(request.getSession());
+    Session session = getSession(request.getSession());
     if (session == null) {
       setSessionNotFound(request.getSession(), responseObserver);
       return;
@@ -2026,7 +2028,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
   public void rollback(RollbackRequest request, StreamObserver<Empty> responseObserver) {
     requests.add(request);
     Preconditions.checkNotNull(request.getTransactionId());
-    Session session = sessions.get(request.getSession());
+    Session session = getSession(request.getSession());
     if (session == null) {
       setSessionNotFound(request.getSession(), responseObserver);
       return;
@@ -2103,7 +2105,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
       TransactionSelector transactionSelector,
       PartitionOptions options,
       StreamObserver<PartitionResponse> responseObserver) {
-    Session session = sessions.get(sessionName);
+    Session session = getSession(sessionName);
     if (session == null) {
       setSessionNotFound(sessionName, responseObserver);
       return;
@@ -2401,5 +2403,32 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
 
   public void setStreamingReadExecutionTime(SimulatedExecutionTime streamingReadExecutionTime) {
     this.streamingReadExecutionTime = Preconditions.checkNotNull(streamingReadExecutionTime);
+  }
+
+  Session addSession(Session session) {
+    Session prev;
+    if (session.getMultiplexed()) {
+      prev = multiplexedSessions.putIfAbsent(session.getName(), session);
+    } else {
+      prev = sessions.putIfAbsent(session.getName(), session);
+    }
+    return prev;
+  }
+
+  void removeSession(String name) {
+    if (multiplexedSessions.containsKey(name)) {
+      multiplexedSessions.remove(name);
+    } else {
+      sessions.remove(name);
+    }
+  }
+
+  Session getSession(String name) {
+    if (multiplexedSessions.containsKey(name)) {
+      return multiplexedSessions.get(name);
+    } else if (sessions.containsKey(name)) {
+      return sessions.get(name);
+    }
+    return null;
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -1884,7 +1884,10 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
   }
 
   private void simulateAbort(Session session, ByteString transactionId) {
-    ensureMostRecentTransaction(session, transactionId);
+    if (!session.getMultiplexed()) {
+      // multiplexed sessions allow concurrent transactions on a single session.
+      ensureMostRecentTransaction(session, transactionId);
+    }
     if (isReadWriteTransaction(transactionId)) {
       if (abortNextStatement.getAndSet(false) || abortProbability > random.nextDouble()) {
         rollbackTransaction(transactionId);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MultiplexedSessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MultiplexedSessionPoolTest.java
@@ -36,6 +36,7 @@ import io.opencensus.trace.Tracing;
 import io.opentelemetry.api.OpenTelemetry;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -81,6 +82,7 @@ public class MultiplexedSessionPoolTest extends BaseSessionPoolTest {
             .setMaxSessions(2)
             .setUseMultiplexedSession(true)
             .build();
+    Assume.assumeTrue(options.getUseMultiplexedSession());
   }
 
   @Test
@@ -97,7 +99,7 @@ public class MultiplexedSessionPoolTest extends BaseSessionPoolTest {
       assertNotNull(multiplexedSessionFuture.get());
     }
     verify(sessionClient, times(1))
-        .createMultiplexedSession(any(MultiplexedSessionInitializationConsumer.class));
+        .asyncCreateMultiplexedSession(any(MultiplexedSessionInitializationConsumer.class));
   }
 
   @Test
@@ -136,7 +138,7 @@ public class MultiplexedSessionPoolTest extends BaseSessionPoolTest {
               return null;
             })
         .when(sessionClient)
-        .createMultiplexedSession(any(MultiplexedSessionInitializationConsumer.class));
+        .asyncCreateMultiplexedSession(any(MultiplexedSessionInitializationConsumer.class));
     options =
         options
             .toBuilder()
@@ -151,7 +153,7 @@ public class MultiplexedSessionPoolTest extends BaseSessionPoolTest {
     for (int i = 0; i < 5; i++) {
       SpannerException e =
           assertThrows(
-              SpannerException.class, () -> pool.getMultiplexedSessionWithFallback().get());
+              SpannerException.class, () -> pool.getMultiplexedSessionWithFallback().get().get());
       assertEquals(ErrorCode.DEADLINE_EXCEEDED, e.getErrorCode());
     }
     // assert that all 5 requests failed with exception
@@ -168,6 +170,6 @@ public class MultiplexedSessionPoolTest extends BaseSessionPoolTest {
               return null;
             })
         .when(sessionClient)
-        .createMultiplexedSession(any(MultiplexedSessionInitializationConsumer.class));
+        .asyncCreateMultiplexedSession(any(MultiplexedSessionInitializationConsumer.class));
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadAsyncTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadAsyncTest.java
@@ -185,6 +185,10 @@ public class ReadAsyncTest {
 
   @Test
   public void invalidDatabase() throws Exception {
+    if (isMultiplexedSessionsEnabled()) {
+      mockSpanner.setCreateSessionExecutionTime(
+          SimulatedExecutionTime.stickyDatabaseNotFoundException("invalid-database"));
+    }
     mockSpanner.setBatchCreateSessionsExecutionTime(
         SimulatedExecutionTime.stickyDatabaseNotFoundException("invalid-database"));
     DatabaseClient invalidClient =
@@ -438,5 +442,12 @@ public class ReadAsyncTest {
     SpannerException e = assertThrows(SpannerException.class, () -> get(res));
     assertThat(e.getErrorCode()).isEqualTo(ErrorCode.CANCELLED);
     assertThat(values).containsExactly("v1");
+  }
+
+  private boolean isMultiplexedSessionsEnabled() {
+    if (spanner.getOptions() == null || spanner.getOptions().getSessionPoolOptions() == null) {
+      return false;
+    }
+    return spanner.getOptions().getSessionPoolOptions().getUseMultiplexedSession();
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadAsyncTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadAsyncTest.java
@@ -262,14 +262,23 @@ public class ReadAsyncTest {
       // Wait until at least one row has been fetched. At that moment there should be one session
       // checked out.
       dataReceived.await();
-      assertThat(clientImpl.pool.getNumberOfSessionsInUse()).isEqualTo(1);
+
+      if (isMultiplexedSessionsEnabled()) {
+        assertThat(clientImpl.pool.getNumberOfSessionsInUse()).isEqualTo(0);
+      } else {
+        assertThat(clientImpl.pool.getNumberOfSessionsInUse()).isEqualTo(1);
+      }
     }
     // The read-only transaction is now closed, but the ready callback will continue to receive
     // data. As it tries to put the data into a synchronous queue and the underlying buffer can also
     // only hold 1 row, the async result set has not yet finished. The read-only transaction will
     // release the session back into the pool when all async statements have finished. The number of
     // sessions in use is therefore still 1.
-    assertThat(clientImpl.pool.getNumberOfSessionsInUse()).isEqualTo(1);
+    if (isMultiplexedSessionsEnabled()) {
+      assertThat(clientImpl.pool.getNumberOfSessionsInUse()).isEqualTo(0);
+    } else {
+      assertThat(clientImpl.pool.getNumberOfSessionsInUse()).isEqualTo(1);
+    }
     List<String> resultList = new ArrayList<>();
     do {
       results.drainTo(resultList);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolOptionsTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 
 import com.google.cloud.spanner.SessionPoolOptions.InactiveTransactionRemovalOptions;
 import java.util.ArrayList;
@@ -249,6 +250,8 @@ public class SessionPoolOptionsTest {
 
   @Test
   public void testUseMultiplexedSession() {
+    // skip these tests since this configuration can have dual behaviour in different test-runners
+    assumeFalse(SessionPoolOptions.newBuilder().build().getUseMultiplexedSession());
     assertEquals(false, SessionPoolOptions.newBuilder().build().getUseMultiplexedSession());
     assertEquals(
         true,

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpanTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpanTest.java
@@ -301,11 +301,26 @@ public class SpanTest {
             "Acquired session",
             "Using Session",
             "Starting/Resuming stream");
-    verifyAnnotations(
-        failOnOverkillTraceComponent.getAnnotations().stream()
-            .distinct()
-            .collect(Collectors.toList()),
-        expectedAnnotations);
+    List<String> expectedAnnotationsForMultiplexedSession =
+        ImmutableList.of(
+            "Requesting 2 sessions",
+            "Request for 1 sessions returned 1 sessions",
+            "Creating 2 sessions",
+            "Using Session",
+            "Starting/Resuming stream");
+    if (spanner.getOptions().getSessionPoolOptions().getUseMultiplexedSession()) {
+      verifyAnnotations(
+          failOnOverkillTraceComponent.getAnnotations().stream()
+              .distinct()
+              .collect(Collectors.toList()),
+          expectedAnnotationsForMultiplexedSession);
+    } else {
+      verifyAnnotations(
+          failOnOverkillTraceComponent.getAnnotations().stream()
+              .distinct()
+              .collect(Collectors.toList()),
+          expectedAnnotations);
+    }
   }
 
   @Test
@@ -335,11 +350,28 @@ public class SpanTest {
             "Starting/Resuming stream",
             "Creating Transaction",
             "Transaction Creation Done");
-    verifyAnnotations(
-        failOnOverkillTraceComponent.getAnnotations().stream()
-            .distinct()
-            .collect(Collectors.toList()),
-        expectedAnnotations);
+    List<String> expectedAnnotationsForMultiplexedSession =
+        ImmutableList.of(
+            "Requesting 2 sessions",
+            "Request for 1 sessions returned 1 sessions",
+            "Creating 2 sessions",
+            "Using Session",
+            "Starting/Resuming stream",
+            "Creating Transaction",
+            "Transaction Creation Done");
+    if (isMultiplexedSessionsEnabled()) {
+      verifyAnnotations(
+          failOnOverkillTraceComponent.getAnnotations().stream()
+              .distinct()
+              .collect(Collectors.toList()),
+          expectedAnnotationsForMultiplexedSession);
+    } else {
+      verifyAnnotations(
+          failOnOverkillTraceComponent.getAnnotations().stream()
+              .distinct()
+              .collect(Collectors.toList()),
+          expectedAnnotations);
+    }
   }
 
   @Test
@@ -381,7 +413,13 @@ public class SpanTest {
     assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCode());
 
     Map<String, Boolean> spans = failOnOverkillTraceComponent.getSpans();
-    assertThat(spans.size()).isEqualTo(3);
+
+    if (isMultiplexedSessionsEnabled()) {
+      assertThat(spans.size()).isEqualTo(4);
+      assertThat(spans).containsEntry("CloudSpannerOperation.CreateMultiplexedSession", true);
+    } else {
+      assertThat(spans.size()).isEqualTo(3);
+    }
     assertThat(spans).containsEntry("CloudSpanner.ReadWriteTransaction", true);
     assertThat(spans).containsEntry("CloudSpannerOperation.BatchCreateSessions", true);
     assertThat(spans).containsEntry("CloudSpannerOperation.BatchCreateSessionsRequest", true);
@@ -406,7 +444,14 @@ public class SpanTest {
 
   private void verifyAnnotations(List<String> actualAnnotations, List<String> expectedAnnotations) {
     assertEquals(
-        actualAnnotations.stream().distinct().sorted().collect(Collectors.toList()),
-        expectedAnnotations.stream().sorted().collect(Collectors.toList()));
+        expectedAnnotations.stream().sorted().collect(Collectors.toList()),
+        actualAnnotations.stream().distinct().sorted().collect(Collectors.toList()));
+  }
+
+  private boolean isMultiplexedSessionsEnabled() {
+    if (spanner.getOptions() == null || spanner.getOptions().getSessionPoolOptions() == null) {
+      return false;
+    }
+    return spanner.getOptions().getSessionPoolOptions().getUseMultiplexedSession();
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerGaxRetryTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerGaxRetryTest.java
@@ -206,6 +206,9 @@ public class SpannerGaxRetryTest {
 
   @Test
   public void singleUseTimeout() {
+    if (isMultiplexedSessionsEnabled()) {
+      mockSpanner.setCreateSessionExecutionTime(ONE_SECOND);
+    }
     mockSpanner.setBatchCreateSessionsExecutionTime(ONE_SECOND);
     try (ResultSet rs = clientWithTimeout.singleUse().executeQuery(SELECT1AND2)) {
       SpannerException e = assertThrows(SpannerException.class, () -> rs.next());
@@ -250,6 +253,9 @@ public class SpannerGaxRetryTest {
 
   @Test
   public void singleUseReadOnlyTransactionTimeout() {
+    if (isMultiplexedSessionsEnabled()) {
+      mockSpanner.setCreateSessionExecutionTime(ONE_SECOND);
+    }
     mockSpanner.setBatchCreateSessionsExecutionTime(ONE_SECOND);
     try (ResultSet rs =
         clientWithTimeout.singleUseReadOnlyTransaction().executeQuery(SELECT1AND2)) {
@@ -383,5 +389,12 @@ public class SpannerGaxRetryTest {
         }
       }
     }
+  }
+
+  private boolean isMultiplexedSessionsEnabled() {
+    if (spanner.getOptions() == null || spanner.getOptions().getSessionPoolOptions() == null) {
+      return false;
+    }
+    return spanner.getOptions().getSessionPoolOptions().getUseMultiplexedSession();
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractMockServerTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.spanner.connection;
 import com.google.cloud.spanner.ForceCloseSpannerFunction;
 import com.google.cloud.spanner.MockSpannerServiceImpl;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.admin.database.v1.MockDatabaseAdminImpl;
 import com.google.cloud.spanner.admin.instance.v1.MockInstanceAdminImpl;
@@ -292,5 +293,12 @@ public abstract class AbstractMockServerTest {
 
   ITConnection createITConnection(ConnectionOptions options) {
     return new ITConnectionImpl(options);
+  }
+
+  boolean isMultiplexedSessionsEnabled(Spanner spanner) {
+    if (spanner.getOptions() == null || spanner.getOptions().getSessionPoolOptions() == null) {
+      return false;
+    }
+    return spanner.getOptions().getSessionPoolOptions().getUseMultiplexedSession();
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionTest.java
@@ -289,8 +289,12 @@ public class ConnectionTest {
 
         assertThat(count1.isDone()).isTrue();
         assertThat(count2.isDone()).isTrue();
+        if (isMultiplexedSessionsEnabled(connection1.getSpanner())) {
+          assertThat(mockSpanner.numSessionsCreated()).isEqualTo(2);
+        } else {
+          assertThat(mockSpanner.numSessionsCreated()).isEqualTo(1);
+        }
       }
-      assertThat(mockSpanner.numSessionsCreated()).isEqualTo(1);
     }
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITClosedSessionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITClosedSessionTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.spanner.it;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 
 import com.google.cloud.spanner.AbortedException;
 import com.google.cloud.spanner.Database;
@@ -59,6 +60,11 @@ public class ITClosedSessionTest {
 
   @BeforeClass
   public static void setUpDatabase() {
+    // For multiplexed sessions, it will never be invalidated by the server and hence the client
+    // will never receive an exception with code NOT_FOUND and the text 'Session not found'.
+    assumeFalse(
+        env.getTestHelper().getOptions().getSessionPoolOptions().getUseMultiplexedSession());
+
     // Empty database.
     db = env.getTestHelper().createTestDatabase();
     client = (DatabaseClientWithClosedSessionImpl) env.getTestHelper().getDatabaseClient(db);


### PR DESCRIPTION
Tests have been parameterized or skipped when test runners pass the env variable `GOOGLE_CLOUD_SPANNER_ENABLE_MULTIPLEXED_SESSIONS`. We presently have created separate test runners (unit, emulator and integration tests) which run during pre-submits and test the multiplexed session code path.


**Pending Stuff**

1. `ChannelUsageTest` has been disabled (with a followup TODO) when multiplexed sessions is enabled. We are coordinating with GRPC team to see how this can be enabled. This is the only test which currently exudes a flaky behavior very frequently.