### PR TITLE
fix(spanner): release resources in TransactionManager

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionManagerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionManagerImpl.java
@@ -81,8 +81,8 @@ final class TransactionManagerImpl implements TransactionManager, SessionTransac
       txnState = TransactionState.COMMIT_FAILED;
       throw e2;
     } finally {
-      // At this point, if the TransactionState is not ABORTED, then the transaction has reached a
-      // terminal state.
+      // At this point, if the TransactionState is not ABORTED, then the transaction has reached an
+      // end state.
       // We can safely call close() to release resources.
       if (getState() != TransactionState.ABORTED) {
         close();
@@ -99,7 +99,7 @@ final class TransactionManagerImpl implements TransactionManager, SessionTransac
       txn.rollback();
     } finally {
       txnState = TransactionState.ROLLED_BACK;
-      // At this point, the TransactionState is ROLLED_BACK which is a terminal state.
+      // At this point, the TransactionState is ROLLED_BACK which is an end state.
       // We can safely call close() to release resources.
       close();
     }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionManagerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionManagerImpl.java
@@ -81,7 +81,8 @@ final class TransactionManagerImpl implements TransactionManager, SessionTransac
       txnState = TransactionState.COMMIT_FAILED;
       throw e2;
     } finally {
-      // At this point, if the TransactionState is not ABORTED, then the transaction has reached a terminal state.
+      // At this point, if the TransactionState is not ABORTED, then the transaction has reached a
+      // terminal state.
       // We can safely call close() to release resources.
       if (getState() != TransactionState.ABORTED) {
         close();

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionManagerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionManagerImpl.java
@@ -80,6 +80,12 @@ final class TransactionManagerImpl implements TransactionManager, SessionTransac
     } catch (SpannerException e2) {
       txnState = TransactionState.COMMIT_FAILED;
       throw e2;
+    } finally {
+      // At this point, if the TransactionState is not ABORTED, then the transaction has reached a terminal state.
+      // We can safely call close() to release resources.
+      if (getState() != TransactionState.ABORTED) {
+        close();
+      }
     }
   }
 
@@ -92,6 +98,9 @@ final class TransactionManagerImpl implements TransactionManager, SessionTransac
       txn.rollback();
     } finally {
       txnState = TransactionState.ROLLED_BACK;
+      // At this point, the TransactionState is ROLLED_BACK which is a terminal state.
+      // We can safely call close() to release resources.
+      close();
     }
   }
 


### PR DESCRIPTION
The `close()` method in `TransactionManager` was only being called when used within a `try-with-resources` block, as `TransactionManager` implements `AutoCloseable`.  

However, in cases where `try-with-resources` was not used or `.close()` was not explicitly called, `close()` was never invoked, leading to resource leaks—such as spans not being closed properly. This is particularly an issue in JDBC, where `try-with-resources` cannot be used.  

This PR ensures that `close()` is implicitly invoked whenever the transaction reaches an end state, preventing resource leaks.  