### PR TITLE
perf: Skip gRPC trailers for StreamingRead & ExecuteStreamingSql

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/GrpcStreamIterator.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/GrpcStreamIterator.java
@@ -52,6 +52,7 @@ class GrpcStreamIterator extends AbstractIterator<PartialResultSet>
   private TimeUnit streamWaitTimeoutUnit;
   private long streamWaitTimeoutValue;
   private SpannerException error;
+  private boolean done;
 
   @VisibleForTesting
   GrpcStreamIterator(int prefetchChunks, boolean cancelQueryWhenClientIsClosed) {
@@ -166,11 +167,17 @@ class GrpcStreamIterator extends AbstractIterator<PartialResultSet>
     @Override
     public void onPartialResultSet(PartialResultSet results) {
       addToStream(results);
+      if (results.getLast()) {
+        done = true;
+        addToStream(END_OF_STREAM);
+      }
     }
 
     @Override
     public void onCompleted() {
-      addToStream(END_OF_STREAM);
+      if (!done) {
+        addToStream(END_OF_STREAM);
+      }
     }
 
     @Override

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GrpcResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GrpcResultSetTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.spanner;
 import static com.google.common.testing.SerializableTester.reserialize;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -1114,5 +1115,59 @@ public class GrpcResultSetTest {
         () -> {
           resultSet.getProtoEnum(0, Genre::forNumber);
         });
+  }
+
+  @Test
+  public void verifyResultSetWithLastTrue() {
+    long[] longArray = {111, 333, 444, 0, -1, -2234, Long.MAX_VALUE, Long.MIN_VALUE};
+
+    consumer.onPartialResultSet(
+        PartialResultSet.newBuilder()
+            .setMetadata(
+                makeMetadata(Type.struct(Type.StructField.of("f", Type.array(Type.int64())))))
+            .addValues(Value.int64Array(longArray).toProto())
+            .setLast(false)
+            .build());
+    assertTrue(resultSet.next());
+    consumer.onPartialResultSet(
+        PartialResultSet.newBuilder()
+            .setMetadata(
+                makeMetadata(Type.struct(Type.StructField.of("f", Type.array(Type.int64())))))
+            .addValues(Value.int64Array(longArray).toProto())
+            .setLast(true)
+            .build());
+    assertTrue(resultSet.next());
+    assertFalse(resultSet.next());
+    consumer.onCompleted();
+  }
+
+  @Test
+  public void shouldThrowDeadlineExceededIfLastTrueIsNotReceived() {
+    long[] longArray = {111, 333, 444, 0, -1, -2234, Long.MAX_VALUE, Long.MIN_VALUE};
+
+    consumer.onPartialResultSet(
+        PartialResultSet.newBuilder()
+            .setMetadata(
+                makeMetadata(Type.struct(Type.StructField.of("f", Type.array(Type.int64())))))
+            .addValues(Value.int64Array(longArray).toProto())
+            .setLast(false)
+            .build());
+    assertTrue(resultSet.next());
+    consumer.onPartialResultSet(
+        PartialResultSet.newBuilder()
+            .setMetadata(
+                makeMetadata(Type.struct(Type.StructField.of("f", Type.array(Type.int64())))))
+            .addValues(Value.int64Array(longArray).toProto())
+            .setLast(false)
+            .build());
+    assertTrue(resultSet.next());
+    SpannerException spannerException =
+        assertThrows(
+            SpannerException.class,
+            () -> {
+              assertThat(resultSet.next()).isFalse();
+            });
+    assertEquals("DEADLINE_EXCEEDED: stream wait timeout", spannerException.getMessage());
+    consumer.onCompleted();
   }
 }


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-spanner/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes: b/394475581

**Description:**
gRPC trailers are headers which is usually sent after all the messages are sent by the server in the stream. Trailers usually causes additional latency of 250-300 μs after last message is sent in the stream. From the server, we will receiving last field which tells us about last PartialResultSet and we no longer will be waiting for trailers to assume that all the messages are received.

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
