### PR TITLE
refactor: use RpcPriority internally in the Connection API

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ClientSideStatementValueConverters.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ClientSideStatementValueConverters.java
@@ -30,7 +30,6 @@ import com.google.common.base.Strings;
 import com.google.protobuf.Duration;
 import com.google.protobuf.util.Durations;
 import com.google.spanner.v1.DirectedReadOptions;
-import com.google.spanner.v1.RequestOptions.Priority;
 import java.util.Base64;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -499,9 +498,9 @@ class ClientSideStatementValueConverters {
   }
 
   /** Converter for converting strings to {@link RpcPriority} values. */
-  static class RpcPriorityConverter implements ClientSideStatementValueConverter<Priority> {
-    private final CaseInsensitiveEnumMap<Priority> values =
-        new CaseInsensitiveEnumMap<>(Priority.class);
+  static class RpcPriorityConverter implements ClientSideStatementValueConverter<RpcPriority> {
+    private final CaseInsensitiveEnumMap<RpcPriority> values =
+        new CaseInsensitiveEnumMap<>(RpcPriority.class);
     private final Pattern allowedValues;
 
     public RpcPriorityConverter(String allowedValues) {
@@ -512,19 +511,19 @@ class ClientSideStatementValueConverters {
     }
 
     @Override
-    public Class<Priority> getParameterClass() {
-      return Priority.class;
+    public Class<RpcPriority> getParameterClass() {
+      return RpcPriority.class;
     }
 
     @Override
-    public Priority convert(String value) {
+    public RpcPriority convert(String value) {
       Matcher matcher = allowedValues.matcher(value);
       if (matcher.find()) {
         if (matcher.group(0).equalsIgnoreCase("null")) {
-          return Priority.PRIORITY_UNSPECIFIED;
+          return RpcPriority.UNSPECIFIED;
         }
       }
-      return values.get("PRIORITY_" + value);
+      return values.get(value);
     }
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionStatementExecutor.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionStatementExecutor.java
@@ -16,12 +16,12 @@
 
 package com.google.cloud.spanner.connection;
 
+import com.google.cloud.spanner.Options.RpcPriority;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.connection.PgTransactionMode.IsolationLevel;
 import com.google.protobuf.Duration;
 import com.google.spanner.v1.DirectedReadOptions;
-import com.google.spanner.v1.RequestOptions.Priority;
 
 /**
  * The Cloud Spanner JDBC driver supports a number of client side statements that are interpreted by
@@ -134,7 +134,7 @@ interface ConnectionStatementExecutor {
 
   StatementResult statementResetAll();
 
-  StatementResult statementSetRPCPriority(Priority priority);
+  StatementResult statementSetRPCPriority(RpcPriority priority);
 
   StatementResult statementShowRPCPriority();
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionStatementExecutorImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionStatementExecutorImpl.java
@@ -102,16 +102,13 @@ import com.google.cloud.spanner.connection.ReadOnlyStalenessUtil.DurationValueGe
 import com.google.cloud.spanner.connection.StatementResult.ClientSideStatementType;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Duration;
 import com.google.spanner.v1.DirectedReadOptions;
 import com.google.spanner.v1.PlanNode;
 import com.google.spanner.v1.QueryPlan;
 import com.google.spanner.v1.RequestOptions;
-import com.google.spanner.v1.RequestOptions.Priority;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -137,16 +134,6 @@ class ConnectionStatementExecutorImpl implements ConnectionStatementExecutor {
     public boolean hasDuration() {
       return connection.hasStatementTimeout();
     }
-  }
-
-  private static final Map<Priority, RpcPriority> validRPCPriorityValues;
-
-  static {
-    ImmutableMap.Builder<Priority, RpcPriority> builder = ImmutableMap.builder();
-    builder.put(Priority.PRIORITY_HIGH, RpcPriority.HIGH);
-    builder.put(Priority.PRIORITY_MEDIUM, RpcPriority.MEDIUM);
-    builder.put(Priority.PRIORITY_LOW, RpcPriority.LOW);
-    validRPCPriorityValues = builder.build();
   }
 
   /** The connection to execute the statements on. */
@@ -552,9 +539,8 @@ class ConnectionStatementExecutorImpl implements ConnectionStatementExecutor {
   }
 
   @Override
-  public StatementResult statementSetRPCPriority(Priority priority) {
-    RpcPriority value = validRPCPriorityValues.get(priority);
-    getConnection().setRPCPriority(value);
+  public StatementResult statementSetRPCPriority(RpcPriority priority) {
+    getConnection().setRPCPriority(priority);
     return noResult(SET_RPC_PRIORITY);
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/RpcPriorityConverterTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/RpcPriorityConverterTest.java
@@ -19,9 +19,9 @@ package com.google.cloud.spanner.connection;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import com.google.cloud.spanner.Options.RpcPriority;
 import com.google.cloud.spanner.connection.ClientSideStatementImpl.CompileException;
 import com.google.cloud.spanner.connection.ClientSideStatementValueConverters.RpcPriorityConverter;
-import com.google.spanner.v1.RequestOptions.Priority;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -34,18 +34,18 @@ public class RpcPriorityConverterTest {
     String allowedValues = "'(HIGH|MEDIUM|LOW|NULL)'";
     RpcPriorityConverter converter =
         new ClientSideStatementValueConverters.RpcPriorityConverter(allowedValues);
-    assertEquals(Priority.PRIORITY_HIGH, converter.convert("high"));
-    assertEquals(Priority.PRIORITY_HIGH, converter.convert("HIGH"));
-    assertEquals(Priority.PRIORITY_HIGH, converter.convert("High"));
+    assertEquals(RpcPriority.HIGH, converter.convert("high"));
+    assertEquals(RpcPriority.HIGH, converter.convert("HIGH"));
+    assertEquals(RpcPriority.HIGH, converter.convert("High"));
 
-    assertEquals(Priority.PRIORITY_MEDIUM, converter.convert("medium"));
-    assertEquals(Priority.PRIORITY_MEDIUM, converter.convert("Medium"));
+    assertEquals(RpcPriority.MEDIUM, converter.convert("medium"));
+    assertEquals(RpcPriority.MEDIUM, converter.convert("Medium"));
 
-    assertEquals(Priority.PRIORITY_LOW, converter.convert("Low"));
+    assertEquals(RpcPriority.LOW, converter.convert("Low"));
 
     assertNull(converter.convert(""));
     assertNull(converter.convert(" "));
     assertNull(converter.convert("random string"));
-    assertEquals(Priority.PRIORITY_UNSPECIFIED, converter.convert("NULL"));
+    assertEquals(RpcPriority.UNSPECIFIED, converter.convert("NULL"));
   }
 }


### PR DESCRIPTION
The Connection API used the (proto) enum Priority internally, while the actual connection property uses the public-facing
`com.google.cloud.spanner.RpcPriority` in public APIs. This change modifies the internal parser to also directly use the public-facing enum, instead of going through the proto enum definition first, only to translate to the public enum at a later moment.
