### PR TITLE
chore: fallback for Partitioned Operations with multiplexed session

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -404,6 +404,27 @@ abstract class AbstractReadContext
       }
     }
 
+    void initFallbackTransaction() {
+      synchronized (txnLock) {
+        span.addAnnotation("Creating Transaction");
+        TransactionOptions.Builder options = TransactionOptions.newBuilder();
+        if (timestamp != null) {
+          options
+              .getReadOnlyBuilder()
+              .setReadTimestamp(timestamp.toProto())
+              .setReturnReadTimestamp(true);
+        } else {
+          bound.applyToBuilder(options.getReadOnlyBuilder()).setReturnReadTimestamp(true);
+        }
+        final BeginTransactionRequest request =
+            BeginTransactionRequest.newBuilder()
+                .setSession(session.getName())
+                .setOptions(options)
+                .build();
+        initTransactionInternal(request);
+      }
+    }
+
     void initTransaction() {
       SessionImpl.throwIfTransactionsPending();
 
@@ -419,40 +440,43 @@ abstract class AbstractReadContext
           return;
         }
         span.addAnnotation("Creating Transaction");
-        try {
-          TransactionOptions.Builder options = TransactionOptions.newBuilder();
-          bound.applyToBuilder(options.getReadOnlyBuilder()).setReturnReadTimestamp(true);
-          final BeginTransactionRequest request =
-              BeginTransactionRequest.newBuilder()
-                  .setSession(session.getName())
-                  .setOptions(options)
-                  .build();
-          Transaction transaction =
-              rpc.beginTransaction(request, getTransactionChannelHint(), isRouteToLeader());
-          if (!transaction.hasReadTimestamp()) {
-            throw SpannerExceptionFactory.newSpannerException(
-                ErrorCode.INTERNAL, "Missing expected transaction.read_timestamp metadata field");
-          }
-          if (transaction.getId().isEmpty()) {
-            throw SpannerExceptionFactory.newSpannerException(
-                ErrorCode.INTERNAL, "Missing expected transaction.id metadata field");
-          }
-          try {
-            timestamp = Timestamp.fromProto(transaction.getReadTimestamp());
-          } catch (IllegalArgumentException e) {
-            throw SpannerExceptionFactory.newSpannerException(
-                ErrorCode.INTERNAL, "Bad value in transaction.read_timestamp metadata field", e);
-          }
-          transactionId = transaction.getId();
-          span.addAnnotation(
-              "Transaction Creation Done",
-              ImmutableMap.of(
-                  "Id", transaction.getId().toStringUtf8(), "Timestamp", timestamp.toString()));
+        TransactionOptions.Builder options = TransactionOptions.newBuilder();
+        bound.applyToBuilder(options.getReadOnlyBuilder()).setReturnReadTimestamp(true);
+        final BeginTransactionRequest request =
+            BeginTransactionRequest.newBuilder()
+                .setSession(session.getName())
+                .setOptions(options)
+                .build();
+        initTransactionInternal(request);
+      }
+    }
 
-        } catch (SpannerException e) {
-          span.addAnnotation("Transaction Creation Failed", e);
-          throw e;
+    private void initTransactionInternal(BeginTransactionRequest request) {
+      try {
+        Transaction transaction =
+            rpc.beginTransaction(request, getTransactionChannelHint(), isRouteToLeader());
+        if (!transaction.hasReadTimestamp()) {
+          throw SpannerExceptionFactory.newSpannerException(
+              ErrorCode.INTERNAL, "Missing expected transaction.read_timestamp metadata field");
         }
+        if (transaction.getId().isEmpty()) {
+          throw SpannerExceptionFactory.newSpannerException(
+              ErrorCode.INTERNAL, "Missing expected transaction.id metadata field");
+        }
+        try {
+          timestamp = Timestamp.fromProto(transaction.getReadTimestamp());
+        } catch (IllegalArgumentException e) {
+          throw SpannerExceptionFactory.newSpannerException(
+              ErrorCode.INTERNAL, "Bad value in transaction.read_timestamp metadata field", e);
+        }
+        transactionId = transaction.getId();
+        span.addAnnotation(
+            "Transaction Creation Done",
+            ImmutableMap.of(
+                "Id", transaction.getId().toStringUtf8(), "Timestamp", timestamp.toString()));
+      } catch (SpannerException e) {
+        span.addAnnotation("Transaction Creation Failed", e);
+        throw e;
       }
     }
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -404,6 +404,10 @@ abstract class AbstractReadContext
       }
     }
 
