### PR TITLE
perf: optimize parsing in Connection API

### DIFF
--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -927,5 +927,23 @@
     <className>com/google/cloud/spanner/connection/ConnectionOptions</className>
     <field>VALID_PROPERTIES</field>
   </difference>
+
+  <!-- Remove supportsExplain() from the parser -->
+  <difference>
+    <differenceType>7002</differenceType>
+    <className>com/google/cloud/spanner/connection/AbstractStatementParser</className>
+    <method>boolean supportsExplain()</method>
+  </difference>
+  <difference>
+    <differenceType>7002</differenceType>
+    <className>com/google/cloud/spanner/connection/PostgreSQLStatementParser</className>
+    <method>boolean supportsExplain()</method>
+  </difference>
+  <difference>
+    <differenceType>7002</differenceType>
+    <className>com/google/cloud/spanner/connection/SpannerStatementParser</className>
+    <method>boolean supportsExplain()</method>
+  </difference>
+
   
 </differences>

--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -517,6 +517,19 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>org.openjdk.jmh</groupId>
+                  <artifactId>jmh-generator-annprocess</artifactId>
+                  <version>1.37</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Statement.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Statement.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.google.cloud.spanner.ReadContext.QueryAnalyzeMode;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.spanner.v1.ExecuteSqlRequest.QueryOptions;
 import java.io.Serializable;
 import java.util.Collections;
