### PR TITLE
feat: allow DML batches in transactions to execute analyzeUpdate

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractBaseUnitOfWork.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractBaseUnitOfWork.java
@@ -167,8 +167,6 @@ abstract class AbstractBaseUnitOfWork implements UnitOfWork {
     return null;
   }
 
-  abstract boolean isSingleUse();
-
   /**
    * Returns a descriptive name for the type of transaction / unit of work. This is used in error
    * messages.

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractMultiUseTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractMultiUseTransaction.java
@@ -96,7 +96,7 @@ abstract class AbstractMultiUseTransaction extends AbstractBaseUnitOfWork {
   }
 
   @Override
-  boolean isSingleUse() {
+  public boolean isSingleUse() {
     return false;
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DdlBatch.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DdlBatch.java
@@ -97,7 +97,7 @@ class DdlBatch extends AbstractBaseUnitOfWork {
   }
 
   @Override
-  boolean isSingleUse() {
+  public boolean isSingleUse() {
     return false;
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SingleUseTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SingleUseTransaction.java
@@ -179,7 +179,7 @@ class SingleUseTransaction extends AbstractBaseUnitOfWork {
   }
 
   @Override
-  boolean isSingleUse() {
+  public boolean isSingleUse() {
     return true;
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/UnitOfWork.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/UnitOfWork.java
@@ -77,6 +77,9 @@ interface UnitOfWork {
   /** @return <code>true</code> if this unit of work is still active. */
   boolean isActive();
 
+  /** Returns true if this transaction can only be used for a single statement. */
+  boolean isSingleUse();
+
   /**
    * Commits the changes in this unit of work to the database. For read-only transactions, this only
    * closes the {@link ReadContext}. This method will throw a {@link SpannerException} if called for


### PR DESCRIPTION
Executing analyzeUpdate in a DML Batch inside a transaction should be possible, as the parent transaction can be used for that.