### PR TITLE
chore(spanner): update sample tests instance id

### DIFF
--- a/samples/install-without-bom/pom.xml
+++ b/samples/install-without-bom/pom.xml
@@ -143,8 +143,8 @@
         <version>3.2.5</version>
         <configuration>
           <systemPropertyVariables>
-            <spanner.test.instance>java-client-integration-test</spanner.test.instance>
-            <spanner.test.instance.mr>java-client-mr-integration-test</spanner.test.instance.mr>
+            <spanner.test.instance>java-client-integration-tests</spanner.test.instance>
+            <spanner.test.instance.mr>java-client-mr-integration-tests</spanner.test.instance.mr>
             <spanner.test.instance.config>nam11</spanner.test.instance.config>
             <spanner.test.key.location>us-east1</spanner.test.key.location>
             <spanner.test.key.ring>java-client-integration-test-cmek-ring</spanner.test.key.ring>

--- a/samples/snapshot/pom.xml
+++ b/samples/snapshot/pom.xml
@@ -142,8 +142,8 @@
         <version>3.2.5</version>
         <configuration>
           <systemPropertyVariables>
-            <spanner.test.instance>java-client-integration-test</spanner.test.instance>
-            <spanner.test.instance.mr>java-client-mr-integration-test</spanner.test.instance.mr>
+            <spanner.test.instance>java-client-integration-tests</spanner.test.instance>
+            <spanner.test.instance.mr>java-client-mr-integration-tests</spanner.test.instance.mr>
             <spanner.test.instance.config>nam11</spanner.test.instance.config>
             <spanner.test.key.location>us-east1</spanner.test.key.location>
             <spanner.test.key.ring>java-client-integration-test-cmek-ring</spanner.test.key.ring>

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -178,8 +178,8 @@
         <version>3.2.5</version>
         <configuration>
           <systemPropertyVariables>
-            <spanner.test.instance>java-client-integration-test</spanner.test.instance>
-            <spanner.test.instance.mr>java-client-mr-integration-test</spanner.test.instance.mr>
+            <spanner.test.instance>java-client-integration-tests</spanner.test.instance>
+            <spanner.test.instance.mr>java-client-mr-integration-tests</spanner.test.instance.mr>
             <spanner.test.instance.config>nam11</spanner.test.instance.config>
             <spanner.test.key.location>us-east1</spanner.test.key.location>
             <spanner.test.key.ring>java-client-integration-test-cmek-ring</spanner.test.key.ring>


### PR DESCRIPTION
The sample tests that are running as nightly build are failing from 6 months with the following error:
```
ERROR] com.example.spanner.UpdateDatabaseSampleIT.testUpdateDatabase -- Time elapsed: 0 s <<< ERROR!
java.util.concurrent.ExecutionException: com.google.api.gax.rpc.NotFoundException: io.grpc.StatusRuntimeException: NOT_FOUND: 
Instance not found: projects/gcloud-devel/instances/java-client-integration-test
``` 

The instance id `java-client-integration-test` does not exist in this project. Instead the instance that is there is `java-client-integration-tests`
https://screenshot.googleplex.com/4YnhRoyTcqAoAr7