### PR TITLE
chore(spanner): Update instance region

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestEnv.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestEnv.java
@@ -143,7 +143,7 @@ public class IntegrationTestEnv extends ExternalResource {
   private void initializeInstance(InstanceId instanceId) throws Exception {
     InstanceConfig instanceConfig;
     try {
-      instanceConfig = instanceAdminClient.getInstanceConfig("regional-us-central1");
+      instanceConfig = instanceAdminClient.getInstanceConfig("regional-us-east4");
     } catch (Throwable ignore) {
       instanceConfig =
           Iterators.get(instanceAdminClient.listInstanceConfigs().iterateAll().iterator(), 0, null);

--- a/samples/native-image/src/main/java/com/example/spanner/InstanceOperations.java
+++ b/samples/native-image/src/main/java/com/example/spanner/InstanceOperations.java
@@ -35,7 +35,7 @@ public class InstanceOperations {
 
     InstanceInfo instanceInfo =
         InstanceInfo.newBuilder(InstanceId.of(projectId, instanceId))
-            .setInstanceConfigId(InstanceConfigId.of(projectId, "regional-us-central1"))
+            .setInstanceConfigId(InstanceConfigId.of(projectId, "regional-us-east4"))
             .setNodeCount(1)
             .setDisplayName(instanceId)
             .build();

--- a/samples/snippets/src/main/java/com/example/spanner/CreateInstanceExample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/CreateInstanceExample.java
@@ -47,9 +47,9 @@ class CreateInstanceExample {
             .setDisplayName(displayName)
             .setNodeCount(nodeCount)
             .setConfig(
-                InstanceConfigName.of(projectId, "regional-us-central1").toString())
+                InstanceConfigName.of(projectId, "regional-us-east4").toString())
             .build();
-    
+
     try (Spanner spanner =
         SpannerOptions.newBuilder()
             .setProjectId(projectId)

--- a/samples/snippets/src/main/java/com/example/spanner/CreateInstanceWithAutoscalingConfigExample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/CreateInstanceWithAutoscalingConfigExample.java
@@ -45,7 +45,7 @@ class CreateInstanceWithAutoscalingConfigExample {
             .getService();
         InstanceAdminClient instanceAdminClient = spanner.createInstanceAdminClient()) {
       // Set Instance configuration.
-      String configId = "regional-us-central1";
+      String configId = "regional-us-east4";
       String displayName = "Descriptive name";
 
       // Create an autoscaling config.

--- a/samples/snippets/src/main/java/com/example/spanner/CreateInstanceWithProcessingUnitsExample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/CreateInstanceWithProcessingUnitsExample.java
@@ -44,7 +44,7 @@ class CreateInstanceWithProcessingUnitsExample {
         InstanceAdminClient instanceAdminClient = spanner.createInstanceAdminClient()) {
 
       // Set Instance configuration.
-      String configId = "regional-us-central1";
+      String configId = "regional-us-east4";
       // This will create an instance with the processing power of 0.2 nodes.
       int processingUnits = 500;
       String displayName = "Descriptive name";

--- a/samples/snippets/src/main/java/com/example/spanner/admin/archived/CreateInstanceExample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/admin/archived/CreateInstanceExample.java
@@ -42,7 +42,7 @@ class CreateInstanceExample {
     InstanceAdminClient instanceAdminClient = spanner.getInstanceAdminClient();
 
     // Set Instance configuration.
-    String configId = "regional-us-central1";
+    String configId = "regional-us-east4";
     int nodeCount = 2;
     String displayName = "Descriptive name";
 

--- a/samples/snippets/src/main/java/com/example/spanner/admin/archived/CreateInstanceWithAutoscalingConfigExample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/admin/archived/CreateInstanceWithAutoscalingConfigExample.java
@@ -44,7 +44,7 @@ class CreateInstanceWithAutoscalingConfigExample {
     InstanceAdminClient instanceAdminClient = spanner.getInstanceAdminClient();
 
     // Set Instance configuration.
-    String configId = "regional-us-central1";
+    String configId = "regional-us-east4";
     // Create an autoscaling config.
     AutoscalingConfig autoscalingConfig =
         AutoscalingConfig.newBuilder()

--- a/samples/snippets/src/main/java/com/example/spanner/admin/archived/CreateInstanceWithProcessingUnitsExample.java
+++ b/samples/snippets/src/main/java/com/example/spanner/admin/archived/CreateInstanceWithProcessingUnitsExample.java
@@ -42,7 +42,7 @@ class CreateInstanceWithProcessingUnitsExample {
     InstanceAdminClient instanceAdminClient = spanner.getInstanceAdminClient();
 
     // Set Instance configuration.
-    String configId = "regional-us-central1";
+    String configId = "regional-us-east4";
     // This will create an instance with the processing power of 0.2 nodes.
     int processingUnits = 500;
     String displayName = "Descriptive name";


### PR DESCRIPTION
As a part of an effort to lower `us-central-1` scaling risk we are moving instances (used for testing) that are created in `regional-us-central1` to `regional-us-east4`.
b/355497681