### PR TITLE
feat: add TransactionMutationLimitExceededException as cause to SpannerBatchUpdateException

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerBatchUpdateException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerBatchUpdateException.java
@@ -17,11 +17,16 @@
 package com.google.cloud.spanner;
 
 public class SpannerBatchUpdateException extends SpannerException {
-  private long[] updateCounts;
+  private final long[] updateCounts;
+
   /** Private constructor. Use {@link SpannerExceptionFactory} to create instances. */
   SpannerBatchUpdateException(
-      DoNotConstructDirectly token, ErrorCode code, String message, long[] counts) {
-    super(token, code, false, message, null);
+      DoNotConstructDirectly token,
+      ErrorCode code,
+      String message,
+      long[] counts,
+      Throwable cause) {
+    super(token, code, false, message, cause);
     updateCounts = counts;
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
@@ -118,7 +118,11 @@ public final class SpannerExceptionFactory {
   public static SpannerBatchUpdateException newSpannerBatchUpdateException(
       ErrorCode code, String message, long[] updateCounts) {
     DoNotConstructDirectly token = DoNotConstructDirectly.ALLOWED;
-    return new SpannerBatchUpdateException(token, code, message, updateCounts);
+    SpannerException cause = null;
+    if (isTransactionMutationLimitException(code, message)) {
+      cause = new TransactionMutationLimitExceededException(token, code, message, null, null);
+    }
+    return new SpannerBatchUpdateException(token, code, message, updateCounts, cause);
   }
 
   /** Constructs a specific error that */

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionMutationLimitExceededException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionMutationLimitExceededException.java
@@ -26,6 +26,8 @@ import javax.annotation.Nullable;
 public class TransactionMutationLimitExceededException extends SpannerException {
   private static final long serialVersionUID = 1L;
 
+  private static final String ERROR_MESSAGE = "The transaction contains too many mutations.";
+
   /** Private constructor. Use {@link SpannerExceptionFactory} to create instances. */
   TransactionMutationLimitExceededException(
       DoNotConstructDirectly token,
@@ -36,10 +38,14 @@ public class TransactionMutationLimitExceededException extends SpannerException 
     super(token, errorCode, /*retryable = */ false, message, cause, apiException);
   }
 
+  static boolean isTransactionMutationLimitException(ErrorCode code, String message) {
+    return code == ErrorCode.INVALID_ARGUMENT && message != null && message.contains(ERROR_MESSAGE);
+  }
+
   static boolean isTransactionMutationLimitException(Throwable cause) {
     if (cause == null
         || cause.getMessage() == null
-        || !cause.getMessage().contains("The transaction contains too many mutations.")) {
+        || !cause.getMessage().contains(ERROR_MESSAGE)) {
       return false;
     }
     // Spanner includes a hint that points to the Spanner limits documentation page when the error

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -1070,7 +1070,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
           // In all other cases, we should throw a BatchUpdateException.
           if (response.getStatus().getCode() == Code.ABORTED_VALUE) {
             throw createAbortedExceptionForBatchDml(response);
-          } else if (response.getStatus().getCode() != 0) {
+          } else if (response.getStatus().getCode() != Code.OK_VALUE) {
             throw newSpannerBatchUpdateException(
                 ErrorCode.fromRpcStatus(response.getStatus()),
                 response.getStatus().getMessage(),
@@ -1137,7 +1137,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
                   // In all other cases, we should throw a BatchUpdateException.
                   if (batchDmlResponse.getStatus().getCode() == Code.ABORTED_VALUE) {
                     throw createAbortedExceptionForBatchDml(batchDmlResponse);
-                  } else if (batchDmlResponse.getStatus().getCode() != 0) {
+                  } else if (batchDmlResponse.getStatus().getCode() != Code.OK_VALUE) {
                     throw newSpannerBatchUpdateException(
                         ErrorCode.fromRpcStatus(batchDmlResponse.getStatus()),
                         batchDmlResponse.getStatus().getMessage(),


### PR DESCRIPTION
If a DML batch fails due to a TransactionMutationLimitExceededException, then add that specific exception as the cause to the SpannerBatchUpdateException. This makes it easier to detect this specific error, and potentially retry the individual statements as PDML.
