### PR TITLE
chore: add connection property for API tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.41.0')
+implementation platform('com.google.cloud:libraries-bom:26.42.0')
 
 implementation 'com.google.cloud:google-cloud-spanner'
 ```

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
@@ -159,6 +159,7 @@ public class SpannerPool {
     private final boolean useVirtualGrpcTransportThreads;
     private final OpenTelemetry openTelemetry;
     private final Boolean enableExtendedTracing;
+    private final Boolean enableApiTracing;
 
     @VisibleForTesting
     static SpannerPoolKey of(ConnectionOptions options) {
@@ -188,6 +189,7 @@ public class SpannerPool {
       this.useVirtualGrpcTransportThreads = options.isUseVirtualGrpcTransportThreads();
       this.openTelemetry = options.getOpenTelemetry();
       this.enableExtendedTracing = options.isEnableExtendedTracing();
+      this.enableApiTracing = options.isEnableApiTracing();
     }
 
     @Override
@@ -208,7 +210,8 @@ public class SpannerPool {
           && Objects.equals(
               this.useVirtualGrpcTransportThreads, other.useVirtualGrpcTransportThreads)
           && Objects.equals(this.openTelemetry, other.openTelemetry)
-          && Objects.equals(this.enableExtendedTracing, other.enableExtendedTracing);
+          && Objects.equals(this.enableExtendedTracing, other.enableExtendedTracing)
+          && Objects.equals(this.enableApiTracing, other.enableApiTracing);
     }
 
     @Override
@@ -225,7 +228,8 @@ public class SpannerPool {
           this.routeToLeader,
           this.useVirtualGrpcTransportThreads,
           this.openTelemetry,
-          this.enableExtendedTracing);
+          this.enableExtendedTracing,
+          this.enableApiTracing);
     }
   }
 
@@ -363,6 +367,9 @@ public class SpannerPool {
     }
     if (key.enableExtendedTracing != null) {
       builder.setEnableExtendedTracing(key.enableExtendedTracing);
+    }
+    if (key.enableApiTracing != null) {
+      builder.setEnableApiTracing(key.enableApiTracing);
     }
     if (key.numChannels != null) {
       builder.setNumChannels(key.numChannels);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
@@ -1165,4 +1165,29 @@ public class ConnectionOptionsTest {
             .build()
             .getMaxCommitDelay());
   }
+
+  @Test
+  public void testEnableApiTracing() {
+    assertNull(
+        ConnectionOptions.newBuilder()
+            .setUri(
+                "cloudspanner:/projects/test-project-123/instances/test-instance/databases/test-database")
+            .setCredentials(NoCredentials.getInstance())
+            .build()
+            .isEnableApiTracing());
+    assertTrue(
+        ConnectionOptions.newBuilder()
+            .setUri(
+                "cloudspanner:/projects/test-project-123/instances/test-instance/databases/test-database?enableApiTracing=true")
+            .setCredentials(NoCredentials.getInstance())
+            .build()
+            .isEnableApiTracing());
+    assertFalse(
+        ConnectionOptions.newBuilder()
+            .setUri(
+                "cloudspanner:/projects/test-project-123/instances/test-instance/databases/test-database?enableApiTracing=false")
+            .setCredentials(NoCredentials.getInstance())
+            .build()
+            .isEnableApiTracing());
+  }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SpannerPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SpannerPoolTest.java
@@ -521,16 +521,19 @@ public class SpannerPoolTest {
         SpannerPoolKey.of(
             ConnectionOptions.newBuilder()
                 .setUri("cloudspanner:/projects/p/instances/i/databases/d")
+                .setCredentials(NoCredentials.getInstance())
                 .build());
     SpannerPoolKey keyWithApiTracingEnabled =
         SpannerPoolKey.of(
             ConnectionOptions.newBuilder()
                 .setUri("cloudspanner:/projects/p/instances/i/databases/d?enableApiTracing=true")
+                .setCredentials(NoCredentials.getInstance())
                 .build());
     SpannerPoolKey keyWithApiTracingDisabled =
         SpannerPoolKey.of(
             ConnectionOptions.newBuilder()
                 .setUri("cloudspanner:/projects/p/instances/i/databases/d?enableApiTracing=false")
+                .setCredentials(NoCredentials.getInstance())
                 .build());
 
     assertNotEquals(keyWithoutApiTracingConfig, keyWithApiTracingEnabled);
@@ -542,18 +545,21 @@ public class SpannerPoolTest {
         SpannerPoolKey.of(
             ConnectionOptions.newBuilder()
                 .setUri("cloudspanner:/projects/p/instances/i/databases/d?enableApiTracing=true")
+                .setCredentials(NoCredentials.getInstance())
                 .build()));
     assertEquals(
         keyWithApiTracingDisabled,
         SpannerPoolKey.of(
             ConnectionOptions.newBuilder()
                 .setUri("cloudspanner:/projects/p/instances/i/databases/d?enableApiTracing=false")
+                .setCredentials(NoCredentials.getInstance())
                 .build()));
     assertEquals(
         keyWithoutApiTracingConfig,
         SpannerPoolKey.of(
             ConnectionOptions.newBuilder()
                 .setUri("cloudspanner:/projects/p/instances/i/databases/d")
+                .setCredentials(NoCredentials.getInstance())
                 .build()));
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SpannerPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SpannerPoolTest.java
@@ -516,6 +516,48 @@ public class SpannerPoolTest {
   }
 
   @Test
+  public void testEnableApiTracing() {
+    SpannerPoolKey keyWithoutApiTracingConfig =
+        SpannerPoolKey.of(
+            ConnectionOptions.newBuilder()
+                .setUri("cloudspanner:/projects/p/instances/i/databases/d")
+                .build());
+    SpannerPoolKey keyWithApiTracingEnabled =
+        SpannerPoolKey.of(
+            ConnectionOptions.newBuilder()
+                .setUri("cloudspanner:/projects/p/instances/i/databases/d?enableApiTracing=true")
+                .build());
+    SpannerPoolKey keyWithApiTracingDisabled =
+        SpannerPoolKey.of(
+            ConnectionOptions.newBuilder()
+                .setUri("cloudspanner:/projects/p/instances/i/databases/d?enableApiTracing=false")
+                .build());
+
+    assertNotEquals(keyWithoutApiTracingConfig, keyWithApiTracingEnabled);
+    assertNotEquals(keyWithoutApiTracingConfig, keyWithApiTracingDisabled);
+    assertNotEquals(keyWithApiTracingEnabled, keyWithApiTracingDisabled);
+
+    assertEquals(
+        keyWithApiTracingEnabled,
+        SpannerPoolKey.of(
+            ConnectionOptions.newBuilder()
+                .setUri("cloudspanner:/projects/p/instances/i/databases/d?enableApiTracing=true")
+                .build()));
+    assertEquals(
+        keyWithApiTracingDisabled,
+        SpannerPoolKey.of(
+            ConnectionOptions.newBuilder()
+                .setUri("cloudspanner:/projects/p/instances/i/databases/d?enableApiTracing=false")
+                .build()));
+    assertEquals(
+        keyWithoutApiTracingConfig,
+        SpannerPoolKey.of(
+            ConnectionOptions.newBuilder()
+                .setUri("cloudspanner:/projects/p/instances/i/databases/d")
+                .build()));
+  }
+
+  @Test
   public void testOpenTelemetry() {
     SpannerPool pool = createSubjectAndMocks();
     Spanner spanner1;


### PR DESCRIPTION
Add a connection URL property for enabling API tracing, so it can be set in the JDBC connection URL.
