### PR TITLE
chore: wire up x-goog-spanner-request-id for BatchCreateSessions

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
@@ -27,6 +27,9 @@ import com.google.common.base.Function;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.spanner.v1.BatchWriteResponse;
 import io.opentelemetry.api.common.Attributes;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 
 class DatabaseClientImpl implements DatabaseClient {
@@ -40,6 +43,8 @@ class DatabaseClientImpl implements DatabaseClient {
   @VisibleForTesting final MultiplexedSessionDatabaseClient multiplexedSessionDatabaseClient;
   @VisibleForTesting final boolean useMultiplexedSessionPartitionedOps;
   @VisibleForTesting final boolean useMultiplexedSessionForRW;
+  private final int dbId;
+  private final AtomicInteger nthRequest;
 
   final boolean useMultiplexedSessionBlindWrite;
 
@@ -86,6 +91,15 @@ class DatabaseClientImpl implements DatabaseClient {
     this.tracer = tracer;
     this.useMultiplexedSessionForRW = useMultiplexedSessionForRW;
     this.commonAttributes = commonAttributes;
+
+    this.dbId = this.dbIdFromClientId(this.clientId);
+    this.nthRequest = new AtomicInteger(0);
+  }
+
+  private int dbIdFromClientId(String clientId) {
+    int i = clientId.indexOf("-");
+    String strWithValue = clientId.substring(i + 1);
+    return Integer.parseInt(strWithValue);
   }
 
   @VisibleForTesting
@@ -179,14 +193,30 @@ class DatabaseClientImpl implements DatabaseClient {
         return getMultiplexedSessionDatabaseClient()
             .writeAtLeastOnceWithOptions(mutations, options);
       }
+
+      int nthRequest = this.nextNthRequest();
+      int channelId = 1; /* TODO: infer the channelId from the gRPC channel of the session */
+      XGoogSpannerRequestId reqId = XGoogSpannerRequestId.of(this.dbId, channelId, nthRequest, 0);
+
       return runWithSessionRetry(
-          session -> session.writeAtLeastOnceWithOptions(mutations, options));
+          (session) -> {
+            reqId.incrementAttempt();
+            // TODO: Update the channelId depending on the session that is inferred.
+            List<TransactionOption> allOptions = Arrays.asList(options);
+            allOptions.add(new Options.RequestIdOption(reqId));
+            return session.writeAtLeastOnceWithOptions(
+                mutations, allOptions.toArray(new TransactionOption[0]));
+          });
     } catch (RuntimeException e) {
       span.setStatus(e);
       throw e;
     } finally {
       span.end();
     }
