### PR TITLE
feat: support isolation level REPEATABLE_READ for R/W transactions

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -641,8 +641,8 @@ abstract class AbstractReadContext
    *   <li>Specific {@link QueryOptions} passed in for this query.
    *   <li>Any value specified in a valid environment variable when the {@link SpannerOptions}
    *       instance was created.
-   *   <li>The default {@link SpannerOptions#getDefaultQueryOptions()} specified for the database
-   *       where the query is executed.
+   *   <li>The default {@link SpannerOptions#getDefaultQueryOptions(DatabaseId)} ()} specified for
+   *       the database where the query is executed.
    * </ol>
    */
   @VisibleForTesting

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClient.java
@@ -111,6 +111,10 @@ public interface DatabaseClient {
    *       applied to any other requests on the transaction.
    *   <li>{@link Options#commitStats()}: Request that the server includes commit statistics in the
    *       {@link CommitResponse}.
+   *   <li>{@link Options#repeatableReadIsolationLevel()}: Request Repeatable Read Isolation Level
+   *       from the backend.
+   *   <li>{@link Options#serializableIsolationLevel()}: Request Serializable Isolation Level from
+   *       the backend.
    * </ul>
    *
    * @return a response with the timestamp at which the write was committed
@@ -186,6 +190,10 @@ public interface DatabaseClient {
    *       applied to any other requests on the transaction.
    *   <li>{@link Options#commitStats()}: Request that the server includes commit statistics in the
    *       {@link CommitResponse}.
+   *   <li>{@link Options#repeatableReadIsolationLevel()}: Request Repeatable Read Isolation Level
+   *       from the backend.
+   *   <li>{@link Options#serializableIsolationLevel()}: Request Serializable Isolation Level from
+   *       the backend.
    * </ul>
    *
    * @return a response with the timestamp at which the write was committed
@@ -414,6 +422,10 @@ public interface DatabaseClient {
    *       applied to any other requests on the transaction.
    *   <li>{@link Options#commitStats()}: Request that the server includes commit statistics in the
    *       {@link CommitResponse}.
+   *   <li>{@link Options#repeatableReadIsolationLevel()}: Request Repeatable Read Isolation Level
+   *       from the backend.
+   *   <li>{@link Options#serializableIsolationLevel()}: Request Serializable Isolation Level from
+   *       the backend.
    * </ul>
    */
   TransactionRunner readWriteTransaction(TransactionOption... options);
@@ -454,6 +466,10 @@ public interface DatabaseClient {
    *       applied to any other requests on the transaction.
    *   <li>{@link Options#commitStats()}: Request that the server includes commit statistics in the
    *       {@link CommitResponse}.
+   *   <li>{@link Options#repeatableReadIsolationLevel()}: Request Repeatable Read Isolation Level
+   *       from the backend.
+   *   <li>{@link Options#serializableIsolationLevel()}: Request Serializable Isolation Level from
+   *       the backend.
    * </ul>
    */
   TransactionManager transactionManager(TransactionOption... options);
@@ -494,6 +510,10 @@ public interface DatabaseClient {
    *       applied to any other requests on the transaction.
    *   <li>{@link Options#commitStats()}: Request that the server includes commit statistics in the
    *       {@link CommitResponse}.
+   *   <li>{@link Options#repeatableReadIsolationLevel()}: Request Repeatable Read Isolation Level
+   *       from the backend.
+   *   <li>{@link Options#serializableIsolationLevel()}: Request Serializable Isolation Level from
+   *       the backend.
    * </ul>
    */
   AsyncRunner runAsync(TransactionOption... options);
@@ -548,6 +568,10 @@ public interface DatabaseClient {
    *       applied to any other requests on the transaction.
    *   <li>{@link Options#commitStats()}: Request that the server includes commit statistics in the
    *       {@link CommitResponse}.
+   *   <li>{@link Options#repeatableReadIsolationLevel()}: Request Repeatable Read Isolation Level
+   *       from the backend.
+   *   <li>{@link Options#serializableIsolationLevel()}: Request Serializable Isolation Level from
+   *       the backend.
    * </ul>
    */
   AsyncTransactionManager transactionManagerAsync(TransactionOption... options);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClient.java
@@ -22,6 +22,7 @@ import com.google.cloud.spanner.Options.RpcPriority;
 import com.google.cloud.spanner.Options.TransactionOption;
 import com.google.cloud.spanner.Options.UpdateOption;
 import com.google.spanner.v1.BatchWriteResponse;
+import com.google.spanner.v1.TransactionOptions.IsolationLevel;
 
 /**
  * Interface for all the APIs that are used to read/write data into a Cloud Spanner database. An
@@ -111,10 +112,6 @@ public interface DatabaseClient {
    *       applied to any other requests on the transaction.
    *   <li>{@link Options#commitStats()}: Request that the server includes commit statistics in the
    *       {@link CommitResponse}.
-   *   <li>{@link Options#repeatableReadIsolationLevel()}: Request Repeatable Read Isolation Level
-   *       from the backend.
-   *   <li>{@link Options#serializableIsolationLevel()}: Request Serializable Isolation Level from
-   *       the backend.
    * </ul>
    *
    * @return a response with the timestamp at which the write was committed
@@ -190,10 +187,6 @@ public interface DatabaseClient {
    *       applied to any other requests on the transaction.
    *   <li>{@link Options#commitStats()}: Request that the server includes commit statistics in the
    *       {@link CommitResponse}.
-   *   <li>{@link Options#repeatableReadIsolationLevel()}: Request Repeatable Read Isolation Level
-   *       from the backend.
-   *   <li>{@link Options#serializableIsolationLevel()}: Request Serializable Isolation Level from
-   *       the backend.
    * </ul>
    *
    * @return a response with the timestamp at which the write was committed
@@ -422,10 +415,8 @@ public interface DatabaseClient {
    *       applied to any other requests on the transaction.
    *   <li>{@link Options#commitStats()}: Request that the server includes commit statistics in the
    *       {@link CommitResponse}.
-   *   <li>{@link Options#repeatableReadIsolationLevel()}: Request Repeatable Read Isolation Level
-   *       from the backend.
-   *   <li>{@link Options#serializableIsolationLevel()}: Request Serializable Isolation Level from
-   *       the backend.
+   *   <li>{@link Options#isolationLevelOption(IsolationLevel)}: The isolation level for the
+   *       transaction
    * </ul>
    */
   TransactionRunner readWriteTransaction(TransactionOption... options);
@@ -466,10 +457,8 @@ public interface DatabaseClient {
    *       applied to any other requests on the transaction.
    *   <li>{@link Options#commitStats()}: Request that the server includes commit statistics in the
    *       {@link CommitResponse}.
-   *   <li>{@link Options#repeatableReadIsolationLevel()}: Request Repeatable Read Isolation Level
-   *       from the backend.
-   *   <li>{@link Options#serializableIsolationLevel()}: Request Serializable Isolation Level from
-   *       the backend.
+   *   <li>{@link Options#isolationLevelOption(IsolationLevel)}: The isolation level for the
+   *       transaction
    * </ul>
    */
   TransactionManager transactionManager(TransactionOption... options);
@@ -510,10 +499,8 @@ public interface DatabaseClient {
    *       applied to any other requests on the transaction.
    *   <li>{@link Options#commitStats()}: Request that the server includes commit statistics in the
    *       {@link CommitResponse}.
-   *   <li>{@link Options#repeatableReadIsolationLevel()}: Request Repeatable Read Isolation Level
-   *       from the backend.
-   *   <li>{@link Options#serializableIsolationLevel()}: Request Serializable Isolation Level from
-   *       the backend.
+   *   <li>{@link Options#isolationLevelOption(IsolationLevel)}: The isolation level for the
+   *       transaction
    * </ul>
    */
   AsyncRunner runAsync(TransactionOption... options);
@@ -568,10 +555,8 @@ public interface DatabaseClient {
    *       applied to any other requests on the transaction.
    *   <li>{@link Options#commitStats()}: Request that the server includes commit statistics in the
    *       {@link CommitResponse}.
-   *   <li>{@link Options#repeatableReadIsolationLevel()}: Request Repeatable Read Isolation Level
-   *       from the backend.
-   *   <li>{@link Options#serializableIsolationLevel()}: Request Serializable Isolation Level from
-   *       the backend.
+   *   <li>{@link Options#isolationLevelOption(IsolationLevel)}: The isolation level for the
+   *       transaction
    * </ul>
    */
   AsyncTransactionManager transactionManagerAsync(TransactionOption... options);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClient.java
@@ -415,7 +415,7 @@ public interface DatabaseClient {
    *       applied to any other requests on the transaction.
    *   <li>{@link Options#commitStats()}: Request that the server includes commit statistics in the
    *       {@link CommitResponse}.
-   *   <li>{@link Options#isolationLevelOption(IsolationLevel)}: The isolation level for the
+   *   <li>{@link Options#isolationLevel(IsolationLevel)}: The isolation level for the
    *       transaction
    * </ul>
    */
@@ -457,7 +457,7 @@ public interface DatabaseClient {
    *       applied to any other requests on the transaction.
    *   <li>{@link Options#commitStats()}: Request that the server includes commit statistics in the
    *       {@link CommitResponse}.
-   *   <li>{@link Options#isolationLevelOption(IsolationLevel)}: The isolation level for the
+   *   <li>{@link Options#isolationLevel(IsolationLevel)}: The isolation level for the
    *       transaction
    * </ul>
    */
@@ -499,7 +499,7 @@ public interface DatabaseClient {
    *       applied to any other requests on the transaction.
    *   <li>{@link Options#commitStats()}: Request that the server includes commit statistics in the
    *       {@link CommitResponse}.
-   *   <li>{@link Options#isolationLevelOption(IsolationLevel)}: The isolation level for the
+   *   <li>{@link Options#isolationLevel(IsolationLevel)}: The isolation level for the
    *       transaction
    * </ul>
    */
@@ -555,7 +555,7 @@ public interface DatabaseClient {
    *       applied to any other requests on the transaction.
    *   <li>{@link Options#commitStats()}: Request that the server includes commit statistics in the
    *       {@link CommitResponse}.
-   *   <li>{@link Options#isolationLevelOption(IsolationLevel)}: The isolation level for the
+   *   <li>{@link Options#isolationLevel(IsolationLevel)}: The isolation level for the
    *       transaction
    * </ul>
    */

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClient.java
@@ -415,8 +415,7 @@ public interface DatabaseClient {
    *       applied to any other requests on the transaction.
    *   <li>{@link Options#commitStats()}: Request that the server includes commit statistics in the
    *       {@link CommitResponse}.
-   *   <li>{@link Options#isolationLevel(IsolationLevel)}: The isolation level for the
-   *       transaction
+   *   <li>{@link Options#isolationLevel(IsolationLevel)}: The isolation level for the transaction
    * </ul>
    */
   TransactionRunner readWriteTransaction(TransactionOption... options);
@@ -457,8 +456,7 @@ public interface DatabaseClient {
    *       applied to any other requests on the transaction.
    *   <li>{@link Options#commitStats()}: Request that the server includes commit statistics in the
    *       {@link CommitResponse}.
-   *   <li>{@link Options#isolationLevel(IsolationLevel)}: The isolation level for the
-   *       transaction
+   *   <li>{@link Options#isolationLevel(IsolationLevel)}: The isolation level for the transaction
    * </ul>
    */
   TransactionManager transactionManager(TransactionOption... options);
@@ -499,8 +497,7 @@ public interface DatabaseClient {
    *       applied to any other requests on the transaction.
    *   <li>{@link Options#commitStats()}: Request that the server includes commit statistics in the
    *       {@link CommitResponse}.
-   *   <li>{@link Options#isolationLevel(IsolationLevel)}: The isolation level for the
-   *       transaction
+   *   <li>{@link Options#isolationLevel(IsolationLevel)}: The isolation level for the transaction
    * </ul>
    */
   AsyncRunner runAsync(TransactionOption... options);
@@ -555,8 +552,7 @@ public interface DatabaseClient {
    *       applied to any other requests on the transaction.
    *   <li>{@link Options#commitStats()}: Request that the server includes commit statistics in the
    *       {@link CommitResponse}.
-   *   <li>{@link Options#isolationLevel(IsolationLevel)}: The isolation level for the
-   *       transaction
+   *   <li>{@link Options#isolationLevel(IsolationLevel)}: The isolation level for the transaction
    * </ul>
    */
   AsyncTransactionManager transactionManagerAsync(TransactionOption... options);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
@@ -163,7 +163,7 @@ public final class Options implements Serializable {
   /**
    * Specifying this instructs the transaction to request {@link IsolationLevel} from the backend.
    */
-  public static TransactionOption isolationLevelOption(IsolationLevel isolationLevel) {
+  public static TransactionOption isolationLevel(IsolationLevel isolationLevel) {
     return new IsolationLevelOption(isolationLevel);
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
@@ -163,7 +163,7 @@ public final class Options implements Serializable {
   /**
    * Specifying this instructs the transaction to request {@link IsolationLevel} from the backend.
    */
-  public static IsolationLevelOption isolationLevelOption(IsolationLevel isolationLevel) {
+  public static TransactionOption isolationLevelOption(IsolationLevel isolationLevel) {
     return new IsolationLevelOption(isolationLevel);
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -1652,8 +1652,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     }
 
     /**
-     * Provides the default read-write transaction options for all databases, limited to setting the
-     * {@link IsolationLevel}. These defaults are overridden by any explicit {@link
+     * Provides the default read-write transaction options for all databases. These defaults are overridden by any explicit {@link
      * com.google.cloud.spanner.Options.TransactionOption} provided through {@link DatabaseClient}.
      *
      * <p>Example Usage:

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -1652,8 +1652,9 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     }
 
     /**
-     * Provides the default read-write transaction options for all databases. These defaults are overridden by any explicit {@link
-     * com.google.cloud.spanner.Options.TransactionOption} provided through {@link DatabaseClient}.
+     * Provides the default read-write transaction options for all databases. These defaults are
+     * overridden by any explicit {@link com.google.cloud.spanner.Options.TransactionOption}
+     * provided through {@link DatabaseClient}.
      *
      * <p>Example Usage:
      *

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -643,8 +643,12 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
           if (tx == null) {
             return TransactionSelector.newBuilder()
                 .setBegin(
-                    SessionImpl.createReadWriteTransactionOptions(
-                        options, getPreviousTransactionId()))
+                    this.session
+                        .defaultTransactionOptions()
+                        .toBuilder()
+                        .mergeFrom(
+                            SessionImpl.createReadWriteTransactionOptions(
+                                options, getPreviousTransactionId())))
                 .build();
           } else {
             // Wait for the transaction to come available. The tx.get() call will fail with an

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -49,7 +49,6 @@ import com.google.cloud.ByteArray;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.AsyncResultSet.CallbackResponse;
-import com.google.cloud.spanner.AsyncTransactionManager.TransactionContextFuture;
 import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
 import com.google.cloud.spanner.Options.RpcLockHint;
@@ -1346,10 +1345,7 @@ public class DatabaseClientImplTest {
   public void testWrite() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Timestamp timestamp =
-        client.write(
-            Collections.singletonList(
-                Mutation.newInsertBuilder("FOO").set("ID").to(1L).set("NAME").to("Bar").build()));
+    Timestamp timestamp = MockSpannerTestActions.writeInsertMutation(client);
     assertNotNull(timestamp);
 
     List<BeginTransactionRequest> beginTransactions =
@@ -1376,10 +1372,7 @@ public class DatabaseClientImplTest {
     mockSpanner.setCommitExecutionTime(
         SimulatedExecutionTime.ofException(
             mockSpanner.createAbortedException(ByteString.copyFromUtf8("test"))));
-    Timestamp timestamp =
-        client.write(
-            Collections.singletonList(
-                Mutation.newInsertBuilder("FOO").set("ID").to(1L).set("NAME").to("Bar").build()));
+    Timestamp timestamp = MockSpannerTestActions.writeInsertMutation(client);
     assertNotNull(timestamp);
 
     List<CommitRequest> commitRequests = mockSpanner.getRequestsOfType(CommitRequest.class);
@@ -1395,10 +1388,7 @@ public class DatabaseClientImplTest {
     mockSpanner.setCommitExecutionTime(
         SimulatedExecutionTime.ofException(
             mockSpanner.createAbortedException(ByteString.copyFromUtf8("test"))));
-    Timestamp timestamp =
-        client.writeAtLeastOnce(
-            Collections.singletonList(
-                Mutation.newInsertBuilder("FOO").set("ID").to(1L).set("NAME").to("Bar").build()));
+    Timestamp timestamp = MockSpannerTestActions.writeAtLeastOnceInsertMutation(client);
     assertNotNull(timestamp);
 
     List<CommitRequest> commitRequests = mockSpanner.getRequestsOfType(CommitRequest.class);
@@ -1409,10 +1399,8 @@ public class DatabaseClientImplTest {
   public void testWriteWithOptions() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    client.writeWithOptions(
-        Collections.singletonList(
-            Mutation.newInsertBuilder("FOO").set("ID").to(1L).set("NAME").to("Bar").build()),
-        Options.priority(RpcPriority.HIGH));
+    MockSpannerTestActions.writeInsertMutationWithOptions(
+        client, Options.priority(RpcPriority.HIGH));
 
     List<BeginTransactionRequest> beginTransactions =
         mockSpanner.getRequestsOfType(BeginTransactionRequest.class);
@@ -1447,10 +1435,8 @@ public class DatabaseClientImplTest {
   public void testWriteWithExcludeTxnFromChangeStreams() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    client.writeWithOptions(
-        Collections.singletonList(
-            Mutation.newInsertBuilder("FOO").set("ID").to(1L).set("NAME").to("Bar").build()),
-        Options.excludeTxnFromChangeStreams());
+    MockSpannerTestActions.writeInsertMutationWithOptions(
+        client, Options.excludeTxnFromChangeStreams());
 
     List<BeginTransactionRequest> beginTransactions =
         mockSpanner.getRequestsOfType(BeginTransactionRequest.class);
@@ -1465,10 +1451,7 @@ public class DatabaseClientImplTest {
   public void testWriteAtLeastOnce() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    Timestamp timestamp =
-        client.writeAtLeastOnce(
-            Collections.singletonList(
-                Mutation.newInsertBuilder("FOO").set("ID").to(1L).set("NAME").to("Bar").build()));
+    Timestamp timestamp = MockSpannerTestActions.writeAtLeastOnceInsertMutation(client);
     assertNotNull(timestamp);
 
     List<CommitRequest> commitRequests = mockSpanner.getRequestsOfType(CommitRequest.class);
@@ -1508,10 +1491,8 @@ public class DatabaseClientImplTest {
   public void testWriteAtLeastOnceWithOptions() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    client.writeAtLeastOnceWithOptions(
-        Collections.singletonList(
-            Mutation.newInsertBuilder("FOO").set("ID").to(1L).set("NAME").to("Bar").build()),
-        Options.priority(RpcPriority.LOW));
+    MockSpannerTestActions.writeAtLeastOnceWithOptionsInsertMutation(
+        client, Options.priority(RpcPriority.LOW));
 
     List<CommitRequest> commitRequests = mockSpanner.getRequestsOfType(CommitRequest.class);
     assertThat(commitRequests).hasSize(1);
@@ -1527,10 +1508,8 @@ public class DatabaseClientImplTest {
   public void testWriteAtLeastOnceWithTagOptions() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    client.writeAtLeastOnceWithOptions(
-        Collections.singletonList(
-            Mutation.newInsertBuilder("FOO").set("ID").to(1L).set("NAME").to("Bar").build()),
-        Options.tag("app=spanner,env=test"));
+    MockSpannerTestActions.writeAtLeastOnceWithOptionsInsertMutation(
+        client, Options.tag("app=spanner,env=test"));
 
     List<CommitRequest> commitRequests = mockSpanner.getRequestsOfType(CommitRequest.class);
     assertThat(commitRequests).hasSize(1);
@@ -1547,10 +1526,8 @@ public class DatabaseClientImplTest {
   public void testWriteAtLeastOnceWithExcludeTxnFromChangeStreams() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    client.writeAtLeastOnceWithOptions(
-        Collections.singletonList(
-            Mutation.newInsertBuilder("FOO").set("ID").to(1L).set("NAME").to("Bar").build()),
-        Options.excludeTxnFromChangeStreams());
+    MockSpannerTestActions.writeAtLeastOnceWithOptionsInsertMutation(
+        client, Options.excludeTxnFromChangeStreams());
 
     List<CommitRequest> commitRequests = mockSpanner.getRequestsOfType(CommitRequest.class);
     assertThat(commitRequests).hasSize(1);
@@ -2016,13 +1993,8 @@ public class DatabaseClientImplTest {
   public void testCommitWithTag() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    TransactionRunner runner =
-        client.readWriteTransaction(Options.tag("app=spanner,env=test,action=commit"));
-    runner.run(
-        transaction -> {
-          transaction.buffer(Mutation.delete("TEST", KeySet.all()));
-          return null;
-        });
+    MockSpannerTestActions.commitDeleteTransaction(
+        client, Options.tag("app=spanner,env=test,action=commit"));
 
     List<BeginTransactionRequest> beginTransactions =
         mockSpanner.getRequestsOfType(BeginTransactionRequest.class);
@@ -2045,12 +2017,8 @@ public class DatabaseClientImplTest {
   public void testTransactionManagerCommitWithTag() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    try (TransactionManager manager =
-        client.transactionManager(Options.tag("app=spanner,env=test,action=manager"))) {
-      TransactionContext transaction = manager.begin();
-      transaction.buffer(Mutation.delete("TEST", KeySet.all()));
-      manager.commit();
-    }
+    MockSpannerTestActions.transactionManagerCommit(
+        client, Options.tag("app=spanner,env=test,action=manager"));
 
     List<BeginTransactionRequest> beginTransactions =
         mockSpanner.getRequestsOfType(BeginTransactionRequest.class);
@@ -2076,14 +2044,8 @@ public class DatabaseClientImplTest {
   public void testAsyncRunnerCommitWithTag() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    AsyncRunner runner = client.runAsync(Options.tag("app=spanner,env=test,action=runner"));
-    get(
-        runner.runAsync(
-            txn -> {
-              txn.buffer(Mutation.delete("TEST", KeySet.all()));
-              return ApiFutures.immediateFuture(null);
-            },
-            executor));
+    MockSpannerTestActions.asyncRunnerCommit(
+        client, executor, Options.tag("app=spanner,env=test,action=runner"));
 
     List<BeginTransactionRequest> beginTransactions =
         mockSpanner.getRequestsOfType(BeginTransactionRequest.class);
@@ -2109,19 +2071,8 @@ public class DatabaseClientImplTest {
   public void testAsyncTransactionManagerCommitWithTag() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    try (AsyncTransactionManager manager =
-        client.transactionManagerAsync(Options.tag("app=spanner,env=test,action=manager"))) {
-      TransactionContextFuture transaction = manager.beginAsync();
-      get(
-          transaction
-              .then(
-                  (txn, input) -> {
-                    txn.buffer(Mutation.delete("TEST", KeySet.all()));
-                    return ApiFutures.immediateFuture(null);
-                  },
-                  executor)
-              .commitAsync());
-    }
+    MockSpannerTestActions.transactionManagerAsyncCommit(
+        client, executor, Options.tag("app=spanner,env=test,action=manager"));
 
     List<BeginTransactionRequest> beginTransactions =
         mockSpanner.getRequestsOfType(BeginTransactionRequest.class);
@@ -2162,8 +2113,8 @@ public class DatabaseClientImplTest {
   public void testReadWriteTxnWithExcludeTxnFromChangeStreams_batchUpdate() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    TransactionRunner runner = client.readWriteTransaction(Options.excludeTxnFromChangeStreams());
-    runner.run(transaction -> transaction.batchUpdate(Collections.singletonList(UPDATE_STATEMENT)));
+    MockSpannerTestActions.executeBatchUpdateTransaction(
+        client, Options.excludeTxnFromChangeStreams());
 
     List<ExecuteBatchDmlRequest> requests =
         mockSpanner.getRequestsOfType(ExecuteBatchDmlRequest.class);
@@ -2193,12 +2144,7 @@ public class DatabaseClientImplTest {
   public void testCommitWithExcludeTxnFromChangeStreams() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    TransactionRunner runner = client.readWriteTransaction(Options.excludeTxnFromChangeStreams());
-    runner.run(
-        transaction -> {
-          transaction.buffer(Mutation.delete("TEST", KeySet.all()));
-          return null;
-        });
+    MockSpannerTestActions.commitDeleteTransaction(client, Options.excludeTxnFromChangeStreams());
 
     List<BeginTransactionRequest> beginTransactions =
         mockSpanner.getRequestsOfType(BeginTransactionRequest.class);
@@ -2213,12 +2159,7 @@ public class DatabaseClientImplTest {
   public void testTransactionManagerCommitWithExcludeTxnFromChangeStreams() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    try (TransactionManager manager =
-        client.transactionManager(Options.excludeTxnFromChangeStreams())) {
-      TransactionContext transaction = manager.begin();
-      transaction.buffer(Mutation.delete("TEST", KeySet.all()));
-      manager.commit();
-    }
+    MockSpannerTestActions.transactionManagerCommit(client, Options.excludeTxnFromChangeStreams());
 
     List<BeginTransactionRequest> beginTransactions =
         mockSpanner.getRequestsOfType(BeginTransactionRequest.class);
@@ -2233,14 +2174,8 @@ public class DatabaseClientImplTest {
   public void testAsyncRunnerCommitWithExcludeTxnFromChangeStreams() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    AsyncRunner runner = client.runAsync(Options.excludeTxnFromChangeStreams());
-    get(
-        runner.runAsync(
-            txn -> {
-              txn.buffer(Mutation.delete("TEST", KeySet.all()));
-              return ApiFutures.immediateFuture(null);
-            },
-            executor));
+    MockSpannerTestActions.asyncRunnerCommit(
+        client, executor, Options.excludeTxnFromChangeStreams());
 
     List<BeginTransactionRequest> beginTransactions =
         mockSpanner.getRequestsOfType(BeginTransactionRequest.class);
@@ -2255,19 +2190,8 @@ public class DatabaseClientImplTest {
   public void testAsyncTransactionManagerCommitWithExcludeTxnFromChangeStreams() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    try (AsyncTransactionManager manager =
-        client.transactionManagerAsync(Options.excludeTxnFromChangeStreams())) {
-      TransactionContextFuture transaction = manager.beginAsync();
-      get(
-          transaction
-              .then(
-                  (txn, input) -> {
-                    txn.buffer(Mutation.delete("TEST", KeySet.all()));
-                    return ApiFutures.immediateFuture(null);
-                  },
-                  executor)
-              .commitAsync());
-    }
+    MockSpannerTestActions.transactionManagerAsyncCommit(
+        client, executor, Options.excludeTxnFromChangeStreams());
 
     List<BeginTransactionRequest> beginTransactions =
         mockSpanner.getRequestsOfType(BeginTransactionRequest.class);
@@ -4196,12 +4120,7 @@ public class DatabaseClientImplTest {
   public void testCommitWithPriority() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    TransactionRunner runner = client.readWriteTransaction(Options.priority(RpcPriority.HIGH));
-    runner.run(
-        transaction -> {
-          transaction.buffer(Mutation.delete("TEST", KeySet.all()));
-          return null;
-        });
+    MockSpannerTestActions.commitDeleteTransaction(client, Options.priority(RpcPriority.HIGH));
 
     List<CommitRequest> requests = mockSpanner.getRequestsOfType(CommitRequest.class);
     assertThat(requests).hasSize(1);
@@ -4214,12 +4133,7 @@ public class DatabaseClientImplTest {
   public void testTransactionManagerCommitWithPriority() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    try (TransactionManager manager =
-        client.transactionManager(Options.priority(RpcPriority.HIGH))) {
-      TransactionContext transaction = manager.begin();
-      transaction.buffer(Mutation.delete("TEST", KeySet.all()));
-      manager.commit();
-    }
+    MockSpannerTestActions.transactionManagerCommit(client, Options.priority(RpcPriority.HIGH));
 
     List<CommitRequest> requests = mockSpanner.getRequestsOfType(CommitRequest.class);
     assertThat(requests).hasSize(1);
@@ -4232,14 +4146,7 @@ public class DatabaseClientImplTest {
   public void testAsyncRunnerCommitWithPriority() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    AsyncRunner runner = client.runAsync(Options.priority(RpcPriority.HIGH));
-    get(
-        runner.runAsync(
-            txn -> {
-              txn.buffer(Mutation.delete("TEST", KeySet.all()));
-              return ApiFutures.immediateFuture(null);
-            },
-            executor));
+    MockSpannerTestActions.asyncRunnerCommit(client, executor, Options.priority(RpcPriority.HIGH));
 
     List<CommitRequest> requests = mockSpanner.getRequestsOfType(CommitRequest.class);
     assertThat(requests).hasSize(1);
@@ -4252,19 +4159,8 @@ public class DatabaseClientImplTest {
   public void testAsyncTransactionManagerCommitWithPriority() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    try (AsyncTransactionManager manager =
-        client.transactionManagerAsync(Options.priority(RpcPriority.HIGH))) {
-      TransactionContextFuture transaction = manager.beginAsync();
-      get(
-          transaction
-              .then(
-                  (txn, input) -> {
-                    txn.buffer(Mutation.delete("TEST", KeySet.all()));
-                    return ApiFutures.immediateFuture(null);
-                  },
-                  executor)
-              .commitAsync());
-    }
+    MockSpannerTestActions.transactionManagerAsyncCommit(
+        client, executor, Options.priority(RpcPriority.HIGH));
 
     List<CommitRequest> requests = mockSpanner.getRequestsOfType(CommitRequest.class);
     assertThat(requests).hasSize(1);
@@ -4277,12 +4173,7 @@ public class DatabaseClientImplTest {
   public void testCommitWithoutMaxCommitDelay() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    TransactionRunner runner = client.readWriteTransaction();
-    runner.run(
-        transaction -> {
-          transaction.buffer(Mutation.delete("TEST", KeySet.all()));
-          return null;
-        });
+    MockSpannerTestActions.commitDeleteTransaction(client);
 
     List<CommitRequest> requests = mockSpanner.getRequestsOfType(CommitRequest.class);
     assertThat(requests).hasSize(1);
@@ -4294,13 +4185,8 @@ public class DatabaseClientImplTest {
   public void testCommitWithMaxCommitDelay() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    TransactionRunner runner =
-        client.readWriteTransaction(Options.maxCommitDelay(java.time.Duration.ofMillis(100)));
-    runner.run(
-        transaction -> {
-          transaction.buffer(Mutation.delete("TEST", KeySet.all()));
-          return null;
-        });
+    MockSpannerTestActions.commitDeleteTransaction(
+        client, Options.maxCommitDelay(java.time.Duration.ofMillis(100)));
 
     List<CommitRequest> requests = mockSpanner.getRequestsOfType(CommitRequest.class);
     assertThat(requests).hasSize(1);
@@ -4315,11 +4201,8 @@ public class DatabaseClientImplTest {
   public void testTransactionManagerCommitWithMaxCommitDelay() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    TransactionManager manager =
-        client.transactionManager(Options.maxCommitDelay(java.time.Duration.ofMillis(100)));
-    TransactionContext transaction = manager.begin();
-    transaction.buffer(Mutation.delete("TEST", KeySet.all()));
-    manager.commit();
+    MockSpannerTestActions.transactionManagerCommit(
+        client, Options.maxCommitDelay(java.time.Duration.ofMillis(100)));
 
     List<CommitRequest> requests = mockSpanner.getRequestsOfType(CommitRequest.class);
     assertThat(requests).hasSize(1);
@@ -4334,14 +4217,8 @@ public class DatabaseClientImplTest {
   public void testAsyncRunnerCommitWithMaxCommitDelay() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    AsyncRunner runner = client.runAsync(Options.maxCommitDelay(java.time.Duration.ofMillis(100)));
-    get(
-        runner.runAsync(
-            txn -> {
-              txn.buffer(Mutation.delete("TEST", KeySet.all()));
-              return ApiFutures.immediateFuture(null);
-            },
-            executor));
+    MockSpannerTestActions.asyncRunnerCommit(
+        client, executor, Options.maxCommitDelay(java.time.Duration.ofMillis(100)));
 
     List<CommitRequest> requests = mockSpanner.getRequestsOfType(CommitRequest.class);
     assertThat(requests).hasSize(1);
@@ -4356,19 +4233,8 @@ public class DatabaseClientImplTest {
   public void testAsyncTransactionManagerCommitWithMaxCommitDelay() {
     DatabaseClient client =
         spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
-    try (AsyncTransactionManager manager =
-        client.transactionManagerAsync(Options.maxCommitDelay(java.time.Duration.ofMillis(100)))) {
-      TransactionContextFuture transaction = manager.beginAsync();
-      get(
-          transaction
-              .then(
-                  (txn, input) -> {
-                    txn.buffer(Mutation.delete("TEST", KeySet.all()));
-                    return ApiFutures.immediateFuture(null);
-                  },
-                  executor)
-              .commitAsync());
-    }
+    MockSpannerTestActions.transactionManagerAsyncCommit(
+        client, executor, Options.maxCommitDelay(java.time.Duration.ofMillis(100)));
 
     List<CommitRequest> requests = mockSpanner.getRequestsOfType(CommitRequest.class);
     assertThat(requests).hasSize(1);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -98,6 +98,7 @@ import com.google.spanner.v1.ResultSetMetadata;
 import com.google.spanner.v1.ResultSetStats;
 import com.google.spanner.v1.StructType;
 import com.google.spanner.v1.StructType.Field;
+import com.google.spanner.v1.TransactionOptions.IsolationLevel;
 import com.google.spanner.v1.Type;
 import com.google.spanner.v1.TypeAnnotationCode;
 import com.google.spanner.v1.TypeCode;
@@ -1928,6 +1929,9 @@ public class DatabaseClientImplTest {
         .isEqualTo("app=spanner,env=test,action=read");
     assertThat(request.getRequestOptions().getTransactionTag())
         .isEqualTo("app=spanner,env=test,action=txn");
+    assertEquals(
+        IsolationLevel.ISOLATION_LEVEL_UNSPECIFIED,
+        request.getTransaction().getBegin().getIsolationLevel());
   }
 
   @Test
@@ -1950,6 +1954,9 @@ public class DatabaseClientImplTest {
     assertNotNull(request.getTransaction().getBegin());
     assertTrue(request.getTransaction().getBegin().hasReadWrite());
     assertFalse(request.getTransaction().getBegin().getExcludeTxnFromChangeStreams());
+    assertEquals(
+        IsolationLevel.ISOLATION_LEVEL_UNSPECIFIED,
+        request.getTransaction().getBegin().getIsolationLevel());
   }
 
   @Test
@@ -1976,6 +1983,9 @@ public class DatabaseClientImplTest {
     assertNotNull(request.getTransaction().getBegin());
     assertTrue(request.getTransaction().getBegin().hasReadWrite());
     assertFalse(request.getTransaction().getBegin().getExcludeTxnFromChangeStreams());
+    assertEquals(
+        IsolationLevel.ISOLATION_LEVEL_UNSPECIFIED,
+        request.getTransaction().getBegin().getIsolationLevel());
   }
 
   @Test
@@ -2049,6 +2059,9 @@ public class DatabaseClientImplTest {
     assertNotNull(beginTransaction.getOptions());
     assertTrue(beginTransaction.getOptions().hasReadWrite());
     assertFalse(beginTransaction.getOptions().getExcludeTxnFromChangeStreams());
+    assertEquals(
+        IsolationLevel.ISOLATION_LEVEL_UNSPECIFIED,
+        beginTransaction.getOptions().getIsolationLevel());
 
     List<CommitRequest> requests = mockSpanner.getRequestsOfType(CommitRequest.class);
     assertThat(requests).hasSize(1);
@@ -2079,6 +2092,9 @@ public class DatabaseClientImplTest {
     assertNotNull(beginTransaction.getOptions());
     assertTrue(beginTransaction.getOptions().hasReadWrite());
     assertFalse(beginTransaction.getOptions().getExcludeTxnFromChangeStreams());
+    assertEquals(
+        IsolationLevel.ISOLATION_LEVEL_UNSPECIFIED,
+        beginTransaction.getOptions().getIsolationLevel());
 
     List<CommitRequest> requests = mockSpanner.getRequestsOfType(CommitRequest.class);
     assertThat(requests).hasSize(1);
@@ -2114,6 +2130,9 @@ public class DatabaseClientImplTest {
     assertNotNull(beginTransaction.getOptions());
     assertTrue(beginTransaction.getOptions().hasReadWrite());
     assertFalse(beginTransaction.getOptions().getExcludeTxnFromChangeStreams());
+    assertEquals(
+        IsolationLevel.ISOLATION_LEVEL_UNSPECIFIED,
+        beginTransaction.getOptions().getIsolationLevel());
 
     List<CommitRequest> requests = mockSpanner.getRequestsOfType(CommitRequest.class);
     assertThat(requests).hasSize(1);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplWithDefaultRWTransactionOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplWithDefaultRWTransactionOptionsTest.java
@@ -57,9 +57,9 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class DatabaseClientImplWithDefaultRWTransactionOptionsTest {
   private static final TransactionOption SERIALIZABLE_ISOLATION_OPTION =
-      Options.isolationLevelOption(IsolationLevel.SERIALIZABLE);
+      Options.isolationLevel(IsolationLevel.SERIALIZABLE);
   private static final TransactionOption RR_ISOLATION_OPTION =
-      Options.isolationLevelOption(IsolationLevel.REPEATABLE_READ);
+      Options.isolationLevel(IsolationLevel.REPEATABLE_READ);
   private static final DatabaseId DATABASE_ID =
       DatabaseId.of("[PROJECT]", "[INSTANCE]", "[DATABASE]");
   private static MockSpannerServiceImpl mockSpanner;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplWithTransactionOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplWithTransactionOptionsTest.java
@@ -1,0 +1,497 @@
+package com.google.cloud.spanner;
+
+import static com.google.cloud.spanner.SpannerApiFutures.get;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.grpc.testing.LocalChannelProvider;
+import com.google.cloud.NoCredentials;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.AsyncTransactionManager.TransactionContextFuture;
+import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.cloud.spanner.Options.RpcPriority;
+import com.google.cloud.spanner.SpannerOptions.Builder.TransactionOptions.TransactionOptionsBuilder;
+import com.google.protobuf.AbstractMessage;
+import com.google.protobuf.ListValue;
+import com.google.spanner.v1.BeginTransactionRequest;
+import com.google.spanner.v1.CommitRequest;
+import com.google.spanner.v1.ExecuteBatchDmlRequest;
+import com.google.spanner.v1.ExecuteSqlRequest;
+import com.google.spanner.v1.ReadRequest;
+import com.google.spanner.v1.ResultSetMetadata;
+import com.google.spanner.v1.StructType;
+import com.google.spanner.v1.StructType.Field;
+import com.google.spanner.v1.TransactionOptions.IsolationLevel;
+import com.google.spanner.v1.TypeCode;
+import io.grpc.Server;
+import io.grpc.Status;
+import io.grpc.inprocess.InProcessServerBuilder;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class DatabaseClientImplWithTransactionOptionsTest {
+
+  private static MockSpannerServiceImpl mockSpanner;
+  private static Server server;
+  private static ExecutorService executor;
+  private static LocalChannelProvider channelProvider;
+  private static final Statement UPDATE_STATEMENT =
+      Statement.of("UPDATE FOO SET BAR=1 WHERE BAZ=2");
+  private static final Statement INVALID_UPDATE_STATEMENT =
+      Statement.of("UPDATE NON_EXISTENT_TABLE SET BAR=1 WHERE BAZ=2");
+  private static final Statement INVALID_SELECT_STATEMENT =
+      Statement.of("SELECT * FROM NON_EXISTENT_TABLE");
+  private static final long UPDATE_COUNT = 1L;
+  private static final Statement SELECT1 = Statement.of("SELECT 1 AS COL1");
+  private static final ResultSetMetadata SELECT1_METADATA =
+      ResultSetMetadata.newBuilder()
+          .setRowType(
+              StructType.newBuilder()
+                  .addFields(
+                      Field.newBuilder()
+                          .setName("COL1")
+                          .setType(
+                              com.google.spanner.v1.Type.newBuilder()
+                                  .setCode(TypeCode.INT64)
+                                  .build())
+                          .build())
+                  .build())
+          .build();
+  private static final com.google.spanner.v1.ResultSet SELECT1_RESULTSET =
+      com.google.spanner.v1.ResultSet.newBuilder()
+          .addRows(
+              ListValue.newBuilder()
+                  .addValues(com.google.protobuf.Value.newBuilder().setStringValue("1").build())
+                  .build())
+          .setMetadata(SELECT1_METADATA)
+          .build();
+  private Spanner spanner;
+  private Spanner spannerWithRepeatableReadOption;
+  private Spanner spannerWithSerializableOption;
+  private DatabaseClient client;
+  private DatabaseClient clientWithRepeatableReadOption;
+  private DatabaseClient clientWithSerializableOption;
+
+  @BeforeClass
+  public static void startStaticServer() throws IOException {
+    mockSpanner = new MockSpannerServiceImpl();
+    mockSpanner.setAbortProbability(0.0D); // We don't want any unpredictable aborted transactions.
+    mockSpanner.putStatementResult(StatementResult.update(UPDATE_STATEMENT, UPDATE_COUNT));
+    mockSpanner.putStatementResult(StatementResult.query(SELECT1, SELECT1_RESULTSET));
+    mockSpanner.putStatementResult(
+        StatementResult.exception(
+            INVALID_UPDATE_STATEMENT,
+            Status.INVALID_ARGUMENT.withDescription("invalid statement").asRuntimeException()));
+    mockSpanner.putStatementResult(
+        StatementResult.exception(
+            INVALID_SELECT_STATEMENT,
+            Status.INVALID_ARGUMENT.withDescription("invalid statement").asRuntimeException()));
+    mockSpanner.putStatementResult(
+        StatementResult.read(
+            "FOO", KeySet.all(), Collections.singletonList("ID"), SELECT1_RESULTSET));
+
+    String uniqueName = InProcessServerBuilder.generateName();
+    executor = Executors.newSingleThreadExecutor();
+    server =
+        InProcessServerBuilder.forName(uniqueName)
+            // We need to use a real executor for timeouts to occur.
+            .scheduledExecutorService(new ScheduledThreadPoolExecutor(1))
+            .addService(mockSpanner)
+            .build()
+            .start();
+    channelProvider = LocalChannelProvider.create(uniqueName);
+  }
+
+  @AfterClass
+  public static void stopServer() throws InterruptedException {
+    server.shutdown();
+    server.awaitTermination();
+  }
+
+  @Before
+  public void setUp() {
+    mockSpanner.reset();
+    mockSpanner.removeAllExecutionTimes();
+    SpannerOptions.Builder spannerOptionsBuilder =
+        SpannerOptions.newBuilder()
+            .setProjectId("[PROJECT]")
+            .setChannelProvider(channelProvider)
+            .setCredentials(NoCredentials.getInstance());
+    spanner = spannerOptionsBuilder.build().getService();
+    spannerWithRepeatableReadOption =
+        spannerOptionsBuilder
+            .setDefaultTransactionOptions(
+                TransactionOptionsBuilder.newBuilder()
+                    .setIsolationLevel(Options.repeatableReadIsolationLevel())
+                    .build())
+            .build()
+            .getService();
+    spannerWithSerializableOption =
+        spannerOptionsBuilder
+            .setDefaultTransactionOptions(
+                TransactionOptionsBuilder.newBuilder()
+                    .setIsolationLevel(Options.serializableIsolationLevel())
+                    .build())
+            .build()
+            .getService();
+    client = spanner.getDatabaseClient(DatabaseId.of("[PROJECT]", "[INSTANCE]", "[DATABASE]"));
+    clientWithRepeatableReadOption =
+        spannerWithRepeatableReadOption.getDatabaseClient(
+            DatabaseId.of("[PROJECT]", "[INSTANCE]", "[DATABASE]"));
+    clientWithSerializableOption =
+        spannerWithSerializableOption.getDatabaseClient(
+            DatabaseId.of("[PROJECT]", "[INSTANCE]", "[DATABASE]"));
+  }
+
+  @After
+  public void tearDown() {
+    spanner.close();
+    spannerWithRepeatableReadOption.close();
+    spannerWithSerializableOption.close();
+  }
+
+  @Test
+  public void testWrite_WithNoIsolationLevel() {
+    Timestamp timestamp =
+        client.write(
+            Collections.singletonList(
+                Mutation.newInsertBuilder("FOO").set("ID").to(1L).set("NAME").to("Bar").build()));
+    assertNotNull(timestamp);
+    validateIsolationLevel(IsolationLevel.ISOLATION_LEVEL_UNSPECIFIED);
+  }
+
+  @Test
+  public void testWrite_WithRRSpannerOptions() {
+    Timestamp timestamp =
+        clientWithRepeatableReadOption.write(
+            Collections.singletonList(
+                Mutation.newInsertBuilder("FOO").set("ID").to(1L).set("NAME").to("Bar").build()));
+    assertNotNull(timestamp);
+    validateIsolationLevel(IsolationLevel.REPEATABLE_READ);
+  }
+
+  @Test
+  public void testWriteWithOptions_WithRRSpannerOptions() {
+    clientWithRepeatableReadOption.writeWithOptions(
+        Collections.singletonList(
+            Mutation.newInsertBuilder("FOO").set("ID").to(1L).set("NAME").to("Bar").build()),
+        Options.priority(RpcPriority.HIGH));
+    validateIsolationLevel(IsolationLevel.REPEATABLE_READ);
+  }
+
+  @Test
+  public void testWriteWithOptions_WithSerializableTxnOption() {
+    clientWithRepeatableReadOption.writeWithOptions(
+        Collections.singletonList(
+            Mutation.newInsertBuilder("FOO").set("ID").to(1L).set("NAME").to("Bar").build()),
+        Options.serializableIsolationLevel());
+    validateIsolationLevel(IsolationLevel.SERIALIZABLE);
+  }
+
+  @Test
+  public void testWriteAtLeastOnce_WithSerializableSpannerOptions() {
+    Timestamp timestamp =
+        clientWithSerializableOption.writeAtLeastOnce(
+            Collections.singletonList(
+                Mutation.newInsertBuilder("FOO").set("ID").to(1L).set("NAME").to("Bar").build()));
+    assertNotNull(timestamp);
+    validateIsolationLevel(IsolationLevel.SERIALIZABLE);
+  }
+
+  @Test
+  public void testWriteAtLeastOnceWithOptions_WithRRTxnOption() {
+    clientWithSerializableOption.writeAtLeastOnceWithOptions(
+        Collections.singletonList(
+            Mutation.newInsertBuilder("FOO").set("ID").to(1L).set("NAME").to("Bar").build()),
+        Options.repeatableReadIsolationLevel());
+    validateIsolationLevel(IsolationLevel.REPEATABLE_READ);
+  }
+
+  @Test
+  public void testReadWriteTxn_WithRRSpannerOption_batchUpdate() {
+    TransactionRunner runner = clientWithRepeatableReadOption.readWriteTransaction();
+    runner.run(transaction -> transaction.batchUpdate(Collections.singletonList(UPDATE_STATEMENT)));
+    validateIsolationLevel(IsolationLevel.REPEATABLE_READ);
+  }
+
+  @Test
+  public void testReadWriteTxn_WithSerializableTxnOption_batchUpdate() {
+    TransactionRunner runner =
+        clientWithRepeatableReadOption.readWriteTransaction(Options.serializableIsolationLevel());
+    runner.run(transaction -> transaction.batchUpdate(Collections.singletonList(UPDATE_STATEMENT)));
+    validateIsolationLevel(IsolationLevel.SERIALIZABLE);
+  }
+
+  @Test
+  public void testPartitionedDML_WithRRSpannerOption() {
+    clientWithRepeatableReadOption.executePartitionedUpdate(UPDATE_STATEMENT);
+    validateIsolationLevel(IsolationLevel.ISOLATION_LEVEL_UNSPECIFIED);
+  }
+
+  @Test
+  public void testCommit_WithSerializableTxnOption() {
+    TransactionRunner runner = client.readWriteTransaction(Options.serializableIsolationLevel());
+    runner.run(
+        transaction -> {
+          transaction.buffer(Mutation.delete("TEST", KeySet.all()));
+          return null;
+        });
+
+    validateIsolationLevel(IsolationLevel.SERIALIZABLE);
+  }
+
+  @Test
+  public void testTransactionManagerCommit_WithRRTxnOption() {
+    try (TransactionManager manager =
+        clientWithSerializableOption.transactionManager(Options.repeatableReadIsolationLevel())) {
+      TransactionContext transaction = manager.begin();
+      transaction.buffer(Mutation.delete("TEST", KeySet.all()));
+      manager.commit();
+    }
+
+    validateIsolationLevel(IsolationLevel.REPEATABLE_READ);
+  }
+
+  @Test
+  public void testAsyncRunnerCommit_WithRRSpannerOption() {
+    AsyncRunner runner = clientWithRepeatableReadOption.runAsync();
+    get(
+        runner.runAsync(
+            txn -> {
+              txn.buffer(Mutation.delete("TEST", KeySet.all()));
+              return ApiFutures.immediateFuture(null);
+            },
+            executor));
+
+    validateIsolationLevel(IsolationLevel.REPEATABLE_READ);
+  }
+
+  @Test
+  public void testAsyncTransactionManagerCommit_WithSerializableTxnOption() {
+    try (AsyncTransactionManager manager =
+        clientWithRepeatableReadOption.transactionManagerAsync(
+            Options.serializableIsolationLevel())) {
+      TransactionContextFuture transaction = manager.beginAsync();
+      get(
+          transaction
+              .then(
+                  (txn, input) -> {
+                    txn.buffer(Mutation.delete("TEST", KeySet.all()));
+                    return ApiFutures.immediateFuture(null);
+                  },
+                  executor)
+              .commitAsync());
+    }
+
+    validateIsolationLevel(IsolationLevel.SERIALIZABLE);
+  }
+
+  @Test
+  public void testReadWriteTxn_WithNoOptions() {
+    client
+        .readWriteTransaction()
+        .run(
+            transaction -> {
+              try (ResultSet rs = transaction.executeQuery(SELECT1)) {
+                while (rs.next()) {
+                  assertEquals(rs.getLong(0), 1);
+                }
+              }
+              return null;
+            });
+    validateIsolationLevel(IsolationLevel.ISOLATION_LEVEL_UNSPECIFIED);
+  }
+
+  @Test
+  public void executeSqlWithRWTransactionOptions_RepeatableRead() {
+    client
+        .readWriteTransaction(Options.repeatableReadIsolationLevel())
+        .run(
+            transaction -> {
+              try (ResultSet rs = transaction.executeQuery(SELECT1)) {
+                while (rs.next()) {
+                  assertEquals(rs.getLong(0), 1);
+                }
+              }
+              return null;
+            });
+    validateIsolationLevel(IsolationLevel.REPEATABLE_READ);
+  }
+
+  @Test
+  public void
+      executeSqlWithDefaultSpannerOptions_SerializableAndRWTransactionOptions_RepeatableRead() {
+    clientWithSerializableOption
+        .readWriteTransaction(Options.repeatableReadIsolationLevel())
+        .run(
+            transaction -> {
+              try (ResultSet rs = transaction.executeQuery(SELECT1)) {
+                while (rs.next()) {
+                  assertEquals(rs.getLong(0), 1);
+                }
+              }
+              return null;
+            });
+    validateIsolationLevel(IsolationLevel.REPEATABLE_READ);
+  }
+
+  @Test
+  public void
+      executeSqlWithDefaultSpannerOptions_RepeatableReadAndRWTransactionOptions_Serializable() {
+    clientWithRepeatableReadOption
+        .readWriteTransaction(Options.serializableIsolationLevel())
+        .run(
+            transaction -> {
+              try (ResultSet rs = transaction.executeQuery(SELECT1)) {
+                while (rs.next()) {
+                  assertEquals(rs.getLong(0), 1);
+                }
+              }
+              return null;
+            });
+    validateIsolationLevel(IsolationLevel.SERIALIZABLE);
+  }
+
+  @Test
+  public void executeSqlWithDefaultSpannerOptions_RepeatableReadAndNoRWTransactionOptions() {
+    clientWithRepeatableReadOption
+        .readWriteTransaction()
+        .run(
+            transaction -> {
+              try (ResultSet rs = transaction.executeQuery(SELECT1)) {
+                while (rs.next()) {
+                  assertEquals(rs.getLong(0), 1);
+                }
+              }
+              return null;
+            });
+    validateIsolationLevel(IsolationLevel.REPEATABLE_READ);
+  }
+
+  @Test
+  public void executeSqlWithRWTransactionOptions_Serializable() {
+    client
+        .readWriteTransaction(Options.serializableIsolationLevel())
+        .run(
+            transaction -> {
+              try (ResultSet rs = transaction.executeQuery(SELECT1)) {
+                while (rs.next()) {
+                  assertEquals(rs.getLong(0), 1);
+                }
+              }
+              return null;
+            });
+    validateIsolationLevel(IsolationLevel.SERIALIZABLE);
+  }
+
+  @Test
+  public void readWithRWTransactionOptions_RepeatableRead() {
+    client
+        .readWriteTransaction(Options.repeatableReadIsolationLevel())
+        .run(
+            transaction -> {
+              try (ResultSet rs =
+                  transaction.read("FOO", KeySet.all(), Collections.singletonList("ID"))) {
+                while (rs.next()) {
+                  assertEquals(rs.getLong(0), 1);
+                }
+              }
+              return null;
+            });
+    validateIsolationLevel(IsolationLevel.REPEATABLE_READ);
+  }
+
+  @Test
+  public void readWithRWTransactionOptions_Serializable() {
+    client
+        .readWriteTransaction(Options.serializableIsolationLevel())
+        .run(
+            transaction -> {
+              try (ResultSet rs =
+                  transaction.read("FOO", KeySet.all(), Collections.singletonList("ID"))) {
+                while (rs.next()) {
+                  assertEquals(rs.getLong(0), 1);
+                }
+              }
+              return null;
+            });
+    validateIsolationLevel(IsolationLevel.SERIALIZABLE);
+  }
+
+  @Test
+  public void beginTransactionWithRWTransactionOptions_RepeatableRead() {
+    client
+        .readWriteTransaction(Options.repeatableReadIsolationLevel())
+        .run(
+            transaction -> {
+              try (ResultSet rs = transaction.executeQuery(INVALID_SELECT_STATEMENT)) {
+                SpannerException e = assertThrows(SpannerException.class, () -> rs.next());
+                assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCode());
+              }
+              return transaction.executeUpdate(UPDATE_STATEMENT);
+            });
+    validateIsolationLevel(IsolationLevel.REPEATABLE_READ);
+  }
+
+  @Test
+  public void beginTransactionWithRWTransactionOptions_Serializable() {
+    client
+        .readWriteTransaction(Options.serializableIsolationLevel())
+        .run(
+            transaction -> {
+              try (ResultSet rs = transaction.executeQuery(INVALID_SELECT_STATEMENT)) {
+                SpannerException e = assertThrows(SpannerException.class, () -> rs.next());
+                assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCode());
+              }
+              return transaction.executeUpdate(UPDATE_STATEMENT);
+            });
+    validateIsolationLevel(IsolationLevel.SERIALIZABLE);
+  }
+
+  private void validateIsolationLevel(IsolationLevel isolationLevel) {
+    boolean foundMatchingRequest = false;
+    for (AbstractMessage request : mockSpanner.getRequests()) {
+      if (request instanceof ExecuteSqlRequest) {
+        foundMatchingRequest = true;
+        assertEquals(
+            ((ExecuteSqlRequest) request).getTransaction().getBegin().getIsolationLevel(),
+            isolationLevel);
+      } else if (request instanceof BeginTransactionRequest) {
+        foundMatchingRequest = true;
+        assertEquals(
+            ((BeginTransactionRequest) request).getOptions().getIsolationLevel(), isolationLevel);
+      } else if (request instanceof ReadRequest) {
+        foundMatchingRequest = true;
+        assertEquals(
+            ((ReadRequest) request).getTransaction().getBegin().getIsolationLevel(),
+            isolationLevel);
+      } else if (request instanceof CommitRequest) {
+        foundMatchingRequest = true;
+        assertEquals(
+            ((CommitRequest) request).getSingleUseTransaction().getIsolationLevel(),
+            isolationLevel);
+      } else if (request instanceof ExecuteBatchDmlRequest) {
+        foundMatchingRequest = true;
+        assertEquals(
+            ((ExecuteBatchDmlRequest) request).getTransaction().getBegin().getIsolationLevel(),
+            isolationLevel);
+      }
+      if (foundMatchingRequest) {
+        break;
+      }
+    }
+  }
+}

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
@@ -590,19 +590,7 @@ public class InlineBeginTransactionTest {
       DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
       mockSpanner.setExecuteStreamingSqlExecutionTime(
           SimulatedExecutionTime.ofStreamException(Status.UNAVAILABLE.asRuntimeException(), 0));
-      long value =
-          client
-              .readWriteTransaction()
-              .run(
-                  transaction -> {
-                    // The first attempt will return UNAVAILABLE and retry internally.
-                    try (ResultSet rs = transaction.executeQuery(SELECT1)) {
-                      while (rs.next()) {
-                        return rs.getLong(0);
-                      }
-                    }
-                    return 0L;
-                  });
+      long value = MockSpannerTestActions.executeSelect1(client);
       assertThat(value).isEqualTo(1L);
       assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(0);
       assertThat(countRequests(ExecuteSqlRequest.class)).isEqualTo(2);
@@ -614,20 +602,7 @@ public class InlineBeginTransactionTest {
       DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
       mockSpanner.setStreamingReadExecutionTime(
           SimulatedExecutionTime.ofStreamException(Status.UNAVAILABLE.asRuntimeException(), 0));
-      Long value =
-          client
-              .readWriteTransaction()
-              .run(
-                  transaction -> {
-                    // The first attempt will return UNAVAILABLE and retry internally.
-                    try (ResultSet rs =
-                        transaction.read("FOO", KeySet.all(), Collections.singletonList("ID"))) {
-                      while (rs.next()) {
-                        return rs.getLong(0);
-                      }
-                    }
-                    return 0L;
-                  });
+      Long value = MockSpannerTestActions.executeReadFoo(client);
       assertThat(value).isEqualTo(1L);
       assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(0);
       assertThat(countRequests(ReadRequest.class)).isEqualTo(2);
@@ -641,22 +616,7 @@ public class InlineBeginTransactionTest {
           SimulatedExecutionTime.ofExceptions(
               Arrays.asList(
                   Status.UNAVAILABLE.asRuntimeException(), Status.ABORTED.asRuntimeException())));
-      Long value =
-          client
-              .readWriteTransaction()
-              .run(
-                  transaction -> {
-                    // The first attempt will return UNAVAILABLE and retry internally.
-                    // The second attempt will return ABORTED and should cause the transaction to
-                    // retry.
-                    try (ResultSet rs =
-                        transaction.read("FOO", KeySet.all(), Collections.singletonList("ID"))) {
-                      if (rs.next()) {
-                        return rs.getLong(0);
-                      }
-                    }
-                    return 0L;
-                  });
+      Long value = MockSpannerTestActions.executeReadFoo(client);
       assertThat(value).isEqualTo(1L);
       assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(1);
       assertThat(countRequests(ReadRequest.class)).isEqualTo(3);
@@ -670,21 +630,7 @@ public class InlineBeginTransactionTest {
           SimulatedExecutionTime.ofExceptions(
               Arrays.asList(
                   Status.UNAVAILABLE.asRuntimeException(), Status.ABORTED.asRuntimeException())));
-      Long value =
-          client
-              .readWriteTransaction()
-              .run(
-                  transaction -> {
-                    // The first attempt will return UNAVAILABLE and retry internally.
-                    // The second attempt will return ABORTED and should cause the transaction to
-                    // retry.
-                    try (ResultSet rs = transaction.executeQuery(SELECT1)) {
-                      if (rs.next()) {
-                        return rs.getLong(0);
-                      }
-                    }
-                    return 0L;
-                  });
+      Long value = MockSpannerTestActions.executeSelect1(client);
       assertThat(value).isEqualTo(1L);
       assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(1);
       assertThat(countRequests(ExecuteSqlRequest.class)).isEqualTo(3);
@@ -721,24 +667,7 @@ public class InlineBeginTransactionTest {
           SimulatedExecutionTime.ofExceptions(
               Arrays.asList(
                   Status.UNAVAILABLE.asRuntimeException(), Status.ABORTED.asRuntimeException())));
-      Long value =
-          client
-              .readWriteTransaction()
-              .run(
-                  transaction -> {
-                    // The first attempt will return UNAVAILABLE and retry internally.
-                    // The second attempt will return ABORTED and should cause the transaction to
-                    // retry.
-                    try (ResultSet rs =
-                        transaction.read("FOO", KeySet.all(), Collections.singletonList("ID"))) {
-                      if (rs.next()) {
-                        return rs.getLong(0);
-                      }
-                    } catch (AbortedException e) {
-                      // Ignore the AbortedException and let the commit handle it.
-                    }
-                    return 0L;
-                  });
+      Long value = MockSpannerTestActions.executeReadFoo(client);
       assertThat(value).isEqualTo(1L);
       assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(1);
       assertThat(countRequests(ReadRequest.class)).isEqualTo(3);
@@ -780,23 +709,7 @@ public class InlineBeginTransactionTest {
           SimulatedExecutionTime.ofExceptions(
               Arrays.asList(
                   Status.UNAVAILABLE.asRuntimeException(), Status.ABORTED.asRuntimeException())));
-      Long value =
-          client
-              .readWriteTransaction()
-              .run(
-                  transaction -> {
-                    // The first attempt will return UNAVAILABLE and retry internally.
-                    // The second attempt will return ABORTED and should cause the transaction to
-                    // retry.
-                    try (ResultSet rs = transaction.executeQuery(SELECT1)) {
-                      if (rs.next()) {
-                        return rs.getLong(0);
-                      }
-                    } catch (AbortedException e) {
-                      // Ignore the AbortedException and let the commit handle it.
-                    }
-                    return 0L;
-                  });
+      Long value = MockSpannerTestActions.executeSelect1(client);
       assertThat(value).isEqualTo(1L);
       assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(1);
       assertThat(countRequests(ExecuteSqlRequest.class)).isEqualTo(3);
@@ -959,20 +872,7 @@ public class InlineBeginTransactionTest {
       DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
       mockSpanner.setCommitExecutionTime(
           SimulatedExecutionTime.ofException(Status.UNAVAILABLE.asRuntimeException()));
-      Long value =
-          client
-              .readWriteTransaction()
-              .run(
-                  transaction -> {
-                    // The first attempt will return UNAVAILABLE and retry internally.
-                    try (ResultSet rs =
-                        transaction.read("FOO", KeySet.all(), Collections.singletonList("ID"))) {
-                      if (rs.next()) {
-                        return rs.getLong(0);
-                      }
-                    }
-                    return 0L;
-                  });
+      Long value = MockSpannerTestActions.executeReadFoo(client);
       assertThat(value).isEqualTo(1L);
       assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(0);
       assertThat(countRequests(ReadRequest.class)).isEqualTo(1);
@@ -1013,18 +913,7 @@ public class InlineBeginTransactionTest {
     public void testInlinedBeginTxWithQuery() {
       DatabaseClient client =
           spanner.getDatabaseClient(DatabaseId.of("[PROJECT]", "[INSTANCE]", "[DATABASE]"));
-      long updateCount =
-          client
-              .readWriteTransaction()
-              .run(
-                  transaction -> {
-                    try (ResultSet rs = transaction.executeQuery(SELECT1)) {
-                      while (rs.next()) {
-                        return rs.getLong(0);
-                      }
-                    }
-                    return 0L;
-                  });
+      long updateCount = MockSpannerTestActions.executeSelect1(client);
       assertThat(updateCount).isEqualTo(1L);
       assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(0);
       assertThat(countRequests(ExecuteSqlRequest.class)).isEqualTo(1);
@@ -1035,19 +924,7 @@ public class InlineBeginTransactionTest {
     @Test
     public void testInlinedBeginTxWithRead() {
       DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
-      long updateCount =
-          client
-              .readWriteTransaction()
-              .run(
-                  transaction -> {
-                    try (ResultSet rs =
-                        transaction.read("FOO", KeySet.all(), Collections.singletonList("ID"))) {
-                      while (rs.next()) {
-                        return rs.getLong(0);
-                      }
-                    }
-                    return 0L;
-                  });
+      long updateCount = MockSpannerTestActions.executeReadFoo(client);
       assertThat(updateCount).isEqualTo(1L);
       assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(0);
       assertThat(countRequests(ReadRequest.class)).isEqualTo(1);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerTestActions.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerTestActions.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+import static com.google.cloud.spanner.MockSpannerTestUtil.INVALID_SELECT_STATEMENT;
+import static com.google.cloud.spanner.MockSpannerTestUtil.SELECT1;
+import static com.google.cloud.spanner.MockSpannerTestUtil.UPDATE_STATEMENT;
+import static com.google.cloud.spanner.SpannerApiFutures.get;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.google.api.core.ApiFutures;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.AsyncTransactionManager.TransactionContextFuture;
+import com.google.cloud.spanner.Options.TransactionOption;
+import java.util.Collections;
+import java.util.concurrent.Executor;
+
+public class MockSpannerTestActions {
+
+  static final Mutation TEST_MUTATION =
+      Mutation.newInsertBuilder("foo").set("id").to(1L).set("name").to("bar").build();
+
+  static Timestamp writeInsertMutation(DatabaseClient client) {
+    return client.write(Collections.singletonList(TEST_MUTATION));
+  }
+
+  static void writeInsertMutationWithOptions(DatabaseClient client, TransactionOption... options) {
+    client.writeWithOptions(Collections.singletonList(TEST_MUTATION), options);
+  }
+
+  static Timestamp writeAtLeastOnceInsertMutation(DatabaseClient client) {
+    return client.writeAtLeastOnce(Collections.singletonList(TEST_MUTATION));
+  }
+
+  static void writeAtLeastOnceWithOptionsInsertMutation(
+      DatabaseClient client, TransactionOption... options) {
+    client.writeAtLeastOnceWithOptions(Collections.singletonList(TEST_MUTATION), options);
+  }
+
+  static void executeBatchUpdateTransaction(DatabaseClient client, TransactionOption... options) {
+    client
+        .readWriteTransaction(options)
+        .run(transaction -> transaction.batchUpdate(Collections.singletonList(UPDATE_STATEMENT)));
+  }
+
+  static void executePartitionedUpdate(DatabaseClient client) {
+    client.executePartitionedUpdate(UPDATE_STATEMENT);
+  }
+
+  static void commitDeleteTransaction(DatabaseClient client, TransactionOption... options) {
+    client
+        .readWriteTransaction(options)
+        .run(
+            transaction -> {
+              transaction.buffer(Mutation.delete("TEST", KeySet.all()));
+              return null;
+            });
+  }
+
+  static void transactionManagerCommit(DatabaseClient client, TransactionOption... options) {
+    try (TransactionManager manager = client.transactionManager(options)) {
+      TransactionContext transaction = manager.begin();
+      transaction.buffer(Mutation.delete("TEST", KeySet.all()));
+      manager.commit();
+    }
+  }
+
+  static void asyncRunnerCommit(
+      DatabaseClient client, Executor executor, TransactionOption... options) {
+    AsyncRunner runner = client.runAsync(options);
+    SpannerApiFutures.get(
+        runner.runAsync(
+            txn -> {
+              txn.buffer(Mutation.delete("TEST", KeySet.all()));
+              return ApiFutures.immediateFuture(null);
+            },
+            executor));
+  }
+
+  static void transactionManagerAsyncCommit(
+      DatabaseClient client, Executor executor, TransactionOption... options) {
+    try (AsyncTransactionManager manager = client.transactionManagerAsync(options)) {
+      TransactionContextFuture transaction = manager.beginAsync();
+      get(
+          transaction
+              .then(
+                  (txn, input) -> {
+                    txn.buffer(Mutation.delete("TEST", KeySet.all()));
+                    return ApiFutures.immediateFuture(null);
+                  },
+                  executor)
+              .commitAsync());
+    }
+  }
+
+  static Long executeSelect1(DatabaseClient client, TransactionOption... options) {
+    return client
+        .readWriteTransaction(options)
+        .run(
+            transaction -> {
+              try (ResultSet rs = transaction.executeQuery(SELECT1)) {
+                while (rs.next()) {
+                  return rs.getLong(0);
+                }
+              } catch (AbortedException e) {
+
+              }
+              return 0L;
+            });
+  }
+
+  static Long executeReadFoo(DatabaseClient client, TransactionOption... options) {
+    return client
+        .readWriteTransaction(options)
+        .run(
+            transaction -> {
+              try (ResultSet rs =
+                  transaction.read("FOO", KeySet.all(), Collections.singletonList("ID"))) {
+                while (rs.next()) {
+                  return rs.getLong(0);
+                }
+              } catch (AbortedException e) {
+                // Ignore the AbortedException and let the commit handle it.
+              }
+              return 0L;
+            });
+  }
+
+  static Long executeInvalidAndValidSql(DatabaseClient client, TransactionOption... options) {
+    return client
+        .readWriteTransaction(options)
+        .run(
+            transaction -> {
+              // This query carries the BeginTransaction, but fails. The BeginTransaction will
+              // then be carried by the subsequent statement.
+              try (ResultSet rs = transaction.executeQuery(INVALID_SELECT_STATEMENT)) {
+                SpannerException e = assertThrows(SpannerException.class, () -> rs.next());
+                assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCode());
+              }
+              return transaction.executeUpdate(UPDATE_STATEMENT);
+            });
+  }
+}

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerTestUtil.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerTestUtil.java
@@ -50,7 +50,8 @@ public class MockSpannerTestUtil {
           .setMetadata(SELECT1_METADATA)
           .build();
   public static final Statement SELECT1_FROM_TABLE = Statement.of("SELECT 1 FROM FOO WHERE 1=1");
-
+  static final Statement INVALID_SELECT_STATEMENT =
+      Statement.of("SELECT * FROM NON_EXISTENT_TABLE");
   static final String TEST_PROJECT = "my-project";
   static final String TEST_INSTANCE = "my-instance";
   static final String TEST_DATABASE = "my-database";

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OptionsTest.java
@@ -382,8 +382,7 @@ public class OptionsTest {
   @Test
   public void testTransactionOptionsIsolationLevel() {
     Options options =
-        Options.fromTransactionOptions(
-            Options.isolationLevelOption(IsolationLevel.REPEATABLE_READ));
+        Options.fromTransactionOptions(Options.isolationLevel(IsolationLevel.REPEATABLE_READ));
     assertEquals(options.isolationLevel(), IsolationLevel.REPEATABLE_READ);
     assertEquals(
         "isolationLevel: " + IsolationLevel.REPEATABLE_READ.name() + " ", options.toString());
@@ -789,11 +788,9 @@ public class OptionsTest {
   @Test
   public void transactionOptionsIsolationLevel() {
     Options option1 =
-        Options.fromTransactionOptions(
-            Options.isolationLevelOption(IsolationLevel.REPEATABLE_READ));
+        Options.fromTransactionOptions(Options.isolationLevel(IsolationLevel.REPEATABLE_READ));
     Options option2 =
-        Options.fromTransactionOptions(
-            Options.isolationLevelOption(IsolationLevel.REPEATABLE_READ));
+        Options.fromTransactionOptions(Options.isolationLevel(IsolationLevel.REPEATABLE_READ));
     Options option3 = Options.fromTransactionOptions();
 
     assertEquals(option1, option2);
@@ -870,8 +867,8 @@ public class OptionsTest {
   @Test
   public void testOptions_WithMultipleDifferentIsolationLevels() {
     TransactionOption[] transactionOptions = {
-      Options.isolationLevelOption(IsolationLevel.REPEATABLE_READ),
-      Options.isolationLevelOption(IsolationLevel.SERIALIZABLE)
+      Options.isolationLevel(IsolationLevel.REPEATABLE_READ),
+      Options.isolationLevel(IsolationLevel.SERIALIZABLE)
     };
     Options options = Options.fromTransactionOptions(transactionOptions);
     assertEquals(options.isolationLevel(), IsolationLevel.SERIALIZABLE);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
@@ -48,6 +48,7 @@ import com.google.spanner.v1.ResultSetMetadata;
 import com.google.spanner.v1.RollbackRequest;
 import com.google.spanner.v1.Session;
 import com.google.spanner.v1.Transaction;
+import com.google.spanner.v1.TransactionOptions;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Scope;
@@ -90,6 +91,8 @@ public class SessionImplTest {
   public void setUp() {
     MockitoAnnotations.initMocks(this);
     when(spannerOptions.getNumChannels()).thenReturn(4);
+    when(spannerOptions.getDefaultTransactionOptions())
+        .thenReturn(TransactionOptions.getDefaultInstance());
     when(spannerOptions.getPrefetchChunks()).thenReturn(1);
     when(spannerOptions.getDatabaseRole()).thenReturn("role");
     when(spannerOptions.getRetrySettings()).thenReturn(RetrySettings.newBuilder().build());

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -88,6 +88,7 @@ import com.google.spanner.v1.ExecuteSqlRequest;
 import com.google.spanner.v1.ResultSetStats;
 import com.google.spanner.v1.RollbackRequest;
 import com.google.spanner.v1.Transaction;
+import com.google.spanner.v1.TransactionOptions;
 import io.opencensus.metrics.LabelValue;
 import io.opencensus.metrics.MetricRegistry;
 import io.opencensus.metrics.Metrics;
@@ -1478,6 +1479,8 @@ public class SessionPoolTest extends BaseSessionPoolTest {
           .thenReturn(
               SpannerStubSettings.newBuilder().executeStreamingSqlSettings().getRetryableCodes());
       final SessionImpl closedSession = mock(SessionImpl.class);
+      when(closedSession.defaultTransactionOptions())
+          .thenReturn(TransactionOptions.getDefaultInstance());
       when(closedSession.getName())
           .thenReturn("projects/dummy/instances/dummy/database/dummy/sessions/session-closed");
       when(closedSession.getErrorHandler()).thenReturn(DefaultErrorHandler.INSTANCE);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
@@ -37,8 +37,7 @@ import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.TransportOptions;
-import com.google.cloud.spanner.SpannerOptions.Builder.TransactionOptions;
-import com.google.cloud.spanner.SpannerOptions.Builder.TransactionOptions.TransactionOptionsBuilder;
+import com.google.cloud.spanner.SpannerOptions.Builder.DefaultReadWriteTransactionOptions;
 import com.google.cloud.spanner.SpannerOptions.FixedCloseableExecutorProvider;
 import com.google.cloud.spanner.SpannerOptions.SpannerCallContextTimeoutConfigurator;
 import com.google.cloud.spanner.admin.database.v1.stub.DatabaseAdminStubSettings;
@@ -772,19 +771,20 @@ public class SpannerOptionsTest {
 
   @Test
   public void testTransactionOptions() {
-    TransactionOptions transactionOptions =
-        TransactionOptionsBuilder.newBuilder()
-            .setIsolationLevel(Options.isolationLevelOption(IsolationLevel.SERIALIZABLE))
+    DefaultReadWriteTransactionOptions transactionOptions =
+        DefaultReadWriteTransactionOptions.newBuilder()
+            .setIsolationLevel(IsolationLevel.SERIALIZABLE)
             .build();
-    assertNull(
+    assertNotNull(
         SpannerOptions.newBuilder().setProjectId("p").build().getDefaultTransactionOptions());
     assertThat(
             SpannerOptions.newBuilder()
                 .setProjectId("p")
                 .setDefaultTransactionOptions(transactionOptions)
                 .build()
-                .getDefaultTransactionOptions())
-        .isEqualTo(transactionOptions);
+                .getDefaultTransactionOptions()
+                .getIsolationLevel())
+        .isEqualTo(IsolationLevel.SERIALIZABLE);
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
@@ -37,7 +37,6 @@ import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.TransportOptions;
-import com.google.cloud.spanner.Options.TransactionOption;
 import com.google.cloud.spanner.SpannerOptions.Builder.TransactionOptions;
 import com.google.cloud.spanner.SpannerOptions.Builder.TransactionOptions.TransactionOptionsBuilder;
 import com.google.cloud.spanner.SpannerOptions.FixedCloseableExecutorProvider;
@@ -64,6 +63,7 @@ import com.google.spanner.v1.PartitionReadRequest;
 import com.google.spanner.v1.ReadRequest;
 import com.google.spanner.v1.RollbackRequest;
 import com.google.spanner.v1.SpannerGrpc;
+import com.google.spanner.v1.TransactionOptions.IsolationLevel;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -774,29 +774,17 @@ public class SpannerOptionsTest {
   public void testTransactionOptions() {
     TransactionOptions transactionOptions =
         TransactionOptionsBuilder.newBuilder()
-            .setIsolationLevel(Options.serializableIsolationLevel())
+            .setIsolationLevel(Options.isolationLevelOption(IsolationLevel.SERIALIZABLE))
             .build();
-    assertNull(SpannerOptions.newBuilder().setProjectId("p").build().getTransactionOptions());
+    assertNull(
+        SpannerOptions.newBuilder().setProjectId("p").build().getDefaultTransactionOptions());
     assertThat(
             SpannerOptions.newBuilder()
                 .setProjectId("p")
                 .setDefaultTransactionOptions(transactionOptions)
                 .build()
-                .getTransactionOptions())
-        .isEqualTo(new TransactionOption[] {Options.serializableIsolationLevel()});
-  }
-
-  @Test
-  public void testTransactionOptionsWithError() {
-    assertNull(SpannerOptions.newBuilder().setProjectId("p").build().getTransactionOptions());
-    SpannerException e =
-        assertThrows(
-            SpannerException.class,
-            () ->
-                TransactionOptionsBuilder.newBuilder()
-                    .setIsolationLevel(Options.commitStats())
-                    .build());
-    assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCode());
+                .getDefaultTransactionOptions())
+        .isEqualTo(transactionOptions);
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
@@ -49,6 +49,7 @@ import com.google.spanner.v1.ResultSetMetadata;
 import com.google.spanner.v1.ResultSetStats;
 import com.google.spanner.v1.Session;
 import com.google.spanner.v1.Transaction;
+import com.google.spanner.v1.TransactionOptions;
 import io.opentelemetry.api.OpenTelemetry;
 import java.util.Collections;
 import java.util.UUID;
@@ -207,6 +208,8 @@ public class TransactionManagerImplTest {
   public void usesPreparedTransaction() {
     SpannerOptions options = mock(SpannerOptions.class);
     when(options.getNumChannels()).thenReturn(4);
+    when(options.getDefaultTransactionOptions())
+        .thenReturn(TransactionOptions.getDefaultInstance());
     GrpcTransportOptions transportOptions = mock(GrpcTransportOptions.class);
     when(transportOptions.getExecutorFactory()).thenReturn(new TestExecutorFactory());
     when(options.getTransportOptions()).thenReturn(transportOptions);
@@ -288,6 +291,8 @@ public class TransactionManagerImplTest {
     when(options.getNumChannels()).thenReturn(4);
     GrpcTransportOptions transportOptions = mock(GrpcTransportOptions.class);
     when(transportOptions.getExecutorFactory()).thenReturn(new TestExecutorFactory());
+    when(options.getDefaultTransactionOptions())
+        .thenReturn(TransactionOptions.getDefaultInstance());
     when(options.getTransportOptions()).thenReturn(transportOptions);
     SessionPoolOptions sessionPoolOptions =
         SessionPoolOptions.newBuilder().setMinSessions(0).setIncStep(1).build();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
@@ -58,6 +58,7 @@ import com.google.spanner.v1.ResultSetStats;
 import com.google.spanner.v1.RollbackRequest;
 import com.google.spanner.v1.Session;
 import com.google.spanner.v1.Transaction;
+import com.google.spanner.v1.TransactionOptions;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -160,6 +161,8 @@ public class TransactionRunnerImplTest {
   public void usesPreparedTransaction() {
     SpannerOptions options = mock(SpannerOptions.class);
     when(options.getNumChannels()).thenReturn(4);
+    when(options.getDefaultTransactionOptions())
+        .thenReturn(TransactionOptions.getDefaultInstance());
     GrpcTransportOptions transportOptions = mock(GrpcTransportOptions.class);
     when(transportOptions.getExecutorFactory()).thenReturn(new TestExecutorFactory());
     when(options.getTransportOptions()).thenReturn(transportOptions);
@@ -316,7 +319,8 @@ public class TransactionRunnerImplTest {
   public void inlineBegin() {
     SpannerImpl spanner = mock(SpannerImpl.class);
     SpannerOptions options = mock(SpannerOptions.class);
-
+    when(options.getDefaultTransactionOptions())
+        .thenReturn(TransactionOptions.getDefaultInstance());
     when(spanner.getRpc()).thenReturn(rpc);
     when(spanner.getDefaultQueryOptions(Mockito.any(DatabaseId.class)))
         .thenReturn(QueryOptions.getDefaultInstance());


### PR DESCRIPTION
Isolation level support added in various write APIs:
```
write
writeWithOptions
writeAtleastOnceWithOptions
readWriteTransaction
transactionManager
transactionManagerAsync
runAsync
```
Note: Samples and integration tests will be added in separate PRs.