### PR TITLE
ci(spanner): Upgrade dependencies which are missing in Airlock

### DIFF
--- a/google-cloud-spanner-bom/pom.xml
+++ b/google-cloud-spanner-bom/pom.xml
@@ -113,6 +113,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>3.6.0</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -133,6 +133,7 @@
         <?m2e ignore?>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.6.0</version>
       </plugin>
 
       <plugin>

--- a/grpc-google-cloud-spanner-admin-database-v1/pom.xml
+++ b/grpc-google-cloud-spanner-admin-database-v1/pom.xml
@@ -83,6 +83,7 @@
         <?m2e ignore?>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.6.0</version>
       </plugin>
     </plugins>
   </build>

--- a/grpc-google-cloud-spanner-admin-instance-v1/pom.xml
+++ b/grpc-google-cloud-spanner-admin-instance-v1/pom.xml
@@ -83,6 +83,7 @@
         <?m2e ignore?>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.6.0</version>
       </plugin>
     </plugins>
   </build>

--- a/grpc-google-cloud-spanner-executor-v1/pom.xml
+++ b/grpc-google-cloud-spanner-executor-v1/pom.xml
@@ -75,6 +75,7 @@
           <?m2e ignore?>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>flatten-maven-plugin</artifactId>
+          <version>1.6.0</version>
         </plugin>
     </plugins>
   </build>

--- a/grpc-google-cloud-spanner-v1/pom.xml
+++ b/grpc-google-cloud-spanner-v1/pom.xml
@@ -75,6 +75,7 @@
         <?m2e ignore?>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.6.0</version>
       </plugin>
     </plugins>
   </build>

--- a/proto-google-cloud-spanner-admin-database-v1/pom.xml
+++ b/proto-google-cloud-spanner-admin-database-v1/pom.xml
@@ -41,6 +41,7 @@
         <?m2e ignore?>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.6.0</version>
       </plugin>
     </plugins>
   </build>

--- a/proto-google-cloud-spanner-admin-instance-v1/pom.xml
+++ b/proto-google-cloud-spanner-admin-instance-v1/pom.xml
@@ -41,6 +41,7 @@
         <?m2e ignore?>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.6.0</version>
       </plugin>
     </plugins>
   </build>

--- a/proto-google-cloud-spanner-executor-v1/pom.xml
+++ b/proto-google-cloud-spanner-executor-v1/pom.xml
@@ -64,6 +64,7 @@
           <?m2e ignore?>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>flatten-maven-plugin</artifactId>
+          <version>1.6.0</version>
         </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/proto-google-cloud-spanner-v1/pom.xml
+++ b/proto-google-cloud-spanner-v1/pom.xml
@@ -37,6 +37,7 @@
         <?m2e ignore?>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.6.0</version>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Updates the version of `maven-checkstyle-plugin` and `flatten-maven-plugin` to versions that are available in Airlock (or that will be available in Airlock?)