@@ -140,7 +141,7 @@ public final class Statement implements Serializable {
 
   /** Creates a {@code Statement} with the given SQL text {@code sql}. */
   public static Statement of(String sql) {
-    return newBuilder(sql).build();
+    return new Statement(sql, ImmutableMap.of(), /*queryOptions=*/ null);
   }
 
   /** Creates a new statement builder with the SQL text {@code sql}. */

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractStatementParser.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractStatementParser.java
@@ -617,8 +617,6 @@ public abstract class AbstractStatementParser {
     return statementStartsWith(sql, dmlStatements);
   }
 
-  protected abstract boolean supportsExplain();
-
   private boolean statementStartsWith(String sql, Iterable<String> checkStatements) {
     Preconditions.checkNotNull(sql);
     Iterator<String> tokens = Splitter.onPattern("\\s+").split(sql).iterator();
@@ -626,12 +624,6 @@ public abstract class AbstractStatementParser {
       return false;
     }
     String token = tokens.next();
-    if (supportsExplain() && token.equalsIgnoreCase("EXPLAIN")) {
-      if (!tokens.hasNext()) {
-        return false;
-      }
-      token = tokens.next();
-    }
     for (String check : checkStatements) {
       if (token.equalsIgnoreCase(check)) {
         return true;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/PostgreSQLStatementParser.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/PostgreSQLStatementParser.java
@@ -46,15 +46,6 @@ public class PostgreSQLStatementParser extends AbstractStatementParser {
     return Dialect.POSTGRESQL;
   }
 
-  /**
-   * Indicates whether the parser supports the {@code EXPLAIN} clause. The PostgreSQL parser does
-   * not support it.
-   */
-  @Override
-  protected boolean supportsExplain() {
-    return false;
-  }
-
   @Override
   boolean supportsNestedComments() {
     return true;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/PostgreSQLStatementParser.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/PostgreSQLStatementParser.java
@@ -125,7 +125,8 @@ public class PostgreSQLStatementParser extends AbstractStatementParser {
     int multiLineCommentStartIdx = -1;
     StringBuilder res = new StringBuilder(sql.length());
     int index = 0;
-    while (index < sql.length()) {
+    int length = sql.length();
+    while (index < length) {
       char c = sql.charAt(index);
       if (isInSingleLineComment) {
         if (c == '\n') {
@@ -134,10 +135,10 @@ public class PostgreSQLStatementParser extends AbstractStatementParser {
           res.append(c);
         }
       } else if (multiLineCommentLevel > 0) {
-        if (sql.length() > index + 1 && c == ASTERISK && sql.charAt(index + 1) == SLASH) {
+        if (length > index + 1 && c == ASTERISK && sql.charAt(index + 1) == SLASH) {
           multiLineCommentLevel--;
           if (multiLineCommentLevel == 0) {
-            if (!whitespaceBeforeOrAfterMultiLineComment && (sql.length() > index + 2)) {
+            if (!whitespaceBeforeOrAfterMultiLineComment && (length > index + 2)) {
               whitespaceBeforeOrAfterMultiLineComment =
                   Character.isWhitespace(sql.charAt(index + 2));
             }
@@ -145,23 +146,23 @@ public class PostgreSQLStatementParser extends AbstractStatementParser {
             // neither at the start nor at the end of SQL string, append an extra space.
             if (!whitespaceBeforeOrAfterMultiLineComment
                 && (multiLineCommentStartIdx != 0)
-                && (index != sql.length() - 2)) {
+                && (index != length - 2)) {
               res.append(' ');
             }
           }
           index++;
-        } else if (sql.length() > index + 1 && c == SLASH && sql.charAt(index + 1) == ASTERISK) {
+        } else if (length > index + 1 && c == SLASH && sql.charAt(index + 1) == ASTERISK) {
           multiLineCommentLevel++;
           index++;
         }
       } else {
         // Check for -- which indicates the start of a single-line comment.
-        if (sql.length() > index + 1 && c == HYPHEN && sql.charAt(index + 1) == HYPHEN) {
+        if (length > index + 1 && c == HYPHEN && sql.charAt(index + 1) == HYPHEN) {
           // This is a single line comment.
           isInSingleLineComment = true;
           index += 2;
           continue;
-        } else if (sql.length() > index + 1 && c == SLASH && sql.charAt(index + 1) == ASTERISK) {
+        } else if (length > index + 1 && c == SLASH && sql.charAt(index + 1) == ASTERISK) {
           multiLineCommentLevel++;
           if (index >= 1) {
             whitespaceBeforeOrAfterMultiLineComment = Character.isWhitespace(sql.charAt(index - 1));

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerStatementParser.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerStatementParser.java
@@ -46,15 +46,6 @@ public class SpannerStatementParser extends AbstractStatementParser {
     return Dialect.GOOGLE_STANDARD_SQL;
   }
 
-  /**
-   * Indicates whether the parser supports the {@code EXPLAIN} clause. The Spanner parser does
-   * support it.
-   */
-  @Override
-  protected boolean supportsExplain() {
-    return true;
-  }
-
   @Override
   boolean supportsNestedComments() {
     return false;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementParserBenchmark.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementParserBenchmark.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.connection;
+
+import com.google.cloud.spanner.Dialect;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Fork(value = 1, warmups = 0)
+@Warmup(iterations = 1, time = 5)
+@Measurement(iterations = 5, time = 5)
+public class StatementParserBenchmark {
+  private static final Dialect dialect = Dialect.POSTGRESQL;
+  private static final AbstractStatementParser parser =
+      AbstractStatementParser.getInstance(dialect);
+
+  private static String longQueryText = generateLongQuery(100 * 1024); // 100kb
+
+  /** Generates a long SQL-looking string. */
+  private static String generateLongQuery(int length) {
+    StringBuilder sb = new StringBuilder(length + 50);
+    sb.append("SELECT * FROM foo WHERE 1");
+    while (sb.length() < length) {
+      sb.append(" OR abcdefghijklmnopqrstuvwxyz");
+    }
+    return sb.toString();
+  }
+
+  @Benchmark
+  public boolean isQueryTest() {
+    return parser.isQuery("CREATE TABLE FOO (ID INT64, NAME STRING(100)) PRIMARY KEY (ID)");
+  }
+
+  @Benchmark
+  public boolean longQueryTest() {
+    return parser.isQuery(longQueryText);
+  }
+}


### PR DESCRIPTION
This fixes a performance bottleneck I noticed while profiling pgadapter under a TPCC workload.

#### With change

```
Benchmark                                Mode  Cnt       Score      Error  Units
StatementParserBenchmark.isQueryTest    thrpt    5  475330.395 ± 2522.511  ops/s
StatementParserBenchmark.longDmlTest    thrpt    5    3611.682 ±   58.704  ops/s
StatementParserBenchmark.longQueryTest  thrpt    5    5015.354 ±    8.138  ops/s
```

#### Main

```
Benchmark                                Mode  Cnt       Score       Error  Units
StatementParserBenchmark.isQueryTest    thrpt    5  338079.227 ± 26995.410  ops/s
StatementParserBenchmark.longDmlTest    thrpt    5    1153.123 ±     5.604  ops/s
StatementParserBenchmark.longQueryTest  thrpt    5    2011.550 ±    72.433  ops/s
```