### PR TITLE
chore: retry in-flight transactions on regular sessions when multiplexed sessions encounter UNIMPLEMENTED errors

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DelayedMultiplexedSessionTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DelayedMultiplexedSessionTransaction.java
@@ -44,14 +44,17 @@ class DelayedMultiplexedSessionTransaction extends AbstractMultiplexedSessionDat
   private final ISpan span;
 
   private final ApiFuture<SessionReference> sessionFuture;
+  private final SessionPool sessionPool;
 
   DelayedMultiplexedSessionTransaction(
       MultiplexedSessionDatabaseClient client,
       ISpan span,
-      ApiFuture<SessionReference> sessionFuture) {
+      ApiFuture<SessionReference> sessionFuture,
+      SessionPool sessionPool) {
     this.client = client;
     this.span = span;
     this.sessionFuture = sessionFuture;
+    this.sessionPool = sessionPool;
   }
 
   @Override
@@ -189,7 +192,12 @@ class DelayedMultiplexedSessionTransaction extends AbstractMultiplexedSessionDat
             this.sessionFuture,
             sessionReference ->
                 new MultiplexedSessionTransaction(
-                        client, span, sessionReference, NO_CHANNEL_HINT, /* singleUse = */ false)
+                        client,
+                        span,
+                        sessionReference,
+                        NO_CHANNEL_HINT,
+                        /* singleUse = */ false,
+                        this.sessionPool)
                     .readWriteTransaction(options),
             MoreExecutors.directExecutor()));
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MultiplexedSessionDatabaseClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MultiplexedSessionDatabaseClient.java
@@ -89,17 +89,17 @@ class MultiplexedSessionTransactionRunner implements TransactionRunner {
 
   @Override
   public Timestamp getCommitTimestamp() {
-    return null;
+    return this.transactionRunner.getCommitTimestamp();
   }
 
   @Override
   public CommitResponse getCommitResponse() {
-    return null;
+    return this.transactionRunner.getCommitResponse();
   }
 
   @Override
   public TransactionRunner allowNestedTransaction() {
-    return null;
+    return this.transactionRunner.allowNestedTransaction();
   }
 }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -1004,7 +1004,7 @@ class SessionPool {
    * {@link TransactionRunner} that automatically handles {@link SessionNotFoundException}s by
    * replacing the underlying session and then restarts the transaction.
    */
-  private static final class SessionPoolTransactionRunner<I extends SessionFuture>
+  static final class SessionPoolTransactionRunner<I extends SessionFuture>
       implements TransactionRunner {
 
     private I session;
@@ -1012,7 +1012,7 @@ class SessionPool {
     private final TransactionOption[] options;
     private TransactionRunner runner;
 
-    private SessionPoolTransactionRunner(
+    SessionPoolTransactionRunner(
         I session,
         SessionReplacementHandler<I> sessionReplacementHandler,
         TransactionOption... options) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
@@ -333,6 +333,9 @@ class SpannerImpl extends BaseService<SpannerOptions> implements Spanner {
       boolean useMultiplexedSessionForRW,
       Attributes commonAttributes) {
     if (multiplexedSessionClient != null) {
+      // Set the session pool in the multiplexed session client.
+      // This is required to handle fallback to regular sessions for in-progress transactions that
+      // use multiplexed sessions but fail with UNIMPLEMENTED errors.
       multiplexedSessionClient.setPool(pool);
     }
     return new DatabaseClientImpl(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
@@ -332,6 +332,9 @@ class SpannerImpl extends BaseService<SpannerOptions> implements Spanner {
       boolean useMultiplexedSessionPartitionedOps,
       boolean useMultiplexedSessionForRW,
       Attributes commonAttributes) {
+    if (multiplexedSessionClient != null) {
+      multiplexedSessionClient.setPool(pool);
+    }
     return new DatabaseClientImpl(
         clientId,
         pool,

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MultiplexedSessionDatabaseClientMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MultiplexedSessionDatabaseClientMockServerTest.java
@@ -1252,7 +1252,7 @@ public class MultiplexedSessionDatabaseClientMockServerTest extends AbstractMock
         request.getPrecommitToken().getPrecommitToken());
   }
 
-  private Spanner setupSpannerForAbortedBeginTransactionTests() {
+  private Spanner setupSpannerBySkippingBeginTransactionVerificationForMux() {
     return SpannerOptions.newBuilder()
         .setProjectId("test-project")
         .setChannelProvider(channelProvider)
@@ -1297,7 +1297,7 @@ public class MultiplexedSessionDatabaseClientMockServerTest extends AbstractMock
     // ABORT error in the BeginTransaction RPC:
     // 1. The mutation key is correctly included in the BeginTransaction request.
     // 2. The precommit token is properly set in the Commit request.
-    Spanner spanner = setupSpannerForAbortedBeginTransactionTests();
+    Spanner spanner = setupSpannerBySkippingBeginTransactionVerificationForMux();
 
     // Force the BeginTransaction RPC to return Aborted the first time it is called. The exception
     // is cleared after the first call, so the retry should succeed.
@@ -1336,7 +1336,7 @@ public class MultiplexedSessionDatabaseClientMockServerTest extends AbstractMock
     // ABORT error in the BeginTransaction RPC:
     // 1. The mutation key is correctly included in the BeginTransaction request.
     // 2. The precommit token is properly set in the Commit request.
-    Spanner spanner = setupSpannerForAbortedBeginTransactionTests();
+    Spanner spanner = setupSpannerBySkippingBeginTransactionVerificationForMux();
 
     // Force the BeginTransaction RPC to return Aborted the first time it is called. The exception
     // is cleared after the first call, so the retry should succeed.
@@ -1382,7 +1382,7 @@ public class MultiplexedSessionDatabaseClientMockServerTest extends AbstractMock
     // 1. The mutation key is correctly included in the BeginTransaction request.
     // 2. The precommit token is properly set in the Commit request.
 
-    Spanner spanner = setupSpannerForAbortedBeginTransactionTests();
+    Spanner spanner = setupSpannerBySkippingBeginTransactionVerificationForMux();
 
     // Force the BeginTransaction RPC to return Aborted the first time it is called. The exception
     // is cleared after the first call, so the retry should succeed.
@@ -1422,7 +1422,7 @@ public class MultiplexedSessionDatabaseClientMockServerTest extends AbstractMock
     // ABORT in BeginTransaction RPC, the mutation key is correctly set in the BeginTransaction
     // request
     // and precommit token is set in Commit request.
-    Spanner spanner = setupSpannerForAbortedBeginTransactionTests();
+    Spanner spanner = setupSpannerBySkippingBeginTransactionVerificationForMux();
 
     // Force the BeginTransaction RPC to return Aborted the first time it is called. The exception
     // is cleared after the first call, so the retry should succeed.
@@ -1970,7 +1970,7 @@ public class MultiplexedSessionDatabaseClientMockServerTest extends AbstractMock
     // 3. Upon encountering the UNIMPLEMENTED error, the entire transaction callable is retried
     // using regular sessions, but the inline begin fails again.
     // 4. A final retry executes the explicit BeginTransaction on a regular session.
-    Spanner spanner = setupSpannerForAbortedBeginTransactionTests();
+    Spanner spanner = setupSpannerBySkippingBeginTransactionVerificationForMux();
     mockSpanner.setBeginTransactionExecutionTime(
         SimulatedExecutionTime.ofException(
             Status.UNIMPLEMENTED
@@ -2020,7 +2020,7 @@ public class MultiplexedSessionDatabaseClientMockServerTest extends AbstractMock
     // using regular sessions. However, the Commit request fails due to a SessionNotFound error.
     // 3. A final retry is triggered to handle the SessionNotFound error by selecting a new session
     // from the pool, leading to a successful transaction.
-    Spanner spanner = setupSpannerForAbortedBeginTransactionTests();
+    Spanner spanner = setupSpannerBySkippingBeginTransactionVerificationForMux();
 
     // The first ExecuteSql request that does an inline begin with multiplexed sessions fail with
     // UNIMPLEMENTED error.
@@ -2077,7 +2077,7 @@ public class MultiplexedSessionDatabaseClientMockServerTest extends AbstractMock
     // 3. Upon encountering the UNIMPLEMENTED error, the entire transaction callable for the second
     // read-write transaction is retried using a regular session.
 
-    Spanner spanner = setupSpannerForAbortedBeginTransactionTests();
+    Spanner spanner = setupSpannerBySkippingBeginTransactionVerificationForMux();
 
     DatabaseClientImpl client =
         (DatabaseClientImpl) spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));


### PR DESCRIPTION
Before this change, when a transaction using a multiplexed session encountered an `UNIMPLEMENTED` error with the message `Transaction type read_write not supported with multiplexed sessions` from the backend, the transaction would fail abruptly without any special handling.

This PR introduces handling for this scenario in the `TransactionRunner`, where transactions encountering the `UNIMPLEMENTED` error with the message `Transaction type read_write not supported with multiplexed sessions` are automatically retried using a regular session.


