### PR TITLE
feat: add transaction runner for connections

### DIFF
--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -814,6 +814,12 @@
     <className>com/google/cloud/spanner/connection/TransactionRetryListener</className>
     <method>void retryDmlAsPartitionedDmlFailed(java.util.UUID, com.google.cloud.spanner.Statement, java.lang.Throwable)</method>
   </difference>
-  
+
+  <!-- Added transaction runner. -->
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/connection/Connection</className>
+    <method>java.lang.Object runTransaction(com.google.cloud.spanner.connection.Connection$TransactionCallable)</method>
+  </difference>
   
 </differences>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionManagerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionManagerImpl.java
@@ -99,7 +99,7 @@ final class TransactionManagerImpl implements TransactionManager, SessionTransac
   public TransactionContext resetForRetry() {
     if (txn == null || !txn.isAborted() && txnState != TransactionState.ABORTED) {
       throw new IllegalStateException(
-          "resetForRetry can only be called if the previous attempt" + " aborted");
+          "resetForRetry can only be called if the previous attempt aborted");
     }
     try (IScope s = tracer.withSpan(span)) {
       boolean useInlinedBegin = txn.transactionId != null;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/Connection.java
@@ -835,6 +835,21 @@ public interface Connection extends AutoCloseable {
    */
   ApiFuture<Void> rollbackAsync();
 
+  /** Functional interface for the {@link #runTransaction(TransactionCallable)} method. */
+  interface TransactionCallable<T> {
+    /** This method is invoked with a fresh transaction on the connection. */
+    T run(Connection transaction);
+  }
+
+  /**
+   * Runs the given callable in a transaction. The transaction type is determined by the current
+   * state of the connection. That is; if the connection is in read/write mode, the transaction type
+   * will be a read/write transaction. If the connection is in read-only mode, it will be a
+   * read-only transaction. The transaction will automatically be retried if it is aborted by
+   * Spanner.
+   */
+  <T> T runTransaction(TransactionCallable<T> callable);
+
   /** Returns the current savepoint support for this connection. */
   SavepointSupport getSavepointSupport();
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ReadWriteTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ReadWriteTransaction.java
@@ -1262,6 +1262,11 @@ class ReadWriteTransaction extends AbstractMultiUseTransaction {
   }
 
   @Override
+  public void resetForRetry() {
+    txContextFuture = ApiFutures.immediateFuture(txManager.resetForRetry());
+  }
+
+  @Override
   String getUnitOfWorkName() {
     return "read/write transaction";
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/TransactionRunnerImpl.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.connection;
+
+import static com.google.cloud.spanner.SpannerApiFutures.get;
+
+import com.google.cloud.spanner.AbortedException;
+import com.google.cloud.spanner.SpannerExceptionFactory;
+import com.google.cloud.spanner.connection.Connection.TransactionCallable;
+import com.google.cloud.spanner.connection.ConnectionImpl.Caller;
+import com.google.cloud.spanner.connection.UnitOfWork.CallType;
+
+class TransactionRunnerImpl {
+  private final ConnectionImpl connection;
+
+  TransactionRunnerImpl(ConnectionImpl connection) {
+    this.connection = connection;
+  }
+
+  <T> T run(TransactionCallable<T> callable) {
+    connection.beginTransaction();
+    // Disable internal retries during this transaction.
+    connection.setRetryAbortsInternally(/* retryAbortsInternally = */ false, /* local = */ true);
+    UnitOfWork transaction = connection.getCurrentUnitOfWorkOrStartNewUnitOfWork();
+    while (true) {
+      try {
+        T result = callable.run(connection);
+        get(connection.commitAsync(CallType.SYNC, Caller.TRANSACTION_RUNNER));
+        return result;
+      } catch (AbortedException abortedException) {
+        try {
+          //noinspection BusyWait
+          Thread.sleep(abortedException.getRetryDelayInMillis());
+          connection.resetForRetry(transaction);
+        } catch (InterruptedException interruptedException) {
+          connection.rollbackAsync(CallType.SYNC, Caller.TRANSACTION_RUNNER);
+          throw SpannerExceptionFactory.propagateInterrupt(interruptedException);
+        } catch (Throwable t) {
+          connection.rollbackAsync(CallType.SYNC, Caller.TRANSACTION_RUNNER);
+          throw t;
+        }
+      } catch (Throwable t) {
+        connection.rollbackAsync(CallType.SYNC, Caller.TRANSACTION_RUNNER);
+        throw t;
+      }
+    }
+  }
+}

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/UnitOfWork.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/UnitOfWork.java
@@ -125,6 +125,10 @@ interface UnitOfWork {
   ApiFuture<Void> rollbackAsync(
       @Nonnull CallType callType, @Nonnull EndTransactionCallback callback);
 
+  default void resetForRetry() {
+    throw new UnsupportedOperationException();
+  }
+
   /** @see Connection#savepoint(String) */
   void savepoint(@Nonnull String name, @Nonnull Dialect dialect);
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/RunTransactionMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/RunTransactionMockServerTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.connection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.spanner.ErrorCode;
+import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.SpannerException;
+import com.google.spanner.v1.CommitRequest;
+import com.google.spanner.v1.ExecuteSqlRequest;
+import com.google.spanner.v1.RollbackRequest;
+import io.grpc.Status;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class RunTransactionMockServerTest extends AbstractMockServerTest {
+
+  @Test
+  public void testRunTransaction() {
+    try (Connection connection = createConnection()) {
+      connection.runTransaction(
+          transaction -> {
+            assertEquals(1L, transaction.executeUpdate(INSERT_STATEMENT));
+            assertEquals(1L, transaction.executeUpdate(INSERT_STATEMENT));
+            return null;
+          });
+    }
+    assertEquals(2, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
+  }
+
+  @Test
+  public void testRunTransactionInAutoCommit() {
+    try (Connection connection = createConnection()) {
+      connection.setAutocommit(true);
+
+      connection.runTransaction(
+          transaction -> {
+            assertEquals(1L, transaction.executeUpdate(INSERT_STATEMENT));
+            assertEquals(1L, transaction.executeUpdate(INSERT_STATEMENT));
+            return null;
+          });
+    }
+    assertEquals(2, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
+  }
+
+  @Test
+  public void testRunTransactionInReadOnly() {
+    try (Connection connection = createConnection()) {
+      connection.setReadOnly(true);
+      connection.setAutocommit(false);
+
+      assertEquals(
+          RANDOM_RESULT_SET_ROW_COUNT,
+          connection
+              .runTransaction(
+                  transaction -> {
+                    int rows = 0;
+                    try (ResultSet resultSet = transaction.executeQuery(SELECT_RANDOM_STATEMENT)) {
+                      while (resultSet.next()) {
+                        rows++;
+                      }
+                    }
+                    return rows;
+                  })
+              .intValue());
+    }
+    assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    assertEquals(0, mockSpanner.countRequestsOfType(CommitRequest.class));
+    assertEquals(0, mockSpanner.countRequestsOfType(RollbackRequest.class));
+  }
+
+  @Test
+  public void testRunTransaction_rollbacksAfterException() {
+    try (Connection connection = createConnection()) {
+      SpannerException exception =
+          assertThrows(
+              SpannerException.class,
+              () ->
+                  connection.runTransaction(
+                      transaction -> {
+                        assertEquals(1L, transaction.executeUpdate(INSERT_STATEMENT));
+                        mockSpanner.setExecuteSqlExecutionTime(
+                            SimulatedExecutionTime.ofException(
+                                Status.INVALID_ARGUMENT
+                                    .withDescription("invalid statement")
+                                    .asRuntimeException()));
+                        // This statement will fail.
+                        transaction.executeUpdate(INSERT_STATEMENT);
+                        return null;
+                      }));
+      assertEquals(ErrorCode.INVALID_ARGUMENT, exception.getErrorCode());
+      assertTrue(exception.getMessage(), exception.getMessage().endsWith("invalid statement"));
+    }
+    assertEquals(2, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    assertEquals(0, mockSpanner.countRequestsOfType(CommitRequest.class));
+    assertEquals(1, mockSpanner.countRequestsOfType(RollbackRequest.class));
+  }
+
+  @Test
+  public void testRunTransactionCommitAborted() {
+    final AtomicInteger attempts = new AtomicInteger();
+    try (Connection connection = createConnection()) {
+      connection.runTransaction(
+          transaction -> {
+            assertEquals(1L, transaction.executeUpdate(INSERT_STATEMENT));
+            assertEquals(1L, transaction.executeUpdate(INSERT_STATEMENT));
+            if (attempts.incrementAndGet() == 1) {
+              mockSpanner.abortNextStatement();
+            }
+            return null;
+          });
+    }
+    assertEquals(2, attempts.get());
+    assertEquals(4, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    assertEquals(2, mockSpanner.countRequestsOfType(CommitRequest.class));
+  }
+
+  @Test
+  public void testRunTransactionDmlAborted() {
+    final AtomicInteger attempts = new AtomicInteger();
+    try (Connection connection = createConnection()) {
+      assertTrue(connection.isRetryAbortsInternally());
+      connection.runTransaction(
+          transaction -> {
+            assertFalse(transaction.isRetryAbortsInternally());
+            if (attempts.incrementAndGet() == 1) {
+              mockSpanner.abortNextStatement();
+            }
+            assertEquals(1L, transaction.executeUpdate(INSERT_STATEMENT));
+            assertEquals(1L, transaction.executeUpdate(INSERT_STATEMENT));
+            return null;
+          });
+      assertTrue(connection.isRetryAbortsInternally());
+    }
+    assertEquals(2, attempts.get());
+    assertEquals(3, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
+  }
+
+  @Test
+  public void testRunTransactionQueryAborted() {
+    final AtomicInteger attempts = new AtomicInteger();
+    try (Connection connection = createConnection()) {
+      int rowCount =
+          connection.runTransaction(
+              transaction -> {
+                if (attempts.incrementAndGet() == 1) {
+                  mockSpanner.abortNextStatement();
+                }
+                int rows = 0;
+                try (ResultSet resultSet = transaction.executeQuery(SELECT_RANDOM_STATEMENT)) {
+                  while (resultSet.next()) {
+                    rows++;
+                  }
+                }
+                return rows;
+              });
+      assertEquals(RANDOM_RESULT_SET_ROW_COUNT, rowCount);
+    }
+    assertEquals(2, attempts.get());
+    assertEquals(2, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
+  }
+
+  @Test
+  public void testCommitInRunTransaction() {
+    try (Connection connection = createConnection()) {
+      connection.runTransaction(
+          transaction -> {
+            assertEquals(1L, transaction.executeUpdate(INSERT_STATEMENT));
+            SpannerException exception = assertThrows(SpannerException.class, transaction::commit);
+            assertEquals(ErrorCode.FAILED_PRECONDITION, exception.getErrorCode());
+            assertEquals(
+                "FAILED_PRECONDITION: Cannot call commit when a transaction runner is active",
+                exception.getMessage());
+            return null;
+          });
+    }
+    assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
+  }
+
+  @Test
+  public void testRollbackInRunTransaction() {
+    try (Connection connection = createConnection()) {
+      connection.runTransaction(
+          transaction -> {
+            assertEquals(1L, transaction.executeUpdate(INSERT_STATEMENT));
+            SpannerException exception =
+                assertThrows(SpannerException.class, transaction::rollback);
+            assertEquals(ErrorCode.FAILED_PRECONDITION, exception.getErrorCode());
+            assertEquals(
+                "FAILED_PRECONDITION: Cannot call rollback when a transaction runner is active",
+                exception.getMessage());
+            return null;
+          });
+    }
+    assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
+    assertEquals(0, mockSpanner.countRequestsOfType(RollbackRequest.class));
+  }
+}


### PR DESCRIPTION
Adds a `runTransaction` method to `Connection` to allow applications to execute read/write transactions that are automatically retried in the same way as in the standard client library. This feature will be extended to the JDBC driver, so transaction retries can be defined using a runner there as well.
