### PR TITLE
fix: make SessionPoolOptions#setUseMultiplexedSession(boolean) package private

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ implementation 'com.google.cloud:google-cloud-spanner'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-spanner:6.67.0'
+implementation 'com.google.cloud:google-cloud-spanner:6.68.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.67.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-spanner" % "6.68.0"
 ```
 <!-- {x-version-update-end} -->
 
@@ -671,7 +671,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-spanner/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-spanner.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.67.0
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.68.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -712,4 +712,10 @@
     <method>void setProtoDescriptors(byte[])</method>
   </difference>
 
+  <!-- Multiplexed session enable setter to package private -->
+  <difference>
+    <differenceType>7009</differenceType>
+    <className>com/google/cloud/spanner/SessionPoolOptions$Builder</className>
+    <method>com.google.cloud.spanner.SessionPoolOptions$Builder setUseMultiplexedSession(boolean)</method>
+  </difference>
 </differences>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
@@ -755,7 +755,7 @@ public class SessionPoolOptions {
      * SessionPoolOptions#maxSessions} based on the traffic load. Failing to do so will result in
      * higher latencies.
      */
-    public Builder setUseMultiplexedSession(boolean useMultiplexedSession) {
+    Builder setUseMultiplexedSession(boolean useMultiplexedSession) {
       this.useMultiplexedSession = useMultiplexedSession;
       return this;
     }


### PR DESCRIPTION
The `SessionPoolOptions#setUseMultiplexedSessions(boolean)` method was made public by accident. This method is not intended for public use.