### PR TITLE
fix: getRowAsStruct should always return a decoded struct

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/GrpcStruct.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/GrpcStruct.java
@@ -367,12 +367,19 @@ class GrpcStruct extends Struct implements Serializable {
   }
 
   Struct immutableCopy() {
-    return new GrpcStruct(
-        type,
-        new ArrayList<>(rowData),
-        this.decodeMode,
-        this.rowDecoded,
-        this.colDecoded == null ? null : (BitSet) this.colDecoded.clone());
+    GrpcStruct result =
+        new GrpcStruct(
+            type,
+            new ArrayList<>(rowData),
+            this.decodeMode,
+            this.rowDecoded,
+            this.colDecoded == null ? null : (BitSet) this.colDecoded.clone());
+    if (this.decodeMode != DecodeMode.DIRECT) {
+      for (int col = 0; col < getColumnCount(); col++) {
+        result.ensureDecoded(col);
+      }
+    }
+    return result;
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -741,9 +741,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
       extends ServiceOptions.Builder<Spanner, SpannerOptions, SpannerOptions.Builder> {
     static final int DEFAULT_PREFETCH_CHUNKS = 4;
     static final QueryOptions DEFAULT_QUERY_OPTIONS = QueryOptions.getDefaultInstance();
-    // TODO: Set the default to DecodeMode.DIRECT before merging to keep the current default.
-    //       It is currently set to LAZY_PER_COL so it is used in all tests.
-    static final DecodeMode DEFAULT_DECODE_MODE = DecodeMode.LAZY_PER_COL;
+    static final DecodeMode DEFAULT_DECODE_MODE = DecodeMode.DIRECT;
     static final RetrySettings DEFAULT_ADMIN_REQUESTS_LIMIT_EXCEEDED_RETRY_SETTINGS =
         RetrySettings.newBuilder()
             .setInitialRetryDelay(Duration.ofSeconds(5L))


### PR DESCRIPTION
`getRowAsStruct` could return a (partially) undecoded struct, which would have an internally mutable data structure. The returned row should however preferably be an immutable object. To achieve this, the struct should be guaranteed to be decoded before returning it to the caller.