### PR TITLE
chore(spanner): add package protected setter to enable mux for RW

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
@@ -73,6 +73,8 @@ public class SessionPoolOptions {
 
   private final boolean useMultiplexedSession;
 
+  private final boolean useMultiplexedSessionForRW;
+
   // TODO: Change to use java.time.Duration.
   private final Duration multiplexedSessionMaintenanceDuration;
 
@@ -108,6 +110,13 @@ public class SessionPoolOptions {
         (useMultiplexedSessionFromEnvVariable != null)
             ? useMultiplexedSessionFromEnvVariable
             : builder.useMultiplexedSession;
+    // useMultiplexedSessionForRW priority => Environment var > private setter > client default
+    Boolean useMultiplexedSessionForRWFromEnvVariable =
+        getUseMultiplexedSessionForRWFromEnvVariable();
+    this.useMultiplexedSessionForRW =
+        (useMultiplexedSessionForRWFromEnvVariable != null)
+            ? useMultiplexedSessionForRWFromEnvVariable
+            : builder.useMultiplexedSessionForRW;
     this.multiplexedSessionMaintenanceDuration = builder.multiplexedSessionMaintenanceDuration;
   }
 
@@ -144,6 +153,7 @@ public class SessionPoolOptions {
             this.inactiveTransactionRemovalOptions, other.inactiveTransactionRemovalOptions)
         && Objects.equals(this.poolMaintainerClock, other.poolMaintainerClock)
         && Objects.equals(this.useMultiplexedSession, other.useMultiplexedSession)
+        && Objects.equals(this.useMultiplexedSessionForRW, other.useMultiplexedSessionForRW)
         && Objects.equals(
             this.multiplexedSessionMaintenanceDuration,
             other.multiplexedSessionMaintenanceDuration);
@@ -174,6 +184,7 @@ public class SessionPoolOptions {
         this.inactiveTransactionRemovalOptions,
         this.poolMaintainerClock,
         this.useMultiplexedSession,
+        this.useMultiplexedSessionForRW,
         this.multiplexedSessionMaintenanceDuration);
   }
 
@@ -307,6 +318,14 @@ public class SessionPoolOptions {
     return useMultiplexedSession;
   }
 
+  @VisibleForTesting
+  @InternalApi
+  public boolean getUseMultiplexedSessionForRW() {
+    // Multiplexed sessions for R/W are enabled only if both global multiplexed sessions and
+    // read-write multiplexed session flags are set to true.
+    return getUseMultiplexedSession() && useMultiplexedSessionForRW;
+  }
+
   private static Boolean getUseMultiplexedSessionFromEnvVariable() {
     String useMultiplexedSessionFromEnvVariable =
         System.getenv("GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS");
@@ -320,6 +339,12 @@ public class SessionPoolOptions {
             "GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS should be either true or false.");
       }
     }
+    return null;
+  }
+
+  private static Boolean getUseMultiplexedSessionForRWFromEnvVariable() {
+    // Checks the value of env, GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW
+    // This returns null until RW is supported.
     return null;
   }
 
