### PR TITLE
chore: add a random hint for multi-use transactions when they are use…

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ implementation 'com.google.cloud:google-cloud-spanner'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-spanner:6.64.0'
+implementation 'com.google.cloud:google-cloud-spanner:6.65.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.64.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.65.0"
 ```
 <!-- {x-version-update-end} -->
 
@@ -650,7 +650,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-spanner/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-spanner.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.64.0
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.65.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -232,11 +232,8 @@ abstract class AbstractReadContext
     @GuardedBy("lock")
     private Timestamp timestamp;
 
-    private Long channelHint;
-
     private SingleUseReadOnlyTransaction(SingleReadContext.Builder builder) {
       super(builder);
-      this.channelHint = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
     }
 
     @Override
@@ -269,11 +266,6 @@ abstract class AbstractReadContext
               ErrorCode.INTERNAL, "Bad value in transaction.read_timestamp metadata field", e);
         }
       }
-    }
-
-    @Override
-    public Long getTransactionChannelHint() {
-      return channelHint;
     }
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -183,9 +183,15 @@ abstract class AbstractReadContext
     @GuardedBy("lock")
     private boolean used;
 
+    private final Map<SpannerRpc.Option, ?> channelHint;
+
     private SingleReadContext(Builder builder) {
       super(builder);
       this.bound = builder.bound;
+      // single use transaction have a single RPC and hence there is no need
+      // of a channel hint. GAX will automatically choose a hint when used
+      // with a multiplexed session.
+      this.channelHint = getChannelHintOptions(session.getOptions(), null);
     }
 
     @Override
@@ -215,10 +221,7 @@ abstract class AbstractReadContext
 
     @Override
     Map<SpannerRpc.Option, ?> getTransactionChannelHint() {
-      // single use transaction have a single RPC and hence there is no need
-      // of a channel hint. GAX will automatically choose a hint when used
-      // with a multiplexed session.
-      return null;
+      return channelHint;
     }
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -56,6 +56,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -198,6 +199,8 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
     private CommitResponse commitResponse;
     private final Clock clock;
 
+    private Long channelHint;
+
     private TransactionContextImpl(Builder builder) {
       super(builder);
       this.transactionId = builder.transactionId;
@@ -205,6 +208,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
       this.options = builder.options;
       this.finishedAsyncOperations.set(null);
       this.clock = builder.clock;
+      this.channelHint = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
     }
 
     @Override
@@ -557,6 +561,11 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
       }
       // There is already a transactionId available. Include that id as the transaction to use.
       return TransactionSelector.newBuilder().setId(transactionId).build();
+    }
+
+    @Override
+    Long getTransactionChannelHint() {
+      return channelHint;
     }
 
     @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -30,6 +30,8 @@ import com.google.cloud.spanner.Options.ReadOption;
 import com.google.cloud.spanner.Options.TransactionOption;
 import com.google.cloud.spanner.Options.UpdateOption;
 import com.google.cloud.spanner.SessionImpl.SessionTransaction;
+import com.google.cloud.spanner.spi.v1.SpannerRpc;
+import com.google.cloud.spanner.spi.v1.SpannerRpc.Option;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -51,6 +53,7 @@ import com.google.spanner.v1.TransactionOptions;
 import com.google.spanner.v1.TransactionSelector;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -199,7 +202,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
     private CommitResponse commitResponse;
     private final Clock clock;
 
-    private Long channelHint;
+    private final Map<SpannerRpc.Option, ?> channelHint;
 
     private TransactionContextImpl(Builder builder) {
       super(builder);
@@ -208,7 +211,9 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
       this.options = builder.options;
       this.finishedAsyncOperations.set(null);
       this.clock = builder.clock;
-      this.channelHint = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
+      this.channelHint =
+          getChannelHintOptions(
+              session.getOptions(), ThreadLocalRandom.current().nextLong(Long.MAX_VALUE));
     }
 
     @Override
@@ -564,7 +569,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
     }
 
     @Override
-    Long getTransactionChannelHint() {
+    Map<Option, ?> getTransactionChannelHint() {
       return channelHint;
     }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractReadContextTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractReadContextTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import com.google.api.gax.core.ExecutorProvider;
 import com.google.cloud.spanner.Options.RpcPriority;
 import com.google.cloud.spanner.spi.v1.SpannerRpc;
+import com.google.cloud.spanner.spi.v1.SpannerRpc.Option;
 import com.google.spanner.v1.DirectedReadOptions;
 import com.google.spanner.v1.DirectedReadOptions.IncludeReplicas;
 import com.google.spanner.v1.DirectedReadOptions.ReplicaSelection;
@@ -39,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -100,7 +102,7 @@ public class AbstractReadContextTest {
     }
 
     @Override
-    Long getTransactionChannelHint() {
+    Map<SpannerRpc.Option, ?> getTransactionChannelHint() {
       return null;
     }
   }
@@ -116,7 +118,7 @@ public class AbstractReadContextTest {
     }
 
     @Override
-    Long getTransactionChannelHint() {
+    Map<Option, ?> getTransactionChannelHint() {
       return null;
     }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractReadContextTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractReadContextTest.java
@@ -98,6 +98,11 @@ public class AbstractReadContextTest {
     TransactionSelector getTransactionSelector() {
       return TransactionSelector.getDefaultInstance();
     }
+
+    @Override
+    Long getTransactionChannelHint() {
+      return null;
+    }
   }
 
   private final class TestReadContextWithTag extends AbstractReadContext {
@@ -108,6 +113,11 @@ public class AbstractReadContextTest {
     @Override
     TransactionSelector getTransactionSelector() {
       return TransactionSelector.getDefaultInstance();
+    }
+
+    @Override
+    Long getTransactionChannelHint() {
+      return null;
     }
 
     String getTransactionTag() {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionChannelHintTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionChannelHintTest.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+import static com.google.cloud.spanner.MockSpannerTestUtil.READ_COLUMN_NAMES;
+import static com.google.cloud.spanner.MockSpannerTestUtil.READ_ONE_KEY_VALUE_RESULTSET;
+import static com.google.cloud.spanner.MockSpannerTestUtil.READ_ONE_KEY_VALUE_STATEMENT;
+import static com.google.cloud.spanner.MockSpannerTestUtil.READ_TABLE_NAME;
+import static com.google.cloud.spanner.MockSpannerTestUtil.SELECT1;
+import static io.grpc.Grpc.TRANSPORT_ATTR_REMOTE_ADDR;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.google.cloud.NoCredentials;
+import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.cloud.spanner.Options.RpcPriority;
+import com.google.cloud.spanner.ReadContext.QueryAnalyzeMode;
+import com.google.protobuf.ListValue;
+import com.google.spanner.v1.ResultSetMetadata;
+import com.google.spanner.v1.SpannerGrpc;
+import com.google.spanner.v1.StructType;
+import com.google.spanner.v1.StructType.Field;
+import com.google.spanner.v1.TypeCode;
+import io.grpc.Attributes;
+import io.grpc.Context;
+import io.grpc.Contexts;
+import io.grpc.Metadata;
+import io.grpc.Server;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Transaction always utilize a channel hint to ensure multiple RPCs that are part of the same
+ * transaction, they go via same channel. For regular session, the hint is stored per session. For
+ * multiplexed sessions this hint is stored per transaction.
+ *
+ * <p>The below tests assert this behavior for both kinds of sessions.
+ */
+@RunWith(JUnit4.class)
+public class TransactionChannelHintTest {
+
+  private static final Statement SELECT1 = Statement.of("SELECT 1 AS COL1");
+  private static final ResultSetMetadata SELECT1_METADATA =
+      ResultSetMetadata.newBuilder()
+          .setRowType(
+              StructType.newBuilder()
+                  .addFields(
+                      Field.newBuilder()
+                          .setName("COL1")
+                          .setType(
+                              com.google.spanner.v1.Type.newBuilder()
+                                  .setCode(TypeCode.INT64)
+                                  .build())
+                          .build())
+                  .build())
+          .build();
+  private static final com.google.spanner.v1.ResultSet SELECT1_RESULTSET =
+      com.google.spanner.v1.ResultSet.newBuilder()
+          .addRows(
+              ListValue.newBuilder()
+                  .addValues(com.google.protobuf.Value.newBuilder().setStringValue("1").build())
+                  .build())
+          .setMetadata(SELECT1_METADATA)
+          .build();
+
+  private static MockSpannerServiceImpl mockSpanner;
+  private static Server server;
+  private static InetSocketAddress address;
+  private static final Set<InetSocketAddress> executeSqlLocalIps = ConcurrentHashMap.newKeySet();
+  private static final Set<InetSocketAddress> streamingReadLocalIps = ConcurrentHashMap.newKeySet();
+  private static Level originalLogLevel;
+
+  @BeforeClass
+  public static void startServer() throws IOException {
+    mockSpanner = new MockSpannerServiceImpl();
+    mockSpanner.setAbortProbability(0.0D); // We don't want any unpredictable aborted transactions.
+    mockSpanner.putStatementResult(StatementResult.query(SELECT1, SELECT1_RESULTSET));
+    mockSpanner.putStatementResult(
+        StatementResult.query(READ_ONE_KEY_VALUE_STATEMENT, READ_ONE_KEY_VALUE_RESULTSET));
+
+    address = new InetSocketAddress("localhost", 0);
+    server =
+        NettyServerBuilder.forAddress(address)
+            .addService(mockSpanner)
+            // Add a server interceptor to register the remote addresses that we are seeing. This
+            // indicates how many channels are used client side to communicate with the server.
+            .intercept(
+                new ServerInterceptor() {
+                  @Override
+                  public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+                      ServerCall<ReqT, RespT> call,
+                      Metadata headers,
+                      ServerCallHandler<ReqT, RespT> next) {
+                    // Verify that the compressor name header is set.
+                    assertEquals(
+                        "gzip",
+                        headers.get(
+                            Metadata.Key.of(
+                                "x-response-encoding", Metadata.ASCII_STRING_MARSHALLER)));
+                    Attributes attributes = call.getAttributes();
+                    @SuppressWarnings({"unchecked", "deprecation"})
+                    Attributes.Key<InetSocketAddress> key =
+                        (Attributes.Key<InetSocketAddress>)
+                            attributes.keys().stream()
+                                .filter(k -> k.equals(TRANSPORT_ATTR_REMOTE_ADDR))
+                                .findFirst()
+                                .orElse(null);
+                    if (key != null) {
+                      if (call.getMethodDescriptor()
+                          .equals(SpannerGrpc.getExecuteStreamingSqlMethod())) {
+                        executeSqlLocalIps.add(attributes.get(key));
+                      }
+                      if (call.getMethodDescriptor().equals(SpannerGrpc.getStreamingReadMethod())) {
+                        streamingReadLocalIps.add(attributes.get(key));
+                      }
+                    }
+                    return Contexts.interceptCall(Context.current(), call, headers, next);
+                  }
+                })
+            .build()
+            .start();
+  }
+
+  @AfterClass
+  public static void stopServer() throws InterruptedException {
+    server.shutdown();
+    server.awaitTermination();
+  }
+
+  @BeforeClass
+  public static void disableLogging() {
+    Logger logger = Logger.getLogger("");
+    originalLogLevel = logger.getLevel();
+    logger.setLevel(Level.OFF);
+  }
+
+  @AfterClass
+  public static void resetLogging() {
+    Logger logger = Logger.getLogger("");
+    logger.setLevel(originalLogLevel);
+  }
+
+  @After
+  public void reset() {
+    mockSpanner.reset();
+    executeSqlLocalIps.clear();
+    streamingReadLocalIps.clear();
+  }
+
+  private SpannerOptions createSpannerOptions() {
+    String endpoint = address.getHostString() + ":" + server.getPort();
+    return SpannerOptions.newBuilder()
+        .setProjectId("[PROJECT]")
+        .setChannelConfigurator(
+            input -> {
+              input.usePlaintext();
+              return input;
+            })
+        .setCompressorName("gzip")
+        .setHost("http://" + endpoint)
+        .setCredentials(NoCredentials.getInstance())
+        .build();
+  }
+
+  @Test
+  public void testSingleUse_usesSingleChannel() {
+    try (Spanner spanner = createSpannerOptions().getService()) {
+      DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+      try (ResultSet resultSet = client.singleUse().executeQuery(SELECT1)) {
+        while (resultSet.next()) {}
+      }
+    }
+    assertEquals(1, executeSqlLocalIps.size());
+  }
+
+  @Test
+  public void testSingleUse_withTimestampBound_usesSingleChannel() {
+    try (Spanner spanner = createSpannerOptions().getService()) {
+      DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+      try (ResultSet resultSet =
+          client
+              .singleUse(TimestampBound.ofExactStaleness(15L, TimeUnit.SECONDS))
+              .executeQuery(SELECT1)) {
+        while (resultSet.next()) {}
+      }
+    }
+    assertEquals(1, executeSqlLocalIps.size());
+  }
+
+  @Test
+  public void testSingleUseReadOnlyTransaction_usesSingleChannel() {
+    try (Spanner spanner = createSpannerOptions().getService()) {
+      DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+      try (ResultSet resultSet = client.singleUseReadOnlyTransaction().executeQuery(SELECT1)) {
+        while (resultSet.next()) {}
+      }
+    }
+    assertEquals(1, executeSqlLocalIps.size());
+  }
+
+  @Test
+  public void testSingleUseReadOnlyTransaction_withTimestampBound_usesSingleChannel() {
+    try (Spanner spanner = createSpannerOptions().getService()) {
+      DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+      try (ResultSet resultSet =
+          client
+              .singleUseReadOnlyTransaction(TimestampBound.ofExactStaleness(15L, TimeUnit.SECONDS))
+              .executeQuery(SELECT1)) {
+        while (resultSet.next()) {}
+      }
+    }
+    assertEquals(1, executeSqlLocalIps.size());
+  }
+
+  @Test
+  public void testReadOnlyTransaction_usesSingleChannel() {
+    try (Spanner spanner = createSpannerOptions().getService()) {
+      DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+      try (ReadOnlyTransaction transaction = client.readOnlyTransaction()) {
+        try (ResultSet resultSet = transaction.executeQuery(SELECT1)) {
+          while (resultSet.next()) {}
+        }
+        try (ResultSet resultSet = transaction.executeQuery(SELECT1)) {
+          while (resultSet.next()) {}
+        }
+      }
+    }
+    assertEquals(1, executeSqlLocalIps.size());
+  }
+
+  @Test
+  public void testReadOnlyTransaction_withTimestampBound_usesSingleChannel() {
+    try (Spanner spanner = createSpannerOptions().getService()) {
+      DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+      try (ReadOnlyTransaction transaction =
+          client.readOnlyTransaction(TimestampBound.ofExactStaleness(15L, TimeUnit.SECONDS))) {
+        try (ResultSet resultSet = transaction.executeQuery(SELECT1)) {
+          while (resultSet.next()) {}
+        }
+        try (ResultSet resultSet = transaction.executeQuery(SELECT1)) {
+          while (resultSet.next()) {}
+        }
+      }
+    }
+    assertEquals(1, executeSqlLocalIps.size());
+  }
+
+  @Test
+  public void testTransactionManager_usesSingleChannel() {
+    try (Spanner spanner = createSpannerOptions().getService()) {
+      DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+      try (TransactionManager manager = client.transactionManager()) {
+        TransactionContext transaction = manager.begin();
+        while (true) {
+          try {
+            try (ResultSet resultSet =
+                transaction.analyzeQuery(SELECT1, QueryAnalyzeMode.PROFILE)) {
+              while (resultSet.next()) {}
+            }
+
+            try (ResultSet resultSet =
+                transaction.analyzeQuery(SELECT1, QueryAnalyzeMode.PROFILE)) {
+              while (resultSet.next()) {}
+            }
+            manager.commit();
+            assertNotNull(manager.getCommitTimestamp());
+            break;
+          } catch (AbortedException e) {
+            transaction = manager.resetForRetry();
+          }
+        }
+      }
+    }
+    assertEquals(1, executeSqlLocalIps.size());
+  }
+
+  @Test
+  public void testTransactionRunner_usesSingleChannel() {
+    try (Spanner spanner = createSpannerOptions().getService()) {
+      DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+      TransactionRunner runner = client.readWriteTransaction();
+      runner.run(
+          transaction -> {
+            try (ResultSet resultSet =
+                transaction.read(
+                    READ_TABLE_NAME,
+                    KeySet.singleKey(Key.of(1L)),
+                    READ_COLUMN_NAMES,
+                    Options.priority(RpcPriority.HIGH))) {
+              while (resultSet.next()) {}
+            }
+
+            try (ResultSet resultSet =
+                transaction.read(
+                    READ_TABLE_NAME,
+                    KeySet.singleKey(Key.of(1L)),
+                    READ_COLUMN_NAMES,
+                    Options.priority(RpcPriority.HIGH))) {
+              while (resultSet.next()) {}
+            }
+            return null;
+          });
+    }
+    assertEquals(1, streamingReadLocalIps.size());
+  }
+}


### PR DESCRIPTION
Regular sessions maintain a channel hint per session at time of regular session creation. For each multi-use transaction, this hint is fetched from the session object and passed in the RPC. This hint helps to ensure, all RPCs within a multi-use transaction go to the same channel (and hence same SpanFE).

With multiplexed sessions, there is no channel hint being maintained with the session object. Hence, we need to store the hint with the transaction object and then pass it in the RPC methods.