### PR TITLE
chore: disable pool creation for multiplexed sessions

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -2447,7 +2447,7 @@ class SessionPool {
       Attributes attributes,
       AtomicLong numMultiplexedSessionsAcquired,
       AtomicLong numMultiplexedSessionsReleased) {
-    if (poolOptions.getUseMultiplexedSession()) {
+    if (poolOptions.getUseMultiplexedSession() && poolOptions.getUseMultiplexedSessionForRW()) {
       return null;
     }
     SessionPool pool =

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -2447,6 +2447,9 @@ class SessionPool {
       Attributes attributes,
       AtomicLong numMultiplexedSessionsAcquired,
       AtomicLong numMultiplexedSessionsReleased) {
+    if (poolOptions.getUseMultiplexedSession()) {
+      return null;
+    }
     SessionPool pool =
         new SessionPool(
             poolOptions,

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
@@ -298,16 +298,18 @@ class SpannerImpl extends BaseService<SpannerOptions> implements Spanner {
             useMultiplexedSession
                 ? multiplexedSessionDatabaseClient.getNumSessionsReleased()
                 : new AtomicLong();
-        SessionPool pool =
-            SessionPool.createPool(
-                getOptions(),
-                SpannerImpl.this.getSessionClient(db),
-                this.tracer,
-                labelValues,
-                attributesBuilder.build(),
-                numMultiplexedSessionsAcquired,
-                numMultiplexedSessionsReleased);
-        pool.maybeWaitOnMinSessions();
+        SessionPool pool = null;
+        if (!useMultiplexedSession) {
+          SessionPool.createPool(
+              getOptions(),
+              SpannerImpl.this.getSessionClient(db),
+              this.tracer,
+              labelValues,
+              attributesBuilder.build(),
+              numMultiplexedSessionsAcquired,
+              numMultiplexedSessionsReleased);
+          pool.maybeWaitOnMinSessions();
+        }
         DatabaseClientImpl dbClient =
             createDatabaseClient(
                 clientId,

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
@@ -300,14 +300,15 @@ class SpannerImpl extends BaseService<SpannerOptions> implements Spanner {
                 : new AtomicLong();
         SessionPool pool = null;
         if (!useMultiplexedSession) {
-          SessionPool.createPool(
-              getOptions(),
-              SpannerImpl.this.getSessionClient(db),
-              this.tracer,
-              labelValues,
-              attributesBuilder.build(),
-              numMultiplexedSessionsAcquired,
-              numMultiplexedSessionsReleased);
+          pool =
+              SessionPool.createPool(
+                  getOptions(),
+                  SpannerImpl.this.getSessionClient(db),
+                  this.tracer,
+                  labelValues,
+                  attributesBuilder.build(),
+                  numMultiplexedSessionsAcquired,
+                  numMultiplexedSessionsReleased);
           pool.maybeWaitOnMinSessions();
         }
         DatabaseClientImpl dbClient =

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
@@ -299,7 +299,7 @@ class SpannerImpl extends BaseService<SpannerOptions> implements Spanner {
                 ? multiplexedSessionDatabaseClient.getNumSessionsReleased()
                 : new AtomicLong();
         SessionPool pool = null;
-        if (!useMultiplexedSession) {
+        if (!useMultiplexedSession || !useMultiplexedSessionForRW) {
           pool =
               SessionPool.createPool(
                   getOptions(),


### PR DESCRIPTION
This PR ensures that when multiplexed sessions are enabled, the session pool is not initialized. Multiplexed sessions do not require a dedicated session pool, so skipping its initialization optimizes resource usage and reduces unnecessary overhead.