### PR TITLE
chore: add internal option for statement executor type

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
@@ -76,6 +76,7 @@ import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStateme
 import com.google.cloud.spanner.connection.AbstractStatementParser.StatementType;
 import com.google.cloud.spanner.connection.ConnectionProperty.Context;
 import com.google.cloud.spanner.connection.ConnectionState.Type;
+import com.google.cloud.spanner.connection.StatementExecutor.StatementExecutorType;
 import com.google.cloud.spanner.connection.StatementExecutor.StatementTimeout;
 import com.google.cloud.spanner.connection.StatementResult.ResultType;
 import com.google.cloud.spanner.connection.UnitOfWork.CallType;
@@ -302,9 +303,17 @@ class ConnectionImpl implements Connection {
     Preconditions.checkNotNull(options);
     this.leakedException =
         options.isTrackConnectionLeaks() ? new LeakedConnectionException() : null;
+    StatementExecutorType statementExecutorType;
+    if (options.getStatementExecutorType() != null) {
+      statementExecutorType = options.getStatementExecutorType();
+    } else {
+      statementExecutorType =
+          options.isUseVirtualThreads()
+              ? StatementExecutorType.VIRTUAL_THREAD
+              : StatementExecutorType.DIRECT_EXECUTOR;
+    }
     this.statementExecutor =
-        new StatementExecutor(
-            options.isUseVirtualThreads(), options.getStatementExecutionInterceptors());
+        new StatementExecutor(statementExecutorType, options.getStatementExecutionInterceptors());
     this.spannerPool = SpannerPool.INSTANCE;
     this.options = options;
     this.spanner = spannerPool.getSpanner(options, this);
@@ -348,7 +357,11 @@ class ConnectionImpl implements Connection {
     this.leakedException =
         options.isTrackConnectionLeaks() ? new LeakedConnectionException() : null;
     this.statementExecutor =
-        new StatementExecutor(options.isUseVirtualThreads(), Collections.emptyList());
+        new StatementExecutor(
+            options.isUseVirtualThreads()
+                ? StatementExecutorType.VIRTUAL_THREAD
+                : StatementExecutorType.DIRECT_EXECUTOR,
+            Collections.emptyList());
     this.spannerPool = Preconditions.checkNotNull(spannerPool);
     this.options = Preconditions.checkNotNull(options);
     this.spanner = spannerPool.getSpanner(options, this);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
@@ -70,6 +70,7 @@ import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.SpannerOptions;
+import com.google.cloud.spanner.connection.StatementExecutor.StatementExecutorType;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -614,6 +615,7 @@ public class ConnectionOptions {
         new HashMap<>();
     private String uri;
     private Credentials credentials;
+    private StatementExecutorType statementExecutorType;
     private SessionPoolOptions sessionPoolOptions;
     private List<StatementExecutionInterceptor> statementExecutionInterceptors =
         Collections.emptyList();
@@ -777,6 +779,11 @@ public class ConnectionOptions {
       return this;
     }
 
+    Builder setStatementExecutorType(StatementExecutorType statementExecutorType) {
+      this.statementExecutorType = statementExecutorType;
+      return this;
+    }
+
     public Builder setOpenTelemetry(OpenTelemetry openTelemetry) {
       this.openTelemetry = openTelemetry;
       return this;
@@ -814,6 +821,7 @@ public class ConnectionOptions {
   private final String instanceId;
   private final String databaseName;
   private final Credentials credentials;
+  private final StatementExecutorType statementExecutorType;
   private final SessionPoolOptions sessionPoolOptions;
 
   private final OpenTelemetry openTelemetry;
@@ -834,6 +842,7 @@ public class ConnectionOptions {
     ConnectionPropertyValue<Boolean> value = cast(connectionPropertyValues.get(LENIENT.getKey()));
     this.warnings = checkValidProperties(value != null && value.getValue(), uri);
     this.fixedCredentials = builder.credentials;
+    this.statementExecutorType = builder.statementExecutorType;
 
     this.openTelemetry = builder.openTelemetry;
     this.statementExecutionInterceptors =
@@ -1103,6 +1112,10 @@ public class ConnectionOptions {
 
   CredentialsProvider getCredentialsProvider() {
     return getInitialConnectionPropertyValue(CREDENTIALS_PROVIDER);
+  }
+
+  StatementExecutorType getStatementExecutorType() {
+    return this.statementExecutorType;
   }
 
   /** The {@link SessionPoolOptions} of this {@link ConnectionOptions}. */

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractMockServerTest.java
@@ -283,12 +283,18 @@ public abstract class AbstractMockServerTest {
         ConnectionOptions.newBuilder()
             .setUri(getBaseUrl() + additionalUrlOptions)
             .setStatementExecutionInterceptors(interceptors);
+    configureConnectionOptions(builder);
     ConnectionOptions options = builder.build();
     ITConnection connection = createITConnection(options);
     for (TransactionRetryListener listener : transactionRetryListeners) {
       connection.addTransactionRetryListener(listener);
     }
     return connection;
+  }
+
+  protected ConnectionOptions.Builder configureConnectionOptions(
+      ConnectionOptions.Builder builder) {
+    return builder;
   }
 
   protected String getBaseUrl() {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionAsyncApiAbortedTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionAsyncApiAbortedTest.java
@@ -32,7 +32,9 @@ import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
 import com.google.cloud.spanner.Options;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.connection.ConnectionOptions.Builder;
 import com.google.cloud.spanner.connection.ITAbstractSpannerTest.ITConnection;
+import com.google.cloud.spanner.connection.StatementExecutor.StatementExecutorType;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -125,6 +127,11 @@ public class ConnectionAsyncApiAbortedTest extends AbstractMockServerTest {
         super.createConnection(ImmutableList.of(), ImmutableList.of(listener));
     connection.setAutocommit(false);
     return connection;
+  }
+
+  @Override
+  protected Builder configureConnectionOptions(Builder builder) {
+    return builder.setStatementExecutorType(StatementExecutorType.PLATFORM_THREAD);
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionAsyncApiTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionAsyncApiTest.java
@@ -36,7 +36,9 @@ import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerApiFutures;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.connection.ConnectionOptions.Builder;
 import com.google.cloud.spanner.connection.SpannerPool.CheckAndCloseSpannersMode;
+import com.google.cloud.spanner.connection.StatementExecutor.StatementExecutorType;
 import com.google.cloud.spanner.connection.StatementResult.ResultType;
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
@@ -84,6 +86,11 @@ public class ConnectionAsyncApiTest extends AbstractMockServerTest {
     try (Connection connection = createConnection()) {
       connection.getDialect();
     }
+  }
+
+  @Override
+  protected Builder configureConnectionOptions(Builder builder) {
+    return builder.setStatementExecutorType(StatementExecutorType.PLATFORM_THREAD);
   }
 
   @After

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionTest.java
@@ -36,6 +36,8 @@ import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.TimestampBound;
+import com.google.cloud.spanner.connection.ConnectionOptions.Builder;
+import com.google.cloud.spanner.connection.StatementExecutor.StatementExecutorType;
 import com.google.common.collect.ImmutableList;
 import com.google.spanner.v1.BatchCreateSessionsRequest;
 import com.google.spanner.v1.CommitRequest;
@@ -415,6 +417,11 @@ public class ConnectionTest {
 
     protected String getBaseUrl() {
       return super.getBaseUrl() + ";maxSessions=1";
+    }
+
+    @Override
+    protected Builder configureConnectionOptions(Builder builder) {
+      return builder.setStatementExecutorType(StatementExecutorType.PLATFORM_THREAD);
     }
 
     @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementTimeoutTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementTimeoutTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 
 import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.longrunning.OperationTimedPollAlgorithm;
@@ -35,6 +36,7 @@ import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.connection.AbstractConnectionImplTest.ConnectionConsumer;
 import com.google.cloud.spanner.connection.ITAbstractSpannerTest.ITConnection;
+import com.google.cloud.spanner.connection.StatementExecutor.StatementExecutorType;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Collections2;
 import com.google.longrunning.Operation;
@@ -58,9 +60,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
-@RunWith(JUnit4.class)
+@RunWith(Parameterized.class)
 public class StatementTimeoutTest extends AbstractMockServerTest {
 
   private static final String SLOW_SELECT = "SELECT foo FROM bar";
@@ -85,10 +89,18 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
    */
   private static final int TIMEOUT_FOR_SLOW_STATEMENTS = 50;
 
+  @Parameters(name = "statementExecutorType = {0}")
+  public static Object[] parameters() {
+    return StatementExecutorType.values();
+  }
+
+  @Parameter public StatementExecutorType statementExecutorType;
+
   protected ITConnection createConnection() {
     ConnectionOptions options =
         ConnectionOptions.newBuilder()
             .setUri(getBaseUrl() + ";trackSessionLeaks=false")
+            .setStatementExecutorType(statementExecutorType)
             .setConfigurator(
                 optionsConfigurator ->
                     optionsConfigurator
@@ -618,6 +630,10 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
 
   @Test
   public void testCancelReadOnlyAutocommit() {
+    assumeFalse(
+        "Direct executor does not yet support cancelling statements",
+        statementExecutorType == StatementExecutorType.DIRECT_EXECUTOR);
+
     mockSpanner.setExecuteStreamingSqlExecutionTime(
         SimulatedExecutionTime.ofMinimumAndRandomTime(EXECUTION_TIME_SLOW_STATEMENT, 0));
 
@@ -643,6 +659,10 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
 
   @Test
   public void testCancelReadOnlyAutocommitMultipleStatements() {
+    assumeFalse(
+        "Direct executor does not yet support cancelling statements",
+        statementExecutorType == StatementExecutorType.DIRECT_EXECUTOR);
+
     mockSpanner.setExecuteStreamingSqlExecutionTime(
         SimulatedExecutionTime.ofMinimumAndRandomTime(EXECUTION_TIME_SLOW_STATEMENT, 0));
 
@@ -675,6 +695,10 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
 
   @Test
   public void testCancelReadOnlyTransactional() {
+    assumeFalse(
+        "Direct executor does not yet support cancelling statements",
+        statementExecutorType == StatementExecutorType.DIRECT_EXECUTOR);
+
     mockSpanner.setExecuteStreamingSqlExecutionTime(
         SimulatedExecutionTime.ofMinimumAndRandomTime(EXECUTION_TIME_SLOW_STATEMENT, 0));
 
@@ -700,6 +724,10 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
 
   @Test
   public void testCancelReadOnlyTransactionalMultipleStatements() {
+    assumeFalse(
+        "Direct executor does not yet support cancelling statements",
+        statementExecutorType == StatementExecutorType.DIRECT_EXECUTOR);
+
     mockSpanner.setExecuteStreamingSqlExecutionTime(
         SimulatedExecutionTime.ofMinimumAndRandomTime(EXECUTION_TIME_SLOW_STATEMENT, 0));
 
@@ -737,6 +765,10 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
 
   @Test
   public void testCancelReadWriteAutocommit() {
+    assumeFalse(
+        "Direct executor does not yet support cancelling statements",
+        statementExecutorType == StatementExecutorType.DIRECT_EXECUTOR);
+
     mockSpanner.setExecuteStreamingSqlExecutionTime(
         SimulatedExecutionTime.ofMinimumAndRandomTime(EXECUTION_TIME_SLOW_STATEMENT, 0));
 
@@ -761,6 +793,10 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
 
   @Test
   public void testCancelReadWriteAutocommitMultipleStatements() {
+    assumeFalse(
+        "Direct executor does not yet support cancelling statements",
+        statementExecutorType == StatementExecutorType.DIRECT_EXECUTOR);
+
     mockSpanner.setExecuteStreamingSqlExecutionTime(
         SimulatedExecutionTime.ofMinimumAndRandomTime(EXECUTION_TIME_SLOW_STATEMENT, 0));
 
@@ -792,6 +828,10 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
 
   @Test
   public void testCancelReadWriteAutocommitSlowUpdate() {
+    assumeFalse(
+        "Direct executor does not yet support cancelling statements",
+        statementExecutorType == StatementExecutorType.DIRECT_EXECUTOR);
+
     mockSpanner.setExecuteSqlExecutionTime(
         SimulatedExecutionTime.ofMinimumAndRandomTime(EXECUTION_TIME_SLOW_STATEMENT, 0));
 
@@ -815,6 +855,10 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
 
   @Test
   public void testCancelReadWriteAutocommitSlowCommit() {
+    assumeFalse(
+        "Direct executor does not yet support cancelling statements",
+        statementExecutorType == StatementExecutorType.DIRECT_EXECUTOR);
+
     mockSpanner.setCommitExecutionTime(
         SimulatedExecutionTime.ofMinimumAndRandomTime(EXECUTION_TIME_SLOW_STATEMENT, 0));
 
@@ -838,6 +882,10 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
 
   @Test
   public void testCancelReadWriteTransactional() {
+    assumeFalse(
+        "Direct executor does not yet support cancelling statements",
+        statementExecutorType == StatementExecutorType.DIRECT_EXECUTOR);
+
     mockSpanner.setExecuteStreamingSqlExecutionTime(
         SimulatedExecutionTime.ofMinimumAndRandomTime(EXECUTION_TIME_SLOW_STATEMENT, 0));
 
@@ -862,6 +910,10 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
 
   @Test
   public void testCancelReadWriteTransactionalMultipleStatements() {
+    assumeFalse(
+        "Direct executor does not yet support cancelling statements",
+        statementExecutorType == StatementExecutorType.DIRECT_EXECUTOR);
+
     mockSpanner.setExecuteStreamingSqlExecutionTime(
         SimulatedExecutionTime.ofMinimumAndRandomTime(EXECUTION_TIME_SLOW_STATEMENT, 0));
 
@@ -928,6 +980,10 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
 
   @Test
   public void testCancelDdlBatch() {
+    assumeFalse(
+        "Direct executor does not yet support cancelling statements",
+        statementExecutorType == StatementExecutorType.DIRECT_EXECUTOR);
+
     addSlowMockDdlOperation();
 
     try (Connection connection = createConnection()) {
@@ -951,6 +1007,10 @@ public class StatementTimeoutTest extends AbstractMockServerTest {
 
   @Test
   public void testCancelDdlAutocommit() {
+    assumeFalse(
+        "Direct executor does not yet support cancelling statements",
+        statementExecutorType == StatementExecutorType.DIRECT_EXECUTOR);
+
     addSlowMockDdlOperation();
 
     try (Connection connection = createConnection()) {


### PR DESCRIPTION
The Connection API by default uses either a platform thread or a virtual thread for each connection to execute and control the statements of that connection. This is used to enable asynchronous execution of statements and allows a statement to be cancelled by just interrupting this thread. Both these use cases are however not (or only very rarely) used by the most common users of the Connection API; the JDBC driver and PGAdapter. PGAdapter uses the PostgreSQL wire-protocol, which by design is synchronous, and JDBC is also a synchronous API. The latter has a cancel() method that currently requires this threading model, but this can be modified in the JDBC driver.

Using a direct executor instead of a single-threaded executor per connection can save one thread per connection.

The option is intentionally made package-private, so the above-mentioned frameworks can set it by default without it becoming part of the public API.