@@ -529,6 +554,12 @@ public class SessionPoolOptions {
     // Set useMultiplexedSession to true to make multiplexed session the default.
     private boolean useMultiplexedSession = false;
 
+    // This field controls the default behavior of session management for RW operations in Java
+    // client.
+    // Set useMultiplexedSessionForRW to true to make multiplexed session for RW operations the
+    // default.
+    private boolean useMultiplexedSessionForRW = false;
+
     private Duration multiplexedSessionMaintenanceDuration = Duration.ofDays(7);
     private Clock poolMaintainerClock = Clock.INSTANCE;
 
@@ -570,6 +601,7 @@ public class SessionPoolOptions {
       this.randomizePositionQPSThreshold = options.randomizePositionQPSThreshold;
       this.inactiveTransactionRemovalOptions = options.inactiveTransactionRemovalOptions;
       this.useMultiplexedSession = options.useMultiplexedSession;
+      this.useMultiplexedSessionForRW = options.useMultiplexedSessionForRW;
       this.multiplexedSessionMaintenanceDuration = options.multiplexedSessionMaintenanceDuration;
       this.poolMaintainerClock = options.poolMaintainerClock;
     }
@@ -754,6 +786,15 @@ public class SessionPoolOptions {
      */
     Builder setUseMultiplexedSession(boolean useMultiplexedSession) {
       this.useMultiplexedSession = useMultiplexedSession;
+      return this;
+    }
+
+    /**
+     * Sets whether the client should use multiplexed session for R/W operations or not. This method
+     * is package-protected and used internally.
+     */
+    Builder setUseMultiplexedSessionForRW(boolean useMultiplexedSessionForRW) {
+      this.useMultiplexedSessionForRW = useMultiplexedSessionForRW;
       return this;
     }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPoolOptions.java
@@ -791,7 +791,7 @@ public class SessionPoolOptions {
 
     /**
      * Sets whether the client should use multiplexed session for R/W operations or not. This method
-     * is package-protected and used internally.
+     * is intentionally package-private and intended for internal use.
      */
     Builder setUseMultiplexedSessionForRW(boolean useMultiplexedSessionForRW) {
       this.useMultiplexedSessionForRW = useMultiplexedSessionForRW;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
@@ -277,6 +277,9 @@ class SpannerImpl extends BaseService<SpannerOptions> implements Spanner {
 
         boolean useMultiplexedSession =
             getOptions().getSessionPoolOptions().getUseMultiplexedSession();
+        boolean useMultiplexedSessionForRW =
+            getOptions().getSessionPoolOptions().getUseMultiplexedSessionForRW();
+
         MultiplexedSessionDatabaseClient multiplexedSessionDatabaseClient =
             useMultiplexedSession
                 ? new MultiplexedSessionDatabaseClient(SpannerImpl.this.getSessionClient(db))

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolOptionsTest.java
@@ -300,6 +300,52 @@ public class SessionPoolOptionsTest {
   }
 
   @Test
+  public void testUseMultiplexedSessionForRW() {
+    // skip these tests since this configuration can have dual behaviour in different test-runners
+    assumeFalse(SessionPoolOptions.newBuilder().build().getUseMultiplexedSession());
+    assumeFalse(SessionPoolOptions.newBuilder().build().getUseMultiplexedSessionForRW());
+
+    // Verify default client behavior for multiplexed sessions in R/W transactions
+    assertEquals(false, SessionPoolOptions.newBuilder().build().getUseMultiplexedSessionForRW());
+
+    // Client will use multiplexed sessions for R/W transactions if both the fields are set to true.
+    assertEquals(
+        true,
+        SessionPoolOptions.newBuilder()
+            .setUseMultiplexedSession(true)
+            .setUseMultiplexedSessionForRW(true)
+            .build()
+            .getUseMultiplexedSessionForRW());
+    // Client will not use multiplexed sessions for R/W transactions, since one of the field is set
+    // to false.
+    assertEquals(
+        false,
+        SessionPoolOptions.newBuilder()
+            .setUseMultiplexedSession(true)
+            .setUseMultiplexedSessionForRW(false)
+            .build()
+            .getUseMultiplexedSessionForRW());
+    // Client will not use multiplexed sessions for R/W transactions, since one of the field is set
+    // to false.
+    assertEquals(
+        false,
+        SessionPoolOptions.newBuilder()
+            .setUseMultiplexedSession(false)
+            .setUseMultiplexedSessionForRW(true)
+            .build()
+            .getUseMultiplexedSessionForRW());
+    // Client will not use multiplexed sessions for R/W transactions, since both the fields are set
+    // to false.
+    assertEquals(
+        false,
+        SessionPoolOptions.newBuilder()
+            .setUseMultiplexedSession(false)
+            .setUseMultiplexedSessionForRW(false)
+            .build()
+            .getUseMultiplexedSessionForRW());
+  }
+
+  @Test
   public void testMultiplexedSessionMaintenanceDuration() {
     assertEquals(
         Duration.ofDays(7),
@@ -325,6 +371,10 @@ public class SessionPoolOptionsTest {
     assertToBuilderRoundtrip(
         SessionPoolOptions.newBuilder()
             .setUseMultiplexedSession(ThreadLocalRandom.current().nextBoolean())
+            .build());
+    assertToBuilderRoundtrip(
+        SessionPoolOptions.newBuilder()
+            .setUseMultiplexedSessionForRW(ThreadLocalRandom.current().nextBoolean())
             .build());
     assertToBuilderRoundtrip(
         SessionPoolOptions.newBuilder()


### PR DESCRIPTION
This PR adds a package protected setter that can be used to enable/disable multiplexed sessions for R/W operations. This method will be used internally for testing purposes.