### PR TITLE
chore: remove additional lock in multiplexed session background maint…

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ implementation 'com.google.cloud:google-cloud-spanner'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-spanner:6.64.0'
+implementation 'com.google.cloud:google-cloud-spanner:6.65.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.64.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.65.0"
 ```
 <!-- {x-version-update-end} -->
 
@@ -650,7 +650,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-spanner/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-spanner.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.64.0
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.65.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -2644,28 +2644,26 @@ class SessionPool {
     void maintainMultiplexedSession(Instant currentTime) {
       try {
         if (options.getUseMultiplexedSession()) {
-          synchronized (lock) {
-            if (currentMultiplexedSessionReference.get().isDone()) {
-              SessionReference sessionReference = getMultiplexedSessionInstance();
-              if (sessionReference != null
-                  && isMultiplexedSessionStale(sessionReference, currentTime)) {
-                final Instant minExecutionTime =
-                    multiplexedSessionReplacementAttemptTime.plus(
-                        multiplexedSessionCreationRetryDelay);
-                if (currentTime.isBefore(minExecutionTime)) {
-                  return;
-                }
-                /*
-                 This will attempt to create a new multiplexed session. if successfully created then
-                 the existing session will be replaced. Note that there maybe active transactions
-                 running on the stale session. Hence, it is important that we only replace the reference
-                 and not invoke a DeleteSession RPC.
-                */
-                maybeCreateMultiplexedSession(multiplexedMaintainerConsumer);
-
-                // update this only after we have attempted to replace the multiplexed session
-                multiplexedSessionReplacementAttemptTime = currentTime;
+          if (currentMultiplexedSessionReference.get().isDone()) {
+            SessionReference sessionReference = getMultiplexedSessionInstance();
+            if (sessionReference != null
+                && isMultiplexedSessionStale(sessionReference, currentTime)) {
+              final Instant minExecutionTime =
+                  multiplexedSessionReplacementAttemptTime.plus(
+                      multiplexedSessionCreationRetryDelay);
+              if (currentTime.isBefore(minExecutionTime)) {
+                return;
               }
+              /*
+               This will attempt to create a new multiplexed session. if successfully created then
+               the existing session will be replaced. Note that there maybe active transactions
+               running on the stale session. Hence, it is important that we only replace the reference
+               and not invoke a DeleteSession RPC.
+              */
+              maybeCreateMultiplexedSession(multiplexedMaintainerConsumer);
+
+              // update this only after we have attempted to replace the multiplexed session
+              multiplexedSessionReplacementAttemptTime = currentTime;
             }
           }
         }


### PR DESCRIPTION
We are not updating the value of multiplexed session within the background thread. So there is no need to hold a lock. Removing this lock can potentially improve performance.