### PR TITLE
fix: retry specific internal errors

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerErrorInterceptor.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerErrorInterceptor.java
@@ -72,8 +72,7 @@ public final class SpannerErrorInterceptor implements ClientInterceptor {
               public void onClose(Status status, Metadata trailers) {
                 try {
                   // Translate INTERNAL errors that should be retried to a retryable error code.
-                  if (status.getCode() == Code.INTERNAL
-                      && IsRetryableInternalError.INSTANCE.isRetryableInternalError(status)) {
+                  if (IsRetryableInternalError.INSTANCE.isRetryableInternalError(status)) {
                     status =
                         Status.fromCode(Code.UNAVAILABLE).withDescription(status.getDescription());
                   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerErrorInterceptor.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerErrorInterceptor.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spanner.spi.v1;
 
+import com.google.cloud.spanner.IsRetryableInternalError;
 import com.google.rpc.BadRequest;
 import com.google.rpc.Help;
 import com.google.rpc.LocalizedMessage;
@@ -32,6 +33,7 @@ import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
+import io.grpc.Status.Code;
 import io.grpc.protobuf.ProtoUtils;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -69,6 +71,12 @@ public final class SpannerErrorInterceptor implements ClientInterceptor {
               @Override
               public void onClose(Status status, Metadata trailers) {
                 try {
+                  // Translate INTERNAL errors that should be retried to a retryable error code.
+                  if (status.getCode() == Code.INTERNAL
+                      && IsRetryableInternalError.INSTANCE.isRetryableInternalError(status)) {
+                    status =
+                        Status.fromCode(Code.UNAVAILABLE).withDescription(status.getDescription());
+                  }
                   if (trailers.containsKey(LOCALIZED_MESSAGE_KEY)) {
                     status =
                         Status.fromCodeValue(status.getCode().value())

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IsRetryableInternalErrorTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IsRetryableInternalErrorTest.java
@@ -128,6 +128,17 @@ public class IsRetryableInternalErrorTest {
   }
 
   @Test
+  public void testAuthenticationBackendInternalServerErrorIsRetryable() {
+    final StatusRuntimeException exception =
+        new StatusRuntimeException(
+            Status.fromCode(Code.INTERNAL)
+                .withDescription(
+                    "INTERNAL: Authentication backend internal server error. Please retry."));
+
+    assertTrue(predicate.apply(exception));
+  }
+
+  @Test
   public void genericInternalExceptionIsNotRetryable() {
     final InternalException e =
         new InternalException("INTERNAL: Generic.", null, GrpcStatusCode.of(Code.INTERNAL), false);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RetryableInternalErrorTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RetryableInternalErrorTest.java
@@ -30,6 +30,7 @@ import io.grpc.Status;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
 public class RetryableInternalErrorTest extends AbstractMockServerTest {
@@ -42,7 +43,11 @@ public class RetryableInternalErrorTest extends AbstractMockServerTest {
             .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
             .setCredentials(NoCredentials.getInstance())
             .setSessionPoolOption(
-                SessionPoolOptions.newBuilder().setMinSessions(1).setMaxSessions(1).build())
+                SessionPoolOptions.newBuilder()
+                    .setMinSessions(1)
+                    .setMaxSessions(1)
+                    .setWaitForMinSessions(Duration.ofSeconds(1))
+                    .build())
             .build()
             .getService()) {
       DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RetryableInternalErrorTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RetryableInternalErrorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.NoCredentials;
+import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
+import com.google.cloud.spanner.connection.AbstractMockServerTest;
+import com.google.spanner.v1.BatchCreateSessionsRequest;
+import com.google.spanner.v1.ExecuteSqlRequest;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Status;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class RetryableInternalErrorTest extends AbstractMockServerTest {
+  @Test
+  public void testTranslateInternalException() {
+    try (Spanner spanner =
+        SpannerOptions.newBuilder()
+            .setProjectId("my-project")
+            .setHost(String.format("http://localhost:%d", getPort()))
+            .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
+            .setCredentials(NoCredentials.getInstance())
+            .setSessionPoolOption(
+                SessionPoolOptions.newBuilder().setMinSessions(1).setMaxSessions(1).build())
+            .build()
+            .getService()) {
+      DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+      mockSpanner.setBatchCreateSessionsExecutionTime(
+          SimulatedExecutionTime.ofException(
+              Status.INTERNAL
+                  .withDescription("Authentication backend internal server error. Please retry.")
+                  .asRuntimeException()));
+      mockSpanner.setExecuteStreamingSqlExecutionTime(
+          SimulatedExecutionTime.ofException(
+              Status.INTERNAL
+                  .withDescription("Authentication backend internal server error. Please retry.")
+                  .asRuntimeException()));
+      mockSpanner.setExecuteSqlExecutionTime(
+          SimulatedExecutionTime.ofException(
+              Status.INTERNAL
+                  .withDescription("Authentication backend internal server error. Please retry.")
+                  .asRuntimeException()));
+
+      try (ResultSet resultSet = client.singleUse().executeQuery(SELECT1_STATEMENT)) {
+        assertTrue(resultSet.next());
+        assertFalse(resultSet.next());
+      }
+      assertEquals(
+          Long.valueOf(1L),
+          client
+              .readWriteTransaction()
+              .run(transaction -> transaction.executeUpdate(INSERT_STATEMENT)));
+
+      // Verify that all the RPCs were retried.
+      assertEquals(2, mockSpanner.countRequestsOfType(BatchCreateSessionsRequest.class));
+      assertEquals(4, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    }
+  }
+}


### PR DESCRIPTION
Some specific internal errors should be retrid. Instead of adding INTERNAL
as a standard retryable error code, we use an interceptor to catch and
translate those specific errors.

See also b/375684610