### PR TITLE
chore: wire up x-goog-spanner-request-id to all (REQUESTED_BEFORE_CLEANUP_FOR_PR)

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchClientImpl.java
@@ -315,7 +315,9 @@ public class BatchClientImpl implements BatchClient {
 
       final PartitionQueryRequest request = builder.build();
       try {
-        PartitionResponse response = rpc.partitionQuery(request, options);
+        XGoogSpannerRequestId reqId =
+            this.session.requestIdCreator.nextRequestId(1 /* channelId */, 0);
+        PartitionResponse response = rpc.partitionQuery(request, reqId.withOptions(options));
         ImmutableList.Builder<Partition> partitions = ImmutableList.builder();
         for (com.google.spanner.v1.Partition p : response.getPartitionsList()) {
           Partition partition =

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchClientImpl.java
@@ -252,7 +252,9 @@ public class BatchClientImpl implements BatchClient {
 
       final PartitionReadRequest request = builder.build();
       try {
-        PartitionResponse response = rpc.partitionRead(request, options);
+        XGoogSpannerRequestId reqId =
+            this.session.getRequestIdCreator().nextRequestId(1 /* channelId */, 0);
+        PartitionResponse response = rpc.partitionRead(request, reqId.withOptions(options));
         ImmutableList.Builder<Partition> partitions = ImmutableList.builder();
         for (com.google.spanner.v1.Partition p : response.getPartitionsList()) {
           Partition partition =
@@ -316,7 +318,7 @@ public class BatchClientImpl implements BatchClient {
       final PartitionQueryRequest request = builder.build();
       try {
         XGoogSpannerRequestId reqId =
-            this.session.requestIdCreator.nextRequestId(1 /* channelId */, 0);
+            this.session.getRequestIdCreator().nextRequestId(1 /* channelId */, 0);
         PartitionResponse response = rpc.partitionQuery(request, reqId.withOptions(options));
         ImmutableList.Builder<Partition> partitions = ImmutableList.builder();
         for (com.google.spanner.v1.Partition p : response.getPartitionsList()) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
@@ -535,6 +535,7 @@ public final class Options implements Serializable {
   private RpcLockHint lockHint;
   private Boolean lastStatement;
   private IsolationLevel isolationLevel;
+  private XGoogSpannerRequestId reqId;
 
   // Construction is via factory methods below.
   private Options() {}
@@ -589,6 +590,14 @@ public final class Options implements Serializable {
 
   String pageToken() {
     return pageToken;
+  }
+
+  boolean hasReqId() {
+    return reqId != null;
+  }
+
+  XGoogSpannerRequestId reqId() {
+    return reqId;
   }
 
   boolean hasFilter() {
@@ -1050,6 +1059,32 @@ public final class Options implements Serializable {
     @Override
     public boolean equals(Object o) {
       return o instanceof LastStatementUpdateOption;
+    }
+  }
+
+  static final class RequestIdOption extends InternalOption
+      implements TransactionOption, UpdateOption {
+    private final XGoogSpannerRequestId reqId;
+
+    RequestIdOption(XGoogSpannerRequestId reqId) {
+      this.reqId = reqId;
+    }
+
+    @Override
+    void appendToOptions(Options options) {
+      options.reqId = this.reqId;
+    }
+
+    @Override
+    public int hashCode() {
+      return RequestIdOption.class.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      // TODO: Examine why the precedent for LastStatementUpdateOption
+      // does not check against the actual value.
+      return o instanceof RequestIdOption;
     }
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
@@ -765,6 +765,9 @@ public final class Options implements Serializable {
     if (isolationLevel != null) {
       b.append("isolationLevel: ").append(isolationLevel).append(' ');
     }
+    if (reqId != null) {
+      b.append("requestId: ").append(reqId.toString()).append(' ');
+    }
     return b.toString();
   }
 
@@ -807,7 +810,8 @@ public final class Options implements Serializable {
         && Objects.equals(orderBy(), that.orderBy())
         && Objects.equals(isLastStatement(), that.isLastStatement())
         && Objects.equals(lockHint(), that.lockHint())
-        && Objects.equals(isolationLevel(), that.isolationLevel());
+        && Objects.equals(isolationLevel(), that.isolationLevel())
+        && Objects.equals(reqId(), that.reqId());
   }
 
   @Override
@@ -875,6 +879,9 @@ public final class Options implements Serializable {
     }
     if (isolationLevel != null) {
       result = 31 * result + isolationLevel.hashCode();
+    }
+    if (reqId != null) {
+      result = 31 * result + reqId.hashCode();
     }
     return result;
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
@@ -766,7 +766,7 @@ public final class Options implements Serializable {
       b.append("isolationLevel: ").append(isolationLevel).append(' ');
     }
     if (reqId != null) {
-      b.append("requestId: ").append(reqId.toString()).append(' ');
+      b.append("requestId: ").append(reqId.toString());
     }
     return b.toString();
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/PartitionedDmlTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/PartitionedDmlTransaction.java
@@ -81,6 +81,9 @@ public class PartitionedDmlTransaction implements SessionImpl.SessionTransaction
     Stopwatch stopwatch = Stopwatch.createStarted(ticker);
     Options options = Options.fromUpdateOptions(updateOptions);
     XGoogSpannerRequestId reqId = options.reqId();
+    if (reqId == null) {
+      reqId = session.getRequestIdCreator().nextRequestId(1 /*TODO: infer channelId*/, 0);
+    }
 
     try {
       ExecuteSqlRequest request = newTransactionRequestFrom(statement, options);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/PartitionedDmlTransaction.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/PartitionedDmlTransaction.java
@@ -80,9 +80,7 @@ public class PartitionedDmlTransaction implements SessionImpl.SessionTransaction
     long updateCount = 0L;
     Stopwatch stopwatch = Stopwatch.createStarted(ticker);
     Options options = Options.fromUpdateOptions(updateOptions);
-
-    XGoogSpannerRequestId reqId =
-        session.getRequestIdCreator().nextRequestId(1 /*TODO: infer channelId*/, 0);
+    XGoogSpannerRequestId reqId = options.reqId();
 
     try {
       ExecuteSqlRequest request = newTransactionRequestFrom(statement, options);
@@ -219,8 +217,10 @@ public class PartitionedDmlTransaction implements SessionImpl.SessionTransaction
                     .setExcludeTxnFromChangeStreams(
                         options.withExcludeTxnFromChangeStreams() == Boolean.TRUE))
             .build();
-    XGoogSpannerRequestId reqId =
-        session.getRequestIdCreator().nextRequestId(1 /*TODO: infer channelId*/, 1);
+    XGoogSpannerRequestId reqId = options.reqId();
+    if (reqId == null) {
+      reqId = session.getRequestIdCreator().nextRequestId(1 /*TODO: infer channelId*/, 1);
+    }
     Transaction tx = rpc.beginTransaction(request, reqId.withOptions(session.getOptions()), true);
     if (tx.getId().isEmpty()) {
       throw SpannerExceptionFactory.newSpannerException(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionClient.java
@@ -31,10 +31,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.concurrent.GuardedBy;
 
 /** Client for creating single sessions and batches of sessions. */
-class SessionClient implements AutoCloseable {
+class SessionClient implements AutoCloseable, XGoogSpannerRequestId.RequestIdCreator {
   static class SessionId {
     private static final PathTemplate NAME_TEMPLATE =
         PathTemplate.create(
@@ -174,6 +175,12 @@ class SessionClient implements AutoCloseable {
   private final DatabaseId db;
   private final Attributes commonAttributes;
 
+  // SessionClient is created long before a DatabaseClientImpl is created,
+  // as batch sessions are firstly created then later attached to each Client.
+  private static AtomicInteger NTH_ID = new AtomicInteger(0);
+  private final int nthId;
+  private final AtomicInteger nthRequest;
+
   @GuardedBy("this")
   private volatile long sessionChannelCounter;
 
@@ -186,6 +193,8 @@ class SessionClient implements AutoCloseable {
     this.executorFactory = executorFactory;
     this.executor = executorFactory.get();
     this.commonAttributes = spanner.getTracer().createCommonAttributes(db);
+    this.nthId = SessionClient.NTH_ID.incrementAndGet();
+    this.nthRequest = new AtomicInteger(0);
   }
 
   @Override
@@ -201,16 +210,24 @@ class SessionClient implements AutoCloseable {
     return db;
   }
 
+  @Override
+  public XGoogSpannerRequestId nextRequestId(long channelId, int attempt) {
+    return XGoogSpannerRequestId.of(this.nthId, this.nthRequest.incrementAndGet(), channelId, 1);
+  }
+
   /** Create a single session. */
   SessionImpl createSession() {
     // The sessionChannelCounter could overflow, but that will just flip it to Integer.MIN_VALUE,
     // which is also a valid channel hint.
     final Map<SpannerRpc.Option, ?> options;
+    final long channelId;
     synchronized (this) {
       options = optionMap(SessionOption.channelHint(sessionChannelCounter++));
+      channelId = sessionChannelCounter;
     }
     ISpan span = spanner.getTracer().spanBuilder(SpannerImpl.CREATE_SESSION, this.commonAttributes);
     try (IScope s = spanner.getTracer().withSpan(span)) {
+      XGoogSpannerRequestId reqId = this.nextRequestId(channelId, 1);
       com.google.spanner.v1.Session session =
           spanner
               .getRpc()
@@ -218,11 +235,13 @@ class SessionClient implements AutoCloseable {
                   db.getName(),
                   spanner.getOptions().getDatabaseRole(),
                   spanner.getOptions().getSessionLabels(),
-                  options);
+                  reqId.withOptions(options));
       SessionReference sessionReference =
           new SessionReference(
               session.getName(), session.getCreateTime(), session.getMultiplexed(), options);
-      return new SessionImpl(spanner, sessionReference);
+      SessionImpl sessionImpl = new SessionImpl(spanner, sessionReference);
+      sessionImpl.setRequestIdCreator(this);
+      return sessionImpl;
     } catch (RuntimeException e) {
       span.setStatus(e);
       throw e;
@@ -273,6 +292,7 @@ class SessionClient implements AutoCloseable {
               spanner,
               new SessionReference(
                   session.getName(), session.getCreateTime(), session.getMultiplexed(), null));
+      sessionImpl.setRequestIdCreator(this);
       span.addAnnotation(
           String.format("Request for %d multiplexed session returned %d session", 1, 1));
       return sessionImpl;
@@ -387,6 +407,8 @@ class SessionClient implements AutoCloseable {
             .spanBuilderWithExplicitParent(SpannerImpl.BATCH_CREATE_SESSIONS_REQUEST, parent);
     span.addAnnotation(String.format("Requesting %d sessions", sessionCount));
     try (IScope s = spanner.getTracer().withSpan(span)) {
+      XGoogSpannerRequestId reqId =
+          XGoogSpannerRequestId.of(this.nthId, this.nthRequest.incrementAndGet(), channelHint, 1);
       List<com.google.spanner.v1.Session> sessions =
           spanner
               .getRpc()
@@ -395,21 +417,20 @@ class SessionClient implements AutoCloseable {
                   sessionCount,
                   spanner.getOptions().getDatabaseRole(),
                   spanner.getOptions().getSessionLabels(),
-                  options);
+                  reqId.withOptions(options));
       span.addAnnotation(
           String.format(
               "Request for %d sessions returned %d sessions", sessionCount, sessions.size()));
       span.end();
       List<SessionImpl> res = new ArrayList<>(sessionCount);
       for (com.google.spanner.v1.Session session : sessions) {
-        res.add(
+        SessionImpl sessionImpl =
             new SessionImpl(
                 spanner,
                 new SessionReference(
-                    session.getName(),
-                    session.getCreateTime(),
-                    session.getMultiplexed(),
-                    options)));
+                    session.getName(), session.getCreateTime(), session.getMultiplexed(), options));
+        sessionImpl.setRequestIdCreator(this);
+        res.add(sessionImpl);
       }
       return res;
     } catch (RuntimeException e) {
@@ -425,6 +446,8 @@ class SessionClient implements AutoCloseable {
     synchronized (this) {
       options = optionMap(SessionOption.channelHint(sessionChannelCounter++));
     }
-    return new SessionImpl(spanner, new SessionReference(name, options));
+    SessionImpl sessionImpl = new SessionImpl(spanner, new SessionReference(name, options));
+    sessionImpl.setRequestIdCreator(this);
+    return sessionImpl;
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -301,8 +301,7 @@ class SessionImpl implements Session {
     CommitRequest request = requestBuilder.build();
     ISpan span = tracer.spanBuilder(SpannerImpl.COMMIT);
     try (IScope s = tracer.withSpan(span)) {
-      // TODO: Derive the channelId from the session being used currently.
-      XGoogSpannerRequestId reqId = this.requestIdCreator.nextRequestId(1 /* channelId */, 0);
+      XGoogSpannerRequestId reqId = this.requestIdCreator.nextRequestId(1 /* TODO: channelId */, 0);
       return SpannerRetryHelper.runTxWithRetriesOnAborted(
           () -> {
             reqId.incrementAttempt();
@@ -347,7 +346,7 @@ class SessionImpl implements Session {
     Options allOptions = Options.fromTransactionOptions(transactionOptions);
     XGoogSpannerRequestId reqId = allOptions.reqId();
     if (reqId == null) {
-      reqId = this.requestIdCreator.nextRequestId(1 /* channelId */, 1);
+      reqId = this.requestIdCreator.nextRequestId(1 /* TODO: channelId */, 1);
     }
     if (batchWriteRequestOptions != null) {
       requestBuilder.setRequestOptions(batchWriteRequestOptions);
@@ -468,8 +467,7 @@ class SessionImpl implements Session {
   public void close() {
     ISpan span = tracer.spanBuilder(SpannerImpl.DELETE_SESSION);
     try (IScope s = tracer.withSpan(span)) {
-      // TODO: Derive the channelId from the session being used currently.
-      XGoogSpannerRequestId reqId = this.requestIdCreator.nextRequestId(1 /* channelId */, 0);
+      XGoogSpannerRequestId reqId = this.requestIdCreator.nextRequestId(1 /* TODO: channelId */, 0);
       spanner.getRpc().deleteSession(getName(), reqId.withOptions(getOptions()));
     } catch (RuntimeException e) {
       span.setStatus(e);
@@ -502,7 +500,7 @@ class SessionImpl implements Session {
     final BeginTransactionRequest request = requestBuilder.build();
     final ApiFuture<Transaction> requestFuture;
     try (IScope ignore = tracer.withSpan(span)) {
-      XGoogSpannerRequestId reqId = this.requestIdCreator.nextRequestId(1 /* channelId */, 1);
+      XGoogSpannerRequestId reqId = this.requestIdCreator.nextRequestId(1 /* TODO: channelId */, 1);
       requestFuture =
           spanner
               .getRpc()

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -1568,6 +1568,10 @@ class SessionPool {
         throw SpannerExceptionFactory.propagateInterrupt(e);
       }
     }
+
+    public int getChannel() {
+      return get().getChannel();
+    }
   }
 
   interface CachedSession extends Session {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerException.java
@@ -56,6 +56,7 @@ public class SpannerException extends BaseGrpcServiceException {
 
   private final ErrorCode code;
   private final ApiException apiException;
+  private final XGoogSpannerRequestId requestId;
 
   /** Private constructor. Use {@link SpannerExceptionFactory} to create instances. */
   SpannerException(
@@ -83,9 +84,35 @@ public class SpannerException extends BaseGrpcServiceException {
     this.apiException = apiException;
   }
 
+  /** Private constructor. Use {@link SpannerExceptionFactory} to create instances. */
+  SpannerException(
+      DoNotConstructDirectly token,
+      ErrorCode code,
+      boolean retryable,
+      @Nullable String message,
+      @Nullable Throwable cause,
+      @Nullable ApiException apiException,
+      @Nullable XGoogSpannerRequestId requestId) {
+    super(message, cause, code.getCode(), retryable);
+    if (token != DoNotConstructDirectly.ALLOWED) {
+      throw new AssertionError("Do not construct directly: use SpannerExceptionFactory");
+    }
+    this.code = Preconditions.checkNotNull(code);
+    this.apiException = apiException;
+    this.requestId = requestId;
+  }
+
   /** Returns the error code associated with this exception. */
   public ErrorCode getErrorCode() {
     return code;
+  }
+
+  /** Returns the requestId associated with this exception. */
+  public String getRequestId() {
+    if (requestId == null) {
+      return null;
+    }
+    return requestId.toString();
   }
 
   enum DoNotConstructDirectly {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
@@ -61,9 +61,13 @@ public final class SpannerExceptionFactory {
     return newSpannerException(code, message, null);
   }
 
+  public static SpannerException newSpannerException(ErrorCode code, @Nullable String message, @Nullable XGoogSpannerRequestId reqId) {
+    return newSpannerException(code, message, null, reqId);
+  }
+
   public static SpannerException newSpannerException(
       ErrorCode code, @Nullable String message, @Nullable Throwable cause) {
-    return newSpannerExceptionPreformatted(code, formatMessage(code, message), cause);
+    return newSpannerExceptionPreformatted(code, formatMessage(code, message), cause, null);
   }
 
   public static SpannerException propagateInterrupt(InterruptedException e) {
@@ -113,6 +117,10 @@ public final class SpannerExceptionFactory {
    */
   public static SpannerException newSpannerException(Throwable cause) {
     return newSpannerException(null, cause);
+  }
+
+  public static SpannerException newSpannerException(Throwable cause, XGoogSpannerRequestId requestId) {
+    return newSpannerException(null, cause, requestId);
   }
 
   public static SpannerBatchUpdateException newSpannerBatchUpdateException(
@@ -301,7 +309,8 @@ public final class SpannerExceptionFactory {
       ErrorCode code,
       @Nullable String message,
       @Nullable Throwable cause,
-      @Nullable ApiException apiException) {
+      @Nullable ApiException apiException,
+      @Nullable XGoogSpannerRequestId reqId) {
     // This is the one place in the codebase that is allowed to call constructors directly.
     DoNotConstructDirectly token = DoNotConstructDirectly.ALLOWED;
     switch (code) {
@@ -343,7 +352,7 @@ public final class SpannerExceptionFactory {
         // Fall through to the default.
       default:
         return new SpannerException(
-            token, code, isRetryable(code, cause), message, cause, apiException);
+            token, code, isRetryable(code, cause), message, cause, apiException, reqId);
     }
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerRetryHelper.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerRetryHelper.java
@@ -93,9 +93,17 @@ class SpannerRetryHelper {
     try {
       return RetryHelper.runWithRetries(callable, retrySettings, new TxRetryAlgorithm<>(), clock);
     } catch (RetryHelperException e) {
+      System.out.println("\033[35m");
+      e.printStackTrace();
+      System.out.println("\033[00m");
       if (e.getCause() != null) {
         Throwables.throwIfUnchecked(errorHandler.translateException(e.getCause()));
       }
+      throw e;
+    } catch (Exception e) {
+      System.out.println("\033[31mGot an error in runTxWithRetriesOnAborted: ");
+      e.printStackTrace();
+      System.out.println("\033[00m");
       throw e;
     }
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
@@ -17,16 +17,28 @@
 package com.google.cloud.spanner;
 
 import com.google.api.core.InternalApi;
+import com.google.cloud.spanner.spi.v1.SpannerRpc;
 import com.google.common.annotations.VisibleForTesting;
+import io.grpc.Metadata;
 import java.math.BigInteger;
 import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @InternalApi
 public class XGoogSpannerRequestId {
   // 1. Generate the random process Id singleton.
   @VisibleForTesting
   static final String RAND_PROCESS_ID = XGoogSpannerRequestId.generateRandProcessId();
+
+  public static final Metadata.Key<String> REQUEST_HEADER_KEY =
+      Metadata.Key.of("x-goog-spanner-request-id", Metadata.ASCII_STRING_MARSHALLER);
 
   @VisibleForTesting
   static final long VERSION = 1; // The version of the specification being implemented.
@@ -48,6 +60,26 @@ public class XGoogSpannerRequestId {
     return new XGoogSpannerRequestId(nthClientId, nthChannelId, nthRequest, attempt);
   }
 
+  @VisibleForTesting
+  static final Pattern REGEX =
+      Pattern.compile("^(\\d)\\.([0-9a-z]{16})\\.(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)$");
+
+  public static XGoogSpannerRequestId of(String s) {
+    Matcher m = XGoogSpannerRequestId.REGEX.matcher(s);
+    if (!m.matches()) {
+      throw new IllegalStateException(
+          s + " does not match " + XGoogSpannerRequestId.REGEX.pattern());
+    }
+
+    MatchResult mr = m.toMatchResult();
+
+    return new XGoogSpannerRequestId(
+        Long.parseLong(mr.group(3)),
+        Long.parseLong(mr.group(4)),
+        Long.parseLong(mr.group(5)),
+        Long.parseLong(mr.group(6)));
+  }
+
   private static String generateRandProcessId() {
     // Expecting to use 64-bits of randomness to avoid clashes.
     BigInteger bigInt = new BigInteger(64, new SecureRandom());
@@ -66,6 +98,13 @@ public class XGoogSpannerRequestId {
         this.attempt);
   }
 
+  private boolean isGreaterThan(XGoogSpannerRequestId other) {
+    return this.nthClientId > other.nthClientId
+        && this.nthChannelId > other.nthChannelId
+        && this.nthRequest > other.nthRequest
+        && this.attempt > other.attempt;
+  }
+
   @Override
   public boolean equals(Object other) {
     // instanceof for a null object returns false.
@@ -81,8 +120,55 @@ public class XGoogSpannerRequestId {
         && Objects.equals(this.attempt, otherReqId.attempt);
   }
 
+  public void incrementAttempt() {
+    this.attempt++;
+  }
+
+  @SuppressWarnings("unchecked")
+  public Map withOptions(Map options) {
+    Map copyOptions = new HashMap<>();
+    copyOptions.putAll(options);
+    copyOptions.put(SpannerRpc.Option.REQUEST_ID, this.toString());
+    return copyOptions;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(this.nthClientId, this.nthChannelId, this.nthRequest, this.attempt);
+  }
+
+  public interface RequestIdCreator {
+    XGoogSpannerRequestId nextRequestId(long channelId, int attempt);
+  }
+
+  public static class NoopRequestIdCreator implements RequestIdCreator {
+    NoopRequestIdCreator() {}
+
+    @Override
+    public XGoogSpannerRequestId nextRequestId(long channelId, int attempt) {
+      return XGoogSpannerRequestId.of(1, 1, 1, 0);
+    }
+  }
+
+  public static void assertMonotonicityOfIds(String prefix, List<XGoogSpannerRequestId> reqIds) {
+    int size = reqIds.size();
+
+    List<String> violations = new ArrayList<>();
+    for (int i = 1; i < size; i++) {
+      XGoogSpannerRequestId prev = reqIds.get(i - 1);
+      XGoogSpannerRequestId curr = reqIds.get(i);
+      if (prev.isGreaterThan(curr)) {
+        violations.add(String.format("#%d(%s) > #%d(%s)", i - 1, prev, i, curr));
+      }
+    }
+
+    if (violations.size() == 0) {
+      return;
+    }
+
+    throw new IllegalStateException(
+        prefix
+            + " monotonicity violation:"
+            + String.join("\n\t", violations.toArray(new String[0])));
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
@@ -130,7 +130,7 @@ public class XGoogSpannerRequestId {
     if (options != null) {
       copyOptions.putAll(options);
     }
-    copyOptions.put(SpannerRpc.Option.REQUEST_ID, this.toString());
+    copyOptions.put(SpannerRpc.Option.REQUEST_ID, this);
     return copyOptions;
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
@@ -127,7 +127,9 @@ public class XGoogSpannerRequestId {
   @SuppressWarnings("unchecked")
   public Map withOptions(Map options) {
     Map copyOptions = new HashMap<>();
-    copyOptions.putAll(options);
+    if (options != null) {
+      copyOptions.putAll(options);
+    }
     copyOptions.put(SpannerRpc.Option.REQUEST_ID, this.toString());
     return copyOptions;
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -2061,14 +2061,15 @@ public class GapicSpannerRpc implements SpannerRpc {
   }
 
   GrpcCallContext withRequestId(GrpcCallContext context, Map options, String methodName) {
-    String reqId = (String) options.get(Option.REQUEST_ID);
-    if (reqId == null || Objects.equals(reqId, "")) {
+    XGoogSpannerRequestId reqId = (XGoogSpannerRequestId) options.get(Option.REQUEST_ID);
+    if (reqId == null) {
       return context;
     }
 
     Map<String, List<String>> withReqId =
         ImmutableMap.of(
-            XGoogSpannerRequestId.REQUEST_HEADER_KEY.name(), Collections.singletonList(reqId));
+            XGoogSpannerRequestId.REQUEST_HEADER_KEY.name(),
+            Collections.singletonList(reqId.toString()));
     return context.withExtraHeaders(withReqId);
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -2021,7 +2021,10 @@ public class GapicSpannerRpc implements SpannerRpc {
                         GcpManagedChannel.AFFINITY_KEY, String.valueOf(boundedChannelHint)));
       } else {
         // Set channel affinity in GAX.
-        context = context.withChannelAffinity(Option.CHANNEL_HINT.getLong(options).intValue());
+        Long affinity = Option.CHANNEL_HINT.getLong(options);
+        if (affinity != null) {
+          context = context.withChannelAffinity(affinity.intValue());
+        }
       }
       String methodName = method.getFullMethodName();
       context = withRequestId(context, options, methodName);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -1846,6 +1846,7 @@ public class GapicSpannerRpc implements SpannerRpc {
       CommitRequest request, @Nullable Map<Option, ?> options) {
     GrpcCallContext context =
         newCallContext(options, request.getSession(), request, SpannerGrpc.getCommitMethod(), true);
+    System.out.println("\033[32mcommitAsync: " + context + "\033[00m");
     return spannerStub.commitCallable().futureCall(request, context);
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -195,6 +195,7 @@ import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -71,6 +71,7 @@ import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.SpannerOptions.CallContextConfigurator;
 import com.google.cloud.spanner.SpannerOptions.CallCredentialsProvider;
+import com.google.cloud.spanner.XGoogSpannerRequestId;
 import com.google.cloud.spanner.admin.database.v1.stub.DatabaseAdminStub;
 import com.google.cloud.spanner.admin.database.v1.stub.DatabaseAdminStubSettings;
 import com.google.cloud.spanner.admin.database.v1.stub.GrpcDatabaseAdminCallableFactory;
@@ -88,6 +89,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
 import com.google.common.util.concurrent.RateLimiter;
@@ -402,6 +404,8 @@ public class GapicSpannerRpc implements SpannerRpc {
       final String emulatorHost = System.getenv("SPANNER_EMULATOR_HOST");
 
       try {
+        // TODO: make our retry settings to inject and increment
+        // XGoogSpannerRequestId whenever a retry occurs.
         SpannerStubSettings spannerStubSettings =
             options
                 .getSpannerStubSettings()
@@ -2018,6 +2022,8 @@ public class GapicSpannerRpc implements SpannerRpc {
         // Set channel affinity in GAX.
         context = context.withChannelAffinity(Option.CHANNEL_HINT.getLong(options).intValue());
       }
+      String methodName = method.getFullMethodName();
+      context = withRequestId(context, options, methodName);
     }
     if (compressorName != null) {
       // This sets the compressor for Client -> Server.
@@ -2041,12 +2047,25 @@ public class GapicSpannerRpc implements SpannerRpc {
         context
             .withStreamWaitTimeoutDuration(waitTimeout)
             .withStreamIdleTimeoutDuration(idleTimeout);
+
     CallContextConfigurator configurator = SpannerOptions.CALL_CONTEXT_CONFIGURATOR_KEY.get();
     ApiCallContext apiCallContextFromContext = null;
     if (configurator != null) {
       apiCallContextFromContext = configurator.configure(context, request, method);
     }
     return (GrpcCallContext) context.merge(apiCallContextFromContext);
+  }
+
+  GrpcCallContext withRequestId(GrpcCallContext context, Map options, String methodName) {
+    String reqId = (String) options.get(Option.REQUEST_ID);
+    if (reqId == null || Objects.equals(reqId, "")) {
+      return context;
+    }
+
+    Map<String, List<String>> withReqId =
+        ImmutableMap.of(
+            XGoogSpannerRequestId.REQUEST_HEADER_KEY.name(), Collections.singletonList(reqId));
+    return context.withExtraHeaders(withReqId);
   }
 
   void registerResponseObserver(SpannerResponseObserver responseObserver) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerRpc.java
@@ -78,7 +78,8 @@ import javax.annotation.Nullable;
 public interface SpannerRpc extends ServiceRpc {
   /** Options passed in {@link SpannerRpc} methods to control how an RPC is issued. */
   enum Option {
-    CHANNEL_HINT("Channel Hint");
+    CHANNEL_HINT("Channel Hint"),
+    REQUEST_ID("Request Id");
 
     private final String value;
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -227,14 +227,16 @@ public class DatabaseClientImplTest {
         new HashSet(
             Arrays.asList(
                 "google.spanner.v1.Spanner/BatchCreateSessions",
-                "google.spanner.v1.Spanner/DeleteSession",
-                "google.spanner.v1.Spanner/CreateSession",
-                "google.spanner.v1.Spanner/ExecuteStreamingSql",
-                "google.spanner.v1.Spanner/BeginTransaction",
-                "google.spanner.v1.Spanner/ExecuteSql",
                 "google.spanner.v1.Spanner/BatchWrite",
-                "google.spanner.v1.Spanner/StreamingRead",
+                "google.spanner.v1.Spanner/BeginTransaction",
+                "google.spanner.v1.Spanner/CreateSession",
+                "google.spanner.v1.Spanner/DeleteSession",
                 "google.spanner.v1.Spanner/ExecuteBatchDml",
+                "google.spanner.v1.Spanner/ExecuteSql",
+                "google.spanner.v1.Spanner/ExecuteStreamingSql",
+                "google.spanner.v1.Spanner/StreamingRead",
+                "google.spanner.v1.Spanner/PartitionQuery",
+                "google.spanner.v1.Spanner/PartitionRead",
                 "google.spanner.v1.Spanner/Commit"));
     xGoogReqIdInterceptor = new XGoogSpannerRequestIdTest.ServerHeaderEnforcer(checkMethods);
     executor = Executors.newSingleThreadExecutor();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -105,6 +105,7 @@ import io.grpc.Context;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Server;
+import io.grpc.ServerInterceptors;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.inprocess.InProcessServerBuilder;
@@ -119,6 +120,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
@@ -152,6 +154,7 @@ public class DatabaseClientImplTest {
   private static final String DATABASE_NAME =
       String.format(
           "projects/%s/instances/%s/databases/%s", TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE);
+  private static XGoogSpannerRequestIdTest.ServerHeaderEnforcer xGoogReqIdInterceptor;
   private static MockSpannerServiceImpl mockSpanner;
   private static Server server;
   private static LocalChannelProvider channelProvider;
@@ -220,13 +223,27 @@ public class DatabaseClientImplTest {
         StatementResult.query(SELECT1_FROM_TABLE, MockSpannerTestUtil.SELECT1_RESULTSET));
     mockSpanner.setBatchWriteResult(BATCH_WRITE_RESPONSES);
 
+    Set<String> checkMethods =
+        new HashSet(
+            Arrays.asList(
+                "google.spanner.v1.Spanner/BatchCreateSessions",
+                "google.spanner.v1.Spanner/DeleteSession",
+                "google.spanner.v1.Spanner/CreateSession",
+                "google.spanner.v1.Spanner/ExecuteStreamingSql",
+                "google.spanner.v1.Spanner/BeginTransaction",
+                "google.spanner.v1.Spanner/ExecuteSql",
+                "google.spanner.v1.Spanner/BatchWrite",
+                "google.spanner.v1.Spanner/StreamingRead",
+                "google.spanner.v1.Spanner/ExecuteBatchDml",
+                "google.spanner.v1.Spanner/Commit"));
+    xGoogReqIdInterceptor = new XGoogSpannerRequestIdTest.ServerHeaderEnforcer(checkMethods);
     executor = Executors.newSingleThreadExecutor();
     String uniqueName = InProcessServerBuilder.generateName();
     server =
         InProcessServerBuilder.forName(uniqueName)
             // We need to use a real executor for timeouts to occur.
             .scheduledExecutorService(new ScheduledThreadPoolExecutor(1))
-            .addService(mockSpanner)
+            .addService(ServerInterceptors.intercept(mockSpanner, xGoogReqIdInterceptor))
             .build()
             .start();
     channelProvider = LocalChannelProvider.create(uniqueName);
@@ -266,6 +283,7 @@ public class DatabaseClientImplTest {
     spanner.close();
     spannerWithEmptySessionPool.close();
     mockSpanner.reset();
+    xGoogReqIdInterceptor.reset();
     mockSpanner.removeAllExecutionTimes();
   }
 
@@ -1393,6 +1411,10 @@ public class DatabaseClientImplTest {
 
     List<CommitRequest> commitRequests = mockSpanner.getRequestsOfType(CommitRequest.class);
     assertEquals(2, commitRequests.size());
+    xGoogReqIdInterceptor.assertIntegrity();
+    System.out.println(
+        "\033[33mGot: " + xGoogReqIdInterceptor.accumulatedUnaryValues() + "\033[00m");
+    xGoogReqIdInterceptor.printAccumulatedValues();
   }
 
   @Test
@@ -5054,6 +5076,26 @@ public class DatabaseClientImplTest {
           mockSpanner.clearRequests();
         }
       }
+    }
+  }
+
+  @Test
+  public void testSelectHasXGoogRequestIdHeader() {
+    Statement statement =
+        Statement.newBuilder("select id from test where b=@p1")
+            .bind("p1")
+            .toBytesArray(
+                Arrays.asList(ByteArray.copyFrom("test1"), null, ByteArray.copyFrom("test2")))
+            .build();
+    mockSpanner.putStatementResult(StatementResult.query(statement, SELECT1_RESULTSET));
+    DatabaseClient client =
+        spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+    try (ResultSet resultSet = client.singleUse().executeQuery(statement)) {
+      assertTrue(resultSet.next());
+      assertEquals(1L, resultSet.getLong(0));
+      assertFalse(resultSet.next());
+    } finally {
+      xGoogReqIdInterceptor.assertIntegrity();
     }
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/PartitionedDmlTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/PartitionedDmlTransactionTest.java
@@ -97,6 +97,8 @@ public class PartitionedDmlTransactionTest {
   public void setup() {
     MockitoAnnotations.initMocks(this);
     when(session.getName()).thenReturn(sessionId);
+    when(session.getRequestIdCreator())
+        .thenReturn(new XGoogSpannerRequestId.NoopRequestIdCreator());
     when(session.getOptions()).thenReturn(Collections.EMPTY_MAP);
     when(rpc.beginTransaction(any(BeginTransactionRequest.class), anyMap(), eq(true)))
         .thenReturn(Transaction.newBuilder().setId(txId).build());

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ResumableStreamIteratorTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ResumableStreamIteratorTest.java
@@ -162,7 +162,8 @@ public class ResumableStreamIteratorTest {
             new TraceWrapper(Tracing.getTracer(), OpenTelemetry.noop().getTracer(""), false),
             DefaultErrorHandler.INSTANCE,
             SpannerStubSettings.newBuilder().executeStreamingSqlSettings().getRetrySettings(),
-            SpannerStubSettings.newBuilder().executeStreamingSqlSettings().getRetryableCodes()) {
+            SpannerStubSettings.newBuilder().executeStreamingSqlSettings().getRetryableCodes(),
+            new XGoogSpannerRequestId.NoopRequestIdCreator()) {
           @Override
           AbstractResultSet.CloseableIterator<PartialResultSet> startStream(
               @Nullable ByteString resumeToken,

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionClientTests.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionClientTests.java
@@ -153,8 +153,17 @@ public class SessionClientTests {
       assertThat(session.getName()).isEqualTo(sessionName);
 
       session.close();
+
+      final ArgumentCaptor<Map<SpannerRpc.Option, ?>> deleteOptionsCaptor =
+          ArgumentCaptor.forClass(Map.class);
+      final ArgumentCaptor<String> sessionNameCaptor = ArgumentCaptor.forClass(String.class);
+      Mockito.verify(rpc).deleteSession(sessionNameCaptor.capture(), deleteOptionsCaptor.capture());
+      assertEquals(sessionName, sessionNameCaptor.getValue());
       // The same channelHint is passed for deleteSession (contained in "options").
-      Mockito.verify(rpc).deleteSession(sessionName, options.getValue());
+      assertEquals(
+          deleteOptionsCaptor.getValue().get(SpannerRpc.Option.CHANNEL_HINT),
+          options.getValue().get(SpannerRpc.Option.CHANNEL_HINT));
+      assertTrue(deleteOptionsCaptor.getValue().containsKey(SpannerRpc.Option.REQUEST_ID));
     }
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
@@ -148,6 +148,7 @@ public class SessionImplTest {
     ISpan span = new OpenTelemetrySpan(oTspan);
     when(oTspan.makeCurrent()).thenReturn(mock(Scope.class));
     ((SessionImpl) session).setCurrentSpan(span);
+    ((SessionImpl) session).setRequestIdCreator(new XGoogSpannerRequestId.NoopRequestIdCreator());
     // We expect the same options, "options", on all calls on "session".
     options = optionsCaptor.getValue();
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
@@ -463,6 +463,7 @@ public class SessionImplTest {
     mockRead(resultSet);
 
     ReadOnlyTransaction txn = session.readOnlyTransaction(TimestampBound.strong());
+    assertNotNull(txn);
     SpannerException e =
         assertThrows(
             SpannerException.class,

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
@@ -144,11 +144,11 @@ public class SessionImplTest {
     when(rpc.getCommitRetrySettings())
         .thenReturn(SpannerStubSettings.newBuilder().commitSettings().getRetrySettings());
     session = spanner.getSessionClient(db).createSession();
+    ((SessionImpl) session).setRequestIdCreator(new XGoogSpannerRequestId.NoopRequestIdCreator());
     Span oTspan = mock(Span.class);
     ISpan span = new OpenTelemetrySpan(oTspan);
     when(oTspan.makeCurrent()).thenReturn(mock(Scope.class));
     ((SessionImpl) session).setCurrentSpan(span);
-    ((SessionImpl) session).setRequestIdCreator(new XGoogSpannerRequestId.NoopRequestIdCreator());
     // We expect the same options, "options", on all calls on "session".
     options = optionsCaptor.getValue();
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -1350,6 +1350,8 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     when(closedSession.singleUse()).thenReturn(closedContext);
 
     final SessionImpl openSession = mockSession();
+    when(openSession.getRequestIdCreator())
+        .thenReturn(new XGoogSpannerRequestId.NoopRequestIdCreator());
     ReadContext openContext = mock(ReadContext.class);
     ResultSet openResultSet = mock(ResultSet.class);
     when(openResultSet.next()).thenReturn(true, false);
@@ -1394,6 +1396,8 @@ public class SessionPoolTest extends BaseSessionPoolTest {
         .thenThrow(SpannerExceptionFactoryTest.newSessionNotFoundException(sessionName));
 
     final SessionImpl openSession = mockSession();
+    when(openSession.getRequestIdCreator())
+        .thenReturn(new XGoogSpannerRequestId.NoopRequestIdCreator());
     ReadOnlyTransaction openTransaction = mock(ReadOnlyTransaction.class);
     ResultSet openResultSet = mock(ResultSet.class);
     when(openResultSet.next()).thenReturn(true, false);
@@ -1479,6 +1483,8 @@ public class SessionPoolTest extends BaseSessionPoolTest {
           .thenReturn(
               SpannerStubSettings.newBuilder().executeStreamingSqlSettings().getRetryableCodes());
       final SessionImpl closedSession = mock(SessionImpl.class);
+      when(closedSession.getRequestIdCreator())
+        .thenReturn(new XGoogSpannerRequestId.NoopRequestIdCreator());
       when(closedSession.defaultTransactionOptions())
           .thenReturn(TransactionOptions.getDefaultInstance());
       when(closedSession.getName())
@@ -1510,6 +1516,8 @@ public class SessionPoolTest extends BaseSessionPoolTest {
 
       final SessionImpl openSession = mock(SessionImpl.class);
       when(openSession.getErrorHandler()).thenReturn(DefaultErrorHandler.INSTANCE);
+      when(openSession.getRequestIdCreator())
+        .thenReturn(new XGoogSpannerRequestId.NoopRequestIdCreator());
       when(openSession.asyncClose())
           .thenReturn(ApiFutures.immediateFuture(Empty.getDefaultInstance()));
       when(openSession.getName())
@@ -1650,6 +1658,8 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     when(closedSession.writeWithOptions(mutations)).thenThrow(sessionNotFound);
 
     final SessionImpl openSession = mockSession();
+      when(openSession.getRequestIdCreator())
+        .thenReturn(new XGoogSpannerRequestId.NoopRequestIdCreator());
     com.google.cloud.spanner.CommitResponse response =
         mock(com.google.cloud.spanner.CommitResponse.class);
     when(response.getCommitTimestamp()).thenReturn(Timestamp.now());
@@ -1695,6 +1705,8 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     final SessionImpl openSession = mockSession();
     com.google.cloud.spanner.CommitResponse response =
         mock(com.google.cloud.spanner.CommitResponse.class);
+      when(openSession.getRequestIdCreator())
+        .thenReturn(new XGoogSpannerRequestId.NoopRequestIdCreator());
     when(response.getCommitTimestamp()).thenReturn(Timestamp.now());
     when(openSession.writeAtLeastOnceWithOptions(mutations)).thenReturn(response);
     doAnswer(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionContextImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionContextImplTest.java
@@ -67,6 +67,8 @@ public class TransactionContextImplTest {
                     .setCommitTimestamp(Timestamp.newBuilder().setSeconds(99L).setNanos(10).build())
                     .build()));
     when(session.getName()).thenReturn("test");
+    when(session.getRequestIdCreator())
+        .thenReturn(new XGoogSpannerRequestId.NoopRequestIdCreator());
     doNothing().when(span).setStatus(any(Throwable.class));
     doNothing().when(span).end();
     doNothing().when(span).addAnnotation("Starting Commit");
@@ -210,6 +212,8 @@ public class TransactionContextImplTest {
   private void batchDml(int status) {
     SessionImpl session = mock(SessionImpl.class);
     when(session.getName()).thenReturn("test");
+    when(session.getRequestIdCreator())
+        .thenReturn(new XGoogSpannerRequestId.NoopRequestIdCreator());
     SpannerRpc rpc = mock(SpannerRpc.class);
     ExecuteBatchDmlResponse response =
         ExecuteBatchDmlResponse.newBuilder()

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
@@ -121,6 +121,8 @@ public class TransactionRunnerImplTest {
     when(session.getErrorHandler()).thenReturn(DefaultErrorHandler.INSTANCE);
     when(session.newTransaction(eq(Options.fromTransactionOptions()), any())).thenReturn(txn);
     when(session.getTracer()).thenReturn(tracer);
+    when(session.getRequestIdCreator())
+        .thenReturn(new XGoogSpannerRequestId.NoopRequestIdCreator());
     when(rpc.executeQuery(Mockito.any(ExecuteSqlRequest.class), Mockito.anyMap(), eq(true)))
         .thenAnswer(
             invocation -> {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/XGoogSpannerRequestIdTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/XGoogSpannerRequestIdTest.java
@@ -18,18 +18,29 @@ package com.google.cloud.spanner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor.MethodType;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class XGoogSpannerRequestIdTest {
-  private static final Pattern REGEX_RAND_PROCESS_ID =
-      Pattern.compile("1.([0-9a-z]{16})(\\.\\d+){3}\\.(\\d+)$");
 
   @Test
   public void testEquals() {
@@ -48,7 +59,139 @@ public class XGoogSpannerRequestIdTest {
   @Test
   public void testEnsureHexadecimalFormatForRandProcessID() {
     String str = XGoogSpannerRequestId.of(1, 2, 3, 4).toString();
-    Matcher m = XGoogSpannerRequestIdTest.REGEX_RAND_PROCESS_ID.matcher(str);
+    Matcher m = XGoogSpannerRequestId.REGEX.matcher(str);
     assertTrue(m.matches());
+  }
+
+  public static class ServerHeaderEnforcer implements ServerInterceptor {
+    private Map<String, CopyOnWriteArrayList<XGoogSpannerRequestId>> unaryResults;
+    private Map<String, CopyOnWriteArrayList<XGoogSpannerRequestId>> streamingResults;
+    private List<String> gotValues;
+    private Set<String> checkMethods;
+
+    ServerHeaderEnforcer(Set<String> checkMethods) {
+      this.gotValues = new CopyOnWriteArrayList<String>();
+      this.unaryResults =
+          new ConcurrentHashMap<String, CopyOnWriteArrayList<XGoogSpannerRequestId>>();
+      this.streamingResults =
+          new ConcurrentHashMap<String, CopyOnWriteArrayList<XGoogSpannerRequestId>>();
+      this.checkMethods = checkMethods;
+    }
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+        ServerCall<ReqT, RespT> call,
+        final Metadata requestHeaders,
+        ServerCallHandler<ReqT, RespT> next) {
+      boolean isUnary = call.getMethodDescriptor().getType() == MethodType.UNARY;
+      String methodName = call.getMethodDescriptor().getFullMethodName();
+      String gotReqIdStr = requestHeaders.get(XGoogSpannerRequestId.REQUEST_HEADER_KEY);
+      if (!this.checkMethods.contains(methodName)) {
+        System.out.println(
+            "\033[35mBypassing " + methodName + " but has " + gotReqIdStr + "\033[00m");
+        return next.startCall(call, requestHeaders);
+      }
+
+      Map<String, CopyOnWriteArrayList<XGoogSpannerRequestId>> saver = this.streamingResults;
+      if (isUnary) {
+        saver = this.unaryResults;
+      }
+
+      if (Objects.equals(gotReqIdStr, null) || Objects.equals(gotReqIdStr, "")) {
+        Status status =
+            Status.fromCode(Status.Code.INVALID_ARGUMENT)
+                .augmentDescription(
+                    methodName + " lacks " + XGoogSpannerRequestId.REQUEST_HEADER_KEY);
+        call.close(status, requestHeaders);
+        return next.startCall(call, requestHeaders);
+      }
+
+      assertNotNull(gotReqIdStr);
+      // Firstly assert and validate that at least we've got a requestId.
+      Matcher m = XGoogSpannerRequestId.REGEX.matcher(gotReqIdStr);
+      assertTrue(m.matches());
+
+      XGoogSpannerRequestId reqId = XGoogSpannerRequestId.of(gotReqIdStr);
+      if (!saver.containsKey(methodName)) {
+        saver.put(methodName, new CopyOnWriteArrayList<XGoogSpannerRequestId>());
+      }
+
+      saver.get(methodName).add(reqId);
+
+      // Finally proceed with the call.
+      return next.startCall(call, requestHeaders);
+    }
+
+    public String[] accumulatedValues() {
+      return this.gotValues.toArray(new String[0]);
+    }
+
+    public void assertIntegrity() {
+      this.unaryResults.forEach(
+          (String method, CopyOnWriteArrayList<XGoogSpannerRequestId> values) -> {
+            // System.out.println("\033[36munary.method: " + method + "\033[00m");
+            XGoogSpannerRequestId.assertMonotonicityOfIds(method, values);
+          });
+      this.streamingResults.forEach(
+          (String method, CopyOnWriteArrayList<XGoogSpannerRequestId> values) -> {
+            // System.out.println("\033[36mstreaming.method: " + method + "\033[00m");
+            XGoogSpannerRequestId.assertMonotonicityOfIds(method, values);
+          });
+    }
+
+    public static class methodAndRequestId {
+      String method;
+      String requestId;
+
+      public methodAndRequestId(String method, String requestId) {
+        this.method = method;
+        this.requestId = requestId;
+      }
+
+      public String toString() {
+        return "{" + this.method + ":" + this.requestId + "}";
+      }
+    }
+
+    public methodAndRequestId[] accumulatedUnaryValues() {
+      List<methodAndRequestId> accumulated = new ArrayList();
+      this.unaryResults.forEach(
+          (String method, CopyOnWriteArrayList<XGoogSpannerRequestId> values) -> {
+            for (int i = 0; i < values.size(); i++) {
+              accumulated.add(new methodAndRequestId(method, values.get(i).toString()));
+            }
+          });
+      return accumulated.toArray(new methodAndRequestId[0]);
+    }
+
+    public methodAndRequestId[] accumulatedStreamingValues() {
+      List<methodAndRequestId> accumulated = new ArrayList();
+      this.streamingResults.forEach(
+          (String method, CopyOnWriteArrayList<XGoogSpannerRequestId> values) -> {
+            for (int i = 0; i < values.size(); i++) {
+              accumulated.add(new methodAndRequestId(method, values.get(i).toString()));
+            }
+          });
+      return accumulated.toArray(new methodAndRequestId[0]);
+    }
+
+    public void printAccumulatedValues() {
+      methodAndRequestId[] unary = this.accumulatedUnaryValues();
+      System.out.println("accumulatedUnaryvalues");
+      for (int i = 0; i < unary.length; i++) {
+        System.out.println("\t" + unary[i].toString());
+      }
+      methodAndRequestId[] streaming = this.accumulatedStreamingValues();
+      System.out.println("accumulatedStreaminvalues");
+      for (int i = 0; i < streaming.length; i++) {
+        System.out.println("\t" + streaming[i].toString());
+      }
+    }
+
+    public void reset() {
+      this.gotValues.clear();
+      this.unaryResults.clear();
+      this.streamingResults.clear();
+    }
   }
 }


### PR DESCRIPTION
Wires up x-goog-spanner-request-id for piecemeal addition per gRPC method, starting with BatchCreateSessions. This change involves creating TransactionOption, UpdateOption variants that allow holding the request id.

Updates #3537