+  }
+
+  private int nextNthRequest() {
+    return this.nthRequest.incrementAndGet();
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
@@ -29,6 +29,7 @@ import com.google.spanner.v1.BatchWriteResponse;
 import io.opentelemetry.api.common.Attributes;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 
@@ -99,6 +100,9 @@ class DatabaseClientImpl implements DatabaseClient {
   private int dbIdFromClientId(String clientId) {
     int i = clientId.indexOf("-");
     String strWithValue = clientId.substring(i + 1);
+    if (Objects.equals(strWithValue, "")) {
+      strWithValue = "0";
+    }
     return Integer.parseInt(strWithValue);
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
@@ -27,8 +27,8 @@ import com.google.common.base.Function;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.spanner.v1.BatchWriteResponse;
 import io.opentelemetry.api.common.Attributes;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 
@@ -202,7 +202,8 @@ class DatabaseClientImpl implements DatabaseClient {
           (session) -> {
             reqId.incrementAttempt();
             // TODO: Update the channelId depending on the session that is inferred.
-            List<TransactionOption> allOptions = Arrays.asList(options);
+            ArrayList<TransactionOption> allOptions = new ArrayList(Arrays.asList(options));
+            System.out.println("\033[35msession.class: " + session.getClass() + "\033[00m");
             allOptions.add(new Options.RequestIdOption(reqId));
             return session.writeAtLeastOnceWithOptions(
                 mutations, allOptions.toArray(new TransactionOption[0]));

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
@@ -512,6 +512,7 @@ public final class Options implements Serializable {
   private RpcOrderBy orderBy;
   private RpcLockHint lockHint;
   private Boolean lastStatement;
+  private XGoogSpannerRequestId reqId;
 
   // Construction is via factory methods below.
   private Options() {}
@@ -566,6 +567,14 @@ public final class Options implements Serializable {
 
   String pageToken() {
     return pageToken;
+  }
+
+  boolean hasReqId() {
+    return reqId != null;
+  }
+
+  XGoogSpannerRequestId reqId() {
+    return reqId;
   }
 
   boolean hasFilter() {
@@ -1016,6 +1025,32 @@ public final class Options implements Serializable {
     @Override
     public boolean equals(Object o) {
       return o instanceof LastStatementUpdateOption;
+    }
+  }
+
+  static final class RequestIdOption extends InternalOption
+      implements TransactionOption, UpdateOption {
+    private final XGoogSpannerRequestId reqId;
+
+    RequestIdOption(XGoogSpannerRequestId reqId) {
+      this.reqId = reqId;
+    }
+
+    @Override
+    void appendToOptions(Options options) {
+      options.reqId = this.reqId;
+    }
+
+    @Override
+    public int hashCode() {
+      return RequestIdOption.class.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      // TODO: Examine why the precedent for LastStatementUpdateOption
+      // does not check against the actual value.
+      return o instanceof RequestIdOption;
     }
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -123,18 +123,31 @@ class SessionImpl implements Session {
   private final Clock clock;
   private final Map<SpannerRpc.Option, ?> options;
   private final ErrorHandler errorHandler;
+  private XGoogSpannerRequestId.RequestIdCreator requestIdCreator;
 
   SessionImpl(SpannerImpl spanner, SessionReference sessionReference) {
     this(spanner, sessionReference, NO_CHANNEL_HINT);
   }
 
   SessionImpl(SpannerImpl spanner, SessionReference sessionReference, int channelHint) {
+    this(spanner, sessionReference, channelHint, null);
+  }
+
+  SessionImpl(
+      SpannerImpl spanner,
+      SessionReference sessionReference,
+      int channelHint,
+      XGoogSpannerRequestId.RequestIdCreator requestIdCreator) {
     this.spanner = spanner;
     this.tracer = spanner.getTracer();
     this.sessionReference = sessionReference;
     this.clock = spanner.getOptions().getSessionPoolOptions().getPoolMaintainerClock();
     this.options = createOptions(sessionReference, channelHint);
     this.errorHandler = createErrorHandler(spanner.getOptions());
+    this.requestIdCreator = requestIdCreator;
+    if (this.requestIdCreator == null) {
+      this.requestIdCreator = new XGoogSpannerRequestId.NoopRequestIdCreator();
+    }
   }
 
   static Map<SpannerRpc.Option, ?> createOptions(
@@ -269,8 +282,13 @@ class SessionImpl implements Session {
     CommitRequest request = requestBuilder.build();
     ISpan span = tracer.spanBuilder(SpannerImpl.COMMIT);
     try (IScope s = tracer.withSpan(span)) {
+      XGoogSpannerRequestId reqId = this.requestIdCreator.nextRequestId(1 /* channelId */, 0);
       return SpannerRetryHelper.runTxWithRetriesOnAborted(
-          () -> new CommitResponse(spanner.getRpc().commit(request, getOptions())));
+          () -> {
+            reqId.incrementAttempt();
+            return new CommitResponse(
+                spanner.getRpc().commit(request, reqId.withOptions(getOptions())));
+          });
     } catch (RuntimeException e) {
       span.setStatus(e);
       throw e;
@@ -529,5 +547,9 @@ class SessionImpl implements Session {
 
   TraceWrapper getTracer() {
     return tracer;
+  }
+
+  public void setRequestIdCreator(XGoogSpannerRequestId.RequestIdCreator creator) {
+    this.requestIdCreator = creator;
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -130,7 +130,7 @@ class SessionImpl implements Session {
   }
 
   SessionImpl(SpannerImpl spanner, SessionReference sessionReference, int channelHint) {
-    this(spanner, sessionReference, channelHint, null);
+    this(spanner, sessionReference, channelHint, new XGoogSpannerRequestId.NoopRequestIdCreator());
   }
 
   SessionImpl(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -282,6 +282,7 @@ class SessionImpl implements Session {
     CommitRequest request = requestBuilder.build();
     ISpan span = tracer.spanBuilder(SpannerImpl.COMMIT);
     try (IScope s = tracer.withSpan(span)) {
+      // TODO: Derive the channelId from the session being used currently.
       XGoogSpannerRequestId reqId = this.requestIdCreator.nextRequestId(1 /* channelId */, 0);
       return SpannerRetryHelper.runTxWithRetriesOnAborted(
           () -> {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
@@ -22,9 +22,14 @@ import com.google.common.annotations.VisibleForTesting;
 import io.grpc.Metadata;
 import java.math.BigInteger;
 import java.security.SecureRandom;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @InternalApi
 public class XGoogSpannerRequestId {
@@ -55,6 +60,26 @@ public class XGoogSpannerRequestId {
     return new XGoogSpannerRequestId(nthClientId, nthChannelId, nthRequest, attempt);
   }
 
+  @VisibleForTesting
+  static final Pattern REGEX =
+      Pattern.compile("^(\\d)\\.([0-9a-z]{16})\\.(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)$");
+
+  public static XGoogSpannerRequestId of(String s) {
+    Matcher m = XGoogSpannerRequestId.REGEX.matcher(s);
+    if (!m.matches()) {
+      throw new IllegalStateException(
+          s + " does not match " + XGoogSpannerRequestId.REGEX.pattern());
+    }
+
+    MatchResult mr = m.toMatchResult();
+
+    return new XGoogSpannerRequestId(
+        Long.parseLong(mr.group(3)),
+        Long.parseLong(mr.group(4)),
+        Long.parseLong(mr.group(5)),
+        Long.parseLong(mr.group(6)));
+  }
+
   private static String generateRandProcessId() {
     // Expecting to use 64-bits of randomness to avoid clashes.
     BigInteger bigInt = new BigInteger(64, new SecureRandom());
@@ -71,6 +96,13 @@ public class XGoogSpannerRequestId {
         this.nthChannelId,
         this.nthRequest,
         this.attempt);
+  }
+
+  private boolean isGreaterThan(XGoogSpannerRequestId other) {
+    return this.nthClientId > other.nthClientId
+        && this.nthChannelId > other.nthChannelId
+        && this.nthRequest > other.nthRequest
+        && this.attempt > other.attempt;
   }
 
   @Override
@@ -116,5 +148,27 @@ public class XGoogSpannerRequestId {
     public XGoogSpannerRequestId nextRequestId(long channelId, int attempt) {
       return XGoogSpannerRequestId.of(1, 1, 1, 0);
     }
+  }
+
+  public static void assertMonotonicityOfIds(String prefix, List<XGoogSpannerRequestId> reqIds) {
+    int size = reqIds.size();
+
+    List<String> violations = new ArrayList<>();
+    for (int i = 1; i < size; i++) {
+      XGoogSpannerRequestId prev = reqIds.get(i - 1);
+      XGoogSpannerRequestId curr = reqIds.get(i);
+      if (prev.isGreaterThan(curr)) {
+        violations.add(String.format("#%d(%s) > #%d(%s)", i - 1, prev, i, curr));
+      }
+    }
+
+    if (violations.size() == 0) {
+      return;
+    }
+
+    throw new IllegalStateException(
+        prefix
+            + " monotonicity violation:"
+            + String.join("\n\t", violations.toArray(new String[0])));
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
@@ -17,9 +17,13 @@
 package com.google.cloud.spanner;
 
 import com.google.api.core.InternalApi;
+import com.google.cloud.spanner.spi.v1.SpannerRpc;
 import com.google.common.annotations.VisibleForTesting;
+import io.grpc.Metadata;
 import java.math.BigInteger;
 import java.security.SecureRandom;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 @InternalApi
@@ -27,6 +31,9 @@ public class XGoogSpannerRequestId {
   // 1. Generate the random process Id singleton.
   @VisibleForTesting
   static final String RAND_PROCESS_ID = XGoogSpannerRequestId.generateRandProcessId();
+
+  public static final Metadata.Key<String> REQUEST_HEADER_KEY =
+      Metadata.Key.of("x-goog-spanner-request-id", Metadata.ASCII_STRING_MARSHALLER);
 
   @VisibleForTesting
   static final long VERSION = 1; // The version of the specification being implemented.
@@ -79,6 +86,18 @@ public class XGoogSpannerRequestId {
         && Objects.equals(this.nthChannelId, otherReqId.nthChannelId)
         && Objects.equals(this.nthRequest, otherReqId.nthRequest)
         && Objects.equals(this.attempt, otherReqId.attempt);
+  }
+
+  public void incrementAttempt() {
+    this.attempt++;
+  }
+
+  @SuppressWarnings("unchecked")
+  public Map withOptions(Map options) {
+    Map copyOptions = new HashMap<>();
+    copyOptions.putAll(options);
+    copyOptions.put(SpannerRpc.Option.REQUEST_ID, this.toString());
+    return copyOptions;
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
@@ -104,4 +104,17 @@ public class XGoogSpannerRequestId {
   public int hashCode() {
     return Objects.hash(this.nthClientId, this.nthChannelId, this.nthRequest, this.attempt);
   }
+
+  public interface RequestIdCreator {
+    XGoogSpannerRequestId nextRequestId(long channelId, int attempt);
+  }
+
+  public static class NoopRequestIdCreator implements RequestIdCreator {
+    NoopRequestIdCreator() {}
+
+    @Override
+    public XGoogSpannerRequestId nextRequestId(long channelId, int attempt) {
+      return XGoogSpannerRequestId.of(1, 1, 1, 0);
+    }
+  }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -2065,7 +2065,6 @@ public class GapicSpannerRpc implements SpannerRpc {
       return context;
     }
 
-    System.out.println("\033[32moptions.reqId: " + reqId + "\033[00m " + methodName);
     Map<String, List<String>> withReqId =
         ImmutableMap.of(
             XGoogSpannerRequestId.REQUEST_HEADER_KEY.name(), Collections.singletonList(reqId));

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -2061,7 +2061,7 @@ public class GapicSpannerRpc implements SpannerRpc {
 
   GrpcCallContext withRequestId(GrpcCallContext context, Map options, String methodName) {
     String reqId = (String) options.get(Option.REQUEST_ID);
-    if (reqId == null) {
+    if (reqId == null || Objects.equals(reqId, "")) {
       return context;
     }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -71,6 +71,7 @@ import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.SpannerOptions.CallContextConfigurator;
 import com.google.cloud.spanner.SpannerOptions.CallCredentialsProvider;
+import com.google.cloud.spanner.XGoogSpannerRequestId;
 import com.google.cloud.spanner.admin.database.v1.stub.DatabaseAdminStub;
 import com.google.cloud.spanner.admin.database.v1.stub.DatabaseAdminStubSettings;
 import com.google.cloud.spanner.admin.database.v1.stub.GrpcDatabaseAdminCallableFactory;
@@ -88,6 +89,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
 import com.google.common.util.concurrent.RateLimiter;
@@ -2023,6 +2025,8 @@ public class GapicSpannerRpc implements SpannerRpc {
         // Set channel affinity in GAX.
         context = context.withChannelAffinity(Option.CHANNEL_HINT.getLong(options).intValue());
       }
+      String methodName = method.getFullMethodName();
+      context = withRequestId(context, options, methodName);
     }
     if (compressorName != null) {
       // This sets the compressor for Client -> Server.
@@ -2046,12 +2050,26 @@ public class GapicSpannerRpc implements SpannerRpc {
         context
             .withStreamWaitTimeoutDuration(waitTimeout)
             .withStreamIdleTimeoutDuration(idleTimeout);
+
     CallContextConfigurator configurator = SpannerOptions.CALL_CONTEXT_CONFIGURATOR_KEY.get();
     ApiCallContext apiCallContextFromContext = null;
     if (configurator != null) {
       apiCallContextFromContext = configurator.configure(context, request, method);
     }
     return (GrpcCallContext) context.merge(apiCallContextFromContext);
+  }
+
+  GrpcCallContext withRequestId(GrpcCallContext context, Map options, String methodName) {
+    String reqId = (String) options.get(Option.REQUEST_ID);
+    if (reqId == null) {
+      return context;
+    }
+
+    System.out.println("\033[32moptions.reqId: " + reqId + "\033[00m " + methodName);
+    Map<String, List<String>> withReqId =
+        ImmutableMap.of(
+            XGoogSpannerRequestId.REQUEST_HEADER_KEY.name(), Collections.singletonList(reqId));
+    return context.withExtraHeaders(withReqId);
   }
 
   void registerResponseObserver(SpannerResponseObserver responseObserver) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerRpc.java
@@ -78,7 +78,8 @@ import javax.annotation.Nullable;
 public interface SpannerRpc extends ServiceRpc {
   /** Options passed in {@link SpannerRpc} methods to control how an RPC is issued. */
   enum Option {
-    CHANNEL_HINT("Channel Hint");
+    CHANNEL_HINT("Channel Hint"),
+    REQUEST_ID("Request Id");
 
     private final String value;
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -5196,6 +5196,8 @@ public class DatabaseClientImplTest {
       assertTrue(resultSet.next());
       assertEquals(1L, resultSet.getLong(0));
       assertFalse(resultSet.next());
+    } finally {
+      xGoogReqIdInterceptor.assertIntegrity();
     }
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -1409,12 +1409,10 @@ public class DatabaseClientImplTest {
 
     List<CommitRequest> commitRequests = mockSpanner.getRequestsOfType(CommitRequest.class);
     assertEquals(2, commitRequests.size());
-
-    String[] gotRequestIds = xGoogReqIdInterceptor.accumulatedValues();
-    String[] wantRequestIds = {"a", "b"};
-    System.out.println("\033[33mGot: " + gotRequestIds.toString() + "\033[00m");
-    assertEquals(gotRequestIds, wantRequestIds);
-    assertEquals(2, gotRequestIds.length);
+    xGoogReqIdInterceptor.assertIntegrity();
+    System.out.println(
+        "\033[33mGot: " + xGoogReqIdInterceptor.accumulatedUnaryValues() + "\033[00m");
+    xGoogReqIdInterceptor.printAccumulatedValues();
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -272,6 +272,7 @@ public class DatabaseClientImplTest {
     spanner.close();
     spannerWithEmptySessionPool.close();
     mockSpanner.reset();
+    xGoogReqIdInterceptor.reset();
     mockSpanner.removeAllExecutionTimes();
   }
 
@@ -1408,6 +1409,12 @@ public class DatabaseClientImplTest {
 
     List<CommitRequest> commitRequests = mockSpanner.getRequestsOfType(CommitRequest.class);
     assertEquals(2, commitRequests.size());
+
+    String[] gotRequestIds = xGoogReqIdInterceptor.accumulatedValues();
+    String[] wantRequestIds = {"a", "b"};
+    System.out.println("\033[33mGot: " + gotRequestIds.toString() + "\033[00m");
+    assertEquals(gotRequestIds, wantRequestIds);
+    assertEquals(2, gotRequestIds.length);
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/XGoogSpannerRequestIdTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/XGoogSpannerRequestIdTest.java
@@ -102,5 +102,9 @@ public class XGoogSpannerRequestIdTest {
     public String[] accumulatedValues() {
       return this.gotValues.toArray(new String[0]);
     }
+
+    public void reset() {
+      this.gotValues.clear();
+    }
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/XGoogSpannerRequestIdTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/XGoogSpannerRequestIdTest.java
@@ -26,6 +26,7 @@ import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -125,6 +126,55 @@ public class XGoogSpannerRequestIdTest {
             // System.out.println("\033[36mstreaming.method: " + method + "\033[00m");
             XGoogSpannerRequestId.assertMonotonicityOfIds(method, values);
           });
+    }
+
+    public static class methodAndRequestId {
+      String method;
+      String requestId;
+
+      public methodAndRequestId(String method, String requestId) {
+        this.method = method;
+        this.requestId = requestId;
+      }
+
+      public String toString() {
+        return "{" + this.method + ":" + this.requestId + "}";
+      }
+    }
+
+    public methodAndRequestId[] accumulatedUnaryValues() {
+      List<methodAndRequestId> accumulated = new ArrayList();
+      this.unaryResults.forEach(
+          (String method, CopyOnWriteArrayList<XGoogSpannerRequestId> values) -> {
+            for (int i = 0; i < values.size(); i++) {
+              accumulated.add(new methodAndRequestId(method, values.get(i).toString()));
+            }
+          });
+      return accumulated.toArray(new methodAndRequestId[0]);
+    }
+
+    public methodAndRequestId[] accumulatedStreamingValues() {
+      List<methodAndRequestId> accumulated = new ArrayList();
+      this.streamingResults.forEach(
+          (String method, CopyOnWriteArrayList<XGoogSpannerRequestId> values) -> {
+            for (int i = 0; i < values.size(); i++) {
+              accumulated.add(new methodAndRequestId(method, values.get(i).toString()));
+            }
+          });
+      return accumulated.toArray(new methodAndRequestId[0]);
+    }
+
+    public void printAccumulatedValues() {
+      methodAndRequestId[] unary = this.accumulatedUnaryValues();
+      System.out.println("accumulatedUnaryvalues");
+      for (int i = 0; i < unary.length; i++) {
+        System.out.println("\t" + unary[i].toString());
+      }
+      methodAndRequestId[] streaming = this.accumulatedStreamingValues();
+      System.out.println("accumulatedStreaminvalues");
+      for (int i = 0; i < streaming.length; i++) {
+        System.out.println("\t" + streaming[i].toString());
+      }
     }
 
     public void reset() {


### PR DESCRIPTION
Wires up x-goog-spanner-request-id for piecemeal addition per gRPC method, starting with BatchCreateSessions. This change involves creating TransactionOption, UpdateOption variants that allow holding the request id.

Updates #3537