### PR TITLE
fix: always add instance-id for built-in metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>libraries-bom</artifactId>
-      <version>26.50.0</version>
+      <version>26.53.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
@@ -18,8 +18,12 @@ package com.google.cloud.spanner;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.google.api.gax.longrunning.OperationTimedPollAlgorithm;
 import com.google.api.gax.retrying.RetrySettings;
@@ -33,22 +37,20 @@ import com.google.cloud.spanner.connection.RandomResultSetGenerator;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
+import io.grpc.ManagedChannelBuilder;
 import io.grpc.Status;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
-import io.opentelemetry.sdk.metrics.data.HistogramPointData;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import java.time.Duration;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.junit.After;
@@ -173,20 +175,24 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractMockServerTes
 
     MetricData operationLatencyMetricData =
         getMetricData(metricReader, BuiltInMetricsConstant.OPERATION_LATENCIES_NAME);
+    assertNotNull(operationLatencyMetricData);
     long operationLatencyValue = getAggregatedValue(operationLatencyMetricData, expectedAttributes);
     assertThat(operationLatencyValue).isIn(Range.closed(MIN_LATENCY, elapsed));
 
     MetricData attemptLatencyMetricData =
         getMetricData(metricReader, BuiltInMetricsConstant.ATTEMPT_LATENCIES_NAME);
+    assertNotNull(attemptLatencyMetricData);
     long attemptLatencyValue = getAggregatedValue(attemptLatencyMetricData, expectedAttributes);
     assertThat(attemptLatencyValue).isIn(Range.closed(MIN_LATENCY, elapsed));
 
     MetricData operationCountMetricData =
         getMetricData(metricReader, BuiltInMetricsConstant.OPERATION_COUNT_NAME);
+    assertNotNull(operationCountMetricData);
     assertThat(getAggregatedValue(operationCountMetricData, expectedAttributes)).isEqualTo(1);
 
     MetricData attemptCountMetricData =
         getMetricData(metricReader, BuiltInMetricsConstant.ATTEMPT_COUNT_NAME);
+    assertNotNull(attemptCountMetricData);
     assertThat(getAggregatedValue(attemptCountMetricData, expectedAttributes)).isEqualTo(1);
   }
 
@@ -219,6 +225,7 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractMockServerTes
 
     MetricData attemptCountMetricData =
         getMetricData(metricReader, BuiltInMetricsConstant.ATTEMPT_COUNT_NAME);
+    assertNotNull(attemptCountMetricData);
     assertThat(getAggregatedValue(attemptCountMetricData, expectedAttributesBeginTransactionOK))
         .isEqualTo(1);
     // Attempt count should have a failed metric point for Begin Transaction.
@@ -227,6 +234,7 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractMockServerTes
 
     MetricData operationCountMetricData =
         getMetricData(metricReader, BuiltInMetricsConstant.OPERATION_COUNT_NAME);
+    assertNotNull(operationCountMetricData);
     assertThat(getAggregatedValue(operationCountMetricData, expectedAttributesBeginTransactionOK))
         .isEqualTo(1);
     // Operation count should not have a failed metric point for Begin Transaction as overall
@@ -236,9 +244,101 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractMockServerTes
         .isEqualTo(0);
   }
 
