### PR TITLE
chore: use gson Java version util

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/JavaVersionUtil.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/JavaVersionUtil.java
@@ -16,20 +16,13 @@
 
 package com.google.cloud.spanner;
 
+import com.google.gson.internal.JavaVersion;
+
 /** Util class for getting the Java version the tests are executed on. */
 public class JavaVersionUtil {
 
   /** Returns the major Java version (e.g. 8, 11, 17) */
   public static int getJavaMajorVersion() {
-    String version = System.getProperty("java.version");
-    if (version.startsWith("1.")) {
-      version = version.substring(2, 3);
-    } else {
-      int dot = version.indexOf(".");
-      if (dot != -1) {
-        version = version.substring(0, dot);
-      }
-    }
-    return Integer.parseInt(version);
+    return JavaVersion.getMajorJavaVersion();
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MultiplexedSessionDatabaseClientTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MultiplexedSessionDatabaseClientTest.java
@@ -111,7 +111,7 @@ public class MultiplexedSessionDatabaseClientTest {
 
   @Test
   public void testForceDisableEnvVar() throws Exception {
-    assumeTrue(isJava8());
+    assumeTrue(isJava8() && !isWindows());
     assumeFalse(
         System.getenv().containsKey("GOOGLE_CLOUD_SPANNER_FORCE_DISABLE_MULTIPLEXED_SESSIONS"));
 
@@ -145,5 +145,9 @@ public class MultiplexedSessionDatabaseClientTest {
 
   private boolean isJava8() {
     return JavaVersionUtil.getJavaMajorVersion() == 8;
+  }
+
+  private boolean isWindows() {
+    return System.getProperty("os.name").toLowerCase().contains("windows");
   }
 }


### PR DESCRIPTION
Uses the gson Java version checker, which is more production-hardened than the custom one in the Spanner client. It seems that the Spanner implementation does not get it right on all versions on Windows.