### PR TITLE
feat: add option to indicate that a statement is the last in a transaction

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -698,8 +698,8 @@ abstract class AbstractReadContext
     if (!isReadOnly()) {
       builder.setSeqno(getSeqNo());
     }
-    if (options.hasLastStatementSet()) {
-      builder.setLastStatement(options.lastStatementSet());
+    if (options.hasLastStatement()) {
+      builder.setLastStatement(options.isLastStatement());
     }
     builder.setQueryOptions(buildQueryOptions(statement.getQueryOptions()));
     builder.setRequestOptions(buildRequestOptions(options));
@@ -746,8 +746,8 @@ abstract class AbstractReadContext
     if (selector != null) {
       builder.setTransaction(selector);
     }
-    if (options.hasLastStatementSet()) {
-      builder.setLastStatements(options.lastStatementSet());
+    if (options.hasLastStatement()) {
+      builder.setLastStatements(options.isLastStatement());
     }
     builder.setSeqno(getSeqNo());
     builder.setRequestOptions(buildRequestOptions(options));

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -698,6 +698,9 @@ abstract class AbstractReadContext
     if (!isReadOnly()) {
       builder.setSeqno(getSeqNo());
     }
+    if (options.hasLastStatementSet()) {
+      builder.setLastStatement(options.lastStatementSet());
+    }
     builder.setQueryOptions(buildQueryOptions(statement.getQueryOptions()));
     builder.setRequestOptions(buildRequestOptions(options));
     return builder;
@@ -742,6 +745,9 @@ abstract class AbstractReadContext
     TransactionSelector selector = getTransactionSelector();
     if (selector != null) {
       builder.setTransaction(selector);
+    }
+    if (options.hasLastStatementSet()) {
+      builder.setLastStatements(options.lastStatementSet());
     }
     builder.setSeqno(getSeqNo());
     builder.setRequestOptions(buildRequestOptions(options));

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
@@ -108,6 +108,9 @@ public final class Options implements Serializable {
   /** Marker interface to mark options applicable to Update and Write operations */
   public interface UpdateTransactionOption extends UpdateOption, TransactionOption {}
 
+  /** Marker interface for options that can be used with both executeQuery and executeUpdate. */
+  public interface QueryUpdateOption extends QueryOption, UpdateOption {}
+
   /**
    * Marker interface to mark options applicable to Create, Update and Delete operations in admin
    * API.
@@ -246,8 +249,8 @@ public final class Options implements Serializable {
    * commit time (e.g. validation of unique constraints). Given this, successful execution of a DML
    * statement should not be assumed until the transaction commits.
    */
-  public static LastStatementUpdateOption lastStatementSet(Boolean lastStatementSet) {
-    return new LastStatementUpdateOption(lastStatementSet);
+  public static QueryUpdateOption lastStatement() {
+    return new LastStatementUpdateOption();
   }
 
   /**
@@ -508,8 +511,7 @@ public final class Options implements Serializable {
   private DecodeMode decodeMode;
   private RpcOrderBy orderBy;
   private RpcLockHint lockHint;
-
-  private Boolean lastStatementSet;
+  private Boolean lastStatement;
 
   // Construction is via factory methods below.
   private Options() {}
@@ -646,12 +648,12 @@ public final class Options implements Serializable {
     return orderBy == null ? null : orderBy.proto;
   }
 
-  boolean hasLastStatementSet() {
-    return lastStatementSet != null;
+  boolean hasLastStatement() {
+    return lastStatement != null;
   }
 
-  Boolean lastStatementSet() {
-    return lastStatementSet;
+  Boolean isLastStatement() {
+    return lastStatement;
   }
 
   boolean hasLockHint() {
@@ -718,8 +720,8 @@ public final class Options implements Serializable {
     if (orderBy != null) {
       b.append("orderBy: ").append(orderBy).append(' ');
     }
-    if (lastStatementSet != null) {
-      b.append("lastStatementSet: ").append(lastStatementSet).append(' ');
+    if (lastStatement != null) {
+      b.append("lastStatement: ").append(lastStatement).append(' ');
     }
     if (lockHint != null) {
       b.append("lockHint: ").append(lockHint).append(' ');
@@ -764,7 +766,7 @@ public final class Options implements Serializable {
         && Objects.equals(dataBoostEnabled(), that.dataBoostEnabled())
         && Objects.equals(directedReadOptions(), that.directedReadOptions())
         && Objects.equals(orderBy(), that.orderBy())
-        && Objects.equals(lastStatementSet(), that.lastStatementSet());
+        && Objects.equals(isLastStatement(), that.isLastStatement())
         && Objects.equals(lockHint(), that.lockHint());
   }
 
@@ -825,8 +827,8 @@ public final class Options implements Serializable {
     if (orderBy != null) {
       result = 31 * result + orderBy.hashCode();
     }
-    if (lastStatementSet != null) {
-      result = 31 * result + lastStatementSet.hashCode();
+    if (lastStatement != null) {
+      result = 31 * result + lastStatement.hashCode();
     }
     if (lockHint != null) {
       result = 31 * result + lockHint.hashCode();
@@ -997,17 +999,18 @@ public final class Options implements Serializable {
     }
   }
 
-  static final class LastStatementUpdateOption extends InternalOption implements UpdateOption {
+  static final class LastStatementUpdateOption extends InternalOption implements QueryUpdateOption {
 
-    private final Boolean lastStatementSet;
-
-    LastStatementUpdateOption(Boolean lastStatementSet) {
-      this.lastStatementSet = lastStatementSet;
-    }
+    LastStatementUpdateOption() {}
 
     @Override
     void appendToOptions(Options options) {
-      options.lastStatementSet = lastStatementSet;
+      options.lastStatement = true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return o instanceof LastStatementUpdateOption;
     }
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
@@ -237,6 +237,20 @@ public final class Options implements Serializable {
   }
 
   /**
+   * If set to true, this option marks the end of the transaction. The transaction should be
+   * committed or aborted after this statement executes, and attempts to execute any other requests
+   * against this transaction (including reads and queries) will be rejected. Mixing mutations with
+   * statements that are marked as the last statement is not allowed.
+   *
+   * <p>For DML statements, setting this option may cause some error reporting to be deferred until
+   * commit time (e.g. validation of unique constraints). Given this, successful execution of a DML
+   * statement should not be assumed until the transaction commits.
+   */
+  public static LastStatementUpdateOption lastStatementSet(Boolean lastStatementSet) {
+    return new LastStatementUpdateOption(lastStatementSet);
+  }
+
+  /**
    * Specifying this will cause the list operation to start fetching the record from this onwards.
    */
   public static ListOption pageToken(String pageToken) {
@@ -495,6 +509,8 @@ public final class Options implements Serializable {
   private RpcOrderBy orderBy;
   private RpcLockHint lockHint;
 
+  private Boolean lastStatementSet;
+
   // Construction is via factory methods below.
   private Options() {}
 
@@ -630,6 +646,14 @@ public final class Options implements Serializable {
     return orderBy == null ? null : orderBy.proto;
   }
 
+  boolean hasLastStatementSet() {
+    return lastStatementSet != null;
+  }
+
+  Boolean lastStatementSet() {
+    return lastStatementSet;
+  }
+
   boolean hasLockHint() {
     return lockHint != null;
   }
@@ -694,6 +718,9 @@ public final class Options implements Serializable {
     if (orderBy != null) {
       b.append("orderBy: ").append(orderBy).append(' ');
     }
+    if (lastStatementSet != null) {
+      b.append("lastStatementSet: ").append(lastStatementSet).append(' ');
+    }
     if (lockHint != null) {
       b.append("lockHint: ").append(lockHint).append(' ');
     }
@@ -737,6 +764,7 @@ public final class Options implements Serializable {
         && Objects.equals(dataBoostEnabled(), that.dataBoostEnabled())
         && Objects.equals(directedReadOptions(), that.directedReadOptions())
         && Objects.equals(orderBy(), that.orderBy())
+        && Objects.equals(lastStatementSet(), that.lastStatementSet());
         && Objects.equals(lockHint(), that.lockHint());
   }
 
@@ -796,6 +824,9 @@ public final class Options implements Serializable {
     }
     if (orderBy != null) {
       result = 31 * result + orderBy.hashCode();
+    }
+    if (lastStatementSet != null) {
+      result = 31 * result + lastStatementSet.hashCode();
     }
     if (lockHint != null) {
       result = 31 * result + lockHint.hashCode();
@@ -963,6 +994,20 @@ public final class Options implements Serializable {
       if (o == this) return true;
       if (!(o instanceof FilterOption)) return false;
       return Objects.equals(filter, ((FilterOption) o).filter);
+    }
+  }
+
+  static final class LastStatementUpdateOption extends InternalOption implements UpdateOption {
+
+    private final Boolean lastStatementSet;
+
+    LastStatementUpdateOption(Boolean lastStatementSet) {
+      this.lastStatementSet = lastStatementSet;
+    }
+
+    @Override
+    void appendToOptions(Options options) {
+      options.lastStatementSet = lastStatementSet;
     }
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
@@ -1012,7 +1012,7 @@ public final class Options implements Serializable {
     public int hashCode() {
       return LastStatementUpdateOption.class.hashCode();
     }
-    
+
     @Override
     public boolean equals(Object o) {
       return o instanceof LastStatementUpdateOption;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
@@ -1009,6 +1009,11 @@ public final class Options implements Serializable {
     }
 
     @Override
+    public int hashCode() {
+      return LastStatementUpdateOption.class.hashCode();
+    }
+    
+    @Override
     public boolean equals(Object o) {
       return o instanceof LastStatementUpdateOption;
     }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
@@ -265,6 +265,9 @@ public final class SpannerExceptionFactory {
       if (cause instanceof ApiException) {
         return ((ApiException) cause).getErrorDetails();
       }
+      if (cause instanceof SpannerException) {
+        return ((SpannerException) cause).getErrorDetails();
+      }
       prevCause = cause;
       cause = cause.getCause();
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractReadContextTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractReadContextTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -264,6 +265,42 @@ public class AbstractReadContextTest {
             Collections.singleton(Statement.of("SELECT * FROM FOO")),
             Options.fromQueryOptions(Options.priority(RpcPriority.LOW)));
     assertEquals(Priority.PRIORITY_LOW, request.getRequestOptions().getPriority());
+  }
+
+  @Test
+  public void testExecuteSqlLastStatement() {
+    assertFalse(
+        context
+            .getExecuteSqlRequestBuilder(
+                Statement.of("insert into test (id) values (1)"),
+                QueryMode.NORMAL,
+                Options.fromUpdateOptions(),
+                false)
+            .getLastStatement());
+    assertTrue(
+        context
+            .getExecuteSqlRequestBuilder(
+                Statement.of("insert into test (id) values (1)"),
+                QueryMode.NORMAL,
+                Options.fromUpdateOptions(Options.lastStatement()),
+                false)
+            .getLastStatement());
+  }
+
+  @Test
+  public void testExecuteBatchDmlLastStatement() {
+    assertFalse(
+        context
+            .getExecuteBatchDmlRequestBuilder(
+                Collections.singleton(Statement.of("insert into test (id) values (1)")),
+                Options.fromUpdateOptions())
+            .getLastStatements());
+    assertTrue(
+        context
+            .getExecuteBatchDmlRequestBuilder(
+                Collections.singleton(Statement.of("insert into test (id) values (1)")),
+                Options.fromUpdateOptions(Options.lastStatement()))
+            .getLastStatements());
   }
 
   public void executeSqlRequestBuilderWithRequestOptions() {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
@@ -250,6 +251,11 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
 
   @Test
   public void asyncTransactionManagerIsNonBlocking() throws Exception {
+    // TODO: Remove this condition once DelayedAsyncTransactionManager is made non-blocking with
+    // multiplexed sessions.
+    assumeFalse(
+        "DelayedAsyncTransactionManager is currently blocking with multiplexed sessions.",
+        spanner.getOptions().getSessionPoolOptions().getUseMultiplexedSessionForRW());
     mockSpanner.freeze();
     try (AsyncTransactionManager manager = clientWithEmptySessionPool().transactionManagerAsync()) {
       TransactionContextFuture transactionContextFuture = manager.beginAsync();
@@ -633,6 +639,11 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
 
   @Test
   public void asyncTransactionManagerIsNonBlockingWithBatchUpdate() throws Exception {
+    // TODO: Remove this condition once DelayedAsyncTransactionManager is made non-blocking with
+    // multiplexed sessions.
+    assumeFalse(
+        "DelayedAsyncTransactionManager is currently blocking with multiplexed sessions.",
+        spanner.getOptions().getSessionPoolOptions().getUseMultiplexedSessionForRW());
     mockSpanner.freeze();
     try (AsyncTransactionManager manager = clientWithEmptySessionPool().transactionManagerAsync()) {
       TransactionContextFuture transactionContextFuture = manager.beginAsync();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OptionsTest.java
@@ -789,4 +789,22 @@ public class OptionsTest {
     assertNull(option3.withExcludeTxnFromChangeStreams());
     assertThat(option3.toString()).doesNotContain("withExcludeTxnFromChangeStreams: true");
   }
+
+  @Test
+  public void testLastStatement() {
+    Options option1 = Options.fromUpdateOptions(Options.lastStatement());
+    Options option2 = Options.fromUpdateOptions(Options.lastStatement());
+    Options option3 = Options.fromUpdateOptions();
+
+    assertEquals(option1, option2);
+    assertEquals(option1.hashCode(), option2.hashCode());
+    assertNotEquals(option1, option3);
+    assertNotEquals(option1.hashCode(), option3.hashCode());
+
+    assertTrue(option1.isLastStatement());
+    assertThat(option1.toString()).contains("lastStatement: true");
+
+    assertNull(option3.isLastStatement());
+    assertThat(option3.toString()).doesNotContain("lastStatement: true");
+  }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AutoCommitMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AutoCommitMockServerTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.connection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.spanner.ResultSet;
+import com.google.spanner.v1.BeginTransactionRequest;
+import com.google.spanner.v1.CommitRequest;
+import com.google.spanner.v1.ExecuteBatchDmlRequest;
+import com.google.spanner.v1.ExecuteSqlRequest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class AutoCommitMockServerTest extends AbstractMockServerTest {
+
+  @Test
+  public void testQuery() {
+    try (Connection connection = createConnection()) {
+      connection.setAutocommit(true);
+      //noinspection EmptyTryBlock
+      try (ResultSet ignore = connection.executeQuery(SELECT1_STATEMENT)) {}
+    }
+    assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    ExecuteSqlRequest request = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(0);
+    assertTrue(request.getTransaction().hasSingleUse());
+    assertTrue(request.getTransaction().getSingleUse().hasReadOnly());
+    assertFalse(request.getLastStatement());
+  }
+
+  @Test
+  public void testDml() {
+    try (Connection connection = createConnection()) {
+      connection.setAutocommit(true);
+      connection.executeUpdate(INSERT_STATEMENT);
+    }
+    assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    ExecuteSqlRequest request = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(0);
+    assertTrue(request.getTransaction().hasBegin());
+    assertTrue(request.getTransaction().getBegin().hasReadWrite());
+    assertTrue(request.getLastStatement());
+    assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
+  }
+
+  @Test
+  public void testDmlReturning() {
+    try (Connection connection = createConnection()) {
+      connection.setAutocommit(true);
+      //noinspection EmptyTryBlock
+      try (ResultSet ignore = connection.executeQuery(INSERT_RETURNING_STATEMENT)) {}
+    }
+    assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    ExecuteSqlRequest request = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(0);
+    assertTrue(request.getTransaction().hasBegin());
+    assertTrue(request.getTransaction().getBegin().hasReadWrite());
+    assertTrue(request.getLastStatement());
+    assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
+  }
+
+  @Test
+  public void testBatchDml() {
+    try (Connection connection = createConnection()) {
+      connection.setAutocommit(true);
+      connection.startBatchDml();
+      connection.executeUpdate(INSERT_STATEMENT);
+      connection.executeUpdate(INSERT_STATEMENT);
+      connection.runBatch();
+    }
+    assertEquals(1, mockSpanner.countRequestsOfType(ExecuteBatchDmlRequest.class));
+    ExecuteBatchDmlRequest request =
+        mockSpanner.getRequestsOfType(ExecuteBatchDmlRequest.class).get(0);
+    assertTrue(request.getTransaction().hasBegin());
+    assertTrue(request.getTransaction().getBegin().hasReadWrite());
+    assertTrue(request.getLastStatements());
+    assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
+  }
+
+  @Test
+  public void testPartitionedDml() {
+    try (Connection connection = createConnection()) {
+      connection.setAutocommit(true);
+      connection.setAutocommitDmlMode(AutocommitDmlMode.PARTITIONED_NON_ATOMIC);
+      connection.executeUpdate(INSERT_STATEMENT);
+    }
+    assertEquals(1, mockSpanner.countRequestsOfType(BeginTransactionRequest.class));
+    BeginTransactionRequest beginRequest =
+        mockSpanner.getRequestsOfType(BeginTransactionRequest.class).get(0);
+    assertTrue(beginRequest.getOptions().hasPartitionedDml());
+    assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    ExecuteSqlRequest request = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(0);
+    assertTrue(request.getTransaction().hasId());
+    assertFalse(request.getLastStatement());
+    assertEquals(0, mockSpanner.countRequestsOfType(CommitRequest.class));
+  }
+
+  @Test
+  public void testDmlAborted() {
+    try (Connection connection = createConnection()) {
+      connection.setAutocommit(true);
+      mockSpanner.abortNextTransaction();
+      connection.executeUpdate(INSERT_STATEMENT);
+    }
+    assertEquals(2, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    for (ExecuteSqlRequest request : mockSpanner.getRequestsOfType(ExecuteSqlRequest.class)) {
+      assertTrue(request.getTransaction().hasBegin());
+      assertTrue(request.getTransaction().getBegin().hasReadWrite());
+      assertTrue(request.getLastStatement());
+    }
+    assertEquals(2, mockSpanner.countRequestsOfType(CommitRequest.class));
+  }
+
+  @Test
+  public void testDmlReturningAborted() {
+    try (Connection connection = createConnection()) {
+      connection.setAutocommit(true);
+      mockSpanner.abortNextTransaction();
+      //noinspection EmptyTryBlock
+      try (ResultSet ignore = connection.executeQuery(INSERT_RETURNING_STATEMENT)) {}
+    }
+    assertEquals(2, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    for (ExecuteSqlRequest request : mockSpanner.getRequestsOfType(ExecuteSqlRequest.class)) {
+      assertTrue(request.getTransaction().hasBegin());
+      assertTrue(request.getTransaction().getBegin().hasReadWrite());
+      assertTrue(request.getLastStatement());
+    }
+    assertEquals(2, mockSpanner.countRequestsOfType(CommitRequest.class));
+  }
+
+  @Test
+  public void testBatchDmlAborted() {
+    try (Connection connection = createConnection()) {
+      connection.setAutocommit(true);
+      mockSpanner.abortNextTransaction();
+      connection.startBatchDml();
+      connection.executeUpdate(INSERT_STATEMENT);
+      connection.executeUpdate(INSERT_STATEMENT);
+      connection.runBatch();
+    }
+    assertEquals(2, mockSpanner.countRequestsOfType(ExecuteBatchDmlRequest.class));
+    for (ExecuteBatchDmlRequest request :
+        mockSpanner.getRequestsOfType(ExecuteBatchDmlRequest.class)) {
+      assertTrue(request.getTransaction().hasBegin());
+      assertTrue(request.getTransaction().getBegin().hasReadWrite());
+      assertTrue(request.getLastStatements());
+    }
+    assertEquals(2, mockSpanner.countRequestsOfType(CommitRequest.class));
+  }
+}

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AutocommitDmlModeTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AutocommitDmlModeTest.java
@@ -18,6 +18,9 @@ package com.google.cloud.spanner.connection;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -28,6 +31,7 @@ import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.BatchClient;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.Options;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.TransactionContext;
@@ -82,12 +86,12 @@ public class AutocommitDmlModeTest {
                 .setCredentials(NoCredentials.getInstance())
                 .setUri(URI)
                 .build())) {
-      assertThat(connection.isAutocommit(), is(true));
-      assertThat(connection.isReadOnly(), is(false));
-      assertThat(connection.getAutocommitDmlMode(), is(AutocommitDmlMode.TRANSACTIONAL));
+      assertTrue(connection.isAutocommit());
+      assertFalse(connection.isReadOnly());
+      assertEquals(AutocommitDmlMode.TRANSACTIONAL, connection.getAutocommitDmlMode());
 
       connection.execute(Statement.of(UPDATE));
-      verify(txContext).executeUpdate(Statement.of(UPDATE));
+      verify(txContext).executeUpdate(Statement.of(UPDATE), Options.lastStatement());
       verify(dbClient, never()).executePartitionedUpdate(Statement.of(UPDATE));
     }
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionImplTest.java
@@ -354,7 +354,8 @@ public class ConnectionImplTest {
                   public <T> T run(TransactionCallable<T> callable) {
                     commitResponse = new CommitResponse(Timestamp.ofTimeSecondsAndNanos(1, 1));
                     TransactionContext transaction = mock(TransactionContext.class);
-                    when(transaction.executeUpdate(Statement.of(UPDATE))).thenReturn(1L);
+                    when(transaction.executeUpdate(Statement.of(UPDATE), Options.lastStatement()))
+                        .thenReturn(1L);
                     try {
                       return callable.run(transaction);
                     } catch (Exception e) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/RetryDmlAsPartitionedDmlMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/RetryDmlAsPartitionedDmlMockServerTest.java
@@ -83,6 +83,8 @@ public class RetryDmlAsPartitionedDmlMockServerTest extends AbstractMockServerTe
       assertEquals(0, exception.getSuppressed().length);
     }
     assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    ExecuteSqlRequest request = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(0);
+    assertTrue(request.getLastStatement());
     assertEquals(0, mockSpanner.countRequestsOfType(CommitRequest.class));
   }
 
@@ -108,6 +110,7 @@ public class RetryDmlAsPartitionedDmlMockServerTest extends AbstractMockServerTe
     ExecuteSqlRequest transactionalRequest =
         mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(0);
     assertTrue(transactionalRequest.getTransaction().getBegin().hasReadWrite());
+    assertTrue(transactionalRequest.getLastStatement());
 
     // Partitioned DML uses an explicit BeginTransaction RPC.
     assertEquals(1, mockSpanner.countRequestsOfType(BeginTransactionRequest.class));
@@ -117,6 +120,7 @@ public class RetryDmlAsPartitionedDmlMockServerTest extends AbstractMockServerTe
     ExecuteSqlRequest partitionedDmlRequest =
         mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(1);
     assertTrue(partitionedDmlRequest.getTransaction().hasId());
+    assertFalse(partitionedDmlRequest.getLastStatement());
 
     // Partitioned DML transactions are not committed.
     assertEquals(0, mockSpanner.countRequestsOfType(CommitRequest.class));
@@ -163,6 +167,7 @@ public class RetryDmlAsPartitionedDmlMockServerTest extends AbstractMockServerTe
     ExecuteSqlRequest transactionalRequest =
         mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(0);
     assertTrue(transactionalRequest.getTransaction().getBegin().hasReadWrite());
+    assertTrue(transactionalRequest.getLastStatement());
 
     // Partitioned DML uses an explicit BeginTransaction RPC.
     assertEquals(1, mockSpanner.countRequestsOfType(BeginTransactionRequest.class));
@@ -172,6 +177,7 @@ public class RetryDmlAsPartitionedDmlMockServerTest extends AbstractMockServerTe
     ExecuteSqlRequest partitionedDmlRequest =
         mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(1);
     assertTrue(partitionedDmlRequest.getTransaction().hasId());
+    assertFalse(partitionedDmlRequest.getLastStatement());
 
     // Partitioned DML transactions are not committed.
     assertEquals(0, mockSpanner.countRequestsOfType(CommitRequest.class));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SingleUseTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SingleUseTransactionTest.java
@@ -395,6 +395,8 @@ public class SingleUseTransactionTest {
 
     final TransactionContext txContext = mock(TransactionContext.class);
     when(txContext.executeUpdate(Statement.of(VALID_UPDATE))).thenReturn(VALID_UPDATE_COUNT);
+    when(txContext.executeUpdate(Statement.of(VALID_UPDATE), Options.lastStatement()))
+        .thenReturn(VALID_UPDATE_COUNT);
     when(txContext.executeUpdate(Statement.of(SLOW_UPDATE)))
         .thenAnswer(
             invocation -> {
@@ -402,6 +404,9 @@ public class SingleUseTransactionTest {
               return VALID_UPDATE_COUNT;
             });
     when(txContext.executeUpdate(Statement.of(INVALID_UPDATE)))
+        .thenThrow(
+            SpannerExceptionFactory.newSpannerException(ErrorCode.UNKNOWN, "invalid update"));
+    when(txContext.executeUpdate(Statement.of(INVALID_UPDATE), Options.lastStatement()))
         .thenThrow(
             SpannerExceptionFactory.newSpannerException(ErrorCode.UNKNOWN, "invalid update"));
     SimpleTransactionManager txManager = new SimpleTransactionManager(txContext, commitBehavior);


### PR DESCRIPTION
- Adds an option to indicate that a statement is the last in a read/write transaction. This option should only be set for the last statement before committing the transaction. Trying to execute any other statements after this statement will result in an error.
- The `last_statement` option is automatically set for statements that are executed in autocommit mode in the Connection API. This option will also automatically be set for statements executed on a JDBC connection in autocommit mode.

cc @sgorse123