+    /**
+     * Initializes the transaction with the timestamp specified within MultiUseReadOnlyTransaction.
+     * This is used only for fallback of PartitionQueryRequest and PartitionReadRequest with Multiplexed Session.
+     */
     void initFallbackTransaction() {
       synchronized (txnLock) {
         span.addAnnotation("Creating Transaction");

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -406,7 +406,8 @@ abstract class AbstractReadContext
 
     /**
      * Initializes the transaction with the timestamp specified within MultiUseReadOnlyTransaction.
-     * This is used only for fallback of PartitionQueryRequest and PartitionReadRequest with Multiplexed Session.
+     * This is used only for fallback of PartitionQueryRequest and PartitionReadRequest with
+     * Multiplexed Session.
      */
     void initFallbackTransaction() {
       synchronized (txnLock) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchClientImpl.java
@@ -114,7 +114,8 @@ public class BatchClientImpl implements BatchClient {
                 sessionClient.getSpanner().getOptions().getDirectedReadOptions())
             .setSpan(sessionClient.getSpanner().getTracer().getCurrentSpan())
             .setTracer(sessionClient.getSpanner().getTracer()),
-        checkNotNull(bound));
+        checkNotNull(bound),
+        sessionClient);
   }
 
   @Override
@@ -137,7 +138,8 @@ public class BatchClientImpl implements BatchClient {
                 sessionClient.getSpanner().getOptions().getDirectedReadOptions())
             .setSpan(sessionClient.getSpanner().getTracer().getCurrentSpan())
             .setTracer(sessionClient.getSpanner().getTracer()),
