### PR TITLE
fix: do not end transaction span when rolling back to savepoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.41.0')
+implementation platform('com.google.cloud:libraries-bom:26.42.0')
 
 implementation 'com.google.cloud:google-cloud-spanner'
 ```


### PR DESCRIPTION
When a transaction is rolled back to a savepoint instead of rolled back entirely, the transaction span should not be ended, as the transaction continues to live.
