### PR TITLE
fix: multiplexed session metrics were not included in refactor move

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -809,6 +809,7 @@ abstract class AbstractReadContext
 
   @Override
   public void close() {
+    session.onTransactionDone();
     span.end();
     synchronized (lock) {
       isClosed = true;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DelayedReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DelayedReadContext.java
@@ -130,7 +130,14 @@ class DelayedReadContext<T extends ReadContext> implements ReadContext {
   }
 
   @Override
-  public void close() {}
+  public void close() {
+    try {
+      this.readContextFuture.get().close();
+    } catch (Throwable ignore) {
+      // Ignore any errors during close, as this error has already propagated to the user through
+      // other means.
+    }
+  }
 
   /**
    * Represents a {@link ReadContext} using a multiplexed session that is not yet ready. The

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -484,6 +484,8 @@ class SessionImpl implements Session {
 
   void onReadDone() {}
 
+  void onTransactionDone() {}
+
   TraceWrapper getTracer() {
     return tracer;
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
@@ -50,6 +50,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
@@ -271,17 +272,29 @@ class SpannerImpl extends BaseService<SpannerOptions> implements Spanner {
         attributesBuilder.put("database", db.getDatabase());
         attributesBuilder.put("instance_id", db.getInstanceId().getName());
 
+        boolean useMultiplexedSession =
+            getOptions().getSessionPoolOptions().getUseMultiplexedSession();
+        MultiplexedSessionDatabaseClient multiplexedSessionDatabaseClient =
+            useMultiplexedSession
+                ? new MultiplexedSessionDatabaseClient(SpannerImpl.this.getSessionClient(db))
+                : null;
+        AtomicLong numMultiplexedSessionsAcquired =
+            useMultiplexedSession
+                ? multiplexedSessionDatabaseClient.getNumSessionsAcquired()
+                : new AtomicLong();
+        AtomicLong numMultiplexedSessionsReleased =
+            useMultiplexedSession
+                ? multiplexedSessionDatabaseClient.getNumSessionsReleased()
+                : new AtomicLong();
         SessionPool pool =
             SessionPool.createPool(
                 getOptions(),
                 SpannerImpl.this.getSessionClient(db),
                 this.tracer,
                 labelValues,
-                attributesBuilder.build());
-        MultiplexedSessionDatabaseClient multiplexedSessionDatabaseClient =
-            getOptions().getSessionPoolOptions().getUseMultiplexedSession()
-                ? new MultiplexedSessionDatabaseClient(SpannerImpl.this.getSessionClient(db))
-                : null;
+                attributesBuilder.build(),
+                numMultiplexedSessionsAcquired,
+                numMultiplexedSessionsReleased);
         pool.maybeWaitOnMinSessions();
         DatabaseClientImpl dbClient =
             createDatabaseClient(clientId, pool, multiplexedSessionDatabaseClient);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -3859,12 +3859,12 @@ public class DatabaseClientImplTest {
       // Simulate session creation failures on the backend.
       mockSpanner.setCreateSessionExecutionTime(
           SimulatedExecutionTime.ofStickyException(Status.RESOURCE_EXHAUSTED.asRuntimeException()));
-      DatabaseClient client =
-          spannerWithEmptySessionPool.getDatabaseClient(
-              DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
       // This will not cause any failure as getting a session from the pool is guaranteed to be
       // non-blocking, and any exceptions will be delayed until actual query execution.
       mockSpanner.freeze();
+      DatabaseClient client =
+          spannerWithEmptySessionPool.getDatabaseClient(
+              DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
       try (ResultSet rs = client.singleUse().executeQuery(SELECT1)) {
         mockSpanner.unfreeze();
         SpannerException e = assertThrows(SpannerException.class, rs::next);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MultiplexedSessionDatabaseClientMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MultiplexedSessionDatabaseClientMockServerTest.java
@@ -100,6 +100,10 @@ public class MultiplexedSessionDatabaseClientMockServerTest extends AbstractMock
     List<ExecuteSqlRequest> requests = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class);
     assertEquals(2, requests.size());
     assertEquals(requests.get(0).getSession(), requests.get(1).getSession());
+
+    assertNotNull(client.multiplexedSessionDatabaseClient);
+    assertEquals(1L, client.multiplexedSessionDatabaseClient.getNumSessionsAcquired().get());
+    assertEquals(1L, client.multiplexedSessionDatabaseClient.getNumSessionsReleased().get());
   }
 
   @Test
@@ -129,6 +133,10 @@ public class MultiplexedSessionDatabaseClientMockServerTest extends AbstractMock
     List<ExecuteSqlRequest> requests = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class);
     assertEquals(2, requests.size());
     assertNotEquals(requests.get(0).getSession(), requests.get(1).getSession());
+
+    assertNotNull(client.multiplexedSessionDatabaseClient);
+    assertEquals(2L, client.multiplexedSessionDatabaseClient.getNumSessionsAcquired().get());
+    assertEquals(2L, client.multiplexedSessionDatabaseClient.getNumSessionsReleased().get());
   }
 
   @Test
@@ -165,6 +173,12 @@ public class MultiplexedSessionDatabaseClientMockServerTest extends AbstractMock
     Set<String> sessionIds =
         requests.stream().map(ExecuteSqlRequest::getSession).collect(Collectors.toSet());
     assertEquals(4, sessionIds.size());
+
+    for (DatabaseClientImpl client : ImmutableList.of(client1, client2)) {
+      assertNotNull(client.multiplexedSessionDatabaseClient);
+      assertEquals(2L, client.multiplexedSessionDatabaseClient.getNumSessionsAcquired().get());
+      assertEquals(2L, client.multiplexedSessionDatabaseClient.getNumSessionsReleased().get());
+    }
   }
 
   @Test
@@ -196,6 +210,10 @@ public class MultiplexedSessionDatabaseClientMockServerTest extends AbstractMock
     Session session = mockSpanner.getSession(requests.get(0).getSession());
     assertNotNull(session);
     assertFalse(session.getMultiplexed());
+
+    assertNotNull(client.multiplexedSessionDatabaseClient);
+    assertEquals(0L, client.multiplexedSessionDatabaseClient.getNumSessionsAcquired().get());
+    assertEquals(0L, client.multiplexedSessionDatabaseClient.getNumSessionsReleased().get());
   }
 
   @Test
@@ -234,6 +252,10 @@ public class MultiplexedSessionDatabaseClientMockServerTest extends AbstractMock
     Session session = mockSpanner.getSession(requests.get(0).getSession());
     assertNotNull(session);
     assertFalse(session.getMultiplexed());
+
+    assertNotNull(client.multiplexedSessionDatabaseClient);
+    assertEquals(0L, client.multiplexedSessionDatabaseClient.getNumSessionsAcquired().get());
+    assertEquals(0L, client.multiplexedSessionDatabaseClient.getNumSessionsReleased().get());
   }
 
   @Test
@@ -281,6 +303,10 @@ public class MultiplexedSessionDatabaseClientMockServerTest extends AbstractMock
     Session session2 = mockSpanner.getSession(requests.get(1).getSession());
     assertNotNull(session2);
     assertFalse(session2.getMultiplexed());
+
+    assertNotNull(client.multiplexedSessionDatabaseClient);
+    assertEquals(1L, client.multiplexedSessionDatabaseClient.getNumSessionsAcquired().get());
+    assertEquals(1L, client.multiplexedSessionDatabaseClient.getNumSessionsReleased().get());
   }
 
   private void waitForSessionToBeReplaced(DatabaseClientImpl client) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -117,6 +117,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -192,7 +193,9 @@ public class SessionPoolTest extends BaseSessionPoolTest {
         tracer,
         labelValues,
         OpenTelemetry.noop(),
-        null);
+        null,
+        new AtomicLong(),
+        new AtomicLong());
   }
 
   private SessionPool createPool(
@@ -212,7 +215,9 @@ public class SessionPoolTest extends BaseSessionPoolTest {
         tracer,
         labelValues,
         openTelemetry,
-        attributes);
+        attributes,
+        new AtomicLong(),
+        new AtomicLong());
   }
 
   @BeforeClass

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AllTypesMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AllTypesMockServerTest.java
@@ -27,7 +27,6 @@ import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SingerProto.Genre;
 import com.google.cloud.spanner.SingerProto.SingerInfo;
 import com.google.cloud.spanner.Statement;
-import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ListValue;
 import com.google.protobuf.NullValue;
@@ -41,9 +40,6 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.After;
@@ -553,28 +549,6 @@ public class AllTypesMockServerTest extends AbstractMockServerTest {
   @After
   public void clearRequests() {
     mockSpanner.clearRequests();
-  }
-
-  @Test
-  public void testCounter() throws InterruptedException {
-    ExecutorService executor = Executors.newFixedThreadPool(1);
-    Stopwatch watch = Stopwatch.createStarted();
-    for (int n = 0; n < 256; n++) {
-      executor.submit(
-          () -> {
-            try (Connection connection = createConnection()) {
-              connection.setAutocommit(true);
-              for (int i = 0; i < 100; i++) {
-                try (ResultSet resultSet = connection.executeQuery(SELECT_STATEMENT)) {
-                  while (resultSet.next()) {}
-                }
-              }
-            }
-          });
-    }
-    executor.shutdown();
-    assertTrue(executor.awaitTermination(60L, TimeUnit.SECONDS));
-    System.out.println("Elapsed: " + watch.elapsed());
   }
 
   @Test


### PR DESCRIPTION
The metrics for multiplexed sessions were not included in the refactoring that moved multiplexed sessions out of the session pool. This change re-adds those metrics based on the new client for multiplexed sessions.
