### PR TITLE
chore: propagate otel context in Connection API

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.37.0')
+implementation platform('com.google.cloud:libraries-bom:26.38.0')
 
 implementation 'com.google.cloud:google-cloud-spanner'
 ```

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/StatementExecutor.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/StatementExecutor.java
@@ -28,6 +28,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.Duration;
+import io.opentelemetry.context.Context;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -147,13 +148,16 @@ class StatementExecutor {
   /** Creates an {@link ExecutorService} for a {@link StatementExecutor}. */
   private static ListeningExecutorService createExecutorService(boolean useVirtualThreads) {
     return MoreExecutors.listeningDecorator(
-        new ThreadPoolExecutor(
-            1,
-            1,
-            0L,
-            TimeUnit.MILLISECONDS,
-            new LinkedBlockingQueue<>(),
-            useVirtualThreads ? DEFAULT_VIRTUAL_THREAD_FACTORY : DEFAULT_DAEMON_THREAD_FACTORY));
+        Context.taskWrapping(
+            new ThreadPoolExecutor(
+                1,
+                1,
+                0L,
+                TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>(),
+                useVirtualThreads
+                    ? DEFAULT_VIRTUAL_THREAD_FACTORY
+                    : DEFAULT_DAEMON_THREAD_FACTORY)));
   }
 
   private final ListeningExecutorService executor;


### PR DESCRIPTION
Use a TaskWrapping executor in the Connection API to propagate the current OpenTelemetry context to the executor thread. This ensures that the context that is used in the end-user application is propagated to the Spanner client library, and tracing shows a full view of the spans from the application to the gRPC layer.
