### PR TITLE
feat: add option for cancelling queries when closing client

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchClientImpl.java
@@ -54,6 +54,7 @@ public class BatchClientImpl implements BatchClient {
     return new BatchReadOnlyTransactionImpl(
         MultiUseReadOnlyTransaction.newBuilder()
             .setSession(session)
+            .setCancelQueryWhenClientIsClosed(true)
             .setRpc(sessionClient.getSpanner().getRpc())
             .setTimestampBound(bound)
             .setDefaultQueryOptions(
@@ -75,6 +76,7 @@ public class BatchClientImpl implements BatchClient {
     return new BatchReadOnlyTransactionImpl(
         MultiUseReadOnlyTransaction.newBuilder()
             .setSession(session)
+            .setCancelQueryWhenClientIsClosed(true)
             .setRpc(sessionClient.getSpanner().getRpc())
             .setTransactionId(batchTransactionId.getTransactionId())
             .setTimestamp(batchTransactionId.getTimestamp())

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/IsChannelShutdownException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/IsChannelShutdownException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+import com.google.api.gax.rpc.UnavailableException;
+import com.google.common.base.Predicate;
+import io.grpc.Status.Code;
+import io.grpc.StatusRuntimeException;
+
+class IsChannelShutdownException implements Predicate<Throwable> {
+
+  @Override
+  public boolean apply(Throwable input) {
+    Throwable cause = input;
+    do {
+      if (isUnavailableError(cause)
+          && (cause.getMessage().contains("Channel shutdown invoked")
+              || cause.getMessage().contains("Channel shutdownNow invoked"))) {
+        return true;
+      }
+    } while ((cause = cause.getCause()) != null);
+    return false;
+  }
+
+  private boolean isUnavailableError(Throwable cause) {
+    return (cause instanceof UnavailableException)
+        || (cause instanceof StatusRuntimeException
+            && ((StatusRuntimeException) cause).getStatus().getCode() == Code.UNAVAILABLE);
+  }
+}

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/IsChannelShutdownException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/IsChannelShutdownException.java
@@ -21,6 +21,12 @@ import com.google.common.base.Predicate;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
 
+/**
+ * Predicate that checks whether an exception is a ChannelShutdownException. This exception is
+ * thrown by gRPC if the underlying gRPC stub has been shut down and uses the UNAVAILABLE error
+ * code. This means that it would normally be retried by the Spanner client, but this specific
+ * UNAVAILABLE error should not be retried, as it would otherwise directly return the same error.
+ */
 class IsChannelShutdownException implements Predicate<Throwable> {
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
@@ -322,7 +322,9 @@ public final class SpannerExceptionFactory {
       case UNAVAILABLE:
         // SSLHandshakeException is (probably) not retryable, as it is an indication that the server
         // certificate was not accepted by the client.
-        return !hasCauseMatching(cause, Matchers.isSSLHandshakeException);
+        // Channel shutdown is also not a retryable exception.
+        return !(hasCauseMatching(cause, Matchers.isSSLHandshakeException)
+            || hasCauseMatching(cause, Matchers.IS_CHANNEL_SHUTDOWN_EXCEPTION));
       case RESOURCE_EXHAUSTED:
         return SpannerException.extractRetryDelay(cause) > 0;
       default:
@@ -345,5 +347,8 @@ public final class SpannerExceptionFactory {
 
     static final Predicate<Throwable> isRetryableInternalError = new IsRetryableInternalError();
     static final Predicate<Throwable> isSSLHandshakeException = new IsSslHandshakeException();
+
+    static final Predicate<Throwable> IS_CHANNEL_SHUTDOWN_EXCEPTION =
+        new IsChannelShutdownException();
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -158,7 +158,6 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
   private final OpenTelemetry openTelemetry;
   private final boolean enableApiTracing;
   private final boolean enableExtendedTracing;
-  private final boolean cancelStreamsOnClose;
 
   enum TracingFramework {
     OPEN_CENSUS,
@@ -665,7 +664,6 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     openTelemetry = builder.openTelemetry;
     enableApiTracing = builder.enableApiTracing;
     enableExtendedTracing = builder.enableExtendedTracing;
-    cancelStreamsOnClose = builder.cancelStreamsOnClose;
   }
 
   /**
@@ -696,11 +694,6 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     }
 
     default boolean isEnableApiTracing() {
-      return false;
-    }
-
-    @BetaApi
-    default boolean isCancelStreamsOnClose() {
       return false;
     }
   }
@@ -741,11 +734,6 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     @Override
     public boolean isEnableApiTracing() {
       return Boolean.parseBoolean(System.getenv(SPANNER_ENABLE_API_TRACING));
-    }
-
-    @Override
-    public boolean isCancelStreamsOnClose() {
-      return Boolean.parseBoolean(System.getenv(SPANNER_CANCEL_STREAMS_ON_CLOSE));
     }
   }
 
@@ -812,7 +800,6 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     private OpenTelemetry openTelemetry;
     private boolean enableApiTracing = SpannerOptions.environment.isEnableApiTracing();
     private boolean enableExtendedTracing = SpannerOptions.environment.isEnableExtendedTracing();
-    private boolean cancelStreamsOnClose = SpannerOptions.environment.isCancelStreamsOnClose();
 
     private static String createCustomClientLibToken(String token) {
       return token + " " + ServiceOptions.getGoogApiClientLibName();
@@ -878,7 +865,6 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
       this.useVirtualThreads = options.useVirtualThreads;
       this.enableApiTracing = options.enableApiTracing;
       this.enableExtendedTracing = options.enableExtendedTracing;
-      this.cancelStreamsOnClose = options.cancelStreamsOnClose;
     }
 
     @Override
@@ -1406,17 +1392,6 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
       return this;
     }
 
-    /**
-     * Sets whether the Spanner client should keep track of all open query streams and explicitly
-     * cancel these when the client is closed. This forces queries to fail quickly when the client
-     * is closed instead of continuing to run until all results have been consumed.
-     */
-    @BetaApi
-    public Builder setCancelStreamsOnClose(boolean cancelStreamsOnClose) {
-      this.cancelStreamsOnClose = cancelStreamsOnClose;
-      return this;
-    }
-
     @SuppressWarnings("rawtypes")
     @Override
     public SpannerOptions build() {
@@ -1705,16 +1680,6 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
    */
   public boolean isEnableExtendedTracing() {
     return enableExtendedTracing;
-  }
-
-  /**
-   * Returns whether the Spanner client should keep track of all open query streams and explicitly
-   * cancel these when the client is closed. This causes queries to fail quickly when the client is
-   * closed, instead of continue to run until all results have been returned.
-   */
-  @BetaApi
-  public boolean isCancelStreamsOnClose() {
-    return cancelStreamsOnClose;
   }
 
   /** Returns the default query options to use for the specific database. */

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -158,6 +158,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
   private final OpenTelemetry openTelemetry;
   private final boolean enableApiTracing;
   private final boolean enableExtendedTracing;
+  private final boolean cancelStreamsOnClose;
 
   enum TracingFramework {
     OPEN_CENSUS,
@@ -664,6 +665,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     openTelemetry = builder.openTelemetry;
     enableApiTracing = builder.enableApiTracing;
     enableExtendedTracing = builder.enableExtendedTracing;
+    cancelStreamsOnClose = builder.cancelStreamsOnClose;
   }
 
   /**
@@ -696,6 +698,11 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     default boolean isEnableApiTracing() {
       return false;
     }
+
+    @BetaApi
+    default boolean isCancelStreamsOnClose() {
+      return false;
+    }
   }
 
   /**
@@ -709,6 +716,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
         "SPANNER_OPTIMIZER_STATISTICS_PACKAGE";
     private static final String SPANNER_ENABLE_EXTENDED_TRACING = "SPANNER_ENABLE_EXTENDED_TRACING";
     private static final String SPANNER_ENABLE_API_TRACING = "SPANNER_ENABLE_API_TRACING";
+    private static final String SPANNER_CANCEL_STREAMS_ON_CLOSE = "SPANNER_CANCEL_STREAMS_ON_CLOSE";
 
     private SpannerEnvironmentImpl() {}
 
@@ -733,6 +741,11 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     @Override
     public boolean isEnableApiTracing() {
       return Boolean.parseBoolean(System.getenv(SPANNER_ENABLE_API_TRACING));
+    }
+
+    @Override
+    public boolean isCancelStreamsOnClose() {
+      return Boolean.parseBoolean(System.getenv(SPANNER_CANCEL_STREAMS_ON_CLOSE));
     }
   }
 
@@ -799,6 +812,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     private OpenTelemetry openTelemetry;
     private boolean enableApiTracing = SpannerOptions.environment.isEnableApiTracing();
     private boolean enableExtendedTracing = SpannerOptions.environment.isEnableExtendedTracing();
+    private boolean cancelStreamsOnClose = SpannerOptions.environment.isCancelStreamsOnClose();
 
     private static String createCustomClientLibToken(String token) {
       return token + " " + ServiceOptions.getGoogApiClientLibName();
@@ -864,6 +878,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
       this.useVirtualThreads = options.useVirtualThreads;
       this.enableApiTracing = options.enableApiTracing;
       this.enableExtendedTracing = options.enableExtendedTracing;
+      this.cancelStreamsOnClose = options.cancelStreamsOnClose;
     }
 
     @Override
@@ -1391,6 +1406,17 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
       return this;
     }
 
+    /**
+     * Sets whether the Spanner client should keep track of all open query streams and explicitly
+     * cancel these when the client is closed. This forces queries to fail quickly when the client
+     * is closed instead of continuing to run until all results have been consumed.
+     */
+    @BetaApi
+    public Builder setCancelStreamsOnClose(boolean cancelStreamsOnClose) {
+      this.cancelStreamsOnClose = cancelStreamsOnClose;
+      return this;
+    }
+
     @SuppressWarnings("rawtypes")
     @Override
     public SpannerOptions build() {
@@ -1679,6 +1705,16 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
    */
   public boolean isEnableExtendedTracing() {
     return enableExtendedTracing;
+  }
+
+  /**
+   * Returns whether the Spanner client should keep track of all open query streams and explicitly
+   * cancel these when the client is closed. This causes queries to fail quickly when the client is
+   * closed, instead of continue to run until all results have been returned.
+   */
+  @BetaApi
+  public boolean isCancelStreamsOnClose() {
+    return cancelStreamsOnClose;
   }
 
   /** Returns the default query options to use for the specific database. */

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -709,7 +709,6 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
         "SPANNER_OPTIMIZER_STATISTICS_PACKAGE";
     private static final String SPANNER_ENABLE_EXTENDED_TRACING = "SPANNER_ENABLE_EXTENDED_TRACING";
     private static final String SPANNER_ENABLE_API_TRACING = "SPANNER_ENABLE_API_TRACING";
-    private static final String SPANNER_CANCEL_STREAMS_ON_CLOSE = "SPANNER_CANCEL_STREAMS_ON_CLOSE";
 
     private SpannerEnvironmentImpl() {}
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -2120,18 +2120,20 @@ public class GapicSpannerRpc implements SpannerRpc {
     }
 
     void close() {
-      this.controller.cancel();
+      if (this.controller != null) {
+        this.controller.cancel();
+      }
     }
 
     @Override
     public void onStart(StreamController controller) {
-      if (this.consumer.cancelQueryWhenClientIsClosed()) {
-        registerResponseObserver(this);
-      }
       // Disable the auto flow control to allow client library
       // set the number of messages it prefers to request
       controller.disableAutoInboundFlowControl();
       this.controller = controller;
+      if (this.consumer.cancelQueryWhenClientIsClosed()) {
+        registerResponseObserver(this);
+      }
     }
 
     @Override
@@ -2141,6 +2143,7 @@ public class GapicSpannerRpc implements SpannerRpc {
 
     @Override
     public void onError(Throwable t) {
+      // Unregister the response observer when the query has completed with an error.
       if (this.consumer.cancelQueryWhenClientIsClosed()) {
         unregisterResponseObserver(this);
       }
@@ -2149,6 +2152,7 @@ public class GapicSpannerRpc implements SpannerRpc {
 
     @Override
     public void onComplete() {
+      // Unregister the response observer when the query has completed normally.
       if (this.consumer.cancelQueryWhenClientIsClosed()) {
         unregisterResponseObserver(this);
       }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerRpc.java
@@ -152,6 +152,8 @@ public interface SpannerRpc extends ServiceRpc {
     void onCompleted();
 
     void onError(SpannerException e);
+
+    boolean cancelQueryWhenClientIsClosed();
   }
 
   /** Handle for cancellation of a streaming read or query call. */

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerRpc.java
@@ -153,6 +153,13 @@ public interface SpannerRpc extends ServiceRpc {
 
     void onError(SpannerException e);
 
+    /**
+     * Returns true if the stream should be cancelled when the Spanner client is closed. This
+     * returns true for {@link com.google.cloud.spanner.BatchReadOnlyTransaction}, as these use a
+     * non-pooled session. Pooled sessions are deleted when the Spanner client is closed, and this
+     * automatically also cancels any query that uses the session, which means that we don't need to
+     * explicitly cancel those queries when the Spanner client is closed.
+     */
     boolean cancelQueryWhenClientIsClosed();
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/CloseSpannerWithOpenResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/CloseSpannerWithOpenResultSetTest.java
@@ -20,11 +20,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 
 import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
 import com.google.cloud.spanner.connection.AbstractMockServerTest;
 import com.google.cloud.spanner.spi.v1.GapicSpannerRpc;
+import com.google.spanner.v1.DeleteSessionRequest;
+import com.google.spanner.v1.ExecuteSqlRequest;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Status;
 import java.util.ArrayList;
@@ -34,38 +37,44 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
 public class CloseSpannerWithOpenResultSetTest extends AbstractMockServerTest {
 
-  Spanner createSpanner(boolean cancelStreamsOnClose) {
+  Spanner createSpanner() {
     return SpannerOptions.newBuilder()
         .setProjectId("p")
         .setHost(String.format("http://localhost:%d", getPort()))
         .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
         .setCredentials(NoCredentials.getInstance())
-        .setCancelStreamsOnClose(cancelStreamsOnClose)
+        .setSessionPoolOption(
+            SessionPoolOptions.newBuilder().setWaitForMinSessions(Duration.ofSeconds(5L)).build())
         .build()
         .getService();
   }
 
   @After
-  public void unfreezeMockSpanner() {
+  public void cleanup() {
     mockSpanner.unfreeze();
+    mockSpanner.clearRequests();
   }
 
   @Test
-  public void testClosedSpannerWithOpenResultSet_streamsAreCancelled() {
-    Spanner spanner = createSpanner(true);
+  public void testBatchClient_closedSpannerWithOpenResultSet_streamsAreCancelled() {
+    Spanner spanner = createSpanner();
+    assumeFalse(spanner.getOptions().getSessionPoolOptions().getUseMultiplexedSession());
+
     BatchClient client = spanner.getBatchClient(DatabaseId.of("p", "i", "d"));
-    mockSpanner.freezeAfterReturningNumRows(1);
     try (BatchReadOnlyTransaction transaction =
             client.batchReadOnlyTransaction(TimestampBound.strong());
         ResultSet resultSet = transaction.executeQuery(SELECT_RANDOM_STATEMENT)) {
+      mockSpanner.freezeAfterReturningNumRows(1);
       assertTrue(resultSet.next());
       ((SpannerImpl) spanner).close(1, TimeUnit.MILLISECONDS);
       // This should return an error as the stream is cancelled.
@@ -75,17 +84,33 @@ public class CloseSpannerWithOpenResultSetTest extends AbstractMockServerTest {
   }
 
   @Test
-  public void testClosedSpannerWithOpenResultSet() {
-    Spanner spanner = createSpanner(false);
-    BatchClient client = spanner.getBatchClient(DatabaseId.of("p", "i", "d"));
-    mockSpanner.freezeAfterReturningNumRows(1);
-    try (BatchReadOnlyTransaction transaction =
-            client.batchReadOnlyTransaction(TimestampBound.strong());
+  public void testNormalDatabaseClient_closedSpannerWithOpenResultSet_sessionsAreDeleted()
+      throws Exception {
+    Spanner spanner = createSpanner();
+    assumeFalse(spanner.getOptions().getSessionPoolOptions().getUseMultiplexedSession());
+
+    DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+    try (ReadOnlyTransaction transaction = client.readOnlyTransaction(TimestampBound.strong());
         ResultSet resultSet = transaction.executeQuery(SELECT_RANDOM_STATEMENT)) {
+      mockSpanner.freezeAfterReturningNumRows(1);
       assertTrue(resultSet.next());
-      ((SpannerImpl) spanner).close(1, TimeUnit.MILLISECONDS);
-      SpannerException exception = assertThrows(SpannerException.class, resultSet::next);
-      assertEquals(ErrorCode.UNAVAILABLE, exception.getErrorCode());
+      List<ExecuteSqlRequest> executeSqlRequests =
+          mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).stream()
+              .filter(request -> request.getSql().equals(SELECT_RANDOM_STATEMENT.getSql()))
+              .collect(Collectors.toList());
+      assertEquals(1, executeSqlRequests.size());
+      ExecutorService service = Executors.newSingleThreadExecutor();
+      service.submit(spanner::close);
+      // Verify that the session that is used by this transaction is deleted.
+      // That will automatically cancel the query.
+      mockSpanner.waitForRequestsToContain(
+          request ->
+              request instanceof DeleteSessionRequest
+                  && ((DeleteSessionRequest) request)
+                      .getName()
+                      .equals(executeSqlRequests.get(0).getSession()),
+          /*timeoutMillis=*/ 1000L);
+      service.shutdownNow();
     }
   }
 
@@ -99,25 +124,28 @@ public class CloseSpannerWithOpenResultSetTest extends AbstractMockServerTest {
             Status.NOT_FOUND.withDescription("Table not found: foo").asRuntimeException()));
     int numThreads = 16;
     int numQueries = 32;
-    try (Spanner spanner = createSpanner(true)) {
-      DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+    try (Spanner spanner = createSpanner()) {
+      BatchClient client = spanner.getBatchClient(DatabaseId.of("p", "i", "d"));
       ExecutorService service = Executors.newFixedThreadPool(numThreads);
       List<Future<?>> futures = new ArrayList<>(numQueries);
       for (int n = 0; n < numQueries; n++) {
         futures.add(
             service.submit(
                 () -> {
-                  if (ThreadLocalRandom.current().nextInt(10) < 2) {
-                    try (ResultSet resultSet = client.singleUse().executeQuery(invalidStatement)) {
-                      SpannerException exception =
-                          assertThrows(SpannerException.class, resultSet::next);
-                      assertEquals(ErrorCode.NOT_FOUND, exception.getErrorCode());
-                    }
-                  } else {
-                    try (ResultSet resultSet =
-                        client.singleUse().executeQuery(SELECT_RANDOM_STATEMENT)) {
-                      while (resultSet.next()) {
-                        assertNotNull(resultSet.getCurrentRowAsStruct());
+                  try (BatchReadOnlyTransaction transaction =
+                      client.batchReadOnlyTransaction(TimestampBound.strong())) {
+                    if (ThreadLocalRandom.current().nextInt(10) < 2) {
+                      try (ResultSet resultSet = transaction.executeQuery(invalidStatement)) {
+                        SpannerException exception =
+                            assertThrows(SpannerException.class, resultSet::next);
+                        assertEquals(ErrorCode.NOT_FOUND, exception.getErrorCode());
+                      }
+                    } else {
+                      try (ResultSet resultSet =
+                          transaction.executeQuery(SELECT_RANDOM_STATEMENT)) {
+                        while (resultSet.next()) {
+                          assertNotNull(resultSet.getCurrentRowAsStruct());
+                        }
                       }
                     }
                   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/CloseSpannerWithOpenResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/CloseSpannerWithOpenResultSetTest.java
@@ -156,6 +156,7 @@ public class CloseSpannerWithOpenResultSetTest extends AbstractMockServerTest {
         fut.get();
       }
       assertTrue(service.awaitTermination(1L, TimeUnit.MINUTES));
+      // Verify that all response observers have been unregistered.
       assertEquals(
           0, ((GapicSpannerRpc) ((SpannerImpl) spanner).getRpc()).getNumActiveResponseObservers());
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/CloseSpannerWithOpenResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/CloseSpannerWithOpenResultSetTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.NoCredentials;
+import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.cloud.spanner.connection.AbstractMockServerTest;
+import com.google.cloud.spanner.spi.v1.GapicSpannerRpc;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Status;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class CloseSpannerWithOpenResultSetTest extends AbstractMockServerTest {
+
+  Spanner createSpanner(boolean cancelStreamsOnClose) {
+    return SpannerOptions.newBuilder()
+        .setProjectId("p")
+        .setHost(String.format("http://localhost:%d", getPort()))
+        .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
+        .setCredentials(NoCredentials.getInstance())
+        .setCancelStreamsOnClose(cancelStreamsOnClose)
+        .build()
+        .getService();
+  }
+
+  @Test
+  public void testClosedSpannerWithOpenResultSet_streamsAreCancelled() {
+    Spanner spanner = createSpanner(true);
+    BatchClient client = spanner.getBatchClient(DatabaseId.of("p", "i", "d"));
+    mockSpanner.freezeAfterReturningNumRows(1);
+    try (BatchReadOnlyTransaction transaction =
+            client.batchReadOnlyTransaction(TimestampBound.strong());
+        ResultSet resultSet = transaction.executeQuery(SELECT_RANDOM_STATEMENT)) {
+      assertTrue(resultSet.next());
+      ((SpannerImpl) spanner).close(1, TimeUnit.MILLISECONDS);
+      mockSpanner.unfreeze();
+      // This should return an error as the stream is cancelled.
+      SpannerException exception = assertThrows(SpannerException.class, resultSet::next);
+      assertEquals(ErrorCode.CANCELLED, exception.getErrorCode());
+    }
+  }
+
+  @Test
+  public void testClosedSpannerWithOpenResultSet() {
+    Spanner spanner = createSpanner(false);
+    BatchClient client = spanner.getBatchClient(DatabaseId.of("p", "i", "d"));
+    mockSpanner.freezeAfterReturningNumRows(1);
+    try (BatchReadOnlyTransaction transaction =
+            client.batchReadOnlyTransaction(TimestampBound.strong());
+        ResultSet resultSet = transaction.executeQuery(SELECT_RANDOM_STATEMENT)) {
+      assertTrue(resultSet.next());
+      ((SpannerImpl) spanner).close(1, TimeUnit.MILLISECONDS);
+      mockSpanner.unfreeze();
+      SpannerException exception = assertThrows(SpannerException.class, resultSet::next);
+      assertEquals(ErrorCode.UNAVAILABLE, exception.getErrorCode());
+    }
+  }
+
+  @Test
+  public void testStreamsAreCleanedUp() throws Exception {
+    String invalidSql = "select * from foo";
+    Statement invalidStatement = Statement.of(invalidSql);
+    mockSpanner.putStatementResult(
+        StatementResult.exception(
+            invalidStatement,
+            Status.NOT_FOUND.withDescription("Table not found: foo").asRuntimeException()));
+    int numThreads = 16;
+    int numQueries = 32;
+    try (Spanner spanner = createSpanner(true)) {
+      DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+      ExecutorService service = Executors.newFixedThreadPool(numThreads);
+      List<Future<?>> futures = new ArrayList<>(numQueries);
+      for (int n = 0; n < numQueries; n++) {
+        futures.add(
+            service.submit(
+                () -> {
+                  if (ThreadLocalRandom.current().nextInt(10) < 2) {
+                    try (ResultSet resultSet = client.singleUse().executeQuery(invalidStatement)) {
+                      SpannerException exception =
+                          assertThrows(SpannerException.class, resultSet::next);
+                      assertEquals(ErrorCode.NOT_FOUND, exception.getErrorCode());
+                    }
+                  } else {
+                    try (ResultSet resultSet =
+                        client.singleUse().executeQuery(SELECT_RANDOM_STATEMENT)) {
+                      while (resultSet.next()) {
+                        assertNotNull(resultSet.getCurrentRowAsStruct());
+                      }
+                    }
+                  }
+                }));
+      }
+      service.shutdown();
+      for (Future<?> fut : futures) {
+        fut.get();
+      }
+      assertTrue(service.awaitTermination(1L, TimeUnit.MINUTES));
+      assertEquals(
+          0, ((GapicSpannerRpc) ((SpannerImpl) spanner).getRpc()).getNumActiveResponseObservers());
+    }
+  }
+}

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/CloseSpannerWithOpenResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/CloseSpannerWithOpenResultSetTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -52,6 +53,11 @@ public class CloseSpannerWithOpenResultSetTest extends AbstractMockServerTest {
         .getService();
   }
 
+  @After
+  public void unfreezeMockSpanner() {
+    mockSpanner.unfreeze();
+  }
+
   @Test
   public void testClosedSpannerWithOpenResultSet_streamsAreCancelled() {
     Spanner spanner = createSpanner(true);
@@ -62,7 +68,6 @@ public class CloseSpannerWithOpenResultSetTest extends AbstractMockServerTest {
         ResultSet resultSet = transaction.executeQuery(SELECT_RANDOM_STATEMENT)) {
       assertTrue(resultSet.next());
       ((SpannerImpl) spanner).close(1, TimeUnit.MILLISECONDS);
-      mockSpanner.unfreeze();
       // This should return an error as the stream is cancelled.
       SpannerException exception = assertThrows(SpannerException.class, resultSet::next);
       assertEquals(ErrorCode.CANCELLED, exception.getErrorCode());
@@ -79,7 +84,6 @@ public class CloseSpannerWithOpenResultSetTest extends AbstractMockServerTest {
         ResultSet resultSet = transaction.executeQuery(SELECT_RANDOM_STATEMENT)) {
       assertTrue(resultSet.next());
       ((SpannerImpl) spanner).close(1, TimeUnit.MILLISECONDS);
-      mockSpanner.unfreeze();
       SpannerException exception = assertThrows(SpannerException.class, resultSet::next);
       assertEquals(ErrorCode.UNAVAILABLE, exception.getErrorCode());
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GrpcResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GrpcResultSetTest.java
@@ -81,7 +81,7 @@ public class GrpcResultSetTest {
 
   @Before
   public void setUp() {
-    stream = new GrpcStreamIterator(10);
+    stream = new GrpcStreamIterator(10, /*cancelQueryWhenClientIsClosed=*/ false);
     stream.setCall(
         new SpannerRpc.StreamingCall() {
           @Override

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -578,6 +578,7 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
   private final Object lock = new Object();
   private Deque<AbstractMessage> requests = new ConcurrentLinkedDeque<>();
   private volatile CountDownLatch freezeLock = new CountDownLatch(0);
+  private final AtomicInteger freezeAfterReturningNumRows = new AtomicInteger();
   private Queue<Exception> exceptions = new ConcurrentLinkedQueue<>();
   private boolean stickyGlobalExceptions = false;
   private ConcurrentMap<Statement, StatementResult> statementResults = new ConcurrentHashMap<>();
@@ -782,6 +783,10 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
 
   public void unfreeze() {
     freezeLock.countDown();
+  }
+
+  public void freezeAfterReturningNumRows(int numRows) {
+    freezeAfterReturningNumRows.set(numRows);
   }
 
   public void setMaxSessionsInOneBatch(int max) {
@@ -1678,7 +1683,8 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
       ByteString transactionId,
       TransactionSelector transactionSelector,
       StreamObserver<PartialResultSet> responseObserver,
-      SimulatedExecutionTime executionTime) {
+      SimulatedExecutionTime executionTime)
+      throws Exception {
     ResultSetMetadata metadata = resultSet.getMetadata();
     if (transactionId == null) {
       Transaction transaction = getTemporaryTransactionOrNull(transactionSelector);
@@ -1700,6 +1706,12 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
       SimulatedExecutionTime.checkStreamException(
           index, executionTime.exceptions, executionTime.streamIndices);
       responseObserver.onNext(iterator.next());
+      if (freezeAfterReturningNumRows.get() > 0) {
+        if (freezeAfterReturningNumRows.decrementAndGet() == 0) {
+          freeze();
+          freezeLock.await();
+        }
+      }
       index++;
     }
     responseObserver.onCompleted();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadFormatTestRunner.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadFormatTestRunner.java
@@ -114,7 +114,7 @@ public class ReadFormatTestRunner extends ParentRunner<JSONObject> {
     }
 
     private void run() throws Exception {
-      stream = new GrpcStreamIterator(10);
+      stream = new GrpcStreamIterator(10, /*cancelQueryWhenClientIsClosed=*/ false);
       stream.setCall(
           new SpannerRpc.StreamingCall() {
             @Override


### PR DESCRIPTION
Adds the possibility to keep track of all running queries and cancel these when the client is closed. This option is currently only used for queries that are started by `BatchReadOnlyTransaction`s, as these do not use pooled sessions. Queries that use pooled sessions are automatically cancelled when the client is closed, because the sessions are deleted.
