### PR TITLE
feat: [Internal] open telemetry built in metrics for GRPC

### DIFF
--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -751,6 +751,13 @@
     <method>boolean isEnableBuiltInMetrics()</method>
   </difference>
 
+  <!-- Added Built In GRPC Metrics option -->
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/SpannerOptions$SpannerEnvironment</className>
+    <method>boolean isEnableGRPCBuiltInMetrics()</method>
+  </difference>
+
   <!-- Added Monitoring host option -->
   <difference>
     <differenceType>7012</differenceType>
@@ -807,7 +814,7 @@
     <className>com/google/cloud/spanner/connection/Connection</className>
     <method>boolean isKeepTransactionAlive()</method>
   </difference>
-  
+
   <!-- Automatic DML batching -->
   <difference>
     <differenceType>7012</differenceType>
@@ -839,7 +846,7 @@
     <className>com/google/cloud/spanner/connection/Connection</className>
     <method>boolean isAutoBatchDmlUpdateCountVerification()</method>
   </difference>
-  
+
   <!-- Retry DML as Partitioned DML -->
   <difference>
     <differenceType>7012</differenceType>
@@ -863,7 +870,7 @@
     <className>com/google/cloud/spanner/connection/Connection</className>
     <method>java.lang.Object runTransaction(com.google.cloud.spanner.connection.Connection$TransactionCallable)</method>
   </difference>
-  
+
   <!-- Added experimental host option -->
   <difference>
     <differenceType>7012</differenceType>

--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -192,6 +192,10 @@
       <artifactId>grpc-stub</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-opentelemetry</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>api-common</artifactId>
     </dependency>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsConstant.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsConstant.java
