### PR TITLE
chore: Replace channel provider for fixed channel provider.

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -41,6 +41,7 @@ import com.google.api.gax.rpc.ApiClientHeaderProvider;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.FixedHeaderProvider;
+import com.google.api.gax.rpc.FixedTransportChannelProvider;
 import com.google.api.gax.rpc.HeaderProvider;
 import com.google.api.gax.rpc.InstantiatingWatchdogProvider;
 import com.google.api.gax.rpc.OperationCallable;
@@ -402,11 +403,14 @@ public class GapicSpannerRpc implements SpannerRpc {
       final String emulatorHost = System.getenv("SPANNER_EMULATOR_HOST");
 
       try {
+        FixedTransportChannelProvider fixedChannelProvider =
+            FixedTransportChannelProvider.create(channelProvider.getTransportChannel());
+
         SpannerStubSettings spannerStubSettings =
             options
                 .getSpannerStubSettings()
                 .toBuilder()
-                .setTransportChannelProvider(channelProvider)
+                .setTransportChannelProvider(fixedChannelProvider)
                 .setCredentialsProvider(credentialsProvider)
                 .setStreamWatchdogProvider(watchdogProvider)
                 .setTracerFactory(
@@ -446,7 +450,7 @@ public class GapicSpannerRpc implements SpannerRpc {
                 .build();
         SpannerStubSettings.Builder pdmlSettings = options.getSpannerStubSettings().toBuilder();
         pdmlSettings
-            .setTransportChannelProvider(channelProvider)
+            .setTransportChannelProvider(fixedChannelProvider)
             .setCredentialsProvider(credentialsProvider)
             .setStreamWatchdogProvider(watchdogProvider)
             .setTracerFactory(
@@ -476,7 +480,7 @@ public class GapicSpannerRpc implements SpannerRpc {
             options
                 .getInstanceAdminStubSettings()
                 .toBuilder()
-                .setTransportChannelProvider(channelProvider)
+                .setTransportChannelProvider(fixedChannelProvider)
                 .setCredentialsProvider(credentialsProvider)
                 .setStreamWatchdogProvider(watchdogProvider)
                 .setTracerFactory(
@@ -489,7 +493,7 @@ public class GapicSpannerRpc implements SpannerRpc {
             options
                 .getDatabaseAdminStubSettings()
                 .toBuilder()
-                .setTransportChannelProvider(channelProvider)
+                .setTransportChannelProvider(fixedChannelProvider)
                 .setCredentialsProvider(credentialsProvider)
                 .setStreamWatchdogProvider(watchdogProvider)
                 .setTracerFactory(
@@ -538,7 +542,7 @@ public class GapicSpannerRpc implements SpannerRpc {
 
         // Check whether the SPANNER_EMULATOR_HOST env var has been set, and if so, if the emulator
         // is actually running.
-        checkEmulatorConnection(options, channelProvider, credentialsProvider, emulatorHost);
+        checkEmulatorConnection(options, fixedChannelProvider, credentialsProvider, emulatorHost);
       } catch (Exception e) {
         throw newSpannerException(e);
       }


### PR DESCRIPTION
Currently, when creating a stub, the channel provider creates a new channel pool every time, thus we end up with four channel pools to the same target instead of one.

In this PR we create a single channel pool using the existing channel provider and then wrap it into FixedTransportChannelProvider so that any stub using the fixed channel provider uses the created pool instead of creating a new one.

@surbhigarg92 do I also need to change anything in the metrics according to this change?