### PR TITLE
fix: add default implementations for Interval methods in AbstractStructReader

### DIFF
--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -599,16 +599,6 @@
   </difference>
   <difference>
     <differenceType>7013</differenceType>
-    <className>com/google/cloud/spanner/AbstractStructReader</className>
-    <method>com.google.cloud.spanner.Interval getIntervalInternal(int)</method>
-  </difference>
-  <difference>
-    <differenceType>7013</differenceType>
-    <className>com/google/cloud/spanner/AbstractStructReader</className>
-    <method>java.util.List getIntervalListInternal(int)</method>
-  </difference>
-  <difference>
-    <differenceType>7013</differenceType>
     <className>com/google/cloud/spanner/Value</className>
     <method>com.google.cloud.spanner.Interval getInterval()</method>
   </difference>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractStructReader.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractStructReader.java
@@ -67,7 +67,9 @@ public abstract class AbstractStructReader implements StructReader {
 
   protected abstract Date getDateInternal(int columnIndex);
 
-  protected abstract Interval getIntervalInternal(int columnIndex);
+  protected Interval getIntervalInternal(int columnIndex) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
 
   protected <T extends AbstractMessage> T getProtoMessageInternal(int columnIndex, T message) {
     throw new UnsupportedOperationException("Not implemented");
@@ -130,7 +132,9 @@ public abstract class AbstractStructReader implements StructReader {
 
   protected abstract List<Date> getDateListInternal(int columnIndex);
 
-  protected abstract List<Interval> getIntervalListInternal(int columnIndex);
+  protected List<Interval> getIntervalListInternal(int columnIndex) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
 
   protected abstract List<Struct> getStructListInternal(int columnIndex);
 


### PR DESCRIPTION
The PR adds default implementation for following methods of AbstractStructReader.

 getIntervalInternal
 getIntervalListInternal
