### PR TITLE
fix: make DecodeMode.DIRECT the default

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -741,9 +741,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
       extends ServiceOptions.Builder<Spanner, SpannerOptions, SpannerOptions.Builder> {
     static final int DEFAULT_PREFETCH_CHUNKS = 4;
     static final QueryOptions DEFAULT_QUERY_OPTIONS = QueryOptions.getDefaultInstance();
-    // TODO: Set the default to DecodeMode.DIRECT before merging to keep the current default.
-    //       It is currently set to LAZY_PER_COL so it is used in all tests.
-    static final DecodeMode DEFAULT_DECODE_MODE = DecodeMode.LAZY_PER_COL;
+    static final DecodeMode DEFAULT_DECODE_MODE = DecodeMode.DIRECT;
     static final RetrySettings DEFAULT_ADMIN_REQUESTS_LIMIT_EXCEEDED_RETRY_SETTINGS =
         RetrySettings.newBuilder()
             .setInitialRetryDelay(Duration.ofSeconds(5L))

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
@@ -104,16 +104,21 @@ public class SpannerOptionsTest {
 
   @Test
   public void defaultBuilder() {
-    // We need to set the project id since in test environment we cannot obtain a default project
-    // id.
-    SpannerOptions options = SpannerOptions.newBuilder().setProjectId("test-project").build();
+    // We need to set the project id and credentials since in test environments we cannot guarantee
+    // that a default project id and credentials are available.
+    SpannerOptions options =
+        SpannerOptions.newBuilder()
+            .setProjectId("test-project")
+            .setCredentials(NoCredentials.getInstance())
+            .build();
     if (Strings.isNullOrEmpty(System.getenv("SPANNER_EMULATOR_HOST"))) {
-      assertThat(options.getHost()).isEqualTo("https://spanner.googleapis.com");
+      assertEquals("https://spanner.googleapis.com", options.getHost());
     } else {
-      assertThat(options.getHost()).isEqualTo("http://" + System.getenv("SPANNER_EMULATOR_HOST"));
+      assertEquals("http://" + System.getenv("SPANNER_EMULATOR_HOST"), options.getHost());
     }
-    assertThat(options.getPrefetchChunks()).isEqualTo(4);
+    assertEquals(4, options.getPrefetchChunks());
     assertNull(options.getSessionLabels());
+    assertEquals(DecodeMode.DIRECT, options.getDecodeMode());
   }
 
   @Test


### PR DESCRIPTION
DecodeMode.DIRECT should be the default mode for decoding rows.
