### PR TITLE
perf: get database dialect using multiplexed session

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractMultiplexedSessionDatabaseClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractMultiplexedSessionDatabaseClient.java
@@ -27,11 +27,6 @@ import com.google.cloud.Timestamp;
 abstract class AbstractMultiplexedSessionDatabaseClient implements DatabaseClient {
 
   @Override
-  public Dialect getDialect() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public String getDatabaseRole() {
     throw new UnsupportedOperationException();
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
@@ -132,6 +132,10 @@ class DatabaseClientImpl implements DatabaseClient {
 
   @Override
   public Dialect getDialect() {
+    MultiplexedSessionDatabaseClient client = getMultiplexedSessionDatabaseClient();
+    if (client != null) {
+      return client.getDialect();
+    }
     return pool.getDialect();
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -2256,13 +2256,9 @@ class SessionPool {
   @VisibleForTesting
   static final Statement DETERMINE_DIALECT_STATEMENT =
       Statement.newBuilder(
-              "SELECT 'POSTGRESQL' AS DIALECT\n"
-                  + "FROM INFORMATION_SCHEMA.SCHEMATA\n"
-                  + "WHERE SCHEMA_NAME='information_schema'\n"
-                  + "UNION ALL\n"
-                  + "SELECT 'GOOGLE_STANDARD_SQL' AS DIALECT\n"
-                  + "FROM INFORMATION_SCHEMA.SCHEMATA\n"
-                  + "WHERE SCHEMA_NAME='INFORMATION_SCHEMA' AND CATALOG_NAME=''")
+              "select option_value "
+                  + "from information_schema.database_options "
+                  + "where option_name='database_dialect'")
           .build();
 
   private final SessionPoolOptions options;
@@ -3211,7 +3207,9 @@ class SessionPool {
           if (allSessions.size() >= minSessions) {
             waitOnMinSessionsLatch.countDown();
           }
-          if (options.isAutoDetectDialect() && !detectDialectStarted) {
+          if (options.isAutoDetectDialect()
+              && !detectDialectStarted
+              && !options.getUseMultiplexedSession()) {
             // Get the dialect of the underlying database if that has not yet been done. Note that
             // this method will release the session into the pool once it is done.
             detectDialectStarted = true;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractMockServerTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spanner.connection;
 
+import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.ForceCloseSpannerFunction;
 import com.google.cloud.spanner.MockSpannerServiceImpl;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
@@ -198,6 +199,8 @@ public abstract class AbstractMockServerTest {
     mockSpanner.putStatementResult(
         StatementResult.query(SELECT_RANDOM_STATEMENT, RANDOM_RESULT_SET));
     mockSpanner.putStatementResult(StatementResult.query(SELECT1_STATEMENT, SELECT1_RESULTSET));
+    mockSpanner.putStatementResult(
+        StatementResult.detectDialectResult(Dialect.GOOGLE_STANDARD_SQL));
 
     futureParentHandlers = Logger.getLogger(AbstractFuture.class.getName()).getUseParentHandlers();
     exceptionRunnableParentHandlers =

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionTest.java
@@ -674,6 +674,8 @@ public class ConnectionTest {
     public void testGetDialect_DatabaseNotFound() throws Exception {
       mockSpanner.setBatchCreateSessionsExecutionTime(
           SimulatedExecutionTime.stickyDatabaseNotFoundException("invalid-database"));
+      mockSpanner.setCreateSessionExecutionTime(
+          SimulatedExecutionTime.stickyDatabaseNotFoundException("invalid-database"));
       try (Connection connection = createConnection()) {
         SpannerException exception = assertThrows(SpannerException.class, connection::getDialect);
         assertEquals(ErrorCode.NOT_FOUND, exception.getErrorCode());


### PR DESCRIPTION
Get the database dialect using the multiplexed session that is created by the client when multiplexed sessions are enabled. This prevents unnecessarily creating a regular session when MinSessions has been set to zero and multiplexed sessions have been enabled.
