### PR TITLE
chore: ignore irrelevant CreateSession calls in test

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerTest.java
@@ -898,49 +898,29 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
       }
     }
     assertThat(attempt.get()).isEqualTo(2);
-    Iterable<Class<? extends AbstractMessage>> requests = mockSpanner.getRequestTypes();
+    List<Class<? extends AbstractMessage>> requests = mockSpanner.getRequestTypes();
+    // Remove the CreateSession requests for multiplexed sessions, as those are not relevant for
+    // this test.
+    requests.removeIf(request -> request == CreateSessionRequest.class);
     int size = Iterables.size(requests);
     assertThat(size).isIn(Range.closed(5, 6));
-    if (isMultiplexedSessionsEnabled()) {
-      if (size == 6) {
-        assertThat(requests)
-            .containsExactly(
-                CreateSessionRequest.class,
-                BatchCreateSessionsRequest.class,
-                ExecuteBatchDmlRequest.class,
-                BeginTransactionRequest.class,
-                ExecuteBatchDmlRequest.class,
-                CommitRequest.class);
-      } else {
-        assertThat(requests)
-            .containsExactly(
-                CreateSessionRequest.class,
-                BatchCreateSessionsRequest.class,
-                ExecuteBatchDmlRequest.class,
-                CommitRequest.class,
-                BeginTransactionRequest.class,
-                ExecuteBatchDmlRequest.class,
-                CommitRequest.class);
-      }
+    if (size == 5) {
+      assertThat(requests)
+          .containsExactly(
+              BatchCreateSessionsRequest.class,
+              ExecuteBatchDmlRequest.class,
+              BeginTransactionRequest.class,
+              ExecuteBatchDmlRequest.class,
+              CommitRequest.class);
     } else {
-      if (size == 5) {
-        assertThat(requests)
-            .containsExactly(
-                BatchCreateSessionsRequest.class,
-                ExecuteBatchDmlRequest.class,
-                BeginTransactionRequest.class,
-                ExecuteBatchDmlRequest.class,
-                CommitRequest.class);
-      } else {
-        assertThat(requests)
-            .containsExactly(
-                BatchCreateSessionsRequest.class,
-                ExecuteBatchDmlRequest.class,
-                CommitRequest.class,
-                BeginTransactionRequest.class,
-                ExecuteBatchDmlRequest.class,
-                CommitRequest.class);
-      }
+      assertThat(requests)
+          .containsExactly(
+              BatchCreateSessionsRequest.class,
+              ExecuteBatchDmlRequest.class,
+              CommitRequest.class,
+              BeginTransactionRequest.class,
+              ExecuteBatchDmlRequest.class,
+              CommitRequest.class);
     }
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -2162,7 +2162,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
     return result;
   }
 
-  public Iterable<Class<? extends AbstractMessage>> getRequestTypes() {
+  public List<Class<? extends AbstractMessage>> getRequestTypes() {
     List<Class<? extends AbstractMessage>> res = new LinkedList<>();
     for (AbstractMessage m : this.requests) {
       res.add(m.getClass());


### PR DESCRIPTION
The CreateSession calls are irrelevant to the test, as multiplexed sessions are not used for read/write transactions.

Fixes #3090 
