### PR TITLE
test(spanner): update non-retryable error code in unit tests

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncRunnerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncRunnerTest.java
@@ -229,7 +229,7 @@ public class AsyncRunnerTest extends AbstractAsyncTransactionTest {
   public void asyncRunnerCommitFails() throws Exception {
     mockSpanner.setCommitExecutionTime(
         SimulatedExecutionTime.ofException(
-            Status.RESOURCE_EXHAUSTED
+            Status.INVALID_ARGUMENT
                 .withDescription("mutation limit exceeded")
                 .asRuntimeException()));
     AsyncRunner runner = client().runAsync();
@@ -245,7 +245,7 @@ public class AsyncRunnerTest extends AbstractAsyncTransactionTest {
     ExecutionException e = assertThrows(ExecutionException.class, () -> updateCount.get());
     assertThat(e.getCause()).isInstanceOf(SpannerException.class);
     SpannerException se = (SpannerException) e.getCause();
-    assertThat(se.getErrorCode()).isEqualTo(ErrorCode.RESOURCE_EXHAUSTED);
+    assertThat(se.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
     assertThat(se.getMessage()).contains("mutation limit exceeded");
   }
 
@@ -432,7 +432,7 @@ public class AsyncRunnerTest extends AbstractAsyncTransactionTest {
   public void asyncRunnerWithBatchUpdateCommitFails() throws Exception {
     mockSpanner.setCommitExecutionTime(
         SimulatedExecutionTime.ofException(
-            Status.RESOURCE_EXHAUSTED
+            Status.INVALID_ARGUMENT
                 .withDescription("mutation limit exceeded")
                 .asRuntimeException()));
     AsyncRunner runner = client().runAsync();
@@ -448,7 +448,7 @@ public class AsyncRunnerTest extends AbstractAsyncTransactionTest {
     ExecutionException e = assertThrows(ExecutionException.class, () -> updateCount.get());
     assertThat(e.getCause()).isInstanceOf(SpannerException.class);
     SpannerException se = (SpannerException) e.getCause();
-    assertThat(se.getErrorCode()).isEqualTo(ErrorCode.RESOURCE_EXHAUSTED);
+    assertThat(se.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
     assertThat(se.getMessage()).contains("mutation limit exceeded");
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerTest.java
@@ -531,7 +531,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
   public void asyncTransactionManagerCommitFails() throws Exception {
     mockSpanner.setCommitExecutionTime(
         SimulatedExecutionTime.ofException(
-            Status.RESOURCE_EXHAUSTED
+            Status.INVALID_ARGUMENT
                 .withDescription("mutation limit exceeded")
                 .asRuntimeException()));
     try (AsyncTransactionManager mgr = client().transactionManagerAsync()) {
@@ -545,7 +545,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
                               AsyncTransactionManagerHelper.executeUpdateAsync(UPDATE_STATEMENT),
                               executor)
                           .commitAsync()));
-      assertThat(e.getErrorCode()).isEqualTo(ErrorCode.RESOURCE_EXHAUSTED);
+      assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
       assertThat(e.getMessage()).contains("mutation limit exceeded");
     }
   }
@@ -928,7 +928,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
   public void asyncTransactionManagerWithBatchUpdateCommitFails() throws Exception {
     mockSpanner.setCommitExecutionTime(
         SimulatedExecutionTime.ofException(
-            Status.RESOURCE_EXHAUSTED
+            Status.INVALID_ARGUMENT
                 .withDescription("mutation limit exceeded")
                 .asRuntimeException()));
     try (AsyncTransactionManager manager = clientWithEmptySessionPool().transactionManagerAsync()) {
@@ -945,7 +945,7 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
                                       ImmutableList.of(UPDATE_STATEMENT, UPDATE_STATEMENT)),
                               executor)
                           .commitAsync()));
-      assertThat(e.getErrorCode()).isEqualTo(ErrorCode.RESOURCE_EXHAUSTED);
+      assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
       assertThat(e.getMessage()).contains("mutation limit exceeded");
     }
     if (isMultiplexedSessionsEnabled()) {


### PR DESCRIPTION
There are a couple of unit tests that verify the behavior of non-retryable error code. This PR updates the error code since the existing `RESOURCE_EXHAUSTED` error code is made as retryable error code in https://github.com/googleapis/java-spanner/pull/3064