-        batchTransactionId);
+        batchTransactionId,
+        sessionClient);
   }
 
   private boolean canUseMultiplexedSession() {
@@ -160,20 +162,27 @@ public class BatchClientImpl implements BatchClient {
 
   private static class BatchReadOnlyTransactionImpl extends MultiUseReadOnlyTransaction
       implements BatchReadOnlyTransaction {
-    private final String sessionName;
+    private String sessionName;
     private final Map<SpannerRpc.Option, ?> options;
+    private final SessionClient sessionClient;
 
     BatchReadOnlyTransactionImpl(
-        MultiUseReadOnlyTransaction.Builder builder, TimestampBound bound) {
+        MultiUseReadOnlyTransaction.Builder builder,
+        TimestampBound bound,
+        SessionClient sessionClient) {
       super(builder.setTimestampBound(bound));
+      this.sessionClient = sessionClient;
       this.sessionName = session.getName();
       this.options = session.getOptions();
       initTransaction();
     }
 
     BatchReadOnlyTransactionImpl(
-        MultiUseReadOnlyTransaction.Builder builder, BatchTransactionId batchTransactionId) {
+        MultiUseReadOnlyTransaction.Builder builder,
+        BatchTransactionId batchTransactionId,
+        SessionClient sessionClient) {
       super(builder.setTransactionId(batchTransactionId.getTransactionId()));
+      this.sessionClient = sessionClient;
       this.sessionName = session.getName();
       this.options = session.getOptions();
     }
@@ -202,6 +211,18 @@ public class BatchClientImpl implements BatchClient {
         String index,
         KeySet keys,
         Iterable<String> columns,
+        ReadOption... option)
+        throws SpannerException {
+      return partitionReadUsingIndex(partitionOptions, table, index, keys, columns, false, option);
+    }
+
+    public List<Partition> partitionReadUsingIndex(
+        PartitionOptions partitionOptions,
+        String table,
+        String index,
+        KeySet keys,
+        Iterable<String> columns,
+        boolean isFallback,
         ReadOption... option)
         throws SpannerException {
       Options readOptions = Options.fromReadOptions(option);
@@ -246,7 +267,10 @@ public class BatchClientImpl implements BatchClient {
         }
         return partitions.build();
       } catch (SpannerException e) {
-        maybeMarkUnimplementedForPartitionedOps(e);
+        if (!isFallback && maybeMarkUnimplementedForPartitionedOps(e)) {
+          return partitionReadUsingIndex(
+              partitionOptions, table, index, keys, columns, true, option);
+        }
         throw e;
       }
     }
@@ -254,6 +278,15 @@ public class BatchClientImpl implements BatchClient {
     @Override
     public List<Partition> partitionQuery(
         PartitionOptions partitionOptions, Statement statement, QueryOption... option)
+        throws SpannerException {
+      return partitionQuery(partitionOptions, statement, false, option);
+    }
+
+    private List<Partition> partitionQuery(
+        PartitionOptions partitionOptions,
+        Statement statement,
+        boolean isFallback,
+        QueryOption... option)
         throws SpannerException {
       Options queryOptions = Options.fromQueryOptions(option);
       final PartitionQueryRequest.Builder builder =
@@ -291,16 +324,23 @@ public class BatchClientImpl implements BatchClient {
         }
         return partitions.build();
       } catch (SpannerException e) {
-        maybeMarkUnimplementedForPartitionedOps(e);
+        if (!isFallback && maybeMarkUnimplementedForPartitionedOps(e)) {
+          return partitionQuery(partitionOptions, statement, true, option);
+        }
         throw e;
       }
     }
 
-    void maybeMarkUnimplementedForPartitionedOps(SpannerException spannerException) {
+    boolean maybeMarkUnimplementedForPartitionedOps(SpannerException spannerException) {
       if (MultiplexedSessionDatabaseClient.verifyErrorMessage(
           spannerException, "Partitioned operations are not supported with multiplexed sessions")) {
         unimplementedForPartitionedOps.set(true);
+        session.setFallbackSessionReference(sessionClient.createSession().getSessionReference());
+        sessionName = session.getName();
+        initFallbackTransaction();
+        return true;
       }
+      return false;
     }
 
     @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchTransactionId.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchTransactionId.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spanner;
 
 import com.google.cloud.Timestamp;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
 import java.io.Serializable;
@@ -34,6 +35,7 @@ public class BatchTransactionId implements Serializable {
   private final Timestamp timestamp;
   private static final long serialVersionUID = 8067099123096783939L;
 
+  @VisibleForTesting
   BatchTransactionId(String sessionId, ByteString transactionId, Timestamp timestamp) {
     this.transactionId = Preconditions.checkNotNull(transactionId);
     this.sessionId = Preconditions.checkNotNull(sessionId);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -120,7 +120,7 @@ class SessionImpl implements Session {
   static final int NO_CHANNEL_HINT = -1;
 
   private final SpannerImpl spanner;
-  private final SessionReference sessionReference;
+  private SessionReference sessionReference;
   private SessionTransaction activeTransaction;
   private ISpan currentSpan;
   private final Clock clock;
@@ -158,6 +158,14 @@ class SessionImpl implements Session {
   @Override
   public String getName() {
     return sessionReference.getName();
+  }
+
+  /**
+   * Updates the session reference with the fallback session. This should only be used for updating
+   * session reference with regular session in case of unimplemented error in multiplexed session.
+   */
+  void setFallbackSessionReference(SessionReference sessionReference) {
+    this.sessionReference = sessionReference;
   }
 
   Map<SpannerRpc.Option, ?> getOptions() {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MultiplexedSessionDatabaseClientMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MultiplexedSessionDatabaseClientMockServerTest.java
@@ -1574,9 +1574,8 @@ public class MultiplexedSessionDatabaseClientMockServerTest extends AbstractMock
 
   /**
    * Tests the behavior of the server-side kill switch for partitioned query multiplexed sessions.
-   * The BatchReadOnlyTransaction is initiated using BatchTransactionId.
-   * 2 PartitionQueryRequest should be received. First with Multiplexed session and second with
-   * regular session.
+   * The BatchReadOnlyTransaction is initiated using BatchTransactionId. 2 PartitionQueryRequest
+   * should be received. First with Multiplexed session and second with regular session.
    */
   @Test
   public void

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MultiplexedSessionDatabaseClientMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MultiplexedSessionDatabaseClientMockServerTest.java
@@ -1573,8 +1573,9 @@ public class MultiplexedSessionDatabaseClientMockServerTest extends AbstractMock
   }
 
   /**
-   * Tests the behavior of the server-side kill switch for partitioned query multiplexed sessions. 2
-   * PartitionQueryRequest should be received. First with Multiplexed session and second with
+   * Tests the behavior of the server-side kill switch for partitioned query multiplexed sessions.
+   * The BatchReadOnlyTransaction is initiated using BatchTransactionId.
+   * 2 PartitionQueryRequest should be received. First with Multiplexed session and second with
    * regular session.
    */
   @Test


### PR DESCRIPTION
If PartitionQueryRequest or PartitionReadRequest with multiplexed session return unimplemented error, then an implicit fallback to regular session will occur.