### PR TITLE
chore: add transaction.retried attribute to traces

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/OpenTelemetryTracingTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/OpenTelemetryTracingTest.java
@@ -447,6 +447,9 @@ public class OpenTelemetryTracingTest extends AbstractMockServerTest {
             .filter(span -> span.getName().equals("CloudSpannerJdbc.ReadWriteTransaction"))
             .findFirst()
             .orElseThrow(IllegalStateException::new);
+    assertEquals(
+        Boolean.TRUE,
+        transactionSpan.getAttributes().get(AttributeKey.booleanKey("transaction.retried")));
     assertEquals(1, transactionSpan.getTotalRecordedEvents());
     EventData event = transactionSpan.getEvents().get(0);
     assertEquals(


### PR DESCRIPTION
Adds a 'transaction.retried' attribute to Connection API read/write transaction spans if it was retried. This makes it easier to search for transactions that were retried.