### PR TITLE
fix: ignored argument to String.format call

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -3663,10 +3663,9 @@ class SessionPool {
       }
       logger.log(
           Level.WARNING,
-          String.format(
-              "Failed to create multiplexed session. "
-                  + "Pending replacing stale multiplexed session",
-              t));
+          "Failed to create multiplexed session. "
+              + "Pending replacing stale multiplexed session",
+          t);
     }
   }
 


### PR DESCRIPTION
This change fixes a log statement where a `Throwable` is being passed to a `String.format` call without any format specifiers.

Fixes #3054 ☕️
