### PR TITLE
deps: stop declaring own exporter-trace version

### DIFF
--- a/google-cloud-spanner-executor/pom.xml
+++ b/google-cloud-spanner-executor/pom.xml
@@ -45,7 +45,6 @@
     <dependency>
       <groupId>com.google.cloud.opentelemetry</groupId>
       <artifactId>exporter-trace</artifactId>
-      <version>0.33.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>


### PR DESCRIPTION
I think the exporter-trace version is already declared in the google-cloud-shared-config.

This should fix the upper-bound failure in https://github.com/googleapis/java-shared-config/pull/985#issuecomment-2666226982.

CC: @lqiu96 