### PR TITLE
test: do not use RESOURCE_EXHAUSTED as it is retryable

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BatchCreateSessionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BatchCreateSessionsTest.java
@@ -207,13 +207,13 @@ public class BatchCreateSessionsTest {
   }
 
   @Test
-  public void testSpannerReturnsResourceExhausted() throws InterruptedException {
+  public void testSpannerReturnsFailedPrecondition() throws InterruptedException {
     int minSessions = 100;
     int maxSessions = 1000;
     int expectedSessions;
     DatabaseClientImpl client;
     // Make the first BatchCreateSessions return an error.
-    mockSpanner.addException(Status.RESOURCE_EXHAUSTED.asRuntimeException());
+    mockSpanner.addException(Status.FAILED_PRECONDITION.asRuntimeException());
     try (Spanner spanner = createSpanner(minSessions, maxSessions)) {
       // Create a database client which will create a session pool.
       client =

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -808,7 +808,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
       batchCreateSessionsExecutionTime.simulateExecutionTime(
           exceptions, stickyGlobalExceptions, freezeLock);
       if (sessions.size() >= maxTotalSessions) {
-        throw Status.RESOURCE_EXHAUSTED
+        throw Status.FAILED_PRECONDITION
             .withDescription("Maximum number of sessions reached")
             .asRuntimeException();
       }


### PR DESCRIPTION
The test used the error code RESOURCE_EXHAUSTED to indicate that the server could not create any more sessions. This error code is now retryable, causing the test to become flaky. Change the error code to one that is not retryable.

Fixes #3224
