### PR TITLE
feat: support Read RPC OrderBy

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -902,6 +902,9 @@ abstract class AbstractReadContext
     if (readOptions.hasDataBoostEnabled()) {
       builder.setDataBoostEnabled(readOptions.dataBoostEnabled());
     }
+    if (readOptions.hasOrderBy()) {
+      builder.setOrderBy(readOptions.orderBy());
+    }
     if (readOptions.hasDirectedReadOptions()) {
       builder.setDirectedReadOptions(readOptions.directedReadOptions());
     } else if (defaultDirectedReadOptions != null) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractReadContextTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractReadContextTest.java
@@ -33,8 +33,11 @@ import com.google.spanner.v1.ExecuteBatchDmlRequest;
 import com.google.spanner.v1.ExecuteSqlRequest;
 import com.google.spanner.v1.ExecuteSqlRequest.QueryMode;
 import com.google.spanner.v1.ExecuteSqlRequest.QueryOptions;
+import com.google.spanner.v1.ReadRequest;
+import com.google.spanner.v1.ReadRequest.OrderBy;
 import com.google.spanner.v1.RequestOptions;
 import com.google.spanner.v1.RequestOptions.Priority;
+import com.google.spanner.v1.SessionName;
 import com.google.spanner.v1.TransactionSelector;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -221,6 +224,21 @@ public class AbstractReadContextTest {
             Options.fromQueryOptions(Options.dataBoostEnabled(true)),
             false);
     assertTrue(request.getDataBoostEnabled());