@@ -30,7 +30,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @InternalApi
 public class BuiltInMetricsConstant {
@@ -53,18 +52,6 @@ public class BuiltInMetricsConstant {
           "grpc.lb.rls.target_picks",
           "grpc.xds_client.server_failure",
           "grpc.xds_client.resource_updates_invalid");
-
-  public static final Set<String> SPANNER_METRICS =
-      Stream.concat(
-              Stream.of(
-                  OPERATION_LATENCIES_NAME,
-                  ATTEMPT_LATENCIES_NAME,
-                  OPERATION_COUNT_NAME,
-                  ATTEMPT_COUNT_NAME,
-                  GFE_LATENCIES_NAME),
-              GRPC_METRICS_TO_ENABLE.stream())
-          .map(m -> METER_NAME + '/' + m)
-          .collect(Collectors.toSet());
 
   public static final String SPANNER_RESOURCE_TYPE = "spanner_instance_client";
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsConstant.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsConstant.java
@@ -46,6 +46,17 @@ public class BuiltInMetricsConstant {
   static final String OPERATION_COUNT_NAME = "operation_count";
   static final String ATTEMPT_COUNT_NAME = "attempt_count";
 
+  public static final Set<String> SPANNER_METRICS =
+      ImmutableSet.of(
+              OPERATION_LATENCIES_NAME,
+              ATTEMPT_LATENCIES_NAME,
+              OPERATION_COUNT_NAME,
+              ATTEMPT_COUNT_NAME,
+              GFE_LATENCIES_NAME)
+          .stream()
+          .map(m -> METER_NAME + '/' + m)
+          .collect(Collectors.toSet());
+
   static final Collection<String> GRPC_METRICS_TO_ENABLE =
       ImmutableList.of(
           "grpc.lb.rls.default_target_picks",

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsConstant.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsConstant.java
@@ -21,7 +21,6 @@ import com.google.api.gax.tracing.OpenTelemetryMetricsRecorder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentSelector;
@@ -101,9 +100,7 @@ public class BuiltInMetricsConstant {
           DIRECT_PATH_USED_KEY);
 
   public static final Set<String> GRPC_ATTRIBUTES =
-      ImmutableSet.of(
-          "grpc_lb_rls_data_plane_target",
-          "grpc_lb_pick_result");
+      ImmutableSet.of("grpc.lb.rls.data_plane_target", "grpc.lb.pick_result");
 
   static Aggregation AGGREGATION_WITH_MILLIS_HISTOGRAM =
       Aggregation.explicitBucketHistogram(
@@ -204,8 +201,7 @@ public class BuiltInMetricsConstant {
   }
 
   private static void defineGRPCView(ImmutableMap.Builder<InstrumentSelector, View> viewMap) {
-    for (String metric :
-        ImmutableList.copyOf(Iterables.concat(BuiltInMetricsConstant.GRPC_METRICS_TO_ENABLE, BuiltInMetricsConstant.GRPC_METRICS_ENABLED_BY_DEFAULT))) {
+    for (String metric : BuiltInMetricsConstant.GRPC_METRICS_TO_ENABLE) {
       InstrumentSelector selector =
           InstrumentSelector.builder()
               .setName(metric)
@@ -215,8 +211,8 @@ public class BuiltInMetricsConstant {
           BuiltInMetricsConstant.COMMON_ATTRIBUTES.stream()
               .map(AttributeKey::getKey)
               .collect(Collectors.toSet());
-
       attributesFilter.addAll(BuiltInMetricsConstant.GRPC_ATTRIBUTES);
+
       View view =
           View.builder()
               .setName(BuiltInMetricsConstant.METER_NAME + '/' + metric.replace(".", "/"))

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsConstant.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsConstant.java
@@ -21,11 +21,13 @@ import com.google.api.gax.tracing.OpenTelemetryMetricsRecorder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentSelector;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.View;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -36,6 +38,7 @@ public class BuiltInMetricsConstant {
   public static final String METER_NAME = "spanner.googleapis.com/internal/client";
   public static final String GAX_METER_NAME = OpenTelemetryMetricsRecorder.GAX_METER_NAME;
   static final String SPANNER_METER_NAME = "spanner-java";
+  static final String GRPC_METER_NAME = "grpc-java";
   static final String GFE_LATENCIES_NAME = "gfe_latencies";
   static final String OPERATION_LATENCIES_NAME = "operation_latencies";
   static final String ATTEMPT_LATENCIES_NAME = "attempt_latencies";
@@ -66,12 +69,7 @@ public class BuiltInMetricsConstant {
 
   // These metric labels will be promoted to the spanner monitored resource fields
   public static final Set<AttributeKey<String>> SPANNER_PROMOTED_RESOURCE_LABELS =
-      ImmutableSet.of(
-          PROJECT_ID_KEY,
-          INSTANCE_ID_KEY,
-          INSTANCE_CONFIG_ID_KEY,
-          LOCATION_ID_KEY,
-          CLIENT_HASH_KEY);
+      ImmutableSet.of(INSTANCE_ID_KEY);
 
   public static final AttributeKey<String> DATABASE_KEY = AttributeKey.stringKey("database");
   public static final AttributeKey<String> CLIENT_UID_KEY = AttributeKey.stringKey("client_uid");
@@ -102,6 +100,11 @@ public class BuiltInMetricsConstant {
           DIRECT_PATH_ENABLED_KEY,
           DIRECT_PATH_USED_KEY);
 
+  public static final Set<String> GRPC_ATTRIBUTES =
+      ImmutableSet.of(
+          "grpc_lb_rls_data_plane_target",
+          "grpc_lb_pick_result");
+
   static Aggregation AGGREGATION_WITH_MILLIS_HISTOGRAM =
       Aggregation.explicitBucketHistogram(
           ImmutableList.of(
@@ -110,6 +113,21 @@ public class BuiltInMetricsConstant {
               160.0, 200.0, 250.0, 300.0, 400.0, 500.0, 650.0, 800.0, 1000.0, 2000.0, 5000.0,
               10000.0, 20000.0, 50000.0, 100000.0, 200000.0, 400000.0, 800000.0, 1600000.0,
               3200000.0));
+
+  static final Collection<String> GRPC_METRICS_TO_ENABLE =
+      ImmutableList.of(
+          "grpc.lb.rls.default_target_picks",
+          "grpc.lb.rls.target_picks",
+          "grpc.xds_client.server_failure",
+          "grpc.xds_client.resource_updates_invalid");
+
+  static final Collection<String> GRPC_METRICS_ENABLED_BY_DEFAULT =
+      ImmutableList.of(
+          "grpc.client.attempt.sent_total_compressed_message_size",
+          "grpc.client.attempt.rcvd_total_compressed_message_size",
+          "grpc.client.attempt.started",
+          "grpc.client.attempt.duration",
+          "grpc.client.call.duration");
 
   static Map<InstrumentSelector, View> getAllViews() {
     ImmutableMap.Builder<InstrumentSelector, View> views = ImmutableMap.builder();
@@ -153,6 +171,7 @@ public class BuiltInMetricsConstant {
         Aggregation.sum(),
         InstrumentType.COUNTER,
         "1");
+    defineGRPCView(views);
     return views.build();
   }
 
@@ -182,5 +201,28 @@ public class BuiltInMetricsConstant {
             .setAttributeFilter(attributesFilter)
             .build();
     viewMap.put(selector, view);
+  }
+
+  private static void defineGRPCView(ImmutableMap.Builder<InstrumentSelector, View> viewMap) {
+    for (String metric :
+        ImmutableList.copyOf(Iterables.concat(BuiltInMetricsConstant.GRPC_METRICS_TO_ENABLE, BuiltInMetricsConstant.GRPC_METRICS_ENABLED_BY_DEFAULT))) {
+      InstrumentSelector selector =
+          InstrumentSelector.builder()
+              .setName(metric)
+              .setMeterName(BuiltInMetricsConstant.GRPC_METER_NAME)
+              .build();
+      Set<String> attributesFilter =
+          BuiltInMetricsConstant.COMMON_ATTRIBUTES.stream()
+              .map(AttributeKey::getKey)
+              .collect(Collectors.toSet());
+
+      attributesFilter.addAll(BuiltInMetricsConstant.GRPC_ATTRIBUTES);
+      View view =
+          View.builder()
+              .setName(BuiltInMetricsConstant.METER_NAME + '/' + metric.replace(".", "/"))
+              .setAttributeFilter(attributesFilter)
+              .build();
+      viewMap.put(selector, view);
+    }
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsConstant.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsConstant.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @InternalApi
 public class BuiltInMetricsConstant {
@@ -46,14 +47,22 @@ public class BuiltInMetricsConstant {
   static final String OPERATION_COUNT_NAME = "operation_count";
   static final String ATTEMPT_COUNT_NAME = "attempt_count";
 
+  static final Collection<String> GRPC_METRICS_TO_ENABLE =
+      ImmutableList.of(
+          "grpc.lb.rls.default_target_picks",
+          "grpc.lb.rls.target_picks",
+          "grpc.xds_client.server_failure",
+          "grpc.xds_client.resource_updates_invalid");
+
   public static final Set<String> SPANNER_METRICS =
-      ImmutableSet.of(
-              OPERATION_LATENCIES_NAME,
-              ATTEMPT_LATENCIES_NAME,
-              OPERATION_COUNT_NAME,
-              ATTEMPT_COUNT_NAME,
-              GFE_LATENCIES_NAME)
-          .stream()
+      Stream.concat(
+              Stream.of(
+                  OPERATION_LATENCIES_NAME,
+                  ATTEMPT_LATENCIES_NAME,
+                  OPERATION_COUNT_NAME,
+                  ATTEMPT_COUNT_NAME,
+                  GFE_LATENCIES_NAME),
+              GRPC_METRICS_TO_ENABLE.stream())
           .map(m -> METER_NAME + '/' + m)
           .collect(Collectors.toSet());
 
@@ -110,13 +119,6 @@ public class BuiltInMetricsConstant {
               160.0, 200.0, 250.0, 300.0, 400.0, 500.0, 650.0, 800.0, 1000.0, 2000.0, 5000.0,
               10000.0, 20000.0, 50000.0, 100000.0, 200000.0, 400000.0, 800000.0, 1600000.0,
               3200000.0));
-
-  static final Collection<String> GRPC_METRICS_TO_ENABLE =
-      ImmutableList.of(
-          "grpc.lb.rls.default_target_picks",
-          "grpc.lb.rls.target_picks",
-          "grpc.xds_client.server_failure",
-          "grpc.xds_client.resource_updates_invalid");
 
   static final Collection<String> GRPC_METRICS_ENABLED_BY_DEFAULT =
       ImmutableList.of(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsConstant.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsConstant.java
@@ -107,7 +107,7 @@ public class BuiltInMetricsConstant {
           DIRECT_PATH_ENABLED_KEY,
           DIRECT_PATH_USED_KEY);
 
-  public static final Set<String> GRPC_ATTRIBUTES =
+  static final Set<String> GRPC_LB_RLS_ATTRIBUTES =
       ImmutableSet.of("grpc.lb.rls.data_plane_target", "grpc.lb.pick_result");
 
   static Aggregation AGGREGATION_WITH_MILLIS_HISTOGRAM =
@@ -212,7 +212,7 @@ public class BuiltInMetricsConstant {
           BuiltInMetricsConstant.COMMON_ATTRIBUTES.stream()
               .map(AttributeKey::getKey)
               .collect(Collectors.toSet());
-      attributesFilter.addAll(BuiltInMetricsConstant.GRPC_ATTRIBUTES);
+      attributesFilter.addAll(BuiltInMetricsConstant.GRPC_LB_RLS_ATTRIBUTES);
 
       View view =
           View.builder()

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsConstant.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsConstant.java
@@ -51,7 +51,8 @@ public class BuiltInMetricsConstant {
           "grpc.lb.rls.default_target_picks",
           "grpc.lb.rls.target_picks",
           "grpc.xds_client.server_failure",
-          "grpc.xds_client.resource_updates_invalid");
+          "grpc.xds_client.resource_updates_invalid",
+          "grpc.xds_client.resource_updates_valid");
 
   public static final String SPANNER_RESOURCE_TYPE = "spanner_instance_client";
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsProvider.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsProvider.java
@@ -21,6 +21,7 @@ import static com.google.cloud.spanner.BuiltInMetricsConstant.CLIENT_HASH_KEY;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.CLIENT_NAME_KEY;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.CLIENT_UID_KEY;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.INSTANCE_CONFIG_ID_KEY;
+import static com.google.cloud.spanner.BuiltInMetricsConstant.INSTANCE_ID_KEY;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.LOCATION_ID_KEY;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.PROJECT_ID_KEY;
 
@@ -119,6 +120,7 @@ final class BuiltInMetricsProvider {
             .put(PROJECT_ID_KEY.getKey(), projectId)
             .put(INSTANCE_CONFIG_ID_KEY.getKey(), "unknown")
             .put(CLIENT_HASH_KEY.getKey(), generateClientHash(getDefaultTaskValue()))
+            .put(INSTANCE_ID_KEY.getKey(), "unknown")
             .put(LOCATION_ID_KEY.getKey(), detectClientLocation());
 
     return attributesBuilder.build();

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsProvider.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsProvider.java
@@ -31,8 +31,6 @@ import com.google.auth.Credentials;
 import com.google.cloud.opentelemetry.detection.AttributeKeys;
 import com.google.cloud.opentelemetry.detection.DetectedPlatform;
 import com.google.cloud.opentelemetry.detection.GCPPlatformDetector;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import io.grpc.ManagedChannelBuilder;
@@ -41,10 +39,8 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.metrics.InstrumentSelector;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
-import io.opentelemetry.sdk.metrics.View;
 import io.opentelemetry.sdk.resources.Resource;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
@@ -79,7 +75,6 @@ final class BuiltInMetricsProvider {
             SpannerCloudMonitoringExporter.create(projectId, credentials, monitoringHost),
             sdkMeterProviderBuilder);
 
-
         sdkMeterProviderBuilder.setResource(Resource.create(createResourceAttributes(projectId)));
         SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
         this.openTelemetry = OpenTelemetrySdk.builder().setMeterProvider(sdkMeterProvider).build();
@@ -104,7 +99,7 @@ final class BuiltInMetricsProvider {
         GrpcOpenTelemetry.newBuilder()
             .sdk(this.getOrCreateOpenTelemetry(projectId, credentials, monitoringHost))
             .enableMetrics(BuiltInMetricsConstant.GRPC_METRICS_TO_ENABLE)
-            // .disableMetrics(BuiltInMetricsConstant.GRPC_METRICS_ENABLED_BY_DEFAULT)
+            .disableMetrics(BuiltInMetricsConstant.GRPC_METRICS_ENABLED_BY_DEFAULT)
             .build();
     ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder> channelConfigurator =
         channelProviderBuilder.getChannelConfigurator();

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsProvider.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsProvider.java
@@ -75,7 +75,6 @@ final class BuiltInMetricsProvider {
         BuiltInMetricsView.registerBuiltinMetrics(
             SpannerCloudMonitoringExporter.create(projectId, credentials, monitoringHost),
             sdkMeterProviderBuilder);
-
         sdkMeterProviderBuilder.setResource(Resource.create(createResourceAttributes(projectId)));
         SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
         this.openTelemetry = OpenTelemetrySdk.builder().setMeterProvider(sdkMeterProvider).build();
@@ -91,7 +90,7 @@ final class BuiltInMetricsProvider {
     }
   }
 
-  public void enableGrpcMetrics(
+  void enableGrpcMetrics(
       InstantiatingGrpcChannelProvider.Builder channelProviderBuilder,
       String projectId,
       @Nullable Credentials credentials,

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsProvider.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsProvider.java
@@ -24,16 +24,28 @@ import static com.google.cloud.spanner.BuiltInMetricsConstant.INSTANCE_CONFIG_ID
 import static com.google.cloud.spanner.BuiltInMetricsConstant.LOCATION_ID_KEY;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.PROJECT_ID_KEY;
 
+import com.google.api.core.ApiFunction;
+import com.google.api.gax.core.GaxProperties;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.auth.Credentials;
 import com.google.cloud.opentelemetry.detection.AttributeKeys;
 import com.google.cloud.opentelemetry.detection.DetectedPlatform;
 import com.google.cloud.opentelemetry.detection.GCPPlatformDetector;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.opentelemetry.GrpcOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.InstrumentSelector;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
+import io.opentelemetry.sdk.metrics.View;
+import io.opentelemetry.sdk.resources.Resource;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Method;
@@ -66,6 +78,9 @@ final class BuiltInMetricsProvider {
         BuiltInMetricsView.registerBuiltinMetrics(
             SpannerCloudMonitoringExporter.create(projectId, credentials, monitoringHost),
             sdkMeterProviderBuilder);
+
+
+        sdkMeterProviderBuilder.setResource(Resource.create(createResourceAttributes(projectId)));
         SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
         this.openTelemetry = OpenTelemetrySdk.builder().setMeterProvider(sdkMeterProvider).build();
         Runtime.getRuntime().addShutdownHook(new Thread(sdkMeterProvider::close));
@@ -80,15 +95,45 @@ final class BuiltInMetricsProvider {
     }
   }
 
-  Map<String, String> createClientAttributes(String projectId, String client_name) {
+  public void enableGrpcMetrics(
+      InstantiatingGrpcChannelProvider.Builder channelProviderBuilder,
+      String projectId,
+      @Nullable Credentials credentials,
+      @Nullable String monitoringHost) {
+    GrpcOpenTelemetry grpcOpenTelemetry =
+        GrpcOpenTelemetry.newBuilder()
+            .sdk(this.getOrCreateOpenTelemetry(projectId, credentials, monitoringHost))
+            .enableMetrics(BuiltInMetricsConstant.GRPC_METRICS_TO_ENABLE)
+            // .disableMetrics(BuiltInMetricsConstant.GRPC_METRICS_ENABLED_BY_DEFAULT)
+            .build();
+    ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder> channelConfigurator =
+        channelProviderBuilder.getChannelConfigurator();
+    channelProviderBuilder.setChannelConfigurator(
+        b -> {
+          grpcOpenTelemetry.configureChannelBuilder(b);
+          if (channelConfigurator != null) {
+            return channelConfigurator.apply(b);
+          }
+          return b;
+        });
+  }
+
+  Attributes createResourceAttributes(String projectId) {
+    AttributesBuilder attributesBuilder =
+        Attributes.builder()
+            .put(PROJECT_ID_KEY.getKey(), projectId)
+            .put(INSTANCE_CONFIG_ID_KEY.getKey(), "unknown")
+            .put(CLIENT_HASH_KEY.getKey(), generateClientHash(getDefaultTaskValue()))
+            .put(LOCATION_ID_KEY.getKey(), detectClientLocation());
+
+    return attributesBuilder.build();
+  }
+
+  Map<String, String> createClientAttributes() {
     Map<String, String> clientAttributes = new HashMap<>();
-    clientAttributes.put(LOCATION_ID_KEY.getKey(), detectClientLocation());
-    clientAttributes.put(PROJECT_ID_KEY.getKey(), projectId);
-    clientAttributes.put(INSTANCE_CONFIG_ID_KEY.getKey(), "unknown");
-    clientAttributes.put(CLIENT_NAME_KEY.getKey(), client_name);
-    String clientUid = getDefaultTaskValue();
-    clientAttributes.put(CLIENT_UID_KEY.getKey(), clientUid);
-    clientAttributes.put(CLIENT_HASH_KEY.getKey(), generateClientHash(clientUid));
+    clientAttributes.put(
+        CLIENT_NAME_KEY.getKey(), "spanner-java/" + GaxProperties.getLibraryVersion(getClass()));
+    clientAttributes.put(CLIENT_UID_KEY.getKey(), getDefaultTaskValue());
     return clientAttributes;
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsProvider.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsProvider.java
@@ -99,6 +99,7 @@ final class BuiltInMetricsProvider {
         GrpcOpenTelemetry.newBuilder()
             .sdk(this.getOrCreateOpenTelemetry(projectId, credentials, monitoringHost))
             .enableMetrics(BuiltInMetricsConstant.GRPC_METRICS_TO_ENABLE)
+            // Disable gRPCs default metrics as they are not needed for Spanner.
             .disableMetrics(BuiltInMetricsConstant.GRPC_METRICS_ENABLED_BY_DEFAULT)
             .build();
     ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder> channelConfigurator =

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporter.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporter.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.spanner;
 
-import static com.google.cloud.spanner.BuiltInMetricsConstant.SPANNER_METRICS;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporter.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporter.java
@@ -103,25 +103,6 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
 
   @Override
   public CompletableResultCode export(@Nonnull Collection<MetricData> collection) {
-    // TODO: Remove
-    collection.stream()
-        .filter(md -> "grpc-java".equals(md.getInstrumentationScopeInfo().getName()))
-        .forEach(
-            md -> {
-              System.out.println("Name: " + md.getName()); // Print the name
-
-              md.getData()
-                  .getPoints()
-                  .forEach(
-                      point -> {
-                        System.out.println(
-                            "Attributes: "
-                                + point.getAttributes()); // Print attributes for each point
-                      });
-
-              System.out.println("----------------------"); // Separator for readability
-            });
-
     if (client.isShutdown()) {
       logger.log(Level.WARNING, "Exporter is shut down");
       return CompletableResultCode.ofFailure();
@@ -133,10 +114,7 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
   /** Export client built in metrics */
   private CompletableResultCode exportSpannerClientMetrics(Collection<MetricData> collection) {
     // Filter spanner metrics. Only include metrics that contain a project and instance ID.
-    List<MetricData> spannerMetricData =
-        collection.stream()
-            // .filter(md -> SPANNER_METRICS.contains(md.getName()))
-            .collect(Collectors.toList());
+    List<MetricData> spannerMetricData = collection.stream().collect(Collectors.toList());
 
     // Log warnings for metrics that will be skipped.
     boolean mustFilter = false;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporter.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporter.java
@@ -105,17 +105,24 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
 
   @Override
   public CompletableResultCode export(@Nonnull Collection<MetricData> collection) {
-    // Print 
+    // TODO: Remove
     collection.stream()
-        .forEach(md -> {
-          System.out.println("Name: " + md.getName()); // Print the name
+        .filter(md -> "grpc-java".equals(md.getInstrumentationScopeInfo().getName()))
+        .forEach(
+            md -> {
+              System.out.println("Name: " + md.getName()); // Print the name
 
-          md.getData().getPoints().forEach(point -> {
-            System.out.println("Attributes: " + point.getAttributes()); // Print attributes for each point
-          });
+              md.getData()
+                  .getPoints()
+                  .forEach(
+                      point -> {
+                        System.out.println(
+                            "Attributes: "
+                                + point.getAttributes()); // Print attributes for each point
+                      });
 
-          System.out.println("----------------------"); // Separator for readability
-        });
+              System.out.println("----------------------"); // Separator for readability
+            });
 
     if (client.isShutdown()) {
       logger.log(Level.WARNING, "Exporter is shut down");

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporter.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporter.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.spanner;
 
-
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporter.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporter.java
@@ -137,7 +137,7 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
     // Filter spanner metrics. Only include metrics that contain a project and instance ID.
     List<MetricData> spannerMetricData =
         collection.stream()
-            .filter(md -> SPANNER_METRICS.contains(md.getName()))
+            // .filter(md -> SPANNER_METRICS.contains(md.getName()))
             .collect(Collectors.toList());
 
     // Log warnings for metrics that will be skipped.

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterUtils.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterUtils.java
@@ -24,7 +24,6 @@ import static com.google.api.MetricDescriptor.ValueType.DOUBLE;
 import static com.google.api.MetricDescriptor.ValueType.INT64;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.GAX_METER_NAME;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.GRPC_METER_NAME;
-import static com.google.cloud.spanner.BuiltInMetricsConstant.INSTANCE_ID_KEY;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.PROJECT_ID_KEY;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.SPANNER_METER_NAME;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.SPANNER_PROMOTED_RESOURCE_LABELS;
@@ -68,10 +67,6 @@ class SpannerCloudMonitoringExporterUtils {
 
   static String getProjectId(Resource resource) {
     return resource.getAttributes().get(PROJECT_ID_KEY);
-  }
-
-  static String getInstanceId(PointData pointData) {
-    return pointData.getAttributes().get(INSTANCE_ID_KEY);
   }
 
   static List<TimeSeries> convertToSpannerTimeSeries(List<MetricData> collection) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterUtils.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterUtils.java
@@ -83,6 +83,7 @@ class SpannerCloudMonitoringExporterUtils {
           || metricData.getInstrumentationScopeInfo().getName().equals(SPANNER_METER_NAME)
           || metricData.getInstrumentationScopeInfo().getName().equals(GRPC_METER_NAME))) {
         // Filter out metric data for instruments that are not part of the spanner metrics list
+        System.out.println("Skipped some data" + metricData.getInstrumentationScopeInfo().getName().toString());
         continue;
       }
 
@@ -102,7 +103,6 @@ class SpannerCloudMonitoringExporterUtils {
                   convertPointToSpannerTimeSeries(metricData, pointData, monitoredResourceBuilder))
           .forEach(allTimeSeries::add);
     }
-
     return allTimeSeries;
   }
 
@@ -114,6 +114,7 @@ class SpannerCloudMonitoringExporterUtils {
         TimeSeries.newBuilder()
             .setMetricKind(convertMetricKind(metricData))
             .setValueType(convertValueType(metricData.getType()));
+    System.out.println("convertPointToSpannerTimeSeries Metric name " +metricData.getName());
     Metric.Builder metricBuilder = Metric.newBuilder().setType(metricData.getName());
 
     Attributes attributes = pointData.getAttributes();
@@ -123,7 +124,7 @@ class SpannerCloudMonitoringExporterUtils {
         monitoredResourceBuilder.putLabels(key.getKey(), String.valueOf(attributes.get(key)));
       } else {
         metricBuilder.putLabels(
-            key.getKey().replace(".", "/"), String.valueOf(attributes.get(key)));
+            key.getKey().replace(".", "_"), String.valueOf(attributes.get(key)));
       }
     }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterUtils.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterUtils.java
@@ -83,7 +83,8 @@ class SpannerCloudMonitoringExporterUtils {
           || metricData.getInstrumentationScopeInfo().getName().equals(SPANNER_METER_NAME)
           || metricData.getInstrumentationScopeInfo().getName().equals(GRPC_METER_NAME))) {
         // Filter out metric data for instruments that are not part of the spanner metrics list
-        System.out.println("Skipped some data" + metricData.getInstrumentationScopeInfo().getName().toString());
+        System.out.println(
+            "Skipped some data" + metricData.getInstrumentationScopeInfo().getName().toString());
         continue;
       }
 
@@ -114,7 +115,7 @@ class SpannerCloudMonitoringExporterUtils {
         TimeSeries.newBuilder()
             .setMetricKind(convertMetricKind(metricData))
             .setValueType(convertValueType(metricData.getType()));
-    System.out.println("convertPointToSpannerTimeSeries Metric name " +metricData.getName());
+    System.out.println("convertPointToSpannerTimeSeries Metric name " + metricData.getName());
     Metric.Builder metricBuilder = Metric.newBuilder().setType(metricData.getName());
 
     Attributes attributes = pointData.getAttributes();

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterUtils.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterUtils.java
@@ -122,7 +122,8 @@ class SpannerCloudMonitoringExporterUtils {
       if (SPANNER_PROMOTED_RESOURCE_LABELS.contains(key)) {
         monitoredResourceBuilder.putLabels(key.getKey(), String.valueOf(attributes.get(key)));
       } else {
-        metricBuilder.putLabels(key.getKey(), String.valueOf(attributes.get(key)));
+        metricBuilder.putLabels(
+            key.getKey().replace(".", "/"), String.valueOf(attributes.get(key)));
       }
     }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -919,8 +919,8 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
 
     @Override
     public boolean isEnableGRPCBuiltInMetrics() {
-      return !Boolean.parseBoolean(
-          System.getenv(SPANNER_DISABLE_DIRECT_ACCESS_GRPC_BUILTIN_METRICS));
+      return "false"
+          .equalsIgnoreCase(System.getenv(SPANNER_DISABLE_DIRECT_ACCESS_GRPC_BUILTIN_METRICS));
     }
 
     @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -849,6 +849,10 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
       return true;
     }
 
+    default boolean isEnableGRPCBuiltInMetrics() {
+      return false;
+    }
+
     default boolean isEnableEndToEndTracing() {
       return false;
     }
@@ -879,6 +883,8 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     private static final String SPANNER_ENABLE_END_TO_END_TRACING =
         "SPANNER_ENABLE_END_TO_END_TRACING";
     private static final String SPANNER_DISABLE_BUILTIN_METRICS = "SPANNER_DISABLE_BUILTIN_METRICS";
+    private static final String SPANNER_DISABLE_DIRECT_ACCESS_GRPC_BUILTIN_METRICS =
+        "SPANNER_DISABLE_DIRECT_ACCESS_GRPC_BUILTIN_METRICS";
     private static final String SPANNER_MONITORING_HOST = "SPANNER_MONITORING_HOST";
 
     private SpannerEnvironmentImpl() {}
@@ -909,6 +915,12 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     @Override
     public boolean isEnableBuiltInMetrics() {
       return !Boolean.parseBoolean(System.getenv(SPANNER_DISABLE_BUILTIN_METRICS));
+    }
+
+    @Override
+    public boolean isEnableGRPCBuiltInMetrics() {
+      return !Boolean.parseBoolean(
+          System.getenv(SPANNER_DISABLE_DIRECT_ACCESS_GRPC_BUILTIN_METRICS));
     }
 
     @Override
@@ -1973,8 +1985,10 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
   }
 
   public void enablegRPCMetrics(InstantiatingGrpcChannelProvider.Builder channelProviderBuilder) {
-    this.builtInMetricsProvider.enableGrpcMetrics(
-        channelProviderBuilder, this.getProjectId(), getCredentials(), this.monitoringHost);
+    if (SpannerOptions.environment.isEnableGRPCBuiltInMetrics()) {
+      this.builtInMetricsProvider.enableGrpcMetrics(
+          channelProviderBuilder, this.getProjectId(), getCredentials(), this.monitoringHost);
+    }
   }
 
   public ApiTracerFactory getApiTracerFactory(boolean isAdminClient, boolean isEmulatorEnabled) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -27,6 +27,7 @@ import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.grpc.GrpcCallContext;
 import com.google.api.gax.grpc.GrpcInterceptorProvider;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.api.gax.longrunning.OperationTimedPollAlgorithm;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.ApiCallContext;
@@ -1971,6 +1972,11 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     return createApiTracerFactory(false, false);
   }
 
+  public void enablegRPCMetrics(InstantiatingGrpcChannelProvider.Builder channelProviderBuilder) {
+    this.builtInMetricsProvider.enableGrpcMetrics(
+        channelProviderBuilder, this.getProjectId(), getCredentials(), this.monitoringHost);
+  }
+
   public ApiTracerFactory getApiTracerFactory(boolean isAdminClient, boolean isEmulatorEnabled) {
     return createApiTracerFactory(isAdminClient, isEmulatorEnabled);
   }
@@ -2018,8 +2024,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     return openTelemetry != null
         ? new BuiltInMetricsTracerFactory(
             new BuiltInMetricsRecorder(openTelemetry, BuiltInMetricsConstant.METER_NAME),
-            builtInMetricsProvider.createClientAttributes(
-                this.getProjectId(), "spanner-java/" + GaxProperties.getLibraryVersion(getClass())))
+            new HashMap<>())
         : null;
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -374,10 +374,8 @@ public class GapicSpannerRpc implements SpannerRpc {
         defaultChannelProviderBuilder.setAttemptDirectPathXds();
       }
 
-      // Use condition to enable gRPC metrics
-      if (true) {
-        options.enablegRPCMetrics(defaultChannelProviderBuilder);
-      }
+      options.enablegRPCMetrics(defaultChannelProviderBuilder);
+
       if (options.isUseVirtualThreads()) {
         ExecutorService executor =
             tryCreateVirtualThreadPerTaskExecutor("spanner-virtual-grpc-executor");

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -373,6 +373,11 @@ public class GapicSpannerRpc implements SpannerRpc {
         defaultChannelProviderBuilder.setAttemptDirectPath(true);
         defaultChannelProviderBuilder.setAttemptDirectPathXds();
       }
+
+      // Use condition to enable gRPC metrics
+      if (true) {
+        options.enablegRPCMetrics(defaultChannelProviderBuilder);
+      }
       if (options.isUseVirtualThreads()) {
         ExecutorService executor =
             tryCreateVirtualThreadPerTaskExecutor("spanner-virtual-grpc-executor");

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
@@ -91,18 +91,12 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
 
     String client_name = "spanner-java/";
     openTelemetry = OpenTelemetrySdk.builder().setMeterProvider(meterProvider.build()).build();
-    attributes = provider.createClientAttributes("test-project", client_name);
+    attributes = provider.createClientAttributes();
 
     expectedCommonBaseAttributes =
         Attributes.builder()
-            .put(BuiltInMetricsConstant.PROJECT_ID_KEY, "test-project")
-            .put(BuiltInMetricsConstant.INSTANCE_CONFIG_ID_KEY, "unknown")
-            .put(
-                BuiltInMetricsConstant.LOCATION_ID_KEY,
-                BuiltInMetricsProvider.detectClientLocation())
             .put(BuiltInMetricsConstant.CLIENT_NAME_KEY, client_name)
             .put(BuiltInMetricsConstant.CLIENT_UID_KEY, attributes.get("client_uid"))
-            .put(BuiltInMetricsConstant.CLIENT_HASH_KEY, attributes.get("client_hash"))
             .put(BuiltInMetricsConstant.INSTANCE_ID_KEY, "i")
             .put(BuiltInMetricsConstant.DATABASE_KEY, "d")
             .put(BuiltInMetricsConstant.DIRECT_PATH_ENABLED_KEY, "false")

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBuiltInMetricsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBuiltInMetricsTest.java
@@ -36,7 +36,6 @@ import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBuiltInMetricsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBuiltInMetricsTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spanner.it;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.Assume.assumeFalse;
 
 import com.google.cloud.monitoring.v3.MetricServiceClient;
 import com.google.cloud.spanner.Database;
@@ -24,6 +25,7 @@ import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.IntegrationTestEnv;
 import com.google.cloud.spanner.ParallelIntegrationTest;
 import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.testing.EmulatorSpannerHelper;
 import com.google.common.base.Stopwatch;
 import com.google.monitoring.v3.ListTimeSeriesRequest;
 import com.google.monitoring.v3.ListTimeSeriesResponse;
@@ -34,6 +36,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -43,7 +46,6 @@ import org.junit.runners.JUnit4;
 
 @Category(ParallelIntegrationTest.class)
 @RunWith(JUnit4.class)
-// @Ignore("Built-in Metrics are not GA'ed yet. Enable this test once the metrics are released")
 public class ITBuiltInMetricsTest {
 
   private static Database db;
@@ -53,6 +55,10 @@ public class ITBuiltInMetricsTest {
 
   private static MetricServiceClient metricClient;
 
+  private static String[] METRICS = {
+    "operation_latencies", "attempt_latencies", "operation_count", "attempt_count",
+  };
+
   @BeforeClass
   public static void setUp() throws IOException {
     metricClient = MetricServiceClient.create();
@@ -61,8 +67,16 @@ public class ITBuiltInMetricsTest {
     client = env.getTestHelper().getDatabaseClient(db);
   }
 
+  @After
+  public void tearDown() {
+    if (metricClient != null) {
+      metricClient.close();
+    }
+  }
+
   @Test
   public void testBuiltinMetricsWithDefaultOTEL() throws Exception {
+    assumeFalse("This test requires credentials", EmulatorSpannerHelper.isUsingEmulator());
     // This stopwatch is used for to limit fetching of metric data in verifyMetrics
     Stopwatch metricsPollingStopwatch = Stopwatch.createStarted();
     Instant start = Instant.now().minus(Duration.ofMinutes(2));
@@ -79,36 +93,36 @@ public class ITBuiltInMetricsTest {
         .readWriteTransaction()
         .run(transaction -> transaction.executeQuery(Statement.of("Select 1")));
 
-    String metricFilter =
-        String.format(
-            "metric.type=\"spanner.googleapis.com/client/%s\""
-                + " AND resource.type=\"spanner_instance\""
-                + " AND metric.labels.method=\"Spanner.Commit\""
-                + " AND resource.labels.instance_id=\"%s\""
-                + " AND metric.labels.database=\"%s\"",
-            "operation_latencies",
-            db.getId().getInstanceId().getInstance(),
-            db.getId().getDatabase());
+    for (String metric : METRICS) {
+      String metricFilter =
+          String.format(
+              "metric.type=\"spanner.googleapis.com/client/%s\""
+                  + " AND resource.type=\"spanner_instance\""
+                  + " AND metric.labels.method=\"Spanner.Commit\""
+                  + " AND resource.labels.instance_id=\"%s\""
+                  + " AND metric.labels.database=\"%s\"",
+              metric, db.getId().getInstanceId().getInstance(), db.getId().getDatabase());
 
-    ListTimeSeriesRequest.Builder requestBuilder =
-        ListTimeSeriesRequest.newBuilder()
-            .setName(name.toString())
-            .setFilter(metricFilter)
-            .setInterval(interval)
-            .setView(ListTimeSeriesRequest.TimeSeriesView.FULL);
+      ListTimeSeriesRequest.Builder requestBuilder =
+          ListTimeSeriesRequest.newBuilder()
+              .setName(name.toString())
+              .setFilter(metricFilter)
+              .setInterval(interval)
+              .setView(ListTimeSeriesRequest.TimeSeriesView.FULL);
 
-    ListTimeSeriesRequest request = requestBuilder.build();
+      ListTimeSeriesRequest request = requestBuilder.build();
 
-    ListTimeSeriesResponse response = metricClient.listTimeSeriesCallable().call(request);
-    while (response.getTimeSeriesCount() == 0
-        && metricsPollingStopwatch.elapsed(TimeUnit.MINUTES) < 3) {
-      // Call listTimeSeries every minute
-      Thread.sleep(Duration.ofMinutes(1).toMillis());
-      response = metricClient.listTimeSeriesCallable().call(request);
+      ListTimeSeriesResponse response = metricClient.listTimeSeriesCallable().call(request);
+      while (response.getTimeSeriesCount() == 0
+          && metricsPollingStopwatch.elapsed(TimeUnit.MINUTES) < 3) {
+        // Call listTimeSeries every minute
+        Thread.sleep(Duration.ofMinutes(1).toMillis());
+        response = metricClient.listTimeSeriesCallable().call(request);
+      }
+
+      assertWithMessage("Metric" + metric + "didn't return any data.")
+          .that(response.getTimeSeriesCount())
+          .isGreaterThan(0);
     }
-
-    assertWithMessage("View operation_latencies didn't return any data.")
-        .that(response.getTimeSeriesCount())
-        .isGreaterThan(0);
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBuiltInMetricsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBuiltInMetricsTest.java
@@ -44,7 +44,7 @@ import org.junit.runners.JUnit4;
 
 @Category(ParallelIntegrationTest.class)
 @RunWith(JUnit4.class)
-@Ignore("Built-in Metrics are not GA'ed yet. Enable this test once the metrics are released")
+// @Ignore("Built-in Metrics are not GA'ed yet. Enable this test once the metrics are released")
 public class ITBuiltInMetricsTest {
 
   private static Database db;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBuiltInMetricsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITBuiltInMetricsTest.java
@@ -61,6 +61,7 @@ public class ITBuiltInMetricsTest {
 
   @BeforeClass
   public static void setUp() throws IOException {
+    assumeFalse("This test requires credentials", EmulatorSpannerHelper.isUsingEmulator());
     metricClient = MetricServiceClient.create();
     // Enable BuiltinMetrics when the metrics are GA'ed
     db = env.getTestHelper().createTestDatabase();
@@ -76,7 +77,6 @@ public class ITBuiltInMetricsTest {
 
   @Test
   public void testBuiltinMetricsWithDefaultOTEL() throws Exception {
-    assumeFalse("This test requires credentials", EmulatorSpannerHelper.isUsingEmulator());
     // This stopwatch is used for to limit fetching of metric data in verifyMetrics
     Stopwatch metricsPollingStopwatch = Stopwatch.createStarted();
     Instant start = Instant.now().minus(Duration.ofMinutes(2));


### PR DESCRIPTION
This PR adds below GRPC Metrics available for Spanner Engineers. 

These metrics are disabled as default currently. To enable set `SPANNER_DISABLE_DIRECT_ACCESS_GRPC_BUILTIN_METRICS=false` 

- grpc.lb.rls.default_target_picks
- grpc.lb.rls.target_picks
-   grpc.xds_client.server_failure
-   grpc.xds_client.resource_updates_invalid
-   grpc.xds_client.resource_updates_valid