### PR TITLE
test: unflake ReadAsyncTest

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadAsyncTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadAsyncTest.java
@@ -201,9 +201,9 @@ public class ReadAsyncTest {
   }
 
   @Test
-  public void tableNotFound() throws Exception {
+  public void tableNotFound() {
     mockSpanner.setStreamingReadExecutionTime(
-        SimulatedExecutionTime.ofException(
+        SimulatedExecutionTime.ofStickyException(
             Status.NOT_FOUND
                 .withDescription("Table not found: BadTableName")
                 .asRuntimeException()));


### PR DESCRIPTION
Make the expected exception sticky, so that the exception is not cleared if the RPC is retried due to a transient `UNAVAILABLE` error.