### PR TITLE
fix: use core pool size 1 for maintainer

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MultiplexedSessionDatabaseClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MultiplexedSessionDatabaseClient.java
@@ -390,11 +390,14 @@ final class MultiplexedSessionDatabaseClient extends AbstractMultiplexedSessionD
 
   /**
    * It is enough with one executor to maintain the multiplexed sessions in all the clients, as they
-   * do not need to be updated often, and the maintenance task is light.
+   * do not need to be updated often, and the maintenance task is light. The core pool size is set
+   * to 1 to prevent continuous creating and tearing down threads, and to avoid high CPU usage when
+   * running on Java 8 due to <a href="https://bugs.openjdk.org/browse/JDK-8129861">
+   * https://bugs.openjdk.org/browse/JDK-8129861</a>.
    */
   private static final ScheduledExecutorService MAINTAINER_SERVICE =
       Executors.newScheduledThreadPool(
-          /* corePoolSize = */ 0,
+          /* corePoolSize = */ 1,
           ThreadFactoryUtil.createVirtualOrPlatformDaemonThreadFactory(
               "multiplexed-session-maintainer", /* tryVirtual = */ false));
 


### PR DESCRIPTION
The multiplexed session maintainer used a ScheduledExecutorService with a core pool size of zero. This can cause high CPU usage on Java 8 due to https://bugs.openjdk.org/browse/JDK-8129861. Also on higher versions of Java, it is better to use an executor with at least one core thread, instead of letting the executor create a new thread every time a task needs to be executed.

Fixes #3313
Fixes https://github.com/GoogleCloudPlatform/pgadapter/issues/2249
Fixes https://github.com/googleapis/java-spanner-jdbc/issues/1736
