### PR TITLE
chore: use an own executor for session maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-spanner</artifactId>
-  <version>6.78.0</version>
+  <version>6.79.0</version>
 </dependency>
 
 ```

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
@@ -22,7 +22,6 @@ import com.google.api.gax.paging.Page;
 import com.google.cloud.BaseService;
 import com.google.cloud.PageImpl;
 import com.google.cloud.PageImpl.NextPageFetcher;
-import com.google.cloud.grpc.GrpcTransportOptions;
 import com.google.cloud.spanner.SessionClient.SessionId;
 import com.google.cloud.spanner.SpannerOptions.CloseableExecutorProvider;
 import com.google.cloud.spanner.admin.database.v1.stub.DatabaseAdminStubSettings;
@@ -199,11 +198,7 @@ class SpannerImpl extends BaseService<SpannerOptions> implements Spanner {
       if (sessionClients.containsKey(db)) {
         return sessionClients.get(db);
       } else {
-        SessionClient client =
-            new SessionClient(
-                this,
-                db,
-                ((GrpcTransportOptions) getOptions().getTransportOptions()).getExecutorFactory());
+        SessionClient client = new SessionClient(this, db);
         sessionClients.put(db, client);
         return client;
       }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ITSessionPoolIntegrationTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ITSessionPoolIntegrationTest.java
@@ -18,15 +18,12 @@ package com.google.cloud.spanner;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.cloud.grpc.GrpcTransportOptions.ExecutorFactory;
 import com.google.cloud.spanner.SessionPool.PooledSessionFuture;
 import io.opencensus.trace.Tracing;
 import io.opentelemetry.api.OpenTelemetry;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -83,18 +80,6 @@ public class ITSessionPoolIntegrationTest {
     pool =
         SessionPool.createPool(
             options,
-            new ExecutorFactory<ScheduledExecutorService>() {
-
-              @Override
-              public void release(ScheduledExecutorService executor) {
-                executor.shutdown();
-              }
-
-              @Override
-              public ScheduledExecutorService get() {
-                return new ScheduledThreadPoolExecutor(2);
-              }
-            },
             ((SpannerImpl) env.getTestHelper().getClient()).getSessionClient(db.getId()),
             new TraceWrapper(Tracing.getTracer(), OpenTelemetry.noop().getTracer(""), false),
             OpenTelemetry.noop());

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolMaintainerTest.java
@@ -50,7 +50,7 @@ import org.mockito.Mockito;
 
 @RunWith(JUnit4.class)
 public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
-  private ExecutorService executor = Executors.newSingleThreadExecutor();
+  private final ExecutorService executor = Executors.newSingleThreadExecutor();
   private @Mock SpannerImpl client;
   private @Mock SessionClient sessionClient;
   private @Mock SpannerOptions spannerOptions;
@@ -130,7 +130,6 @@ public class SessionPoolMaintainerTest extends BaseSessionPoolTest {
     SessionPool pool =
         SessionPool.createPool(
             options,
-            new TestExecutorFactory(),
             client.getSessionClient(db),
             clock,
             Position.FIRST,

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolStressTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolStressTest.java
@@ -224,7 +224,6 @@ public class SessionPoolStressTest extends BaseSessionPoolTest {
     pool =
         SessionPool.createPool(
             sessionPoolOptions,
-            new TestExecutorFactory(),
             mockSpanner.getSessionClient(db),
             clock,
             Position.RANDOM,

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -163,22 +163,12 @@ public class SessionPoolTest extends BaseSessionPoolTest {
 
   private SessionPool createPool() {
     return SessionPool.createPool(
-        options,
-        new TestExecutorFactory(),
-        client.getSessionClient(db),
-        tracer,
-        OpenTelemetry.noop());
+        options, client.getSessionClient(db), tracer, OpenTelemetry.noop());
   }
 
   private SessionPool createPool(Clock clock) {
     return SessionPool.createPool(
-        options,
-        new TestExecutorFactory(),
-        client.getSessionClient(db),
-        clock,
-        Position.RANDOM,
-        tracer,
-        OpenTelemetry.noop());
+        options, client.getSessionClient(db), clock, Position.RANDOM, tracer, OpenTelemetry.noop());
   }
 
   private SessionPool createPool(
@@ -186,7 +176,6 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     return SessionPool.createPool(
         options,
         TEST_DATABASE_ROLE,
-        new TestExecutorFactory(),
         client.getSessionClient(db),
         clock,
         Position.RANDOM,
@@ -208,7 +197,6 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     return SessionPool.createPool(
         options,
         TEST_DATABASE_ROLE,
-        new TestExecutorFactory(),
         client.getSessionClient(db),
         clock,
         Position.RANDOM,
@@ -1571,11 +1559,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
       when(spanner.getOptions()).thenReturn(spannerOptions);
       SessionPool pool =
           SessionPool.createPool(
-              options,
-              new TestExecutorFactory(),
-              spanner.getSessionClient(db),
-              tracer,
-              OpenTelemetry.noop());
+              options, spanner.getSessionClient(db), tracer, OpenTelemetry.noop());
       try (PooledSessionFuture readWriteSession = pool.getSession()) {
         TransactionRunner runner = readWriteSession.readWriteTransaction();
         try {


### PR DESCRIPTION
The session pool uses the gRPC transport executor for session maintenance. This executor should not be used by any other tasks than internal gRPC tasks. This change therefore creates simple executors for session maintenance and session creation.

Updates https://github.com/GoogleCloudPlatform/pgadapter/issues/2422
