### PR TITLE
chore: add experimental feature for retrying on different gRPC channel

### DIFF
--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -352,10 +352,6 @@
       <artifactId>grpc-rls</artifactId>
       <scope>runtime</scope>
     </dependency>
-<!--    <dependency>-->
-<!--      <groupId>io.grpc</groupId>-->
-<!--      <artifactId>grpc-protobuf-lite</artifactId>-->
-<!--    </dependency>-->
 
     <dependency>
       <groupId>org.graalvm.sdk</groupId>

--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -352,6 +352,10 @@
       <artifactId>grpc-rls</artifactId>
       <scope>runtime</scope>
     </dependency>
+<!--    <dependency>-->
+<!--      <groupId>io.grpc</groupId>-->
+<!--      <artifactId>grpc-protobuf-lite</artifactId>-->
+<!--    </dependency>-->
 
     <dependency>
       <groupId>org.graalvm.sdk</groupId>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ErrorHandler.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ErrorHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+import com.google.api.core.BetaApi;
+import javax.annotation.Nonnull;
+
+/**
+ * The {@link ErrorHandler} interface can be used to implement custom error and retry handling for
+ * specific cases. The default implementation does nothing and falls back to the standard error and
+ * retry handling in Gax and the Spanner client.
+ */
+@BetaApi
+interface ErrorHandler {
+  @Nonnull
+  Throwable translateException(@Nonnull Throwable exception);
+
+  int getMaxAttempts();
+
+  class DefaultErrorHandler implements ErrorHandler {
+    static final DefaultErrorHandler INSTANCE = new DefaultErrorHandler();
+
+    private DefaultErrorHandler() {}
+
+    @Nonnull
+    @Override
+    public Throwable translateException(@Nonnull Throwable exception) {
+      return exception;
+    }
+
+    @Override
+    public int getMaxAttempts() {
+      return 0;
+    }
+  }
+}

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/RetryOnDifferentGrpcChannelErrorHandler.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/RetryOnDifferentGrpcChannelErrorHandler.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+import static com.google.cloud.spanner.SessionImpl.NO_CHANNEL_HINT;
+
+import com.google.api.core.BetaApi;
+import com.google.cloud.spanner.spi.v1.SpannerRpc.Option;
+import javax.annotation.Nonnull;
+
+/**
+ * An experimental error handler that allows DEADLINE_EXCEEDED errors to be retried on a different
+ * gRPC channel. This handler is only used if the system property
+ * 'spanner.retry_deadline_exceeded_on_different_channel' has been set to true, and it is only used
+ * in the following specific cases:
+ *
+ * <ol>
+ *   <li>A DEADLINE_EXCEEDED error during a read/write transaction. The error is translated to a
+ *       {@link RetryOnDifferentGrpcChannelException}, which is caught by the session pool and
+ *       causes a retry of the entire transaction on a different session and different gRPC channel.
+ *   <li>A DEADLINE_EXCEEDED error during a single-use read-only transaction using a multiplexed
+ *       session. Note that errors for the same using a regular session are not retried.
+ * </ol>
+ */
+@BetaApi
+class RetryOnDifferentGrpcChannelErrorHandler implements ErrorHandler {
+  private final int maxAttempts;
+
+  private final SessionImpl session;
+
+  static boolean isEnabled() {
+    return Boolean.parseBoolean(
+        System.getProperty("spanner.retry_deadline_exceeded_on_different_channel", "false"));
+  }
+
+  RetryOnDifferentGrpcChannelErrorHandler(int maxAttempts, SessionImpl session) {
+    this.maxAttempts = maxAttempts;
+    this.session = session;
+  }
+
+  @Override
+  @Nonnull
+  public Throwable translateException(@Nonnull Throwable exception) {
+    if (session == null || !(exception instanceof SpannerException)) {
+      return exception;
+    }
+    SpannerException spannerException = (SpannerException) exception;
+    if (spannerException.getErrorCode() == ErrorCode.DEADLINE_EXCEEDED) {
+      if (session.getIsMultiplexed()
+          || (session.getOptions() != null
+              && session.getOptions().containsKey(Option.CHANNEL_HINT))) {
+        int channel = NO_CHANNEL_HINT;
+        if (session.getOptions() != null && session.getOptions().containsKey(Option.CHANNEL_HINT)) {
+          channel = Option.CHANNEL_HINT.getLong(session.getOptions()).intValue();
+        }
+        return SpannerExceptionFactory.newRetryOnDifferentGrpcChannelException(
+            "Retrying on a new gRPC channel due to a DEADLINE_EXCEEDED error",
+            channel,
+            spannerException);
+      }
+    }
+    return spannerException;
+  }
+
+  @Override
+  public int getMaxAttempts() {
+    return maxAttempts;
+  }
+}

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/RetryOnDifferentGrpcChannelException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/RetryOnDifferentGrpcChannelException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+import javax.annotation.Nullable;
+
+class RetryOnDifferentGrpcChannelException extends SpannerException {
+  private final int channel;
+
+  RetryOnDifferentGrpcChannelException(
+      @Nullable String message, int channel, @Nullable Throwable cause) {
+    // Note: We set retryable=false, as the exception is not retryable in the standard way.
+    super(DoNotConstructDirectly.ALLOWED, ErrorCode.INTERNAL, /*retryable=*/ false, message, cause);
+    this.channel = channel;
+  }
+
+  int getChannel() {
+    return this.channel;
+  }
+}

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -26,6 +26,7 @@ import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.AbstractReadContext.MultiUseReadOnlyTransaction;
 import com.google.cloud.spanner.AbstractReadContext.SingleReadContext;
 import com.google.cloud.spanner.AbstractReadContext.SingleUseReadOnlyTransaction;
