### PR TITLE
fix: shutdown built in metrics meter provider

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInOpenTelemetryMetricsProvider.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInOpenTelemetryMetricsProvider.java
@@ -42,7 +42,6 @@ import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
@@ -68,12 +67,7 @@ final class BuiltInOpenTelemetryMetricsProvider {
             SpannerCloudMonitoringExporter.create(projectId, credentials), sdkMeterProviderBuilder);
         SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
         this.openTelemetry = OpenTelemetrySdk.builder().setMeterProvider(sdkMeterProvider).build();
-        Runtime.getRuntime()
-            .addShutdownHook(
-                new Thread(
-                    () -> {
-                      sdkMeterProvider.shutdown().join(5, TimeUnit.SECONDS);
-                    }));
+        Runtime.getRuntime().addShutdownHook(new Thread(sdkMeterProvider::close));
       }
       return this.openTelemetry;
     } catch (IOException ex) {


### PR DESCRIPTION
This PR calls Meter provider shutdown method when the client is shutdown to clean up the resources and export the remaining metrics data.
