### PR TITLE
fix: remove unused DmlBatch span

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractBaseUnitOfWork.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractBaseUnitOfWork.java
@@ -165,6 +165,11 @@ abstract class AbstractBaseUnitOfWork implements UnitOfWork {
     this.span = Preconditions.checkNotNull(builder.span);
   }
 
+  @Override
+  public Span getSpan() {
+    return this.span;
+  }
+
   ApiFuture<Void> asyncEndUnitOfWorkSpan() {
     return this.statementExecutor.submit(this::endUnitOfWorkSpan);
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
@@ -96,7 +96,6 @@ class ConnectionImpl implements Connection {
   private static final String SINGLE_USE_TRANSACTION = "SingleUseTransaction";
   private static final String READ_ONLY_TRANSACTION = "ReadOnlyTransaction";
   private static final String READ_WRITE_TRANSACTION = "ReadWriteTransaction";
-  private static final String DML_BATCH = "DmlBatch";
   private static final String DDL_BATCH = "DdlBatch";
   private static final String DDL_STATEMENT = "DdlStatement";
 
@@ -1932,7 +1931,8 @@ class ConnectionImpl implements Connection {
               .setStatementTag(statementTag)
               .setExcludeTxnFromChangeStreams(excludeTxnFromChangeStreams)
               .setRpcPriority(rpcPriority)
-              .setSpan(createSpanForUnitOfWork(DML_BATCH))
+              // Use the transaction Span for the DML batch.
+              .setSpan(transactionStack.peek().getSpan())
               .build();
         case DDL_BATCH:
           return DdlBatch.newBuilder()

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/UnitOfWork.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/UnitOfWork.java
@@ -31,6 +31,7 @@ import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.TransactionContext;
 import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStatement;
 import com.google.spanner.v1.ResultSetStats;
+import io.opentelemetry.api.trace.Span;
 import java.util.concurrent.ExecutionException;
 import javax.annotation.Nonnull;
 
@@ -76,6 +77,9 @@ interface UnitOfWork {
 
   /** @return <code>true</code> if this unit of work is still active. */
   boolean isActive();
+
+  /** @return the {@link Span} that is used by this {@link UnitOfWork}. */
+  Span getSpan();
 
   /** Returns true if this transaction can only be used for a single statement. */
   boolean isSingleUse();


### PR DESCRIPTION
The DmlBatch span that was created for DML batches was never used, as all traces were registered on the underlying transaction of the batch. The DmlBatch span was therefore always just an empty sibling span of the Transaction span, which did contain the traces of the statements that were executed.