+  @Test
+  public void testNoNetworkConnection() {
+    // Create a Spanner instance that tries to connect to a server that does not exist.
+    // This simulates a bad network connection.
+    SpannerOptions.Builder builder = SpannerOptions.newBuilder();
+
+    // Set up the client to fail fast.
+    builder
+        .getSpannerStubSettingsBuilder()
+        .applyToAllUnaryMethods(
+            input -> {
+              // This tells the Spanner client to fail directly if it gets an UNAVAILABLE exception.
+              // The 10-second deadline is chosen to ensure that:
+              // 1. The test fails within a reasonable amount of time if retries for whatever reason
+              // has
+              //    been re-enabled.
+              // 2. The timeout is long enough to never be triggered during normal tests.
+              input.setSimpleTimeoutNoRetriesDuration(Duration.ofSeconds(10L));
+              return null;
+            });
+
+    ApiTracerFactory metricsTracerFactory =
+        new MetricsTracerFactory(
+            new OpenTelemetryMetricsRecorder(openTelemetry, BuiltInMetricsConstant.METER_NAME),
+            attributes);
+    Spanner spanner =
+        builder
+            .setProjectId("test-project")
+            .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
+            .setHost("http://localhost:0")
+            .setCredentials(NoCredentials.getInstance())
+            .setSessionPoolOption(
+                SessionPoolOptions.newBuilder()
+                    .setMinSessions(0)
+                    .setUseMultiplexedSession(true)
+                    .setUseMultiplexedSessionForRW(true)
+                    .setSkipVerifyingBeginTransactionForMuxRW(true)
+                    .setFailOnSessionLeak()
+                    .build())
+            // Setting this to false so that Spanner Options does not register Metrics Tracer
+            // factory again.
+            .setBuiltInMetricsEnabled(false)
+            .setApiTracerFactory(metricsTracerFactory)
+            .build()
+            .getService();
+    String instance = "test-instance";
+    DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("test-project", instance, "d"));
+
+    // Using this client will return UNAVAILABLE, as the server is not reachable and we have
+    // disabled retries.
+    SpannerException exception =
+        assertThrows(
+            SpannerException.class, () -> client.singleUse().executeQuery(SELECT_RANDOM).next());
+    assertEquals(ErrorCode.UNAVAILABLE, exception.getErrorCode());
+
+    Attributes expectedAttributesCreateSessionOK =
+        expectedBaseAttributes
+            .toBuilder()
+            .put(BuiltInMetricsConstant.STATUS_KEY, "OK")
+            .put(BuiltInMetricsConstant.METHOD_KEY, "Spanner.CreateSession")
+            // Include the additional attributes that are added by the HeaderInterceptor in the
+            // filter. Note that the DIRECT_PATH_USED attribute is not added, as the request never
+            // leaves the client.
+            .put(BuiltInMetricsConstant.INSTANCE_ID_KEY, instance)
+            .put(BuiltInMetricsConstant.DATABASE_KEY, "d")
+            .put(BuiltInMetricsConstant.DIRECT_PATH_ENABLED_KEY, "false")
+            .build();
+
+    Attributes expectedAttributesCreateSessionFailed =
+        expectedBaseAttributes
+            .toBuilder()
+            .put(BuiltInMetricsConstant.STATUS_KEY, "UNAVAILABLE")
+            .put(BuiltInMetricsConstant.METHOD_KEY, "Spanner.CreateSession")
+            // Include the additional attributes that are added by the HeaderInterceptor in the
+            // filter. Note that the DIRECT_PATH_USED attribute is not added, as the request never
+            // leaves the client.
+            .put(BuiltInMetricsConstant.INSTANCE_ID_KEY, instance)
+            .put(BuiltInMetricsConstant.DATABASE_KEY, "d")
+            .put(BuiltInMetricsConstant.DIRECT_PATH_ENABLED_KEY, "false")
+            .build();
+
+    MetricData attemptCountMetricData =
+        getMetricData(metricReader, BuiltInMetricsConstant.ATTEMPT_COUNT_NAME);
+    assertNotNull(attemptCountMetricData);
+
+    // Attempt count should have a failed metric point for CreateSession.
+    assertEquals(
+        1, getAggregatedValue(attemptCountMetricData, expectedAttributesCreateSessionFailed));
+    // There should be no OK metric points for CreateSession.
+    assertEquals(0, getAggregatedValue(attemptCountMetricData, expectedAttributesCreateSessionOK));
+  }
+
   private MetricData getMetricData(InMemoryMetricReader reader, String metricName) {
     String fullMetricName = BuiltInMetricsConstant.METER_NAME + "/" + metricName;
-    Collection<MetricData> allMetricData = Collections.emptyList();
+    Collection<MetricData> allMetricData;
 
     // Fetch the MetricData with retries
     for (int attemptsLeft = 1000; attemptsLeft > 0; attemptsLeft--) {
@@ -265,28 +365,24 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractMockServerTes
       }
     }
 
-    assertTrue(String.format("MetricData is missing for metric {0}", fullMetricName), false);
+    fail(String.format("MetricData is missing for metric %s", fullMetricName));
     return null;
   }
 
   private long getAggregatedValue(MetricData metricData, Attributes attributes) {
     switch (metricData.getType()) {
       case HISTOGRAM:
-        Optional<HistogramPointData> hd =
-            metricData.getHistogramData().getPoints().stream()
-                .filter(pd -> pd.getAttributes().equals(attributes))
-                .collect(Collectors.toList())
-                .stream()
-                .findFirst();
-        return hd.isPresent() ? (long) hd.get().getSum() / hd.get().getCount() : 0;
+        return metricData.getHistogramData().getPoints().stream()
+            .filter(pd -> pd.getAttributes().equals(attributes))
+            .map(data -> (long) data.getSum() / data.getCount())
+            .findFirst()
+            .orElse(0L);
       case LONG_SUM:
-        Optional<LongPointData> ld =
-            metricData.getLongSumData().getPoints().stream()
-                .filter(pd -> pd.getAttributes().equals(attributes))
-                .collect(Collectors.toList())
-                .stream()
-                .findFirst();
-        return ld.isPresent() ? ld.get().getValue() : 0;
+        return metricData.getLongSumData().getPoints().stream()
+            .filter(pd -> pd.getAttributes().equals(attributes))
+            .map(LongPointData::getValue)
+            .findFirst()
+            .orElse(0L);
       default:
         return 0;
     }


### PR DESCRIPTION
The instance-id was only added for built-in metrics when the headers of the request was sent. This meant that any request that would NOT get sent would not include an instance-id, which again would cause the export of ALL built-in metrics to stop. This would happen because the metric without an instance-id would remain in the collected metrics.

A request would get into this state if the client ran into a network issue that would prevent the client from making a network connection to Spanner.

Fixes #3611