+  }
+
+  @Test
+  public void testGetReadRequestBuilderWithOrderBy() {
+    ReadRequest request =
+        ReadRequest.newBuilder()
+            .setSession(
+                SessionName.of("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]").toString())
+            .setTransaction(TransactionSelector.newBuilder().build())
+            .setTable("table110115790")
+            .setIndex("index100346066")
+            .addAllColumns(new ArrayList<String>())
+            .setOrderByValue(2)
+            .build();
+    assertEquals(OrderBy.ORDER_BY_NO_ORDER, request.getOrderBy());
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -52,6 +52,7 @@ import com.google.cloud.spanner.AsyncResultSet.CallbackResponse;
 import com.google.cloud.spanner.AsyncTransactionManager.TransactionContextFuture;
 import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.cloud.spanner.Options.RpcOrderBy;
 import com.google.cloud.spanner.Options.RpcPriority;
 import com.google.cloud.spanner.Options.TransactionOption;
 import com.google.cloud.spanner.ReadContext.QueryAnalyzeMode;
@@ -89,6 +90,7 @@ import com.google.spanner.v1.ExecuteSqlRequest;
 import com.google.spanner.v1.ExecuteSqlRequest.QueryMode;
 import com.google.spanner.v1.ExecuteSqlRequest.QueryOptions;
 import com.google.spanner.v1.ReadRequest;
+import com.google.spanner.v1.ReadRequest.OrderBy;
 import com.google.spanner.v1.RequestOptions.Priority;
 import com.google.spanner.v1.ResultSetMetadata;
 import com.google.spanner.v1.ResultSetStats;
@@ -1720,6 +1722,27 @@ public class DatabaseClientImplTest {
     assertThat(request.getRequestOptions().getRequestTag())
         .isEqualTo("app=spanner,env=test,action=read");
     assertThat(request.getRequestOptions().getTransactionTag()).isEmpty();
+  }
+
+  @Test
+  public void testExecuteReadWithOrderByOption() {
+    DatabaseClient client =
+        spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+    try (ResultSet resultSet =
+        client
+            .singleUse()
+            .read(
+                READ_TABLE_NAME,
+                KeySet.singleKey(Key.of(1L)),
+                READ_COLUMN_NAMES,
+                Options.orderBy(RpcOrderBy.NO_ORDER))) {
+      consumeResults(resultSet);
+    }
+
+    List<ReadRequest> requests = mockSpanner.getRequestsOfType(ReadRequest.class);
+    assertThat(requests).hasSize(1);
+    ReadRequest request = requests.get(0);
+    assertEquals(OrderBy.ORDER_BY_NO_ORDER, request.getOrderBy());
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OptionsTest.java
@@ -18,16 +18,19 @@ package com.google.cloud.spanner;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import com.google.cloud.spanner.Options.RpcOrderBy;
 import com.google.cloud.spanner.Options.RpcPriority;
 import com.google.spanner.v1.DirectedReadOptions;
 import com.google.spanner.v1.DirectedReadOptions.IncludeReplicas;
 import com.google.spanner.v1.DirectedReadOptions.ReplicaSelection;
+import com.google.spanner.v1.ReadRequest.OrderBy;
 import com.google.spanner.v1.RequestOptions.Priority;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -79,7 +82,8 @@ public class OptionsTest {
             Options.limit(10),
             Options.prefetchChunks(1),
             Options.dataBoostEnabled(true),
-            Options.directedRead(DIRECTED_READ_OPTIONS));
+            Options.directedRead(DIRECTED_READ_OPTIONS),
+            Options.orderBy(RpcOrderBy.NO_ORDER));
     assertThat(options.hasLimit()).isTrue();
     assertThat(options.limit()).isEqualTo(10);
     assertThat(options.hasPrefetchChunks()).isTrue();
@@ -87,6 +91,7 @@ public class OptionsTest {
     assertThat(options.hasDataBoostEnabled()).isTrue();
     assertTrue(options.dataBoostEnabled());
     assertTrue(options.hasDirectedReadOptions());
+    assertTrue(options.hasOrderBy());
     assertEquals(DIRECTED_READ_OPTIONS, options.directedReadOptions());
   }
 
@@ -101,6 +106,7 @@ public class OptionsTest {
     assertThat(options.hasTag()).isFalse();
     assertThat(options.hasDataBoostEnabled()).isFalse();
     assertThat(options.hasDirectedReadOptions()).isFalse();
+    assertThat(options.hasOrderBy()).isFalse();
     assertNull(options.withExcludeTxnFromChangeStreams());
     assertThat(options.toString()).isEqualTo("");
     assertThat(options.equals(options)).isTrue();
@@ -182,7 +188,8 @@ public class OptionsTest {
             Options.limit(limit),
             Options.tag(tag),
             Options.dataBoostEnabled(true),
-            Options.directedRead(DIRECTED_READ_OPTIONS));
+            Options.directedRead(DIRECTED_READ_OPTIONS),
+            Options.orderBy(RpcOrderBy.NO_ORDER));
 
     assertThat(options.toString())
         .isEqualTo(
@@ -197,10 +204,14 @@ public class OptionsTest {
                 + " "
                 + "directedReadOptions: "
                 + DIRECTED_READ_OPTIONS
+                + " "
+                + "orderBy: "
+                + RpcOrderBy.NO_ORDER
                 + " ");
     assertThat(options.tag()).isEqualTo(tag);
     assertEquals(dataBoost, options.dataBoostEnabled());
     assertEquals(DIRECTED_READ_OPTIONS, options.directedReadOptions());
+    assertEquals(OrderBy.ORDER_BY_NO_ORDER, options.orderBy());
   }
 
   @Test
@@ -352,6 +363,24 @@ public class OptionsTest {
     Options options = Options.fromTransactionOptions(Options.priority(priority));
     assertTrue(options.hasPriority());
     assertEquals("priority: " + priority + " ", options.toString());
+  }
+
+  @Test
+  public void testReadOptionsOrderBy() {
+    RpcOrderBy orderBy = RpcOrderBy.NO_ORDER;
+    Options options = Options.fromReadOptions(Options.orderBy(orderBy));
+    assertTrue(options.hasOrderBy());
+    assertEquals("orderBy: " + orderBy + " ", options.toString());
+  }
+
+  @Test
+  public void testReadOptionsWithOrderByEquality() {
+    Options optionsWithNoOrderBy1 = Options.fromReadOptions(Options.orderBy(RpcOrderBy.NO_ORDER));
+    Options optionsWithNoOrderBy2 = Options.fromReadOptions(Options.orderBy(RpcOrderBy.NO_ORDER));
+    assertTrue(optionsWithNoOrderBy1.equals(optionsWithNoOrderBy2));
+
+    Options optionsWithPkOrder = Options.fromReadOptions(Options.orderBy(RpcOrderBy.PRIMARY_KEY));
+    assertFalse(optionsWithNoOrderBy1.equals(optionsWithPkOrder));
   }
 
   @Test


### PR DESCRIPTION
Adds support for setting Read OrderBy.

Customers can set this option only for the Read API. This option will allow users to specify whether they want the results to be returned in primary key order (PRIMARY_KEY) or in an out of order (NO_ORDER). The NO_ORDER is significantly faster than KEY_ORDER, because spanner uses higher parallelism for non-ordered reads.

Go counterpart: https://github.com/googleapis/google-cloud-go/pull/10289