### PR TITLE
chore: disable native metrics when there are no credentials

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -1792,7 +1792,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     return callCredentialsProvider;
   }
 
-  public boolean usesNoCredentials() {
+  private boolean usesNoCredentials() {
     return Objects.equals(getCredentials(), NoCredentials.getInstance());
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -83,6 +83,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -1791,6 +1792,10 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     return callCredentialsProvider;
   }
 
+  public boolean usesNoCredentials() {
+    return Objects.equals(getCredentials(), NoCredentials.getInstance());
+  }
+
   public String getCompressorName() {
     return compressorName;
   }
@@ -1838,7 +1843,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
 
     // Add Metrics Tracer factory if built in metrics are enabled and if the client is data client
     // and if emulator is not enabled.
-    if (isEnableBuiltInMetrics() && !isAdminClient && !isEmulatorEnabled) {
+    if (isEnableBuiltInMetrics() && !isAdminClient && !isEmulatorEnabled && !usesNoCredentials()) {
       ApiTracerFactory metricsTracerFactory = createMetricsApiTracerFactory();
       if (metricsTracerFactory != null) {
         apiTracerFactories.add(metricsTracerFactory);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
@@ -738,7 +738,7 @@ public class SpannerOptionsTest {
 
   @Test
   public void testEndToEndTracingEnablement() {
-    // Test that end to end tracing is disabled by default.
+    // Test that end-to-end tracing is disabled by default.
     assertFalse(SpannerOptions.newBuilder().setProjectId("p").build().isEndToEndTracingEnabled());
     assertTrue(
         SpannerOptions.newBuilder()
@@ -755,7 +755,7 @@ public class SpannerOptionsTest {
   }
 
   @Test
-  public void testmonitoringHost() {
+  public void testMonitoringHost() {
     String metricsEndpoint = "test-endpoint:443";
     assertNull(SpannerOptions.newBuilder().setProjectId("p").build().getMonitoringHost());
     assertThat(


### PR DESCRIPTION
Native metrics were automatically disabled when the emulator is used, but some clients (e.g. PGAdapter) set up the connection to the emulator manually instead of setting the environment variable. Also, when using in-mem mock servers, native metrics should be disabled, as they cannot be exported.

This PR therefore adds an additional check that disables native metrics when the client uses a NoCredentials instance.
