### PR TITLE
chore: reset default to platform thread

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
@@ -292,7 +292,7 @@ class ConnectionImpl implements Connection {
       statementExecutorType =
           options.isUseVirtualThreads()
               ? StatementExecutorType.VIRTUAL_THREAD
-              : StatementExecutorType.DIRECT_EXECUTOR;
+              : StatementExecutorType.PLATFORM_THREAD;
     }
     this.statementExecutor =
         new StatementExecutor(statementExecutorType, options.getStatementExecutionInterceptors());
@@ -342,7 +342,7 @@ class ConnectionImpl implements Connection {
         new StatementExecutor(
             options.isUseVirtualThreads()
                 ? StatementExecutorType.VIRTUAL_THREAD
-                : StatementExecutorType.DIRECT_EXECUTOR,
+                : StatementExecutorType.PLATFORM_THREAD,
             Collections.emptyList());
     this.spannerPool = Preconditions.checkNotNull(spannerPool);
     this.options = Preconditions.checkNotNull(options);


### PR DESCRIPTION
Reset the default to using a platform thread for connections. This was the default before adding an option for setting the executor type, and the new default is causing problems with the async Connection API.

Fixes #3541