### PR TITLE
fix: github workflow vulnerable to script injection

### DIFF
--- a/.github/workflows/hermetic_library_generation.yaml
+++ b/.github/workflows/hermetic_library_generation.yaml
@@ -17,6 +17,9 @@ name: Hermetic library generation upon generation config change through pull req
 on:
   pull_request:
 
+env:
+  HEAD_REF: ${{ github.head_ref }}
+
 jobs:
   library_generation:
     # skip pull requests coming from a forked repository
@@ -35,6 +38,6 @@ jobs:
         [ -z "$(git config user.name)" ] && git config --global user.name "cloud-java-bot"
         bash .github/scripts/hermetic_library_generation.sh \
           --target_branch ${{ github.base_ref }} \
-          --current_branch ${{ github.head_ref }}
+          --current_branch $HEAD_REF
       env:
         GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_TOKEN }}

--- a/.github/workflows/hermetic_library_generation.yaml
+++ b/.github/workflows/hermetic_library_generation.yaml
@@ -19,11 +19,12 @@ on:
 
 env:
   HEAD_REF: ${{ github.head_ref }}
+  REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
 
 jobs:
   library_generation:
     # skip pull requests coming from a forked repository
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.env.REPO_FULL_NAME == github.repository
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -33,7 +34,7 @@ jobs:
     - name: Generate changed libraries
       shell: bash
       run: |
-        set -x
+        set -ex
         [ -z "$(git config user.email)" ] && git config --global user.email "cloud-java-bot@google.com"
         [ -z "$(git config user.name)" ] && git config --global user.name "cloud-java-bot"
         bash .github/scripts/hermetic_library_generation.sh \


### PR DESCRIPTION
Hi! I'm Diogo from Google's Open Source Security Team([GOSST](https://opensource.googleblog.com/2023/04/googles-open-source-security-upstream-team-one-year-later.html)) and I'm dropping by to suggest this small change that will enhance the security of your repository by preventing script injection attacks through your GitHub workflows.

In the piece of code I changed, you were directly using the value of a variable that comes from a user's input, so a malicious user could exploit that input and use it to run arbitrary code. By using an intermediate environment variable, the value of the expression is stored in memory, used as a variable and doesn't interact with the script generation process. This mitigates the script injection risks and also keeps your workflow running exactly as before.

You can find more information about this on this [github documentation](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections) or in this [gitguardian blogpost](https://blog.gitguardian.com/github-actions-security-cheat-sheet/).

Cheers!
