### PR TITLE
feat: Enabling endToEndTracing support in Connection API

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
@@ -240,7 +240,6 @@ public class ConnectionOptions {
   static final boolean DEFAULT_RETURN_COMMIT_STATS = false;
   static final boolean DEFAULT_LENIENT = false;
   static final boolean DEFAULT_ROUTE_TO_LEADER = true;
-  static final boolean DEFAULT_ENABLE_END_TO_END_TRACING = false;
   static final boolean DEFAULT_DELAY_TRANSACTION_START_UNTIL_FIRST_WRITE = false;
   static final boolean DEFAULT_KEEP_TRANSACTION_ALIVE = false;
   static final boolean DEFAULT_TRACK_SESSION_LEAKS = true;
@@ -251,6 +250,7 @@ public class ConnectionOptions {
   static final int DEFAULT_MAX_PARTITIONED_PARALLELISM = 1;
   static final Boolean DEFAULT_ENABLE_EXTENDED_TRACING = null;
   static final Boolean DEFAULT_ENABLE_API_TRACING = null;
+  static final boolean DEFAULT_ENABLE_END_TO_END_TRACING = false;
   static final boolean DEFAULT_AUTO_BATCH_DML = false;
   static final long DEFAULT_AUTO_BATCH_DML_UPDATE_COUNT = 1L;
   static final boolean DEFAULT_AUTO_BATCH_DML_UPDATE_COUNT_VERIFICATION = true;
@@ -269,8 +269,6 @@ public class ConnectionOptions {
   /** Name of the 'routeToLeader' connection property. */
   public static final String ROUTE_TO_LEADER_PROPERTY_NAME = "routeToLeader";
   /** Name of the 'retry aborts internally' connection property. */
-  public static final String ENABLE_END_TO_END_TRACING_PROPERTY_NAME = "enableEndToEndTracing";
-
   public static final String RETRY_ABORTS_INTERNALLY_PROPERTY_NAME = "retryAbortsInternally";
   /** Name of the property to enable/disable virtual threads for the statement executor. */
   public static final String USE_VIRTUAL_THREADS_PROPERTY_NAME = "useVirtualThreads";
@@ -339,6 +337,7 @@ public class ConnectionOptions {
 
   public static final String ENABLE_EXTENDED_TRACING_PROPERTY_NAME = "enableExtendedTracing";
   public static final String ENABLE_API_TRACING_PROPERTY_NAME = "enableApiTracing";
+  public static final String ENABLE_END_TO_END_TRACING_PROPERTY_NAME = "enableEndToEndTracing";
 
   public static final String AUTO_BATCH_DML_PROPERTY_NAME = "auto_batch_dml";
   public static final String AUTO_BATCH_DML_UPDATE_COUNT_PROPERTY_NAME =
@@ -386,10 +385,6 @@ public class ConnectionOptions {
                       ROUTE_TO_LEADER_PROPERTY_NAME,
                       "Should read/write transactions and partitioned DML be routed to leader region (true/false)",
                       DEFAULT_ROUTE_TO_LEADER),
-                  ConnectionProperty.createBooleanProperty(
-                      ENABLE_END_TO_END_TRACING_PROPERTY_NAME,
-                      "Should we enable end to end tracing (true/false)",
-                      DEFAULT_ENABLE_END_TO_END_TRACING),
                   ConnectionProperty.createBooleanProperty(
                       RETRY_ABORTS_INTERNALLY_PROPERTY_NAME,
                       "Should the connection automatically retry Aborted errors (true/false)",
@@ -545,7 +540,14 @@ public class ConnectionOptions {
                           + "to get a detailed view of each RPC that is being executed by your application, "
                           + "or if you want to debug potential latency problems caused by RPCs that are "
                           + "being retried.",
-                      DEFAULT_ENABLE_API_TRACING))));
+                      DEFAULT_ENABLE_API_TRACING),
+                  ConnectionProperty.createBooleanProperty(
+                      ENABLE_END_TO_END_TRACING_PROPERTY_NAME,
+                      "Enable end-to-end tracing (true/false) to generate traces for both the time "
+                          + "that is spent in the client, as well as time that is spent in the Spanner server. "
+                          + "Server side traces would always go to Google Cloud Trace so to see end to end traces, "
+                          + "client should choose an exporter that exports the traces to Google Cloud Trace.",
+                      DEFAULT_ENABLE_END_TO_END_TRACING))));
 
   private static final Set<ConnectionProperty> INTERNAL_PROPERTIES =
       Collections.unmodifiableSet(
@@ -1213,8 +1215,10 @@ public class ConnectionOptions {
     return getInitialConnectionPropertyValue(ROUTE_TO_LEADER);
   }
 
-  /** Whether end-to-end tracing is enabled. */
-  public boolean enableEndToEndTracing() {
+  /**
+   * Whether end-to-end tracing is enabled.
+   */
+  public boolean isEndToEndTracingEnabled() {
     return getInitialConnectionPropertyValue(ENABLE_END_TO_END_TRACING);
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
@@ -26,6 +26,7 @@ import static com.google.cloud.spanner.connection.ConnectionProperties.DATABASE_
 import static com.google.cloud.spanner.connection.ConnectionProperties.DATA_BOOST_ENABLED;
 import static com.google.cloud.spanner.connection.ConnectionProperties.DIALECT;
 import static com.google.cloud.spanner.connection.ConnectionProperties.ENABLE_API_TRACING;
+import static com.google.cloud.spanner.connection.ConnectionProperties.ENABLE_END_TO_END_TRACING;
 import static com.google.cloud.spanner.connection.ConnectionProperties.ENABLE_EXTENDED_TRACING;
 import static com.google.cloud.spanner.connection.ConnectionProperties.ENCODED_CREDENTIALS;
 import static com.google.cloud.spanner.connection.ConnectionProperties.ENDPOINT;
@@ -239,6 +240,7 @@ public class ConnectionOptions {
   static final boolean DEFAULT_RETURN_COMMIT_STATS = false;
   static final boolean DEFAULT_LENIENT = false;
   static final boolean DEFAULT_ROUTE_TO_LEADER = true;
+  static final boolean DEFAULT_ENABLE_END_TO_END_TRACING = false;
   static final boolean DEFAULT_DELAY_TRANSACTION_START_UNTIL_FIRST_WRITE = false;
   static final boolean DEFAULT_KEEP_TRANSACTION_ALIVE = false;
   static final boolean DEFAULT_TRACK_SESSION_LEAKS = true;
@@ -267,6 +269,7 @@ public class ConnectionOptions {
   /** Name of the 'routeToLeader' connection property. */
   public static final String ROUTE_TO_LEADER_PROPERTY_NAME = "routeToLeader";
   /** Name of the 'retry aborts internally' connection property. */
+  public static final String ENABLE_END_TO_END_TRACING_PROPERTY_NAME = "enableEndToEndTracing";
   public static final String RETRY_ABORTS_INTERNALLY_PROPERTY_NAME = "retryAbortsInternally";
   /** Name of the property to enable/disable virtual threads for the statement executor. */
   public static final String USE_VIRTUAL_THREADS_PROPERTY_NAME = "useVirtualThreads";
@@ -382,6 +385,10 @@ public class ConnectionOptions {
                       ROUTE_TO_LEADER_PROPERTY_NAME,
                       "Should read/write transactions and partitioned DML be routed to leader region (true/false)",
                       DEFAULT_ROUTE_TO_LEADER),
+                  ConnectionProperty.createBooleanProperty(
+                      ENABLE_END_TO_END_TRACING_PROPERTY_NAME,
+                      "Should we enable end to end tracing (true/false)",
+                      DEFAULT_ENABLE_END_TO_END_TRACING),
                   ConnectionProperty.createBooleanProperty(
                       RETRY_ABORTS_INTERNALLY_PROPERTY_NAME,
                       "Should the connection automatically retry Aborted errors (true/false)",
@@ -1203,6 +1210,13 @@ public class ConnectionOptions {
    */
   public boolean isRouteToLeader() {
     return getInitialConnectionPropertyValue(ROUTE_TO_LEADER);
+  }
+
+  /**
+   * Whether end-to-end tracing is enabled.
+   */
+  public boolean enableEndToEndTracing() {
+    return getInitialConnectionPropertyValue(ENABLE_END_TO_END_TRACING);
   }
 
   /**

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
@@ -270,6 +270,7 @@ public class ConnectionOptions {
   public static final String ROUTE_TO_LEADER_PROPERTY_NAME = "routeToLeader";
   /** Name of the 'retry aborts internally' connection property. */
   public static final String ENABLE_END_TO_END_TRACING_PROPERTY_NAME = "enableEndToEndTracing";
+
   public static final String RETRY_ABORTS_INTERNALLY_PROPERTY_NAME = "retryAbortsInternally";
   /** Name of the property to enable/disable virtual threads for the statement executor. */
   public static final String USE_VIRTUAL_THREADS_PROPERTY_NAME = "useVirtualThreads";
@@ -1212,9 +1213,7 @@ public class ConnectionOptions {
     return getInitialConnectionPropertyValue(ROUTE_TO_LEADER);
   }
 
-  /**
-   * Whether end-to-end tracing is enabled.
-   */
+  /** Whether end-to-end tracing is enabled. */
   public boolean enableEndToEndTracing() {
     return getInitialConnectionPropertyValue(ENABLE_END_TO_END_TRACING);
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
@@ -1215,9 +1215,7 @@ public class ConnectionOptions {
     return getInitialConnectionPropertyValue(ROUTE_TO_LEADER);
   }
 
-  /**
-   * Whether end-to-end tracing is enabled.
-   */
+  /** Whether end-to-end tracing is enabled. */
   public boolean isEndToEndTracingEnabled() {
     return getInitialConnectionPropertyValue(ENABLE_END_TO_END_TRACING);
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
@@ -545,8 +545,8 @@ public class ConnectionOptions {
                       ENABLE_END_TO_END_TRACING_PROPERTY_NAME,
                       "Enable end-to-end tracing (true/false) to generate traces for both the time "
                           + "that is spent in the client, as well as time that is spent in the Spanner server. "
-                          + "Server side traces would always go to Google Cloud Trace so to see end to end traces, "
-                          + "client should choose an exporter that exports the traces to Google Cloud Trace.",
+                          + "Server side traces can only go to Google Cloud Trace, so to see end to end traces, "
+                          + "the application should configure an exporter that exports the traces to Google Cloud Trace.",
                       DEFAULT_ENABLE_END_TO_END_TRACING))));
 
   private static final Set<ConnectionProperty> INTERNAL_PROPERTIES =

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java
@@ -299,8 +299,8 @@ class ConnectionProperties {
           ENABLE_END_TO_END_TRACING_PROPERTY_NAME,
           "Enable end-to-end tracing (true/false) to generate traces for both the time "
               + "that is spent in the client, as well as time that is spent in the Spanner server. "
-              + "Server side traces would always go to Google Cloud Trace so to see end to end traces, "
-              + "client should choose an exporter that exports the traces to Google Cloud Trace.",
+              + "Server side traces can only go to Google Cloud Trace, so to see end to end traces, "
+              + "the application should configure an exporter that exports the traces to Google Cloud Trace.",
           DEFAULT_ENABLE_END_TO_END_TRACING,
           BooleanConverter.INSTANCE,
           Context.STARTUP);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java
@@ -39,6 +39,7 @@ import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_DATA
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_DDL_IN_TRANSACTION_MODE;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_DELAY_TRANSACTION_START_UNTIL_FIRST_WRITE;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_ENABLE_API_TRACING;
+import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_ENABLE_END_TO_END_TRACING;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_ENABLE_EXTENDED_TRACING;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_ENDPOINT;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_KEEP_TRANSACTION_ALIVE;
@@ -65,6 +66,7 @@ import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_USE_
 import static com.google.cloud.spanner.connection.ConnectionOptions.DELAY_TRANSACTION_START_UNTIL_FIRST_WRITE_NAME;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DIALECT_PROPERTY_NAME;
 import static com.google.cloud.spanner.connection.ConnectionOptions.ENABLE_API_TRACING_PROPERTY_NAME;
+import static com.google.cloud.spanner.connection.ConnectionOptions.ENABLE_END_TO_END_TRACING_PROPERTY_NAME;
 import static com.google.cloud.spanner.connection.ConnectionOptions.ENABLE_EXTENDED_TRACING_PROPERTY_NAME;
 import static com.google.cloud.spanner.connection.ConnectionOptions.ENCODED_CREDENTIALS_PROPERTY_NAME;
 import static com.google.cloud.spanner.connection.ConnectionOptions.ENDPOINT_PROPERTY_NAME;
@@ -255,6 +257,13 @@ class ConnectionProperties {
           ROUTE_TO_LEADER_PROPERTY_NAME,
           "Should read/write transactions and partitioned DML be routed to leader region (true/false)",
           DEFAULT_ROUTE_TO_LEADER,
+          BooleanConverter.INSTANCE,
+          Context.STARTUP);
+  static final ConnectionProperty<Boolean> ENABLE_END_TO_END_TRACING =
+      create(
+          ENABLE_END_TO_END_TRACING_PROPERTY_NAME,
+          "Should we enable end to end tracing (true/false)",
+          DEFAULT_ENABLE_END_TO_END_TRACING,
           BooleanConverter.INSTANCE,
           Context.STARTUP);
   static final ConnectionProperty<Boolean> USE_VIRTUAL_THREADS =

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java
@@ -259,13 +259,6 @@ class ConnectionProperties {
           DEFAULT_ROUTE_TO_LEADER,
           BooleanConverter.INSTANCE,
           Context.STARTUP);
-  static final ConnectionProperty<Boolean> ENABLE_END_TO_END_TRACING =
-      create(
-          ENABLE_END_TO_END_TRACING_PROPERTY_NAME,
-          "Should we enable end to end tracing (true/false)",
-          DEFAULT_ENABLE_END_TO_END_TRACING,
-          BooleanConverter.INSTANCE,
-          Context.STARTUP);
   static final ConnectionProperty<Boolean> USE_VIRTUAL_THREADS =
       create(
           USE_VIRTUAL_THREADS_PROPERTY_NAME,
@@ -299,6 +292,16 @@ class ConnectionProperties {
               + "or if you want to debug potential latency problems caused by RPCs that are "
               + "being retried.",
           DEFAULT_ENABLE_API_TRACING,
+          BooleanConverter.INSTANCE,
+          Context.STARTUP);
+  static final ConnectionProperty<Boolean> ENABLE_END_TO_END_TRACING =
+      create(
+          ENABLE_END_TO_END_TRACING_PROPERTY_NAME,
+          "Enable end-to-end tracing (true/false) to generate traces for both the time "
+              + "that is spent in the client, as well as time that is spent in the Spanner server. "
+              + "Server side traces would always go to Google Cloud Trace so to see end to end traces, "
+              + "client should choose an exporter that exports the traces to Google Cloud Trace.",
+          DEFAULT_ENABLE_END_TO_END_TRACING,
           BooleanConverter.INSTANCE,
           Context.STARTUP);
   static final ConnectionProperty<Integer> MIN_SESSIONS =

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
@@ -210,7 +210,7 @@ public class SpannerPool {
           && Objects.equals(this.userAgent, other.userAgent)
           && Objects.equals(this.routeToLeader, other.routeToLeader)
           && Objects.equals(
-          this.useVirtualGrpcTransportThreads, other.useVirtualGrpcTransportThreads)
+              this.useVirtualGrpcTransportThreads, other.useVirtualGrpcTransportThreads)
           && Objects.equals(this.openTelemetry, other.openTelemetry)
           && Objects.equals(this.enableExtendedTracing, other.enableExtendedTracing)
           && Objects.equals(this.enableApiTracing, other.enableApiTracing)

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
@@ -156,11 +156,11 @@ public class SpannerPool {
     private final String userAgent;
     private final String databaseRole;
     private final boolean routeToLeader;
-    private final boolean enableEndToEndTracing;
     private final boolean useVirtualGrpcTransportThreads;
     private final OpenTelemetry openTelemetry;
     private final Boolean enableExtendedTracing;
     private final Boolean enableApiTracing;
+    private final boolean enableEndToEndTracing;
 
     @VisibleForTesting
     static SpannerPoolKey of(ConnectionOptions options) {
@@ -187,11 +187,11 @@ public class SpannerPool {
       this.usePlainText = options.isUsePlainText();
       this.userAgent = options.getUserAgent();
       this.routeToLeader = options.isRouteToLeader();
-      this.enableEndToEndTracing = options.enableEndToEndTracing();
       this.useVirtualGrpcTransportThreads = options.isUseVirtualGrpcTransportThreads();
       this.openTelemetry = options.getOpenTelemetry();
       this.enableExtendedTracing = options.isEnableExtendedTracing();
       this.enableApiTracing = options.isEnableApiTracing();
+      this.enableEndToEndTracing = options.isEndToEndTracingEnabled();
     }
 
     @Override
@@ -384,7 +384,7 @@ public class SpannerPool {
     if (!options.isRouteToLeader()) {
       builder.disableLeaderAwareRouting();
     }
-    if (options.enableEndToEndTracing()) {
+    if (options.isEndToEndTracingEnabled()) {
       builder.setEnableEndToEndTracing(true);
     }
     if (key.usePlainText) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
@@ -209,12 +209,12 @@ public class SpannerPool {
           && Objects.equals(this.usePlainText, other.usePlainText)
           && Objects.equals(this.userAgent, other.userAgent)
           && Objects.equals(this.routeToLeader, other.routeToLeader)
-          && Objects.equals(this.enableEndToEndTracing, other.enableEndToEndTracing)
           && Objects.equals(
-              this.useVirtualGrpcTransportThreads, other.useVirtualGrpcTransportThreads)
+          this.useVirtualGrpcTransportThreads, other.useVirtualGrpcTransportThreads)
           && Objects.equals(this.openTelemetry, other.openTelemetry)
           && Objects.equals(this.enableExtendedTracing, other.enableExtendedTracing)
-          && Objects.equals(this.enableApiTracing, other.enableApiTracing);
+          && Objects.equals(this.enableApiTracing, other.enableApiTracing)
+          && Objects.equals(this.enableEndToEndTracing, other.enableEndToEndTracing);
     }
 
     @Override
@@ -229,11 +229,11 @@ public class SpannerPool {
           this.databaseRole,
           this.userAgent,
           this.routeToLeader,
-          this.enableEndToEndTracing,
           this.useVirtualGrpcTransportThreads,
           this.openTelemetry,
           this.enableExtendedTracing,
-          this.enableApiTracing);
+          this.enableApiTracing,
+          this.enableEndToEndTracing);
     }
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
@@ -156,6 +156,7 @@ public class SpannerPool {
     private final String userAgent;
     private final String databaseRole;
     private final boolean routeToLeader;
+    private final boolean enableEndToEndTracing;
     private final boolean useVirtualGrpcTransportThreads;
     private final OpenTelemetry openTelemetry;
     private final Boolean enableExtendedTracing;
@@ -186,6 +187,7 @@ public class SpannerPool {
       this.usePlainText = options.isUsePlainText();
       this.userAgent = options.getUserAgent();
       this.routeToLeader = options.isRouteToLeader();
+      this.enableEndToEndTracing = options.enableEndToEndTracing();
       this.useVirtualGrpcTransportThreads = options.isUseVirtualGrpcTransportThreads();
       this.openTelemetry = options.getOpenTelemetry();
       this.enableExtendedTracing = options.isEnableExtendedTracing();
@@ -207,6 +209,7 @@ public class SpannerPool {
           && Objects.equals(this.usePlainText, other.usePlainText)
           && Objects.equals(this.userAgent, other.userAgent)
           && Objects.equals(this.routeToLeader, other.routeToLeader)
+          && Objects.equals(this.enableEndToEndTracing, other.enableEndToEndTracing)
           && Objects.equals(
               this.useVirtualGrpcTransportThreads, other.useVirtualGrpcTransportThreads)
           && Objects.equals(this.openTelemetry, other.openTelemetry)
@@ -226,6 +229,7 @@ public class SpannerPool {
           this.databaseRole,
           this.userAgent,
           this.routeToLeader,
+          this.enableEndToEndTracing,
           this.useVirtualGrpcTransportThreads,
           this.openTelemetry,
           this.enableExtendedTracing,
@@ -379,6 +383,9 @@ public class SpannerPool {
     }
     if (!options.isRouteToLeader()) {
       builder.disableLeaderAwareRouting();
+    }
+    if (options.enableEndToEndTracing()) {
+      builder.setEnableEndToEndTracing(true);
     }
     if (key.usePlainText) {
       // Credentials may not be sent over a plain text channel.

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
@@ -334,13 +334,13 @@ public class ConnectionOptionsTest {
     assertEquals(options.getProjectId(), TEST_PROJECT);
     assertEquals(options.getInstanceId(), TEST_INSTANCE);
     assertEquals(options.getDatabaseName(), TEST_DATABASE);
-    assertTrue(options.enableEndToEndTracing());
+    assertTrue(options.isEndToEndTracingEnabled());
 
     // Test for default behavior for enableEndToEndTracing property.
     builder = ConnectionOptions.newBuilder().setUri(BASE_URI);
     builder.setCredentialsUrl(FILE_TEST_PATH);
     options = builder.build();
-    assertFalse(options.enableEndToEndTracing());
+    assertFalse(options.isEndToEndTracingEnabled());
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
@@ -323,6 +323,27 @@ public class ConnectionOptionsTest {
   }
 
   @Test
+  public void testBuildWithEndToEndTracingEnabled() {
+    final String BASE_URI =
+        "cloudspanner:/projects/test-project-123/instances/test-instance-123/databases/test-database-123";
+    ConnectionOptions.Builder builder = ConnectionOptions.newBuilder();
+    builder.setUri(BASE_URI + "?enableEndToEndTracing=true");
+    builder.setCredentialsUrl(FILE_TEST_PATH);
+    ConnectionOptions options = builder.build();
+    assertEquals(options.getHost(), DEFAULT_HOST);
+    assertEquals(options.getProjectId(), TEST_PROJECT);
+    assertEquals(options.getInstanceId(), TEST_INSTANCE);
+    assertEquals(options.getDatabaseName(), TEST_DATABASE);
+    assertTrue(options.enableEndToEndTracing());
+
+    // Test for default behavior for enableEndToEndTracing property.
+    builder = ConnectionOptions.newBuilder().setUri(BASE_URI);
+    builder.setCredentialsUrl(FILE_TEST_PATH);
+    options = builder.build();
+    assertFalse(options.enableEndToEndTracing());
+  }
+
+  @Test
   public void testBuildWithAutoConfigEmulatorAndHost() {
     ConnectionOptions.Builder builder = ConnectionOptions.newBuilder();
     builder.setUri(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SpannerPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SpannerPoolTest.java
@@ -564,6 +564,54 @@ public class SpannerPoolTest {
   }
 
   @Test
+  public void testEnableEndToEndTracing() {
+    SpannerPoolKey keyWithoutApiTracingConfig =
+        SpannerPoolKey.of(
+            ConnectionOptions.newBuilder()
+                .setUri("cloudspanner:/projects/p/instances/i/databases/d")
+                .setCredentials(NoCredentials.getInstance())
+                .build());
+    SpannerPoolKey keyWithApiTracingEnabled =
+        SpannerPoolKey.of(
+            ConnectionOptions.newBuilder()
+                .setUri("cloudspanner:/projects/p/instances/i/databases/d?enableEndToEndTracing=true")
+                .setCredentials(NoCredentials.getInstance())
+                .build());
+    SpannerPoolKey keyWithApiTracingDisabled =
+        SpannerPoolKey.of(
+            ConnectionOptions.newBuilder()
+                .setUri("cloudspanner:/projects/p/instances/i/databases/d?enableEndToEndTracing=false")
+                .setCredentials(NoCredentials.getInstance())
+                .build());
+
+    assertNotEquals(keyWithoutApiTracingConfig, keyWithApiTracingEnabled);
+    assertEquals(keyWithoutApiTracingConfig, keyWithApiTracingDisabled);
+    assertNotEquals(keyWithApiTracingEnabled, keyWithApiTracingDisabled);
+
+    assertEquals(
+        keyWithApiTracingEnabled,
+        SpannerPoolKey.of(
+            ConnectionOptions.newBuilder()
+                .setUri("cloudspanner:/projects/p/instances/i/databases/d?enableEndToEndTracing=true")
+                .setCredentials(NoCredentials.getInstance())
+                .build()));
+    assertEquals(
+        keyWithApiTracingDisabled,
+        SpannerPoolKey.of(
+            ConnectionOptions.newBuilder()
+                .setUri("cloudspanner:/projects/p/instances/i/databases/d?enableEndToEndTracing=false")
+                .setCredentials(NoCredentials.getInstance())
+                .build()));
+    assertEquals(
+        keyWithoutApiTracingConfig,
+        SpannerPoolKey.of(
+            ConnectionOptions.newBuilder()
+                .setUri("cloudspanner:/projects/p/instances/i/databases/d")
+                .setCredentials(NoCredentials.getInstance())
+                .build()));
+  }
+
+  @Test
   public void testOpenTelemetry() {
     SpannerPool pool = createSubjectAndMocks();
     Spanner spanner1;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SpannerPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SpannerPoolTest.java
@@ -574,13 +574,15 @@ public class SpannerPoolTest {
     SpannerPoolKey keyWithApiTracingEnabled =
         SpannerPoolKey.of(
             ConnectionOptions.newBuilder()
-                .setUri("cloudspanner:/projects/p/instances/i/databases/d?enableEndToEndTracing=true")
+                .setUri(
+                    "cloudspanner:/projects/p/instances/i/databases/d?enableEndToEndTracing=true")
                 .setCredentials(NoCredentials.getInstance())
                 .build());
     SpannerPoolKey keyWithApiTracingDisabled =
         SpannerPoolKey.of(
             ConnectionOptions.newBuilder()
-                .setUri("cloudspanner:/projects/p/instances/i/databases/d?enableEndToEndTracing=false")
+                .setUri(
+                    "cloudspanner:/projects/p/instances/i/databases/d?enableEndToEndTracing=false")
                 .setCredentials(NoCredentials.getInstance())
                 .build());
 
@@ -592,14 +594,16 @@ public class SpannerPoolTest {
         keyWithApiTracingEnabled,
         SpannerPoolKey.of(
             ConnectionOptions.newBuilder()
-                .setUri("cloudspanner:/projects/p/instances/i/databases/d?enableEndToEndTracing=true")
+                .setUri(
+                    "cloudspanner:/projects/p/instances/i/databases/d?enableEndToEndTracing=true")
                 .setCredentials(NoCredentials.getInstance())
                 .build()));
     assertEquals(
         keyWithApiTracingDisabled,
         SpannerPoolKey.of(
             ConnectionOptions.newBuilder()
-                .setUri("cloudspanner:/projects/p/instances/i/databases/d?enableEndToEndTracing=false")
+                .setUri(
+                    "cloudspanner:/projects/p/instances/i/databases/d?enableEndToEndTracing=false")
                 .setCredentials(NoCredentials.getInstance())
                 .build()));
     assertEquals(


### PR DESCRIPTION
By default, EndToEndTracing is disabled from backend.

This PR adds enableEndToEndTracing Boolean connection option for implementing opt-in feature for EndToEndTracing.
Example URL: cloudspanner:/projects/test-project-123/instances/test-instance-123/databases/test-database-123?enableEndToEndTracing=true

Note: You can also pass in enableEndToEndTracing=false, but that is the default behaviour (even if you do not pass in this option).