### PR TITLE
feat: client built in metrics

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -727,6 +727,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     private static final String SPANNER_ENABLE_API_TRACING = "SPANNER_ENABLE_API_TRACING";
     private static final String SPANNER_ENABLE_END_TO_END_TRACING =
         "SPANNER_ENABLE_END_TO_END_TRACING";
+    private static final String SPANNER_DISABLE_BUILTIN_METRICS = "SPANNER_DISABLE_BUILTIN_METRICS";
 
     private SpannerEnvironmentImpl() {}
 
@@ -751,6 +752,11 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     @Override
     public boolean isEnableApiTracing() {
       return Boolean.parseBoolean(System.getenv(SPANNER_ENABLE_API_TRACING));
+    }
+
+    @Override
+    public boolean isEnableBuiltInMetrics() {
+      return !Boolean.parseBoolean(System.getenv(SPANNER_DISABLE_BUILTIN_METRICS));
     }
 
     @Override
@@ -821,7 +827,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     private boolean enableApiTracing = SpannerOptions.environment.isEnableApiTracing();
     private boolean enableExtendedTracing = SpannerOptions.environment.isEnableExtendedTracing();
     private boolean enableEndToEndTracing = SpannerOptions.environment.isEnableEndToEndTracing();
-    private boolean enableBuiltInMetrics = true;
+    private boolean enableBuiltInMetrics = SpannerOptions.environment.isEnableBuiltInMetrics();
 
     private static String createCustomClientLibToken(String token) {
       return token + " " + ServiceOptions.getGoogApiClientLibName();

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -820,8 +820,8 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     private OpenTelemetry openTelemetry;
     private boolean enableApiTracing = SpannerOptions.environment.isEnableApiTracing();
     private boolean enableExtendedTracing = SpannerOptions.environment.isEnableExtendedTracing();
-    private boolean enableBuiltInMetrics = true;
     private boolean enableEndToEndTracing = SpannerOptions.environment.isEnableEndToEndTracing();
+    private boolean enableBuiltInMetrics = true;
 
     private static String createCustomClientLibToken(String token) {
       return token + " " + ServiceOptions.getGoogApiClientLibName();
@@ -1403,10 +1403,10 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     }
 
     /**
-     * Sets whether to enable or disable built in metrics for Data client Operations. Built in
-     * metrics are enabled as default.
+     * Sets whether to enable or disable built in metrics for Data client operations. Built in
+     * metrics are enabled by default.
      */
-    public Builder setEnableBuiltInMetrics(boolean enableBuiltInMetrics) {
+    public Builder setBuiltInMetricsEnabled(boolean enableBuiltInMetrics) {
       this.enableBuiltInMetrics = enableBuiltInMetrics;
       return this;
     }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -706,7 +706,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     }
 
     default boolean isEnableBuiltInMetrics() {
-      return false;
+      return true;
     }
 
     default boolean isEnableEndToEndTracing() {
@@ -725,7 +725,6 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
         "SPANNER_OPTIMIZER_STATISTICS_PACKAGE";
     private static final String SPANNER_ENABLE_EXTENDED_TRACING = "SPANNER_ENABLE_EXTENDED_TRACING";
     private static final String SPANNER_ENABLE_API_TRACING = "SPANNER_ENABLE_API_TRACING";
-    private static final String SPANNER_ENABLE_BUILTIN_METRICS = "SPANNER_ENABLE_BUILTIN_METRICS";
     private static final String SPANNER_ENABLE_END_TO_END_TRACING =
         "SPANNER_ENABLE_END_TO_END_TRACING";
 
@@ -752,13 +751,6 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     @Override
     public boolean isEnableApiTracing() {
       return Boolean.parseBoolean(System.getenv(SPANNER_ENABLE_API_TRACING));
-    }
-
-    @Override
-    public boolean isEnableBuiltInMetrics() {
-      // The environment variable SPANNER_ENABLE_BUILTIN_METRICS is used for testing and will be
-      // removed in the future.
-      return Boolean.parseBoolean(System.getenv(SPANNER_ENABLE_BUILTIN_METRICS));
     }
 
     @Override
@@ -828,7 +820,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     private OpenTelemetry openTelemetry;
     private boolean enableApiTracing = SpannerOptions.environment.isEnableApiTracing();
     private boolean enableExtendedTracing = SpannerOptions.environment.isEnableExtendedTracing();
-    private boolean enableBuiltInMetrics = SpannerOptions.environment.isEnableBuiltInMetrics();
+    private boolean enableBuiltInMetrics = true;
     private boolean enableEndToEndTracing = SpannerOptions.environment.isEnableEndToEndTracing();
 
     private static String createCustomClientLibToken(String token) {
@@ -1410,8 +1402,11 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
       return this;
     }
 
-    /** Enabling this will enable built in metrics for each individual RPC execution. */
-    Builder setEnableBuiltInMetrics(boolean enableBuiltInMetrics) {
+    /**
+     * Sets whether to enable or disable built in metrics for Data client Operations. Built in
+     * metrics are enabled as default.
+     */
+    public Builder setEnableBuiltInMetrics(boolean enableBuiltInMetrics) {
       this.enableBuiltInMetrics = enableBuiltInMetrics;
       return this;
     }
@@ -1749,7 +1744,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
    * Returns true if an {@link com.google.api.gax.tracing.MetricsTracer} should be created and set
    * on the Spanner client.
    */
-  boolean isEnableBuiltInMetrics() {
+  public boolean isEnableBuiltInMetrics() {
     return enableBuiltInMetrics;
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
@@ -148,7 +148,7 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractMockServerTes
                     .build())
             // Setting this to false so that Spanner Options does not register Metrics Tracer
             // factory again.
-            .setEnableBuiltInMetrics(false)
+            .setBuiltInMetricsEnabled(false)
             .setApiTracerFactory(metricsTracerFactory)
             .build()
             .getService();


### PR DESCRIPTION
This PR enables client built-in metrics as default. 

Client built-in metrics support was added in PR https://github.com/googleapis/java-spanner/pull/3346

Below 4 metrics are introduced with this feature. 

- spanner.googleapis.com/client/operation_count
- spanner.googleapis.com/client/operation_latencies
- spanner.googleapis.com/client/attempt_count
- spanner.googleapis.com/client/attempt_latencies

To opt-out from client metrics 
```
Spanner spanner =
        SpannerOptions.newBuilder()
            .setProjectId("test-project")
            .setBuiltInMetricsEnabled(false)
            .build()
            .getService();
```

Other related PRs
https://github.com/googleapis/java-spanner/pull/3359
https://github.com/googleapis/java-spanner/pull/3357
https://github.com/googleapis/java-spanner/pull/3346
https://github.com/googleapis/java-spanner/pull/3415