### PR TITLE
chore: include recommended_package in repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -16,6 +16,7 @@
   "requires_billing": true,
   "codeowner_team": "@googleapis/api-spanner-java",
   "library_type": "GAPIC_COMBO",
-  "excluded_poms": "google-cloud-spanner-bom"
+  "excluded_poms": "google-cloud-spanner-bom",
+  "recommended_package": "com.google.cloud.spanner"
 }
 


### PR DESCRIPTION
Adds a field for recommended_package as part of the revamped Library Overviews.
See go/cloud-rad-overviews-handwritten-repos for more details