### PR TITLE
test: unflake SavepointMockServerTest

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SavepointMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SavepointMockServerTest.java
@@ -90,6 +90,7 @@ public class SavepointMockServerTest extends AbstractMockServerTest {
     mockSpanner.clearRequests();
   }
 
+  @SuppressWarnings("ClassEscapesDefinedScope")
   @Override
   public ITConnection createConnection() {
     return createConnection(
@@ -698,9 +699,10 @@ public class SavepointMockServerTest extends AbstractMockServerTest {
       connection.savepoint("s1");
       connection.execute(INSERT_STATEMENT);
       connection.rollbackToSavepoint("s1");
-      mockSpanner.waitForRequestsToContain(RollbackRequest.class, 1000L);
       String keepAliveTagAfterRollback = "test_keep_alive_tag_after_rollback";
       System.setProperty("spanner.connection.keep_alive_query_tag", keepAliveTagAfterRollback);
+      mockSpanner.waitForRequestsToContain(RollbackRequest.class, 1000L);
+      mockSpanner.clearRequests();
 
       // Verify that we don't get any new keep-alive requests from this point.
       Thread.sleep(2L);


### PR DESCRIPTION
Wait until we have received a `RollbackRequest`, then clear the current requests, and then make sure that no further keep-alive requests are received by the server.

Fixes #3601 
Fixes #3585 