### PR TITLE
fix: adapt to introduction of java.time in gax

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/CompositeTracer.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/CompositeTracer.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.spanner;
 
+import static com.google.api.gax.util.TimeConversionUtils.toJavaTimeDuration;
+
 import com.google.api.core.InternalApi;
 import com.google.api.gax.tracing.ApiTracer;
 import com.google.api.gax.tracing.BaseApiTracer;
@@ -23,7 +25,6 @@ import com.google.api.gax.tracing.MetricsTracer;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
-import org.threeten.bp.Duration;
 
 @InternalApi
 public class CompositeTracer extends BaseApiTracer {
@@ -108,9 +109,14 @@ public class CompositeTracer extends BaseApiTracer {
   }
 
   @Override
-  public void attemptFailed(Throwable error, Duration delay) {
+  public void attemptFailed(Throwable error, org.threeten.bp.Duration delay) {
+    attemptFailedDuration(error, toJavaTimeDuration(delay));
+  }
+
+  @Override
+  public void attemptFailedDuration(Throwable error, java.time.Duration delay) {
     for (ApiTracer child : children) {
-      child.attemptFailed(error, delay);
+      child.attemptFailedDuration(error, delay);
     }
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/CompositeTracer.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/CompositeTracer.java
@@ -121,13 +121,6 @@ public class CompositeTracer extends BaseApiTracer {
   }
 
   @Override
-  public void attemptFailedDuration(Throwable error, java.time.Duration delay) {
-    for (ApiTracer child : children) {
-      child.attemptFailedDuration(error, delay);
-    }
-  }
-
-  @Override
   public void attemptFailedRetriesExhausted(Throwable error) {
     for (ApiTracer child : children) {
       child.attemptFailedRetriesExhausted(error);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/CompositeTracerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/CompositeTracerTest.java
@@ -150,7 +150,7 @@ public class CompositeTracerTest {
   @Test
   public void testAttemptFailed() {
     RuntimeException error = new RuntimeException();
-    Duration delay = org.threeten.bp.Duration.ofMillis(10);
+    Duration delay = Duration.ofMillis(10);
     compositeTracer.attemptFailed(error, delay);
 
     // CompositeTracer's attemptFailed calls the attemptFailedDuration method. This was part of


### PR DESCRIPTION
To be merged after `gapic-generator-java >2.24.0` is merged.

This adapts `CompositeTracer` to also include `attemptFailedDuration`, which was recently introduced in https://github.com/googleapis/sdk-platform-java/pull/1872

Confirmed it works by using `gax 2.51.1-SNAPSHOT`
![image](https://github.com/googleapis/java-spanner/assets/22083784/bc0021a3-8f14-4a9c-ada1-304ed5cd041b)
