### PR TITLE
chore: add directpath_enabled attribute

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsConstant.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsConstant.java
@@ -101,6 +101,7 @@ public class BuiltInMetricsConstant {
           DIRECT_PATH_ENABLED_KEY,
           DIRECT_PATH_USED_KEY);
 
+  public static boolean DIRECT_PATH_ENABLED;
   static Aggregation AGGREGATION_WITH_MILLIS_HISTOGRAM =
       Aggregation.explicitBucketHistogram(
           ImmutableList.of(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/CompositeTracer.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/CompositeTracer.java
@@ -184,7 +184,7 @@ public class CompositeTracer extends BaseApiTracer {
     for (ApiTracer child : children) {
       if (child instanceof MetricsTracer) {
         MetricsTracer metricsTracer = (MetricsTracer) child;
-        attributes.forEach((key, value) -> metricsTracer.addAttributes(key, value));
+        metricsTracer.addAttributes(attributes);
       }
     }
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/HeaderInterceptor.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/HeaderInterceptor.java
@@ -228,6 +228,9 @@ class HeaderInterceptor implements ClientInterceptor {
           attributes.put(BuiltInMetricsConstant.DATABASE_KEY.getKey(), databaseName.getDatabase());
           attributes.put(
               BuiltInMetricsConstant.INSTANCE_ID_KEY.getKey(), databaseName.getInstance());
+          attributes.put(
+              BuiltInMetricsConstant.DIRECT_PATH_ENABLED_KEY.getKey(),
+              String.valueOf(BuiltInMetricsConstant.DIRECT_PATH_ENABLED));
           return attributes;
         });
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/v1/stub/GrpcSpannerStub.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/v1/stub/GrpcSpannerStub.java
@@ -248,6 +248,11 @@ public class GrpcSpannerStub extends SpannerStub {
   }
 
   public static final GrpcSpannerStub create(
+      SpannerStubSettings settings, ClientContext clientContext) throws IOException {
+    return new GrpcSpannerStub(settings, clientContext);
+  }
+
+  public static final GrpcSpannerStub create(
       ClientContext clientContext, GrpcStubCallableFactory callableFactory) throws IOException {
     return new GrpcSpannerStub(
         SpannerStubSettings.newBuilder().build(), clientContext, callableFactory);


### PR DESCRIPTION
As part of this [bug](https://github.com/googleapis/sdk-platform-java/pull/3170) , modification were made in ClientContext which can be used to fetch `isDirectPath()` attribute. 

Recommendation was to pass clientContext in the `GrpcSpannerStub.create` instead of SpannerStubSetting. 
```
SpannerStubSettings stubSettings = options
        .getSpannerStubSettings()
        .toBuilder()
        .setTransportChannelProvider(channelProvider)
        .setCredentialsProvider(credentialsProvider)
        .setStreamWatchdogProvider(watchdogProvider)
        .setTracerFactory(options.getApiTracerFactory())
        .build();
ClientContext clientContext = ClientContext.create(stubSettings);
// create GrpcSpannerStub from clientContext instead. 
// this is equivelant to GrpcSpannerStub.create(stubSettings)
this.spannerStub =
    GrpcSpannerStub.create(clientContext);
// access this property from transport channel.
((GrpcTransportChannel) clientContext.getTransportChannel()).isDirectPath();
```
It was working for the regular calls, however, all the test cases using timeouts were failing. 

Ideally this should have worked the similar way. However , the code [here](https://github.com/googleapis/java-spanner/blob/main/google-cloud-spanner/src/main/java/com/google/cloud/spanner/v1/stub/GrpcSpannerStub.java#L247) is not using the spannerStubSettings from clientContext, instead creating a new `SpannerStubSettings.newBuilder().build()` 

Added a new method in the `GrpcSpannerStub` file which accepts both stubSettings and clientContext.