+import com.google.cloud.spanner.ErrorHandler.DefaultErrorHandler;
 import com.google.cloud.spanner.Options.TransactionOption;
 import com.google.cloud.spanner.Options.UpdateOption;
 import com.google.cloud.spanner.SessionClient.SessionOption;
@@ -116,6 +117,7 @@ class SessionImpl implements Session {
   private ISpan currentSpan;
   private final Clock clock;
   private final Map<SpannerRpc.Option, ?> options;
+  private final ErrorHandler errorHandler;
 
   SessionImpl(SpannerImpl spanner, SessionReference sessionReference) {
     this(spanner, sessionReference, NO_CHANNEL_HINT);
@@ -127,6 +129,7 @@ class SessionImpl implements Session {
     this.sessionReference = sessionReference;
     this.clock = spanner.getOptions().getSessionPoolOptions().getPoolMaintainerClock();
     this.options = createOptions(sessionReference, channelHint);
+    this.errorHandler = createErrorHandler(spanner.getOptions());
   }
 
   static Map<SpannerRpc.Option, ?> createOptions(
@@ -137,6 +140,13 @@ class SessionImpl implements Session {
     return CHANNEL_HINT_OPTIONS[channelHint % CHANNEL_HINT_OPTIONS.length];
   }
 
+  private ErrorHandler createErrorHandler(SpannerOptions options) {
+    if (RetryOnDifferentGrpcChannelErrorHandler.isEnabled()) {
+      return new RetryOnDifferentGrpcChannelErrorHandler(options.getNumChannels(), this);
+    }
+    return DefaultErrorHandler.INSTANCE;
+  }
+
   @Override
   public String getName() {
     return sessionReference.getName();
@@ -144,6 +154,10 @@ class SessionImpl implements Session {
 
   Map<SpannerRpc.Option, ?> getOptions() {
     return options;
+  }
+
+  ErrorHandler getErrorHandler() {
+    return this.errorHandler;
   }
 
   void setCurrentSpan(ISpan span) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -67,6 +67,9 @@ import com.google.cloud.spanner.spi.v1.SpannerRpc;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Ticker;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ForwardingListenableFuture;
 import com.google.common.util.concurrent.ForwardingListenableFuture.SimpleForwardingListenableFuture;
@@ -560,6 +563,8 @@ class SessionPool {
 
   interface SessionReplacementHandler<T extends SessionFuture> {
     T replaceSession(SessionNotFoundException notFound, T sessionFuture);
+
+    T denyListSession(RetryOnDifferentGrpcChannelException retryException, T sessionFuture);
   }
 
   class PooledSessionReplacementHandler implements SessionReplacementHandler<PooledSessionFuture> {
@@ -579,6 +584,28 @@ class SessionPool {
       } else {
         throw e;
       }
+    }
+
+    @Override
+    public PooledSessionFuture denyListSession(
+        RetryOnDifferentGrpcChannelException retryException, PooledSessionFuture session) {
+      int channel = session.get().getChannel();
+      synchronized (lock) {
+        int currentSize = 0;
+        for (int i = 0; i < numChannels; i++) {
+          if (denyListedChannels.getIfPresent(i) != null) {
+            currentSize++;
+          }
+        }
+        if (currentSize < numChannels - 1) {
+          denyListedChannels.put(channel, DENY_LISTED);
+        } else {
+          throw SpannerExceptionFactory.asSpannerException(retryException.getCause());
+        }
+      }
+      session.get().releaseToPosition = Position.LAST;
+      session.close();
+      return getSession();
     }
   }
 
@@ -1003,6 +1030,10 @@ class SessionPool {
             break;
           } catch (SessionNotFoundException e) {
             session = sessionReplacementHandler.replaceSession(e, session);
+            CachedSession cachedSession = session.get();
+            runner = cachedSession.getDelegate().readWriteTransaction();
+          } catch (RetryOnDifferentGrpcChannelException retryException) {
+            session = sessionReplacementHandler.denyListSession(retryException, session);
             CachedSession cachedSession = session.get();
             runner = cachedSession.getDelegate().readWriteTransaction();
           }
@@ -2300,6 +2331,9 @@ class SessionPool {
   private final PooledSessionReplacementHandler pooledSessionReplacementHandler =
       new PooledSessionReplacementHandler();
 
+  private static final Object DENY_LISTED = new Object();
+  private final Cache<Integer, Object> denyListedChannels;
+
   /**
    * Create a session pool with the given options and for the given database. It will also start
    * eagerly creating sessions if {@link SessionPoolOptions#getMinSessions()} is greater than 0.
@@ -2442,6 +2476,20 @@ class SessionPool {
         openTelemetry, attributes, numMultiplexedSessionsAcquired, numMultiplexedSessionsReleased);
     this.waitOnMinSessionsLatch =
         options.getMinSessions() > 0 ? new CountDownLatch(1) : new CountDownLatch(0);
+    this.denyListedChannels =
+        CacheBuilder.newBuilder()
+            .expireAfterWrite(java.time.Duration.ofMinutes(1))
+            .maximumSize(this.numChannels)
+            .concurrencyLevel(1)
+            .ticker(
+                new Ticker() {
+                  @Override
+                  public long read() {
+                    return TimeUnit.NANOSECONDS.convert(
+                        clock.instant().toEpochMilli(), TimeUnit.MILLISECONDS);
+                  }
+                })
+            .build();
   }
 
   /**
@@ -2671,7 +2719,22 @@ class SessionPool {
                 resourceNotFoundException.getMessage()),
             resourceNotFoundException);
       }
-      sess = sessions.poll();
+      if (denyListedChannels.size() > 0 && denyListedChannels.size() < numChannels) {
+        for (PooledSession session : sessions) {
+          if (denyListedChannels.getIfPresent(session.getChannel()) == null) {
+            sessions.remove(session);
+            sess = session;
+            break;
+          }
+          // Size is cached and can change after calling getIfPresent.
+          if (denyListedChannels.size() == 0) {
+            break;
+          }
+        }
+      }
+      if (sess == null) {
+        sess = sessions.poll();
+      }
       if (sess == null) {
         span.addAnnotation("No session available");
         maybeCreateSession();

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
@@ -181,6 +181,12 @@ public final class SpannerExceptionFactory {
     return newSpannerException(ErrorCode.fromGrpcStatus(status), cause.getMessage(), cause);
   }
 
+  /**
+   * Creates a new SpannerException that indicates that the RPC or transaction should be retried on
+   * a different gRPC channel. This is an experimental feature that can be removed in the future.
+   * The exception should not be surfaced to the client application, and should instead be caught
+   * and handled in the client library.
+   */
   static SpannerException newRetryOnDifferentGrpcChannelException(
       String message, int channel, Throwable cause) {
     return new RetryOnDifferentGrpcChannelException(message, channel, cause);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
@@ -181,6 +181,11 @@ public final class SpannerExceptionFactory {
     return newSpannerException(ErrorCode.fromGrpcStatus(status), cause.getMessage(), cause);
   }
 
+  static SpannerException newRetryOnDifferentGrpcChannelException(
+      String message, int channel, Throwable cause) {
+    return new RetryOnDifferentGrpcChannelException(message, channel, cause);
+  }
+
   static SpannerException newSpannerExceptionForCancellation(
       @Nullable Context context, @Nullable Throwable cause) {
     if (context != null && context.isCancelled()) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -1180,7 +1180,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
             throw e;
           }
         };
-    return SpannerRetryHelper.runTxWithRetriesOnAborted(retryCallable);
+    return SpannerRetryHelper.runTxWithRetriesOnAborted(retryCallable, session.getErrorHandler());
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerRpc.java
@@ -94,7 +94,7 @@ public interface SpannerRpc extends ServiceRpc {
       return (T) options.get(this);
     }
 
-    Long getLong(@Nullable Map<Option, ?> options) {
+    public Long getLong(@Nullable Map<Option, ?> options) {
       return get(options);
     }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerRpc.java
@@ -94,6 +94,7 @@ public interface SpannerRpc extends ServiceRpc {
       return (T) options.get(this);
     }
 
+    @InternalApi
     public Long getLong(@Nullable Map<Option, ?> options) {
       return get(options);
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ResumableStreamIteratorTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ResumableStreamIteratorTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.util.BackOff;
+import com.google.cloud.spanner.ErrorHandler.DefaultErrorHandler;
 import com.google.cloud.spanner.v1.stub.SpannerStubSettings;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
@@ -158,6 +159,7 @@ public class ResumableStreamIteratorTest {
             "",
             new OpenTelemetrySpan(mock(io.opentelemetry.api.trace.Span.class)),
             new TraceWrapper(Tracing.getTracer(), OpenTelemetry.noop().getTracer(""), false),
+            DefaultErrorHandler.INSTANCE,
             SpannerStubSettings.newBuilder().executeStreamingSqlSettings().getRetrySettings(),
             SpannerStubSettings.newBuilder().executeStreamingSqlSettings().getRetryableCodes()) {
           @Override

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RetryOnDifferentGrpcChannelMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RetryOnDifferentGrpcChannelMockServerTest.java
@@ -124,6 +124,8 @@ public class RetryOnDifferentGrpcChannelMockServerTest extends AbstractMockServe
   @Test
   public void testReadWriteTransaction_retriesOnNewChannel() {
     SpannerOptions.Builder builder = createSpannerOptionsBuilder();
+    builder.setSessionPoolOption(
+        SessionPoolOptions.newBuilder().setWaitForMinSessions(Duration.ofSeconds(5L)).build());
     mockSpanner.setBeginTransactionExecutionTime(
         SimulatedExecutionTime.ofStickyException(Status.DEADLINE_EXCEEDED.asRuntimeException()));
     AtomicInteger attempts = new AtomicInteger();
@@ -156,6 +158,8 @@ public class RetryOnDifferentGrpcChannelMockServerTest extends AbstractMockServe
   @Test
   public void testReadWriteTransaction_stopsRetrying() {
     SpannerOptions.Builder builder = createSpannerOptionsBuilder();
+    builder.setSessionPoolOption(
+        SessionPoolOptions.newBuilder().setWaitForMinSessions(Duration.ofSeconds(5L)).build());
     mockSpanner.setBeginTransactionExecutionTime(
         SimulatedExecutionTime.ofStickyException(Status.DEADLINE_EXCEEDED.asRuntimeException()));
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RetryOnDifferentGrpcChannelMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RetryOnDifferentGrpcChannelMockServerTest.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+import static io.grpc.Grpc.TRANSPORT_ATTR_REMOTE_ADDR;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.NoCredentials;
+import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
+import com.google.cloud.spanner.connection.AbstractMockServerTest;
+import com.google.common.collect.ImmutableSet;
+import com.google.spanner.v1.BatchCreateSessionsRequest;
+import com.google.spanner.v1.BeginTransactionRequest;
+import com.google.spanner.v1.ExecuteSqlRequest;
+import io.grpc.Attributes;
+import io.grpc.Context;
+import io.grpc.Deadline;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.threeten.bp.Duration;
+
+@RunWith(JUnit4.class)
+public class RetryOnDifferentGrpcChannelMockServerTest extends AbstractMockServerTest {
+  private static final Map<String, Set<InetSocketAddress>> SERVER_ADDRESSES = new HashMap<>();
+
+  @BeforeClass
+  public static void startStaticServer() throws IOException {
+    System.setProperty("spanner.retry_deadline_exceeded_on_different_channel", "true");
+    startStaticServer(createServerInterceptor());
+  }
+
+  @AfterClass
+  public static void removeSystemProperty() {
+    System.clearProperty("spanner.retry_deadline_exceeded_on_different_channel");
+  }
+
+  @After
+  public void clearRequests() {
+    SERVER_ADDRESSES.clear();
+    mockSpanner.clearRequests();
+    mockSpanner.removeAllExecutionTimes();
+  }
+
+  static ServerInterceptor createServerInterceptor() {
+    return new ServerInterceptor() {
+      @Override
+      public <ReqT, RespT> Listener<ReqT> interceptCall(
+          ServerCall<ReqT, RespT> serverCall,
+          Metadata metadata,
+          ServerCallHandler<ReqT, RespT> serverCallHandler) {
+        Attributes attributes = serverCall.getAttributes();
+        //noinspection unchecked,deprecation
+        Attributes.Key<InetSocketAddress> key =
+            (Attributes.Key<InetSocketAddress>)
+                attributes.keys().stream()
+                    .filter(k -> k.equals(TRANSPORT_ATTR_REMOTE_ADDR))
+                    .findFirst()
+                    .orElse(null);
+        if (key != null) {
+          InetSocketAddress address = attributes.get(key);
+          synchronized (SERVER_ADDRESSES) {
+            Set<InetSocketAddress> addresses =
+                SERVER_ADDRESSES.getOrDefault(
+                    serverCall.getMethodDescriptor().getFullMethodName(), new HashSet<>());
+            addresses.add(address);
+            SERVER_ADDRESSES.putIfAbsent(
+                serverCall.getMethodDescriptor().getFullMethodName(), addresses);
+          }
+        }
+        return serverCallHandler.startCall(serverCall, metadata);
+      }
+    };
+  }
+
+  SpannerOptions.Builder createSpannerOptionsBuilder() {
+    return SpannerOptions.newBuilder()
+        .setProjectId("my-project")
+        .setHost(String.format("http://localhost:%d", getPort()))
+        .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
+        .setCredentials(NoCredentials.getInstance());
+  }
+
+  @Test
+  public void testReadWriteTransaction_retriesOnNewChannel() {
+    SpannerOptions.Builder builder = createSpannerOptionsBuilder();
+    mockSpanner.setBeginTransactionExecutionTime(
+        SimulatedExecutionTime.ofStickyException(Status.DEADLINE_EXCEEDED.asRuntimeException()));
+    AtomicInteger attempts = new AtomicInteger();
+
+    try (Spanner spanner = builder.build().getService()) {
+      DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+      client
+          .readWriteTransaction()
+          .run(
+              transaction -> {
+                if (attempts.incrementAndGet() > 1) {
+                  mockSpanner.setBeginTransactionExecutionTime(
+                      MockSpannerServiceImpl.NO_EXECUTION_TIME);
+                }
+                transaction.buffer(Mutation.newInsertBuilder("foo").set("id").to(1L).build());
+                return null;
+              });
+    }
+    assertEquals(2, mockSpanner.countRequestsOfType(BeginTransactionRequest.class));
+    List<BeginTransactionRequest> requests =
+        mockSpanner.getRequestsOfType(BeginTransactionRequest.class);
+    assertNotEquals(requests.get(0).getSession(), requests.get(1).getSession());
+    assertEquals(
+        2,
+        SERVER_ADDRESSES
+            .getOrDefault("google.spanner.v1.Spanner/BeginTransaction", ImmutableSet.of())
+            .size());
+  }
+
+  @Test
+  public void testReadWriteTransaction_stopsRetrying() {
+    SpannerOptions.Builder builder = createSpannerOptionsBuilder();
+    mockSpanner.setBeginTransactionExecutionTime(
+        SimulatedExecutionTime.ofStickyException(Status.DEADLINE_EXCEEDED.asRuntimeException()));
+
+    try (Spanner spanner = builder.build().getService()) {
+      DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+      SpannerException exception =
+          assertThrows(
+              SpannerException.class,
+              () ->
+                  client
+                      .readWriteTransaction()
+                      .run(
+                          transaction -> {
+                            transaction.buffer(
+                                Mutation.newInsertBuilder("foo").set("id").to(1L).build());
+                            return null;
+                          }));
+      assertEquals(ErrorCode.DEADLINE_EXCEEDED, exception.getErrorCode());
+
+      int numChannels = spanner.getOptions().getNumChannels();
+      assertEquals(numChannels, mockSpanner.countRequestsOfType(BeginTransactionRequest.class));
+      List<BeginTransactionRequest> requests =
+          mockSpanner.getRequestsOfType(BeginTransactionRequest.class);
+      Set<String> sessions =
+          requests.stream().map(BeginTransactionRequest::getSession).collect(Collectors.toSet());
+      assertEquals(numChannels, sessions.size());
+      assertEquals(
+          numChannels,
+          SERVER_ADDRESSES
+              .getOrDefault("google.spanner.v1.Spanner/BeginTransaction", ImmutableSet.of())
+              .size());
+    }
+  }
+
+  @Test
+  public void testDenyListedChannelIsCleared() {
+    FakeClock clock = new FakeClock();
+    SpannerOptions.Builder builder = createSpannerOptionsBuilder();
+    builder.setSessionPoolOption(
+        SessionPoolOptions.newBuilder()
+            .setWaitForMinSessions(Duration.ofSeconds(5))
+            .setPoolMaintainerClock(clock)
+            .build());
+    mockSpanner.setBeginTransactionExecutionTime(
+        SimulatedExecutionTime.ofStickyException(Status.DEADLINE_EXCEEDED.asRuntimeException()));
+
+    try (Spanner spanner = builder.build().getService()) {
+      DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+
+      // Retry until all channels have been deny-listed.
+      SpannerException exception =
+          assertThrows(
+              SpannerException.class,
+              () ->
+                  client
+                      .readWriteTransaction()
+                      .run(
+                          transaction -> {
+                            transaction.buffer(
+                                Mutation.newInsertBuilder("foo").set("id").to(1L).build());
+                            return null;
+                          }));
+      assertEquals(ErrorCode.DEADLINE_EXCEEDED, exception.getErrorCode());
+
+      // Now advance the clock by 1 minute. This should clear all deny-listed channels.
+      clock.currentTimeMillis.addAndGet(TimeUnit.MILLISECONDS.convert(2L, TimeUnit.MINUTES));
+      AtomicInteger attempts = new AtomicInteger();
+      client
+          .readWriteTransaction()
+          .run(
+              transaction -> {
+                if (attempts.incrementAndGet() > 1) {
+                  mockSpanner.setBeginTransactionExecutionTime(SimulatedExecutionTime.none());
+                }
+                transaction.buffer(Mutation.newInsertBuilder("foo").set("id").to(1L).build());
+                return null;
+              });
+
+      int numChannels = spanner.getOptions().getNumChannels();
+      // We should have numChannels BeginTransactionRequests from the first transaction, and 2 from
+      // the second transaction.
+      assertEquals(numChannels + 2, mockSpanner.countRequestsOfType(BeginTransactionRequest.class));
+      List<BeginTransactionRequest> requests =
+          mockSpanner.getRequestsOfType(BeginTransactionRequest.class);
+      // The requests should all use different sessions, as deny-listing a session will bring it to
+      // the back of the session pool.
+      Set<String> sessions =
+          requests.stream().map(BeginTransactionRequest::getSession).collect(Collectors.toSet());
+      // We should have used numChannels+1==5 sessions. The reason for that is that first 3 attempts
+      // of the first transaction used 3 different sessions, that were then all deny-listed. The
+      // 4th attempt also failed, but as it would be the last channel to be deny-listed, it was not
+      // deny-listed and instead added to the front of the pool.
+      // The first attempt of the second transaction then uses the same session as the last attempt
+      // of the first transaction. That fails, the session is deny-listed, the transaction is
+      // retried on yet another session and succeeds.
+      assertEquals(numChannels + 1, sessions.size());
+      assertEquals(
+          numChannels,
+          SERVER_ADDRESSES
+              .getOrDefault("google.spanner.v1.Spanner/BeginTransaction", ImmutableSet.of())
+              .size());
+      assertEquals(numChannels, mockSpanner.countRequestsOfType(BatchCreateSessionsRequest.class));
+    }
+  }
+
+  @Test
+  public void testSingleUseQuery_retriesOnNewChannel() {
+    SpannerOptions.Builder builder = createSpannerOptionsBuilder();
+    builder.setSessionPoolOption(
+        SessionPoolOptions.newBuilder().setUseMultiplexedSession(true).build());
+    mockSpanner.setExecuteStreamingSqlExecutionTime(
+        SimulatedExecutionTime.ofException(Status.DEADLINE_EXCEEDED.asRuntimeException()));
+
+    try (Spanner spanner = builder.build().getService()) {
+      DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+      try (ResultSet resultSet = client.singleUse().executeQuery(SELECT1_STATEMENT)) {
+        assertTrue(resultSet.next());
+        assertEquals(1L, resultSet.getLong(0));
+        assertFalse(resultSet.next());
+      }
+    }
+    assertEquals(2, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    List<ExecuteSqlRequest> requests = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class);
+    // The requests use the same multiplexed session.
+    assertEquals(requests.get(0).getSession(), requests.get(1).getSession());
+    // The requests use two different gRPC channels.
+    assertEquals(
+        2,
+        SERVER_ADDRESSES
+            .getOrDefault("google.spanner.v1.Spanner/ExecuteStreamingSql", ImmutableSet.of())
+            .size());
+  }
+
+  @Test
+  public void testSingleUseQuery_stopsRetrying() {
+    SpannerOptions.Builder builder = createSpannerOptionsBuilder();
+    builder.setSessionPoolOption(
+        SessionPoolOptions.newBuilder().setUseMultiplexedSession(true).build());
+    mockSpanner.setExecuteStreamingSqlExecutionTime(
+        SimulatedExecutionTime.ofStickyException(Status.DEADLINE_EXCEEDED.asRuntimeException()));
+
+    try (Spanner spanner = builder.build().getService()) {
+      DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+      try (ResultSet resultSet = client.singleUse().executeQuery(SELECT1_STATEMENT)) {
+        SpannerException exception = assertThrows(SpannerException.class, resultSet::next);
+        assertEquals(ErrorCode.DEADLINE_EXCEEDED, exception.getErrorCode());
+      }
+      int numChannels = spanner.getOptions().getNumChannels();
+      assertEquals(numChannels, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+      List<ExecuteSqlRequest> requests = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class);
+      // The requests use the same multiplexed session.
+      String session = requests.get(0).getSession();
+      for (ExecuteSqlRequest request : requests) {
+        assertEquals(session, request.getSession());
+      }
+      // The requests use all gRPC channels.
+      assertEquals(
+          numChannels,
+          SERVER_ADDRESSES
+              .getOrDefault("google.spanner.v1.Spanner/ExecuteStreamingSql", ImmutableSet.of())
+              .size());
+    }
+  }
+
+  @Test
+  public void testReadWriteTransaction_withGrpcContextDeadline_doesNotRetry() {
+    SpannerOptions.Builder builder = createSpannerOptionsBuilder();
+    builder.setSessionPoolOption(
+        SessionPoolOptions.newBuilder().setWaitForMinSessions(Duration.ofSeconds(5L)).build());
+    mockSpanner.setBeginTransactionExecutionTime(
+        SimulatedExecutionTime.ofMinimumAndRandomTime(500, 500));
+
+    try (Spanner spanner = builder.build().getService()) {
+      DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+      ScheduledExecutorService service = Executors.newScheduledThreadPool(1);
+      Context context =
+          Context.current().withDeadline(Deadline.after(50L, TimeUnit.MILLISECONDS), service);
+      SpannerException exception =
+          assertThrows(
+              SpannerException.class,
+              () ->
+                  context.run(
+                      () ->
+                          client
+                              .readWriteTransaction()
+                              .run(
+                                  transaction -> {
+                                    transaction.buffer(
+                                        Mutation.newInsertBuilder("foo").set("id").to(1L).build());
+                                    return null;
+                                  })));
+      assertEquals(ErrorCode.DEADLINE_EXCEEDED, exception.getErrorCode());
+    }
+    // A gRPC context deadline will still cause the underlying error handler to try to retry the
+    // transaction on a new channel, but as the deadline has been exceeded even before those RPCs
+    // are being executed, the RPC invocation will be skipped, and the error will eventually bubble
+    // up.
+    assertEquals(1, mockSpanner.countRequestsOfType(BeginTransactionRequest.class));
+  }
+}

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -59,6 +59,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.google.api.core.ApiFutures;
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.ErrorHandler.DefaultErrorHandler;
 import com.google.cloud.spanner.MetricRegistryTestUtils.FakeMetricRegistry;
 import com.google.cloud.spanner.MetricRegistryTestUtils.MetricsRecord;
 import com.google.cloud.spanner.MetricRegistryTestUtils.PointWithFunction;
@@ -1478,6 +1479,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
       final SessionImpl closedSession = mock(SessionImpl.class);
       when(closedSession.getName())
           .thenReturn("projects/dummy/instances/dummy/database/dummy/sessions/session-closed");
+      when(closedSession.getErrorHandler()).thenReturn(DefaultErrorHandler.INSTANCE);
 
       Span oTspan = mock(Span.class);
       ISpan span = new OpenTelemetrySpan(oTspan);
@@ -1502,6 +1504,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
       when(closedSession.readWriteTransaction()).thenReturn(closedTransactionRunner);
 
       final SessionImpl openSession = mock(SessionImpl.class);
+      when(openSession.getErrorHandler()).thenReturn(DefaultErrorHandler.INSTANCE);
       when(openSession.asyncClose())
           .thenReturn(ApiFutures.immediateFuture(Empty.getDefaultInstance()));
       when(openSession.getName())

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 import com.google.api.core.ApiFutures;
 import com.google.cloud.grpc.GrpcTransportOptions;
 import com.google.cloud.grpc.GrpcTransportOptions.ExecutorFactory;
+import com.google.cloud.spanner.ErrorHandler.DefaultErrorHandler;
 import com.google.cloud.spanner.SessionClient.SessionId;
 import com.google.cloud.spanner.TransactionRunnerImpl.TransactionContextImpl;
 import com.google.cloud.spanner.spi.v1.SpannerRpc;
@@ -115,6 +116,7 @@ public class TransactionRunnerImplTest {
     MockitoAnnotations.initMocks(this);
     tracer = new TraceWrapper(Tracing.getTracer(), OpenTelemetry.noop().getTracer(""), false);
     firstRun = true;
+    when(session.getErrorHandler()).thenReturn(DefaultErrorHandler.INSTANCE);
     when(session.newTransaction(Options.fromTransactionOptions())).thenReturn(txn);
     when(session.getTracer()).thenReturn(tracer);
     when(rpc.executeQuery(Mockito.any(ExecuteSqlRequest.class), Mockito.anyMap(), eq(true)))


### PR DESCRIPTION
Adds an experimental error handler that retries RPCs that fail with DEADLINE_EXCEEDED on a different gRPC channel.