### PR TITLE
perf: cache the key used for OTEL traces and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>libraries-bom</artifactId>
-      <version>26.54.0</version>
+      <version>26.57.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>


### PR DESCRIPTION
The HeaderInterceptor creates a key consisting of the database name and method name that is used for OpenTelemetry attributes and metrics. The number of unique keys is low. However, the key is constructed from the DatabaseName and method name every time, which leads to a lot of string creation:
1. The DatabaseName.toString() method is called every time. This constructs a new string.
2. The result of DatabaseName.toString() is concatenated with the methodName to create yet another string.

Instead of creating the key every time, we can cache the key values without doing the string creation and concatenation every time.
