### PR TITLE
fix: update max_in_use_session at 10 mins interval

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -2048,7 +2048,7 @@ class SessionPool {
 
     // Does various pool maintenance activities.
     void maintainPool() {
-      Instant currTime = clock.instant();
+      Instant currTime;
       synchronized (lock) {
         if (SessionPool.this.isClosed()) {
           return;
@@ -2061,6 +2061,7 @@ class SessionPool {
         }
         this.prevNumSessionsAcquired = SessionPool.this.numSessionsAcquired;
 
+        currTime = clock.instant();
         // Reset the start time for recording the maximum number of sessions in the pool
         if (currTime.isAfter(SessionPool.this.lastResetTime.plus(Duration.ofMinutes(10)))) {
           SessionPool.this.maxSessionsInUse = SessionPool.this.numSessionsInUse;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -2048,6 +2048,7 @@ class SessionPool {
 
     // Does various pool maintenance activities.
     void maintainPool() {
+      Instant currTime = clock.instant();
       synchronized (lock) {
         if (SessionPool.this.isClosed()) {
           return;
@@ -2059,8 +2060,14 @@ class SessionPool {
                   / (loopFrequency / 1000L);
         }
         this.prevNumSessionsAcquired = SessionPool.this.numSessionsAcquired;
+
+        // Reset the start time for recording the maximum number of sessions in the pool
+        if (currTime.isAfter(SessionPool.this.lastResetTime.plus(Duration.ofMinutes(10)))) {
+          SessionPool.this.maxSessionsInUse = SessionPool.this.numSessionsInUse;
+          SessionPool.this.lastResetTime = currTime;
+        }
       }
-      Instant currTime = clock.instant();
+
       removeIdleSessions(currTime);
       // Now go over all the remaining sessions and see if they need to be kept alive explicitly.
       keepAliveSessions(currTime);
@@ -2308,6 +2315,9 @@ class SessionPool {
 
   @GuardedBy("lock")
   private int maxSessionsInUse = 0;
+
+  @GuardedBy("lock")
+  private Instant lastResetTime = Clock.INSTANCE.instant();
 
   @GuardedBy("lock")
   private long numSessionsAcquired = 0;


### PR DESCRIPTION
This PR fixes the max_in_use_session value. Currently this value is only reset at client initialization. 