### PR TITLE
chore: propagate RuntimeException from DelayedReadContext

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DelayedReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DelayedReadContext.java
@@ -44,6 +44,11 @@ class DelayedReadContext<T extends ReadContext> implements ReadContext {
     try {
       return this.readContextFuture.get();
     } catch (ExecutionException executionException) {
+      // Propagate the underlying exception as a RuntimeException (SpannerException is also a
+      // RuntimeException).
+      if (executionException.getCause() instanceof RuntimeException) {
+        throw (RuntimeException) executionException.getCause();
+      }
       throw SpannerExceptionFactory.asSpannerException(executionException.getCause());
     } catch (InterruptedException interruptedException) {
       throw SpannerExceptionFactory.propagateInterrupt(interruptedException);


### PR DESCRIPTION
Propagate the underlying cause of the ExecutionException as a RuntimeException directly, if this is already a RuntimeException. This keeps the behavior of multiplexed sessions and regular sessions equal, regardless whether the Delayed... route is taken for multiplexed sessions, or the direct route is used.

Fixes #3132
