### PR TITLE
chore(x-goog-spanner-request-id): plumb for BatchCreateSessions

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
@@ -213,15 +213,7 @@ class DatabaseClientImpl implements DatabaseClient {
             return session.writeWithOptions(mutations, withReqId(reqId, options));
           });
     } catch (RuntimeException e) {
-      System.out.println("runtime.crashing out\033[31m");
-      e.printStackTrace();
-      System.out.println("\033[00m");
       span.setStatus(e);
-      throw e;
-    } catch (Exception e) {
-      System.out.println("crashing out\033[31m");
-      e.printStackTrace();
-      System.out.println("\033[00m");
       throw e;
     } finally {
       span.end();

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
@@ -216,15 +216,7 @@ class DatabaseClientImpl implements DatabaseClient {
             return session.writeWithOptions(mutations, withReqId(reqId, options));
           });
     } catch (RuntimeException e) {
-      System.out.println("runtime.crashing out\033[31m");
-      e.printStackTrace();
-      System.out.println("\033[00m");
       span.setStatus(e);
-      throw e;
-    } catch (Exception e) {
-      System.out.println("crashing out\033[31m");
-      e.printStackTrace();
-      System.out.println("\033[00m");
       throw e;
     } finally {
       span.end();

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
@@ -27,8 +27,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.spanner.v1.BatchWriteResponse;
 import io.opentelemetry.api.common.Attributes;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
@@ -465,10 +465,9 @@ class DatabaseClientImpl implements DatabaseClient {
     PooledSessionFuture session = getSession();
     XGoogSpannerRequestId reqId =
         XGoogSpannerRequestId.of(
-            this.dbId, Long.valueOf(session.getChannel()), this.nextNthRequest(), 0);
+            this.dbId, Long.valueOf(session.getChannel()), this.nextNthRequest(), 1);
     while (true) {
       try {
-        reqId.incrementAttempt();
         return callable.apply(session, reqId);
       } catch (SessionNotFoundException e) {
         session =
@@ -476,7 +475,7 @@ class DatabaseClientImpl implements DatabaseClient {
                 pool.getPooledSessionReplacementHandler().replaceSession(e, session);
         reqId =
             XGoogSpannerRequestId.of(
-                this.dbId, Long.valueOf(session.getChannel()), this.nextNthRequest(), 0);
+                this.dbId, Long.valueOf(session.getChannel()), this.nextNthRequest(), 1);
       }
     }
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
@@ -216,7 +216,15 @@ class DatabaseClientImpl implements DatabaseClient {
             return session.writeWithOptions(mutations, withReqId(reqId, options));
           });
     } catch (RuntimeException e) {
+      System.out.println("runtime.crashing out\033[31m");
+      e.printStackTrace();
+      System.out.println("\033[00m");
       span.setStatus(e);
+      throw e;
+    } catch (Exception e) {
+      System.out.println("crashing out\033[31m");
+      e.printStackTrace();
+      System.out.println("\033[00m");
       throw e;
     } finally {
       span.end();

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
@@ -212,7 +212,15 @@ class DatabaseClientImpl implements DatabaseClient {
             return session.writeWithOptions(mutations, withReqId(reqId, options));
           });
     } catch (RuntimeException e) {
+      System.out.println("runtime.crashing out\033[31m");
+      e.printStackTrace();
+      System.out.println("\033[00m");
       span.setStatus(e);
+      throw e;
+    } catch (Exception e) {
+      System.out.println("crashing out\033[31m");
+      e.printStackTrace();
+      System.out.println("\033[00m");
       throw e;
     } finally {
       span.end();

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
@@ -440,9 +440,13 @@ class DatabaseClientImpl implements DatabaseClient {
     if (reqId == null) {
       return options;
     }
-    ArrayList<TransactionOption> allOptions = new ArrayList(Arrays.asList(options));
-    allOptions.add(new Options.RequestIdOption(reqId));
-    return allOptions.toArray(new TransactionOption[0]);
+    if (options == null || options.length == 0) {
+      return new TransactionOption[] {new Options.RequestIdOption(reqId)};
+    }
+    TransactionOption[] allOptions = new TransactionOption[options.length + 1];
+    System.arraycopy(options, 0, allOptions, 0, options.length);
+    allOptions[options.length] = new Options.RequestIdOption(reqId);
+    return allOptions;
   }
 
   private long executePartitionedUpdateWithPooledSession(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseClientImpl.java
@@ -102,7 +102,8 @@ class DatabaseClientImpl implements DatabaseClient {
     this.nthRequest = new AtomicInteger(0);
   }
 
-  private int dbIdFromClientId(String clientId) {
+  @VisibleForTesting
+  int dbIdFromClientId(String clientId) {
     int i = clientId.indexOf("-");
     String strWithValue = clientId.substring(i + 1);
     if (Objects.equals(strWithValue, "")) {
@@ -255,6 +256,11 @@ class DatabaseClientImpl implements DatabaseClient {
 
   private int nextNthRequest() {
     return this.nthRequest.incrementAndGet();
+  }
+
+  @VisibleForTesting
+  int getNthRequest() {
+    return this.nthRequest.get();
   }
 
   @Override
@@ -455,7 +461,8 @@ class DatabaseClientImpl implements DatabaseClient {
     }
   }
 
-  private <T> T runWithSessionRetry(BiFunction<Session, XGoogSpannerRequestId, T> callable) {
+  @VisibleForTesting
+  <T> T runWithSessionRetry(BiFunction<Session, XGoogSpannerRequestId, T> callable) {
     PooledSessionFuture session = getSession();
     XGoogSpannerRequestId reqId =
         XGoogSpannerRequestId.of(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
@@ -177,6 +177,10 @@ public final class Options implements Serializable {
     return EXCLUDE_TXN_FROM_CHANGE_STREAMS_OPTION;
   }
 
+  public static RequestIdOption requestId(XGoogSpannerRequestId reqId) {
+    return new RequestIdOption(reqId);
+  }
+
   /**
    * Specifying this will cause the read to yield at most this many rows. This should be greater
    * than 0.
@@ -535,6 +539,7 @@ public final class Options implements Serializable {
   private RpcLockHint lockHint;
   private Boolean lastStatement;
   private IsolationLevel isolationLevel;
+  private XGoogSpannerRequestId reqId;
 
   // Construction is via factory methods below.
   private Options() {}
@@ -597,6 +602,14 @@ public final class Options implements Serializable {
 
   String filter() {
     return filter;
+  }
+
+  boolean hasReqId() {
+    return reqId != null;
+  }
+
+  XGoogSpannerRequestId reqId() {
+    return reqId;
   }
 
   boolean hasPriority() {
@@ -756,6 +769,9 @@ public final class Options implements Serializable {
     if (isolationLevel != null) {
       b.append("isolationLevel: ").append(isolationLevel).append(' ');
     }
+    if (reqId != null) {
+      b.append("requestId: ").append(reqId.toString());
+    }
     return b.toString();
   }
 
@@ -798,7 +814,8 @@ public final class Options implements Serializable {
         && Objects.equals(orderBy(), that.orderBy())
         && Objects.equals(isLastStatement(), that.isLastStatement())
         && Objects.equals(lockHint(), that.lockHint())
-        && Objects.equals(isolationLevel(), that.isolationLevel());
+        && Objects.equals(isolationLevel(), that.isolationLevel())
+        && Objects.equals(reqId(), that.reqId());
   }
 
   @Override
@@ -866,6 +883,9 @@ public final class Options implements Serializable {
     }
     if (isolationLevel != null) {
       result = 31 * result + isolationLevel.hashCode();
+    }
+    if (reqId != null) {
+      result = 31 * result + reqId.hashCode();
     }
     return result;
   }
@@ -1050,6 +1070,32 @@ public final class Options implements Serializable {
     @Override
     public boolean equals(Object o) {
       return o instanceof LastStatementUpdateOption;
+    }
+  }
+
+  static final class RequestIdOption extends InternalOption
+      implements ReadOption, TransactionOption, UpdateOption {
+    private final XGoogSpannerRequestId reqId;
+
+    RequestIdOption(XGoogSpannerRequestId reqId) {
+      this.reqId = reqId;
+    }
+
+    @Override
+    void appendToOptions(Options options) {
+      options.reqId = this.reqId;
+    }
+
+    @Override
+    public int hashCode() {
+      return RequestIdOption.class.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      // TODO: Examine why the precedent for LastStatementUpdateOption
+      // does not check against the actual value.
+      return o instanceof RequestIdOption;
     }
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
@@ -1093,8 +1093,6 @@ public final class Options implements Serializable {
 
     @Override
     public boolean equals(Object o) {
-      // TODO: Examine why the precedent for LastStatementUpdateOption
-      // does not check against the actual value.
       return o instanceof RequestIdOption;
     }
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionClient.java
@@ -117,8 +117,7 @@ class SessionClient implements AutoCloseable, XGoogSpannerRequestId.RequestIdCre
         Option.REQUEST_ID, requestId);
   }
 
-  static Map<SpannerRpc.Option, ?> createRequestOptions(
-      XGoogSpannerRequestId requestId) {
+  static Map<SpannerRpc.Option, ?> createRequestOptions(XGoogSpannerRequestId requestId) {
     return ImmutableMap.of(Option.REQUEST_ID, requestId);
   }
 
@@ -206,8 +205,6 @@ class SessionClient implements AutoCloseable, XGoogSpannerRequestId.RequestIdCre
     this.executorFactory = executorFactory;
     this.executor = executorFactory.get();
     this.commonAttributes = spanner.getTracer().createCommonAttributes(db);
-    this.nthId = SessionClient.NTH_ID.incrementAndGet();
-    this.nthRequest = new AtomicInteger(0);
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionClient.java
@@ -31,10 +31,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.concurrent.GuardedBy;
 
 /** Client for creating single sessions and batches of sessions. */
-class SessionClient implements AutoCloseable {
+class SessionClient implements AutoCloseable, XGoogSpannerRequestId.RequestIdCreator {
   static class SessionId {
     private static final PathTemplate NAME_TEMPLATE =
         PathTemplate.create(
@@ -174,6 +175,12 @@ class SessionClient implements AutoCloseable {
   private final DatabaseId db;
   private final Attributes commonAttributes;
 
+  // SessionClient is created long before a DatabaseClientImpl is created,
+  // as batch sessions are firstly created then later attached to each Client.
+  private static AtomicInteger NTH_ID = new AtomicInteger(0);
+  private final int nthId;
+  private final AtomicInteger nthRequest;
+
   @GuardedBy("this")
   private volatile long sessionChannelCounter;
 
@@ -186,6 +193,8 @@ class SessionClient implements AutoCloseable {
     this.executorFactory = executorFactory;
     this.executor = executorFactory.get();
     this.commonAttributes = spanner.getTracer().createCommonAttributes(db);
+    this.nthId = SessionClient.NTH_ID.incrementAndGet();
+    this.nthRequest = new AtomicInteger(0);
   }
 
   @Override
@@ -201,16 +210,24 @@ class SessionClient implements AutoCloseable {
     return db;
   }
 
+  @Override
+  public XGoogSpannerRequestId nextRequestId(long channelId, int attempt) {
+    return XGoogSpannerRequestId.of(this.nthId, this.nthRequest.incrementAndGet(), channelId, 1);
+  }
+
   /** Create a single session. */
   SessionImpl createSession() {
     // The sessionChannelCounter could overflow, but that will just flip it to Integer.MIN_VALUE,
     // which is also a valid channel hint.
     final Map<SpannerRpc.Option, ?> options;
+    final long channelId;
     synchronized (this) {
       options = optionMap(SessionOption.channelHint(sessionChannelCounter++));
+      channelId = sessionChannelCounter;
     }
     ISpan span = spanner.getTracer().spanBuilder(SpannerImpl.CREATE_SESSION, this.commonAttributes);
     try (IScope s = spanner.getTracer().withSpan(span)) {
+      XGoogSpannerRequestId reqId = this.nextRequestId(channelId, 1);
       com.google.spanner.v1.Session session =
           spanner
               .getRpc()
@@ -218,11 +235,13 @@ class SessionClient implements AutoCloseable {
                   db.getName(),
                   spanner.getOptions().getDatabaseRole(),
                   spanner.getOptions().getSessionLabels(),
-                  options);
+                  reqId.withOptions(options));
       SessionReference sessionReference =
           new SessionReference(
               session.getName(), session.getCreateTime(), session.getMultiplexed(), options);
-      return new SessionImpl(spanner, sessionReference);
+      SessionImpl sessionImpl = new SessionImpl(spanner, sessionReference);
+      sessionImpl.setRequestIdCreator(this);
+      return sessionImpl;
     } catch (RuntimeException e) {
       span.setStatus(e);
       throw e;
@@ -273,6 +292,7 @@ class SessionClient implements AutoCloseable {
               spanner,
               new SessionReference(
                   session.getName(), session.getCreateTime(), session.getMultiplexed(), null));
+      sessionImpl.setRequestIdCreator(this);
       span.addAnnotation(
           String.format("Request for %d multiplexed session returned %d session", 1, 1));
       return sessionImpl;
@@ -387,6 +407,8 @@ class SessionClient implements AutoCloseable {
             .spanBuilderWithExplicitParent(SpannerImpl.BATCH_CREATE_SESSIONS_REQUEST, parent);
     span.addAnnotation(String.format("Requesting %d sessions", sessionCount));
     try (IScope s = spanner.getTracer().withSpan(span)) {
+      XGoogSpannerRequestId reqId =
+          XGoogSpannerRequestId.of(this.nthId, this.nthRequest.incrementAndGet(), channelHint, 1);
       List<com.google.spanner.v1.Session> sessions =
           spanner
               .getRpc()
@@ -395,21 +417,20 @@ class SessionClient implements AutoCloseable {
                   sessionCount,
                   spanner.getOptions().getDatabaseRole(),
                   spanner.getOptions().getSessionLabels(),
-                  options);
+                  reqId.withOptions(options));
       span.addAnnotation(
           String.format(
               "Request for %d sessions returned %d sessions", sessionCount, sessions.size()));
       span.end();
       List<SessionImpl> res = new ArrayList<>(sessionCount);
       for (com.google.spanner.v1.Session session : sessions) {
-        res.add(
+        SessionImpl sessionImpl =
             new SessionImpl(
                 spanner,
                 new SessionReference(
-                    session.getName(),
-                    session.getCreateTime(),
-                    session.getMultiplexed(),
-                    options)));
+                    session.getName(), session.getCreateTime(), session.getMultiplexed(), options));
+        sessionImpl.setRequestIdCreator(this);
+        res.add(sessionImpl);
       }
       return res;
     } catch (RuntimeException e) {
@@ -425,6 +446,8 @@ class SessionClient implements AutoCloseable {
     synchronized (this) {
       options = optionMap(SessionOption.channelHint(sessionChannelCounter++));
     }
-    return new SessionImpl(spanner, new SessionReference(name, options));
+    SessionImpl sessionImpl = new SessionImpl(spanner, new SessionReference(name, options));
+    sessionImpl.setRequestIdCreator(this);
+    return sessionImpl;
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionClient.java
@@ -117,6 +117,11 @@ class SessionClient implements AutoCloseable, XGoogSpannerRequestId.RequestIdCre
         Option.REQUEST_ID, requestId);
   }
 
+  static Map<SpannerRpc.Option, ?> createRequestOptions(
+      XGoogSpannerRequestId requestId) {
+    return ImmutableMap.of(Option.REQUEST_ID, requestId);
+  }
+
   private final class BatchCreateSessionsRunnable implements Runnable {
     private final long channelHint;
     private final int sessionCount;
@@ -297,7 +302,7 @@ class SessionClient implements AutoCloseable, XGoogSpannerRequestId.RequestIdCre
                   db.getName(),
                   spanner.getOptions().getDatabaseRole(),
                   spanner.getOptions().getSessionLabels(),
-                  createRequestOptions(channelId, reqId),
+                  createRequestOptions(reqId),
                   true);
       SessionImpl sessionImpl =
           new SessionImpl(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionClient.java
@@ -241,7 +241,6 @@ class SessionClient implements AutoCloseable, XGoogSpannerRequestId.RequestIdCre
     XGoogSpannerRequestId reqId = nextRequestId(channelId, 1);
     ISpan span = spanner.getTracer().spanBuilder(SpannerImpl.CREATE_SESSION, this.commonAttributes);
     try (IScope s = spanner.getTracer().withSpan(span)) {
-      XGoogSpannerRequestId reqId = this.nextRequestId(channelId, 1);
       com.google.spanner.v1.Session session =
           spanner
               .getRpc()

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionClient.java
@@ -206,6 +206,8 @@ class SessionClient implements AutoCloseable, XGoogSpannerRequestId.RequestIdCre
     this.executorFactory = executorFactory;
     this.executor = executorFactory.get();
     this.commonAttributes = spanner.getTracer().createCommonAttributes(db);
+    this.nthId = SessionClient.NTH_ID.incrementAndGet();
+    this.nthRequest = new AtomicInteger(0);
   }
 
   @Override
@@ -239,6 +241,7 @@ class SessionClient implements AutoCloseable, XGoogSpannerRequestId.RequestIdCre
     XGoogSpannerRequestId reqId = nextRequestId(channelId, 1);
     ISpan span = spanner.getTracer().spanBuilder(SpannerImpl.CREATE_SESSION, this.commonAttributes);
     try (IScope s = spanner.getTracer().withSpan(span)) {
+      XGoogSpannerRequestId reqId = this.nextRequestId(channelId, 1);
       com.google.spanner.v1.Session session =
           spanner
               .getRpc()

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -149,7 +149,7 @@ class SessionImpl implements Session {
     this.errorHandler = createErrorHandler(spanner.getOptions());
     this.requestIdCreator = requestIdCreator;
     if (this.requestIdCreator == null) {
-      this.requestIdCreator = new XGoogSpannerRequestId.NoopRequestIdCreator();
+      throw new IllegalStateException("requestIdCreator must be non-null");
     }
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -305,7 +305,8 @@ class SessionImpl implements Session {
     try (IScope s = tracer.withSpan(span)) {
       return SpannerRetryHelper.runTxWithRetriesOnAborted(
           () -> {
-            // TODO: Detect an abort and then refresh the reqId.
+            // TODO(@odeke-em): Only increment on UNAVAILABLE and INCREMENT,
+            // instead increment the nthRequest on ABORTED and others.
             reqId.incrementAttempt();
             return new CommitResponse(
                 spanner.getRpc().commit(request, reqId.withOptions(getOptions())));

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -305,6 +305,8 @@ class SessionImpl implements Session {
     try (IScope s = tracer.withSpan(span)) {
       return SpannerRetryHelper.runTxWithRetriesOnAborted(
           () -> {
+            // TODO: Detect an abort and then refresh the reqId.
+            reqId.incrementAttempt();
             return new CommitResponse(
                 spanner.getRpc().commit(request, reqId.withOptions(getOptions())));
           });

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -126,7 +126,7 @@ class SessionImpl implements Session {
   private final Clock clock;
   private final Map<SpannerRpc.Option, ?> options;
   private final ErrorHandler errorHandler;
-  private XGoogSpannerRequestId.RequestIdCreator requestIdCreator;
+  private final XGoogSpannerRequestId.RequestIdCreator requestIdCreator;
 
   SessionImpl(SpannerImpl spanner, SessionReference sessionReference) {
     this(spanner, sessionReference, NO_CHANNEL_HINT);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -305,9 +305,6 @@ class SessionImpl implements Session {
     try (IScope s = tracer.withSpan(span)) {
       return SpannerRetryHelper.runTxWithRetriesOnAborted(
           () -> {
-            // TODO(@odeke-em): Only increment on UNAVAILABLE and INCREMENT,
-            // instead increment the nthRequest on ABORTED and others.
-            reqId.incrementAttempt();
             return new CommitResponse(
                 spanner.getRpc().commit(request, reqId.withOptions(getOptions())));
           });
@@ -322,7 +319,7 @@ class SessionImpl implements Session {
   private XGoogSpannerRequestId reqIdOrFresh(Options options) {
     XGoogSpannerRequestId reqId = options.reqId();
     if (reqId == null) {
-      reqId = this.getRequestIdCreator().nextRequestId(1 /* TODO: channelId */, 0);
+      reqId = this.getRequestIdCreator().nextRequestId(1 /* TODO: channelId */, 1);
     }
     return reqId;
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -305,9 +305,6 @@ class SessionImpl implements Session {
     try (IScope s = tracer.withSpan(span)) {
       return SpannerRetryHelper.runTxWithRetriesOnAborted(
           () -> {
-            // TODO(@odeke-em): Only increment on UNAVAILABLE and INCREMENT,
-            // instead increment the nthRequest on ABORTED and others.
-            reqId.incrementAttempt();
             return new CommitResponse(
                 spanner.getRpc().commit(request, reqId.withOptions(getOptions())));
           });

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -126,18 +126,31 @@ class SessionImpl implements Session {
   private final Clock clock;
   private final Map<SpannerRpc.Option, ?> options;
   private final ErrorHandler errorHandler;
+  private XGoogSpannerRequestId.RequestIdCreator requestIdCreator;
 
   SessionImpl(SpannerImpl spanner, SessionReference sessionReference) {
     this(spanner, sessionReference, NO_CHANNEL_HINT);
   }
 
   SessionImpl(SpannerImpl spanner, SessionReference sessionReference, int channelHint) {
+    this(spanner, sessionReference, channelHint, new XGoogSpannerRequestId.NoopRequestIdCreator());
+  }
+
+  SessionImpl(
+      SpannerImpl spanner,
+      SessionReference sessionReference,
+      int channelHint,
+      XGoogSpannerRequestId.RequestIdCreator requestIdCreator) {
     this.spanner = spanner;
     this.tracer = spanner.getTracer();
     this.sessionReference = sessionReference;
     this.clock = spanner.getOptions().getSessionPoolOptions().getPoolMaintainerClock();
     this.options = createOptions(sessionReference, channelHint);
     this.errorHandler = createErrorHandler(spanner.getOptions());
+    this.requestIdCreator = requestIdCreator;
+    if (this.requestIdCreator == null) {
+      this.requestIdCreator = new XGoogSpannerRequestId.NoopRequestIdCreator();
+    }
   }
 
   static Map<SpannerRpc.Option, ?> createOptions(
@@ -287,15 +300,30 @@ class SessionImpl implements Session {
     }
     CommitRequest request = requestBuilder.build();
     ISpan span = tracer.spanBuilder(SpannerImpl.COMMIT);
+    final XGoogSpannerRequestId reqId = reqIdOrFresh(options);
+
     try (IScope s = tracer.withSpan(span)) {
       return SpannerRetryHelper.runTxWithRetriesOnAborted(
-          () -> new CommitResponse(spanner.getRpc().commit(request, getOptions())));
+          () -> {
+            // TODO: Detect an abort and then refresh the reqId.
+            reqId.incrementAttempt();
+            return new CommitResponse(
+                spanner.getRpc().commit(request, reqId.withOptions(getOptions())));
+          });
     } catch (RuntimeException e) {
       span.setStatus(e);
       throw e;
     } finally {
       span.end();
     }
+  }
+
+  private XGoogSpannerRequestId reqIdOrFresh(Options options) {
+    XGoogSpannerRequestId reqId = options.reqId();
+    if (reqId == null) {
+      reqId = this.getRequestIdCreator().nextRequestId(1 /* TODO: channelId */, 0);
+    }
+    return reqId;
   }
 
   private RequestOptions getRequestOptions(TransactionOption... transactionOptions) {
@@ -325,16 +353,19 @@ class SessionImpl implements Session {
             .setSession(getName())
             .addAllMutationGroups(mutationGroupsProto);
     RequestOptions batchWriteRequestOptions = getRequestOptions(transactionOptions);
+    Options allOptions = Options.fromTransactionOptions(transactionOptions);
+    final XGoogSpannerRequestId reqId = reqIdOrFresh(allOptions);
     if (batchWriteRequestOptions != null) {
       requestBuilder.setRequestOptions(batchWriteRequestOptions);
     }
-    if (Options.fromTransactionOptions(transactionOptions).withExcludeTxnFromChangeStreams()
-        == Boolean.TRUE) {
+    if (allOptions.withExcludeTxnFromChangeStreams() == Boolean.TRUE) {
       requestBuilder.setExcludeTxnFromChangeStreams(true);
     }
     ISpan span = tracer.spanBuilder(SpannerImpl.BATCH_WRITE);
     try (IScope s = tracer.withSpan(span)) {
-      return spanner.getRpc().batchWriteAtLeastOnce(requestBuilder.build(), getOptions());
+      return spanner
+          .getRpc()
+          .batchWriteAtLeastOnce(requestBuilder.build(), reqId.withOptions(getOptions()));
     } catch (Throwable e) {
       span.setStatus(e);
       throw SpannerExceptionFactory.newSpannerException(e);
@@ -435,14 +466,18 @@ class SessionImpl implements Session {
 
   @Override
   public ApiFuture<Empty> asyncClose() {
-    return spanner.getRpc().asyncDeleteSession(getName(), getOptions());
+    XGoogSpannerRequestId reqId =
+        this.getRequestIdCreator().nextRequestId(1 /* TODO: channelId */, 0);
+    return spanner.getRpc().asyncDeleteSession(getName(), reqId.withOptions(getOptions()));
   }
 
   @Override
   public void close() {
     ISpan span = tracer.spanBuilder(SpannerImpl.DELETE_SESSION);
     try (IScope s = tracer.withSpan(span)) {
-      spanner.getRpc().deleteSession(getName(), getOptions());
+      XGoogSpannerRequestId reqId =
+          this.getRequestIdCreator().nextRequestId(1 /* TODO: channelId */, 0);
+      spanner.getRpc().deleteSession(getName(), reqId.withOptions(getOptions()));
     } catch (RuntimeException e) {
       span.setStatus(e);
       throw e;
@@ -472,8 +507,13 @@ class SessionImpl implements Session {
     }
     final BeginTransactionRequest request = requestBuilder.build();
     final ApiFuture<Transaction> requestFuture;
+    XGoogSpannerRequestId reqId =
+        this.getRequestIdCreator().nextRequestId(1 /* TODO: channelId */, 1);
     try (IScope ignore = tracer.withSpan(span)) {
-      requestFuture = spanner.getRpc().beginTransactionAsync(request, channelHint, routeToLeader);
+      requestFuture =
+          spanner
+              .getRpc()
+              .beginTransactionAsync(request, reqId.withOptions(channelHint), routeToLeader);
     }
     requestFuture.addListener(
         () -> {
@@ -550,5 +590,13 @@ class SessionImpl implements Session {
 
   TraceWrapper getTracer() {
     return tracer;
+  }
+
+  public void setRequestIdCreator(XGoogSpannerRequestId.RequestIdCreator creator) {
+    this.requestIdCreator = creator;
+  }
+
+  public XGoogSpannerRequestId.RequestIdCreator getRequestIdCreator() {
+    return this.requestIdCreator;
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -126,7 +126,7 @@ class SessionImpl implements Session {
   private final Clock clock;
   private final Map<SpannerRpc.Option, ?> options;
   private final ErrorHandler errorHandler;
-  private final XGoogSpannerRequestId.RequestIdCreator requestIdCreator;
+  private XGoogSpannerRequestId.RequestIdCreator requestIdCreator;
 
   SessionImpl(SpannerImpl spanner, SessionReference sessionReference) {
     this(spanner, sessionReference, NO_CHANNEL_HINT);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionPool.java
@@ -1585,6 +1585,10 @@ class SessionPool {
         throw SpannerExceptionFactory.propagateInterrupt(e);
       }
     }
+
+    public int getChannel() {
+      return get().getChannel();
+    }
   }
 
   interface CachedSession extends Session {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
@@ -61,6 +61,16 @@ public class XGoogSpannerRequestId {
   }
 
   @VisibleForTesting
+  long getAttempt() {
+    return this.attempt;
+  }
+
+  @VisibleForTesting
+  long getNthRequest() {
+    return this.nthRequest;
+  }
+
+  @VisibleForTesting
   static final Pattern REGEX =
       Pattern.compile("^(\\d)\\.([0-9a-z]{16})\\.(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)$");
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
@@ -159,26 +159,4 @@ public class XGoogSpannerRequestId {
       return XGoogSpannerRequestId.of(1, 1, 1, 0);
     }
   }
-
-  static void assertMonotonicityOfIds(String prefix, List<XGoogSpannerRequestId> reqIds) {
-    int size = reqIds.size();
-
-    List<String> violations = new ArrayList<>();
-    for (int i = 1; i < size; i++) {
-      XGoogSpannerRequestId prev = reqIds.get(i - 1);
-      XGoogSpannerRequestId curr = reqIds.get(i);
-      if (prev.isGreaterThan(curr)) {
-        violations.add(String.format("#%d(%s) > #%d(%s)", i - 1, prev, i, curr));
-      }
-    }
-
-    if (violations.isEmpty()) {
-      return;
-    }
-
-    throw new IllegalStateException(
-        prefix
-            + " monotonicity violation:"
-            + String.join("\n\t", violations.toArray(new String[0])));
-  }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
@@ -22,9 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.grpc.Metadata;
 import java.math.BigInteger;
 import java.security.SecureRandom;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.MatchResult;
@@ -108,7 +106,8 @@ public class XGoogSpannerRequestId {
         this.attempt);
   }
 
-  private boolean isGreaterThan(XGoogSpannerRequestId other) {
+  @VisibleForTesting
+  boolean isGreaterThan(XGoogSpannerRequestId other) {
     return this.nthClientId > other.nthClientId
         && this.nthChannelId > other.nthChannelId
         && this.nthRequest > other.nthRequest
@@ -159,27 +158,5 @@ public class XGoogSpannerRequestId {
     public XGoogSpannerRequestId nextRequestId(long channelId, int attempt) {
       return XGoogSpannerRequestId.of(1, 1, 1, 0);
     }
-  }
-
-  static void assertMonotonicityOfIds(String prefix, List<XGoogSpannerRequestId> reqIds) {
-    int size = reqIds.size();
-
-    List<String> violations = new ArrayList<>();
-    for (int i = 1; i < size; i++) {
-      XGoogSpannerRequestId prev = reqIds.get(i - 1);
-      XGoogSpannerRequestId curr = reqIds.get(i);
-      if (prev.isGreaterThan(curr)) {
-        violations.add(String.format("#%d(%s) > #%d(%s)", i - 1, prev, i, curr));
-      }
-    }
-
-    if (violations.isEmpty()) {
-      return;
-    }
-
-    throw new IllegalStateException(
-        prefix
-            + " monotonicity violation:"
-            + String.join("\n\t", violations.toArray(new String[0])));
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
@@ -160,7 +160,7 @@ public class XGoogSpannerRequestId {
     }
   }
 
-  public static void assertMonotonicityOfIds(String prefix, List<XGoogSpannerRequestId> reqIds) {
+  static void assertMonotonicityOfIds(String prefix, List<XGoogSpannerRequestId> reqIds) {
     int size = reqIds.size();
 
     List<String> violations = new ArrayList<>();
@@ -172,7 +172,7 @@ public class XGoogSpannerRequestId {
       }
     }
 
-    if (violations.size() == 0) {
+    if (violations.isEmpty()) {
       return;
     }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
@@ -124,8 +124,7 @@ public class XGoogSpannerRequestId {
     this.attempt++;
   }
 
-  @SuppressWarnings("unchecked")
-  public Map withOptions(Map options) {
+  Map<SpannerRpc.Option, ?> withOptions(Map<SpannerRpc.Option, ?> options) {
     Map copyOptions = new HashMap<>();
     if (options != null) {
       copyOptions.putAll(options);
@@ -139,11 +138,11 @@ public class XGoogSpannerRequestId {
     return Objects.hash(this.nthClientId, this.nthChannelId, this.nthRequest, this.attempt);
   }
 
-  public interface RequestIdCreator {
+  interface RequestIdCreator {
     XGoogSpannerRequestId nextRequestId(long channelId, int attempt);
   }
 
-  public static class NoopRequestIdCreator implements RequestIdCreator {
+  static class NoopRequestIdCreator implements RequestIdCreator {
     NoopRequestIdCreator() {}
 
     @Override
@@ -152,7 +151,7 @@ public class XGoogSpannerRequestId {
     }
   }
 
-  public static void assertMonotonicityOfIds(String prefix, List<XGoogSpannerRequestId> reqIds) {
+  static void assertMonotonicityOfIds(String prefix, List<XGoogSpannerRequestId> reqIds) {
     int size = reqIds.size();
 
     List<String> violations = new ArrayList<>();
@@ -164,7 +163,7 @@ public class XGoogSpannerRequestId {
       }
     }
 
-    if (violations.size() == 0) {
+    if (violations.isEmpty()) {
       return;
     }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
@@ -159,4 +159,26 @@ public class XGoogSpannerRequestId {
       return XGoogSpannerRequestId.of(1, 1, 1, 0);
     }
   }
+
+  public static void assertMonotonicityOfIds(String prefix, List<XGoogSpannerRequestId> reqIds) {
+    int size = reqIds.size();
+
+    List<String> violations = new ArrayList<>();
+    for (int i = 1; i < size; i++) {
+      XGoogSpannerRequestId prev = reqIds.get(i - 1);
+      XGoogSpannerRequestId curr = reqIds.get(i);
+      if (prev.isGreaterThan(curr)) {
+        violations.add(String.format("#%d(%s) > #%d(%s)", i - 1, prev, i, curr));
+      }
+    }
+
+    if (violations.size() == 0) {
+      return;
+    }
+
+    throw new IllegalStateException(
+        prefix
+            + " monotonicity violation:"
+            + String.join("\n\t", violations.toArray(new String[0])));
+  }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
@@ -17,16 +17,28 @@
 package com.google.cloud.spanner;
 
 import com.google.api.core.InternalApi;
+import com.google.cloud.spanner.spi.v1.SpannerRpc;
 import com.google.common.annotations.VisibleForTesting;
+import io.grpc.Metadata;
 import java.math.BigInteger;
 import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @InternalApi
 public class XGoogSpannerRequestId {
   // 1. Generate the random process Id singleton.
   @VisibleForTesting
   static final String RAND_PROCESS_ID = XGoogSpannerRequestId.generateRandProcessId();
+
+  public static final Metadata.Key<String> REQUEST_HEADER_KEY =
+      Metadata.Key.of("x-goog-spanner-request-id", Metadata.ASCII_STRING_MARSHALLER);
 
   @VisibleForTesting
   static final long VERSION = 1; // The version of the specification being implemented.
@@ -48,6 +60,26 @@ public class XGoogSpannerRequestId {
     return new XGoogSpannerRequestId(nthClientId, nthChannelId, nthRequest, attempt);
   }
 
+  @VisibleForTesting
+  static final Pattern REGEX =
+      Pattern.compile("^(\\d)\\.([0-9a-z]{16})\\.(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)$");
+
+  public static XGoogSpannerRequestId of(String s) {
+    Matcher m = XGoogSpannerRequestId.REGEX.matcher(s);
+    if (!m.matches()) {
+      throw new IllegalStateException(
+          s + " does not match " + XGoogSpannerRequestId.REGEX.pattern());
+    }
+
+    MatchResult mr = m.toMatchResult();
+
+    return new XGoogSpannerRequestId(
+        Long.parseLong(mr.group(3)),
+        Long.parseLong(mr.group(4)),
+        Long.parseLong(mr.group(5)),
+        Long.parseLong(mr.group(6)));
+  }
+
   private static String generateRandProcessId() {
     // Expecting to use 64-bits of randomness to avoid clashes.
     BigInteger bigInt = new BigInteger(64, new SecureRandom());
@@ -66,6 +98,13 @@ public class XGoogSpannerRequestId {
         this.attempt);
   }
 
+  private boolean isGreaterThan(XGoogSpannerRequestId other) {
+    return this.nthClientId > other.nthClientId
+        && this.nthChannelId > other.nthChannelId
+        && this.nthRequest > other.nthRequest
+        && this.attempt > other.attempt;
+  }
+
   @Override
   public boolean equals(Object other) {
     // instanceof for a null object returns false.
@@ -81,8 +120,57 @@ public class XGoogSpannerRequestId {
         && Objects.equals(this.attempt, otherReqId.attempt);
   }
 
+  public void incrementAttempt() {
+    this.attempt++;
+  }
+
+  @SuppressWarnings("unchecked")
+  public Map withOptions(Map options) {
+    Map copyOptions = new HashMap<>();
+    if (options != null) {
+      copyOptions.putAll(options);
+    }
+    copyOptions.put(SpannerRpc.Option.REQUEST_ID, this);
+    return copyOptions;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(this.nthClientId, this.nthChannelId, this.nthRequest, this.attempt);
+  }
+
+  public interface RequestIdCreator {
+    XGoogSpannerRequestId nextRequestId(long channelId, int attempt);
+  }
+
+  public static class NoopRequestIdCreator implements RequestIdCreator {
+    NoopRequestIdCreator() {}
+
+    @Override
+    public XGoogSpannerRequestId nextRequestId(long channelId, int attempt) {
+      return XGoogSpannerRequestId.of(1, 1, 1, 0);
+    }
+  }
+
+  public static void assertMonotonicityOfIds(String prefix, List<XGoogSpannerRequestId> reqIds) {
+    int size = reqIds.size();
+
+    List<String> violations = new ArrayList<>();
+    for (int i = 1; i < size; i++) {
+      XGoogSpannerRequestId prev = reqIds.get(i - 1);
+      XGoogSpannerRequestId curr = reqIds.get(i);
+      if (prev.isGreaterThan(curr)) {
+        violations.add(String.format("#%d(%s) > #%d(%s)", i - 1, prev, i, curr));
+      }
+    }
+
+    if (violations.size() == 0) {
+      return;
+    }
+
+    throw new IllegalStateException(
+        prefix
+            + " monotonicity violation:"
+            + String.join("\n\t", violations.toArray(new String[0])));
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -1663,7 +1663,7 @@ public class GapicSpannerRpc implements SpannerRpc {
       @Nullable Map<String, String> labels,
       @Nullable Map<Option, ?> options)
       throws SpannerException {
-    // By default sessions are not multiplexed
+    // By default, sessions are not multiplexed
     return createSession(databaseName, databaseRole, labels, options, false);
   }
 
@@ -2052,8 +2052,10 @@ public class GapicSpannerRpc implements SpannerRpc {
           context = context.withChannelAffinity(affinity.intValue());
         }
       }
-      String methodName = method.getFullMethodName();
-      context = withRequestId(context, options, methodName);
+      if (method != null) {
+        String methodName = method.getFullMethodName();
+        context = withRequestId(context, options, methodName);
+      }
     }
     context = context.withExtraHeaders(metadataProvider.newExtraHeaders(resource, projectName));
     if (routeToLeader && leaderAwareRoutingEnabled) {
@@ -2074,7 +2076,8 @@ public class GapicSpannerRpc implements SpannerRpc {
     return (GrpcCallContext) context.merge(apiCallContextFromContext);
   }
 
-  GrpcCallContext withRequestId(GrpcCallContext context, Map options, String methodName) {
+  GrpcCallContext withRequestId(
+      GrpcCallContext context, Map<SpannerRpc.Option, ?> options, String methodName) {
     XGoogSpannerRequestId reqId = (XGoogSpannerRequestId) options.get(Option.REQUEST_ID);
     if (reqId == null) {
       return context;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -2054,7 +2054,7 @@ public class GapicSpannerRpc implements SpannerRpc {
       }
       if (method != null) {
         String methodName = method.getFullMethodName();
-        context = withRequestId(context, options, methodName);
+        context = withRequestId(context, options);
       }
     }
     context = context.withExtraHeaders(metadataProvider.newExtraHeaders(resource, projectName));
@@ -2076,8 +2076,7 @@ public class GapicSpannerRpc implements SpannerRpc {
     return (GrpcCallContext) context.merge(apiCallContextFromContext);
   }
 
-  GrpcCallContext withRequestId(
-      GrpcCallContext context, Map<SpannerRpc.Option, ?> options, String methodName) {
+  GrpcCallContext withRequestId(GrpcCallContext context, Map<SpannerRpc.Option, ?> options) {
     XGoogSpannerRequestId reqId = (XGoogSpannerRequestId) options.get(Option.REQUEST_ID);
     if (reqId == null) {
       return context;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -71,6 +71,7 @@ import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.SpannerOptions.CallContextConfigurator;
 import com.google.cloud.spanner.SpannerOptions.CallCredentialsProvider;
+import com.google.cloud.spanner.XGoogSpannerRequestId;
 import com.google.cloud.spanner.admin.database.v1.stub.DatabaseAdminStub;
 import com.google.cloud.spanner.admin.database.v1.stub.DatabaseAdminStubSettings;
 import com.google.cloud.spanner.admin.database.v1.stub.GrpcDatabaseAdminCallableFactory;
@@ -88,6 +89,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
 import com.google.common.util.concurrent.RateLimiter;
@@ -193,6 +195,7 @@ import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -407,6 +410,8 @@ public class GapicSpannerRpc implements SpannerRpc {
       final String emulatorHost = System.getenv("SPANNER_EMULATOR_HOST");
 
       try {
+        // TODO: make our retry settings to inject and increment
+        // XGoogSpannerRequestId whenever a retry occurs.
         SpannerStubSettings spannerStubSettings =
             options.getSpannerStubSettings().toBuilder()
                 .setTransportChannelProvider(channelProvider)
@@ -2042,8 +2047,13 @@ public class GapicSpannerRpc implements SpannerRpc {
                         GcpManagedChannel.AFFINITY_KEY, String.valueOf(boundedChannelHint)));
       } else {
         // Set channel affinity in GAX.
-        context = context.withChannelAffinity(Option.CHANNEL_HINT.getLong(options).intValue());
+        Long affinity = Option.CHANNEL_HINT.getLong(options);
+        if (affinity != null) {
+          context = context.withChannelAffinity(affinity.intValue());
+        }
       }
+      String methodName = method.getFullMethodName();
+      context = withRequestId(context, options, methodName);
     }
     context = context.withExtraHeaders(metadataProvider.newExtraHeaders(resource, projectName));
     if (routeToLeader && leaderAwareRoutingEnabled) {
@@ -2062,6 +2072,19 @@ public class GapicSpannerRpc implements SpannerRpc {
       apiCallContextFromContext = configurator.configure(context, request, method);
     }
     return (GrpcCallContext) context.merge(apiCallContextFromContext);
+  }
+
+  GrpcCallContext withRequestId(GrpcCallContext context, Map options, String methodName) {
+    XGoogSpannerRequestId reqId = (XGoogSpannerRequestId) options.get(Option.REQUEST_ID);
+    if (reqId == null) {
+      return context;
+    }
+
+    Map<String, List<String>> withReqId =
+        ImmutableMap.of(
+            XGoogSpannerRequestId.REQUEST_HEADER_KEY.name(),
+            Collections.singletonList(reqId.toString()));
+    return context.withExtraHeaders(withReqId);
   }
 
   void registerResponseObserver(SpannerResponseObserver responseObserver) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -2052,10 +2052,7 @@ public class GapicSpannerRpc implements SpannerRpc {
           context = context.withChannelAffinity(affinity.intValue());
         }
       }
-      if (method != null) {
-        String methodName = method.getFullMethodName();
-        context = withRequestId(context, options);
-      }
+      context = withRequestId(context, options);
     }
     context = context.withExtraHeaders(metadataProvider.newExtraHeaders(resource, projectName));
     if (routeToLeader && leaderAwareRoutingEnabled) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerRpc.java
@@ -78,7 +78,8 @@ import javax.annotation.Nullable;
 public interface SpannerRpc extends ServiceRpc {
   /** Options passed in {@link SpannerRpc} methods to control how an RPC is issued. */
   enum Option {
-    CHANNEL_HINT("Channel Hint");
+    CHANNEL_HINT("Channel Hint"),
+    REQUEST_ID("Request Id");
 
     private final String value;
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -5643,10 +5643,11 @@ public class DatabaseClientImplTest {
     TransactionOption option = mock(TransactionOption.class);
     DatabaseClientImpl client = new DatabaseClientImpl(pool, mock(TraceWrapper.class));
 
-    assertEquals(client.dbIdFromClientId(""), 0);
-    assertEquals(client.dbIdFromClientId("client-10"), 10);
-    assertEquals(client.dbIdFromClientId("client--10"), -10);
-    assertThrows(NumberFormatException.class, () -> client.dbIdFromClientId("client10"));
+    for (int i = 0; i < 10; i++) {
+      String dbId = String.format("%d", i);
+      int id = client.dbIdFromClientId(dbId);
+      assertEquals(id, i + 2); // There was already 1 dbId after new DatabaseClientImpl.
+    }
   }
 
   @Test

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OptionsTest.java
@@ -83,6 +83,7 @@ public class OptionsTest {
 
   @Test
   public void allOptionsPresent() {
+    XGoogSpannerRequestId reqId1 = XGoogSpannerRequestId.of(2, 3, 4, 5);
     Options options =
         Options.fromReadOptions(
             Options.limit(10),
@@ -90,6 +91,7 @@ public class OptionsTest {
             Options.dataBoostEnabled(true),
             Options.directedRead(DIRECTED_READ_OPTIONS),
             Options.orderBy(RpcOrderBy.NO_ORDER),
+            Options.requestId(reqId1),
             Options.lockHint(Options.RpcLockHint.SHARED));
     assertThat(options.hasLimit()).isTrue();
     assertThat(options.limit()).isEqualTo(10);
@@ -101,6 +103,7 @@ public class OptionsTest {
     assertTrue(options.hasOrderBy());
     assertTrue(options.hasLockHint());
     assertEquals(DIRECTED_READ_OPTIONS, options.directedReadOptions());
+    assertEquals(options.reqId(), reqId1);
   }
 
   @Test
@@ -872,5 +875,40 @@ public class OptionsTest {
     };
     Options options = Options.fromTransactionOptions(transactionOptions);
     assertEquals(options.isolationLevel(), IsolationLevel.SERIALIZABLE);
+  }
+
+  @Test
+  public void testRequestId() {
+    XGoogSpannerRequestId reqId1 = XGoogSpannerRequestId.of(1, 2, 3, 4);
+    XGoogSpannerRequestId reqId2 = XGoogSpannerRequestId.of(2, 3, 4, 5);
+    Options option1 = Options.fromUpdateOptions(Options.requestId(reqId1));
+    Options option1Prime = Options.fromUpdateOptions(Options.requestId(reqId1));
+    Options option2 = Options.fromUpdateOptions(Options.requestId(reqId2));
+    Options option3 = Options.fromUpdateOptions();
+
+    assertEquals(option1, option1Prime);
+    assertNotEquals(option1, option2);
+    assertEquals(option1.hashCode(), option1Prime.hashCode());
+    assertNotEquals(option1, option2);
+    assertNotEquals(option1, option3);
+    assertNotEquals(option1.hashCode(), option3.hashCode());
+
+    assertTrue(option1.hasReqId());
+    assertThat(option1.toString()).contains("requestId: " + reqId1.toString());
+
+    assertFalse(option3.hasReqId());
+    assertThat(option3.toString()).doesNotContain("requestId");
+  }
+
+  @Test
+  public void testOptions_WithMultipleDifferentRequestIds() {
+    XGoogSpannerRequestId reqId1 = XGoogSpannerRequestId.of(1, 1, 1, 1);
+    XGoogSpannerRequestId reqId2 = XGoogSpannerRequestId.of(1, 1, 1, 2);
+    TransactionOption[] transactionOptions = {
+      Options.requestId(reqId1), Options.requestId(reqId2),
+    };
+    Options options = Options.fromTransactionOptions(transactionOptions);
+    assertNotEquals(options.reqId(), reqId1);
+    assertEquals(options.reqId(), reqId2);
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionClientTests.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionClientTests.java
@@ -19,6 +19,7 @@ package com.google.cloud.spanner;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
@@ -207,7 +208,9 @@ public class SessionClientTests {
       client.createMultiplexedSession(consumer);
     }
     // for multiplexed session there is no channel hint pass in the RPC options
-    assertNull(options.getValue());
+    assertNotNull(options.getValue());
+    assertEquals(options.getValue().get(Option.CHANNEL_HINT), null);
+    assertNotNull(options.getValue().get(Option.REQUEST_ID));
     assertEquals(1, returnedSessionCount.get());
   }
 
@@ -239,7 +242,9 @@ public class SessionClientTests {
       client.createMultiplexedSession(consumer);
     }
     // for multiplexed session there is no channel hint pass in the RPC options
-    assertNull(options.getValue());
+    assertNotNull(options.getValue());
+    assertEquals(options.getValue().get(Option.CHANNEL_HINT), null);
+    assertNotNull(options.getValue().get(Option.REQUEST_ID));
   }
 
   @SuppressWarnings("unchecked")

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionClientTests.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionClientTests.java
@@ -153,8 +153,17 @@ public class SessionClientTests {
       assertThat(session.getName()).isEqualTo(sessionName);
 
       session.close();
+
+      final ArgumentCaptor<Map<SpannerRpc.Option, ?>> deleteOptionsCaptor =
+          ArgumentCaptor.forClass(Map.class);
+      final ArgumentCaptor<String> sessionNameCaptor = ArgumentCaptor.forClass(String.class);
+      Mockito.verify(rpc).deleteSession(sessionNameCaptor.capture(), deleteOptionsCaptor.capture());
+      assertEquals(sessionName, sessionNameCaptor.getValue());
       // The same channelHint is passed for deleteSession (contained in "options").
-      Mockito.verify(rpc).deleteSession(sessionName, options.getValue());
+      assertEquals(
+          deleteOptionsCaptor.getValue().get(SpannerRpc.Option.CHANNEL_HINT),
+          options.getValue().get(SpannerRpc.Option.CHANNEL_HINT));
+      assertTrue(deleteOptionsCaptor.getValue().containsKey(SpannerRpc.Option.REQUEST_ID));
     }
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionClientTests.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionClientTests.java
@@ -18,7 +18,6 @@ package com.google.cloud.spanner;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
@@ -144,6 +144,7 @@ public class SessionImplTest {
     when(rpc.getCommitRetrySettings())
         .thenReturn(SpannerStubSettings.newBuilder().commitSettings().getRetrySettings());
     session = spanner.getSessionClient(db).createSession();
+    ((SessionImpl) session).setRequestIdCreator(new XGoogSpannerRequestId.NoopRequestIdCreator());
     Span oTspan = mock(Span.class);
     ISpan span = new OpenTelemetrySpan(oTspan);
     when(oTspan.makeCurrent()).thenReturn(mock(Scope.class));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
@@ -221,6 +221,10 @@ public class SessionImplTest {
   @Test
   public void writeAtLeastOnce() throws ParseException {
     String timestampString = "2015-10-01T10:54:20.021Z";
+    com.google.protobuf.Timestamp t = Timestamps.parse(timestampString);
+    Transaction txnMetadata = Transaction.newBuilder().setReadTimestamp(t).build();
+    Mockito.when(rpc.beginTransaction(Mockito.any(), Mockito.eq(options), eq(false)))
+        .thenReturn(txnMetadata);
     ArgumentCaptor<CommitRequest> commit = ArgumentCaptor.forClass(CommitRequest.class);
     CommitResponse response =
         CommitResponse.newBuilder().setCommitTimestamp(Timestamps.parse(timestampString)).build();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionImplTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -223,7 +224,7 @@ public class SessionImplTest {
     ArgumentCaptor<CommitRequest> commit = ArgumentCaptor.forClass(CommitRequest.class);
     CommitResponse response =
         CommitResponse.newBuilder().setCommitTimestamp(Timestamps.parse(timestampString)).build();
-    Mockito.when(rpc.commit(commit.capture(), Mockito.eq(options))).thenReturn(response);
+    Mockito.when(rpc.commit(commit.capture(), anyMap())).thenReturn(response);
 
     Timestamp timestamp =
         session.writeAtLeastOnce(
@@ -255,7 +256,7 @@ public class SessionImplTest {
     ArgumentCaptor<CommitRequest> commit = ArgumentCaptor.forClass(CommitRequest.class);
     CommitResponse response =
         CommitResponse.newBuilder().setCommitTimestamp(Timestamps.parse(timestampString)).build();
-    Mockito.when(rpc.commit(commit.capture(), Mockito.eq(options))).thenReturn(response);
+    Mockito.when(rpc.commit(commit.capture(), anyMap())).thenReturn(response);
     session.writeAtLeastOnceWithOptions(
         Collections.singletonList(Mutation.newInsertBuilder("T").set("C").to("x").build()),
         Options.tag(tag));
@@ -340,7 +341,7 @@ public class SessionImplTest {
   public void writeClosesOldSingleUseContext() throws ParseException {
     ReadContext ctx = session.singleUse(TimestampBound.strong());
 
-    Mockito.when(rpc.commit(Mockito.any(), Mockito.eq(options)))
+    Mockito.when(rpc.commit(Mockito.any(), anyMap()))
         .thenReturn(
             CommitResponse.newBuilder()
                 .setCommitTimestamp(Timestamps.parse("2015-10-01T10:54:20.021Z"))
@@ -441,7 +442,7 @@ public class SessionImplTest {
   private void mockRead(final PartialResultSet myResultSet) {
     final ArgumentCaptor<SpannerRpc.ResultStreamConsumer> consumer =
         ArgumentCaptor.forClass(SpannerRpc.ResultStreamConsumer.class);
-    Mockito.when(rpc.read(Mockito.any(), consumer.capture(), Mockito.eq(options), eq(false)))
+    Mockito.when(rpc.read(Mockito.any(), consumer.capture(), anyMap(), eq(false)))
         .then(
             invocation -> {
               consumer.getValue().onPartialResultSet(myResultSet);
@@ -457,8 +458,7 @@ public class SessionImplTest {
         PartialResultSet.newBuilder()
             .setMetadata(newMetadata(Type.struct(Type.StructField.of("C", Type.string()))))
             .build();
-    Mockito.when(rpc.beginTransaction(Mockito.any(), Mockito.eq(options), eq(false)))
-        .thenReturn(txnMetadata);
+    Mockito.when(rpc.beginTransaction(Mockito.any(), anyMap(), eq(false))).thenReturn(txnMetadata);
     mockRead(resultSet);
 
     ReadOnlyTransaction txn = session.readOnlyTransaction(TimestampBound.strong());
@@ -476,8 +476,7 @@ public class SessionImplTest {
         PartialResultSet.newBuilder()
             .setMetadata(newMetadata(Type.struct(Type.StructField.of("C", Type.string()))))
             .build();
-    Mockito.when(rpc.beginTransaction(Mockito.any(), Mockito.eq(options), eq(false)))
-        .thenReturn(txnMetadata);
+    Mockito.when(rpc.beginTransaction(Mockito.any(), anyMap(), eq(false))).thenReturn(txnMetadata);
     mockRead(resultSet);
 
     ReadOnlyTransaction txn = session.readOnlyTransaction(TimestampBound.strong());
@@ -496,8 +495,7 @@ public class SessionImplTest {
         PartialResultSet.newBuilder()
             .setMetadata(newMetadata(Type.struct(Type.StructField.of("C", Type.string()))))
             .build();
-    Mockito.when(rpc.beginTransaction(Mockito.any(), Mockito.eq(options), eq(false)))
-        .thenReturn(txnMetadata);
+    Mockito.when(rpc.beginTransaction(Mockito.any(), anyMap(), eq(false))).thenReturn(txnMetadata);
     mockRead(resultSet);
 
     ReadOnlyTransaction txn = session.readOnlyTransaction(TimestampBound.strong());

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -1644,13 +1644,13 @@ public class SessionPoolTest extends BaseSessionPoolTest {
         SpannerExceptionFactoryTest.newSessionNotFoundException(sessionName);
     List<Mutation> mutations = Collections.singletonList(Mutation.newInsertBuilder("FOO").build());
     final SessionImpl closedSession = mockSession();
-    when(closedSession.writeWithOptions(mutations)).thenThrow(sessionNotFound);
+    when(closedSession.writeWithOptions(eq(mutations), any())).thenThrow(sessionNotFound);
 
     final SessionImpl openSession = mockSession();
     com.google.cloud.spanner.CommitResponse response =
         mock(com.google.cloud.spanner.CommitResponse.class);
     when(response.getCommitTimestamp()).thenReturn(Timestamp.now());
-    when(openSession.writeWithOptions(mutations)).thenReturn(response);
+    when(openSession.writeWithOptions(eq(mutations), any())).thenReturn(response);
     doAnswer(
             invocation -> {
               executor.submit(
@@ -1687,13 +1687,14 @@ public class SessionPoolTest extends BaseSessionPoolTest {
         SpannerExceptionFactoryTest.newSessionNotFoundException(sessionName);
     List<Mutation> mutations = Collections.singletonList(Mutation.newInsertBuilder("FOO").build());
     final SessionImpl closedSession = mockSession();
-    when(closedSession.writeAtLeastOnceWithOptions(mutations)).thenThrow(sessionNotFound);
+    when(closedSession.writeAtLeastOnceWithOptions(eq(mutations), any()))
+        .thenThrow(sessionNotFound);
 
     final SessionImpl openSession = mockSession();
     com.google.cloud.spanner.CommitResponse response =
         mock(com.google.cloud.spanner.CommitResponse.class);
     when(response.getCommitTimestamp()).thenReturn(Timestamp.now());
-    when(openSession.writeAtLeastOnceWithOptions(mutations)).thenReturn(response);
+    when(openSession.writeAtLeastOnceWithOptions(eq(mutations), any())).thenReturn(response);
     doAnswer(
             invocation -> {
               executor.submit(
@@ -1729,10 +1730,10 @@ public class SessionPoolTest extends BaseSessionPoolTest {
         SpannerExceptionFactoryTest.newSessionNotFoundException(sessionName);
     Statement statement = Statement.of("UPDATE FOO SET BAR=1 WHERE 1=1");
     final SessionImpl closedSession = mockSession();
-    when(closedSession.executePartitionedUpdate(statement)).thenThrow(sessionNotFound);
+    when(closedSession.executePartitionedUpdate(eq(statement), any())).thenThrow(sessionNotFound);
 
     final SessionImpl openSession = mockSession();
-    when(openSession.executePartitionedUpdate(statement)).thenReturn(1L);
+    when(openSession.executePartitionedUpdate(eq(statement), any())).thenReturn(1L);
     doAnswer(
             invocation -> {
               executor.submit(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionPoolTest.java
@@ -1644,12 +1644,14 @@ public class SessionPoolTest extends BaseSessionPoolTest {
         SpannerExceptionFactoryTest.newSessionNotFoundException(sessionName);
     List<Mutation> mutations = Collections.singletonList(Mutation.newInsertBuilder("FOO").build());
     final SessionImpl closedSession = mockSession();
+    closedSession.setRequestIdCreator(new XGoogSpannerRequestId.NoopRequestIdCreator());
     when(closedSession.writeWithOptions(eq(mutations), any())).thenThrow(sessionNotFound);
 
     final SessionImpl openSession = mockSession();
     com.google.cloud.spanner.CommitResponse response =
         mock(com.google.cloud.spanner.CommitResponse.class);
     when(response.getCommitTimestamp()).thenReturn(Timestamp.now());
+    openSession.setRequestIdCreator(new XGoogSpannerRequestId.NoopRequestIdCreator());
     when(openSession.writeWithOptions(eq(mutations), any())).thenReturn(response);
     doAnswer(
             invocation -> {
@@ -1687,6 +1689,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
         SpannerExceptionFactoryTest.newSessionNotFoundException(sessionName);
     List<Mutation> mutations = Collections.singletonList(Mutation.newInsertBuilder("FOO").build());
     final SessionImpl closedSession = mockSession();
+    closedSession.setRequestIdCreator(new XGoogSpannerRequestId.NoopRequestIdCreator());
     when(closedSession.writeAtLeastOnceWithOptions(eq(mutations), any()))
         .thenThrow(sessionNotFound);
 
@@ -1694,6 +1697,7 @@ public class SessionPoolTest extends BaseSessionPoolTest {
     com.google.cloud.spanner.CommitResponse response =
         mock(com.google.cloud.spanner.CommitResponse.class);
     when(response.getCommitTimestamp()).thenReturn(Timestamp.now());
+    openSession.setRequestIdCreator(new XGoogSpannerRequestId.NoopRequestIdCreator());
     when(openSession.writeAtLeastOnceWithOptions(eq(mutations), any())).thenReturn(response);
     doAnswer(
             invocation -> {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
@@ -241,7 +241,7 @@ public class TransactionManagerImplTest {
             Mockito.anyString(),
             Mockito.anyString(),
             Mockito.anyMap(),
-            Mockito.eq(null),
+            Mockito.anyMap(),
             Mockito.eq(true)))
         .thenAnswer(
             invocation ->
@@ -324,7 +324,7 @@ public class TransactionManagerImplTest {
             Mockito.anyString(),
             Mockito.anyString(),
             Mockito.anyMap(),
-            Mockito.eq(null),
+            Mockito.anyMap(),
             Mockito.eq(true)))
         .thenAnswer(
             invocation ->

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
@@ -193,7 +193,7 @@ public class TransactionRunnerImplTest {
             Mockito.anyString(),
             Mockito.anyString(),
             Mockito.anyMap(),
-            Mockito.eq(null),
+            Mockito.anyMap(),
             Mockito.eq(true)))
         .thenAnswer(
             invocation ->

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/XGoogSpannerRequestIdTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/XGoogSpannerRequestIdTest.java
@@ -127,12 +127,34 @@ public class XGoogSpannerRequestIdTest {
     public void assertIntegrity() {
       this.unaryResults.forEach(
           (String method, CopyOnWriteArrayList<XGoogSpannerRequestId> values) -> {
-            XGoogSpannerRequestId.assertMonotonicityOfIds(method, values);
+            assertMonotonicityOfIds(method, values);
           });
       this.streamingResults.forEach(
           (String method, CopyOnWriteArrayList<XGoogSpannerRequestId> values) -> {
-            XGoogSpannerRequestId.assertMonotonicityOfIds(method, values);
+            assertMonotonicityOfIds(method, values);
           });
+    }
+
+    private void assertMonotonicityOfIds(String prefix, List<XGoogSpannerRequestId> reqIds) {
+      int size = reqIds.size();
+
+      List<String> violations = new ArrayList<>();
+      for (int i = 1; i < size; i++) {
+        XGoogSpannerRequestId prev = reqIds.get(i - 1);
+        XGoogSpannerRequestId curr = reqIds.get(i);
+        if (prev.isGreaterThan(curr)) {
+          violations.add(String.format("#%d(%s) > #%d(%s)", i - 1, prev, i, curr));
+        }
+      }
+
+      if (violations.isEmpty()) {
+        return;
+      }
+
+      throw new IllegalStateException(
+          prefix
+              + " monotonicity violation:"
+              + String.join("\n\t", violations.toArray(new String[0])));
     }
 
     public static class methodAndRequestId {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/XGoogSpannerRequestIdTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/XGoogSpannerRequestIdTest.java
@@ -18,18 +18,29 @@ package com.google.cloud.spanner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor.MethodType;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class XGoogSpannerRequestIdTest {
-  private static final Pattern REGEX_RAND_PROCESS_ID =
-      Pattern.compile("1.([0-9a-z]{16})(\\.\\d+){3}\\.(\\d+)$");
 
   @Test
   public void testEquals() {
@@ -48,7 +59,135 @@ public class XGoogSpannerRequestIdTest {
   @Test
   public void testEnsureHexadecimalFormatForRandProcessID() {
     String str = XGoogSpannerRequestId.of(1, 2, 3, 4).toString();
-    Matcher m = XGoogSpannerRequestIdTest.REGEX_RAND_PROCESS_ID.matcher(str);
+    Matcher m = XGoogSpannerRequestId.REGEX.matcher(str);
     assertTrue(m.matches());
+  }
+
+  public static class ServerHeaderEnforcer implements ServerInterceptor {
+    private Map<String, CopyOnWriteArrayList<XGoogSpannerRequestId>> unaryResults;
+    private Map<String, CopyOnWriteArrayList<XGoogSpannerRequestId>> streamingResults;
+    private List<String> gotValues;
+    private Set<String> checkMethods;
+
+    ServerHeaderEnforcer(Set<String> checkMethods) {
+      this.gotValues = new CopyOnWriteArrayList<String>();
+      this.unaryResults =
+          new ConcurrentHashMap<String, CopyOnWriteArrayList<XGoogSpannerRequestId>>();
+      this.streamingResults =
+          new ConcurrentHashMap<String, CopyOnWriteArrayList<XGoogSpannerRequestId>>();
+      this.checkMethods = checkMethods;
+    }
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+        ServerCall<ReqT, RespT> call,
+        final Metadata requestHeaders,
+        ServerCallHandler<ReqT, RespT> next) {
+      boolean isUnary = call.getMethodDescriptor().getType() == MethodType.UNARY;
+      String methodName = call.getMethodDescriptor().getFullMethodName();
+      String gotReqIdStr = requestHeaders.get(XGoogSpannerRequestId.REQUEST_HEADER_KEY);
+      if (!this.checkMethods.contains(methodName)) {
+        return next.startCall(call, requestHeaders);
+      }
+
+      Map<String, CopyOnWriteArrayList<XGoogSpannerRequestId>> saver = this.streamingResults;
+      if (isUnary) {
+        saver = this.unaryResults;
+      }
+
+      if (Objects.equals(gotReqIdStr, null) || Objects.equals(gotReqIdStr, "")) {
+        Status status =
+            Status.fromCode(Status.Code.INVALID_ARGUMENT)
+                .augmentDescription(
+                    methodName + " lacks " + XGoogSpannerRequestId.REQUEST_HEADER_KEY);
+        call.close(status, requestHeaders);
+        return next.startCall(call, requestHeaders);
+      }
+
+      assertNotNull(gotReqIdStr);
+      // Firstly assert and validate that at least we've got a requestId.
+      Matcher m = XGoogSpannerRequestId.REGEX.matcher(gotReqIdStr);
+      assertTrue(m.matches());
+
+      XGoogSpannerRequestId reqId = XGoogSpannerRequestId.of(gotReqIdStr);
+      if (!saver.containsKey(methodName)) {
+        saver.put(methodName, new CopyOnWriteArrayList<XGoogSpannerRequestId>());
+      }
+
+      saver.get(methodName).add(reqId);
+
+      // Finally proceed with the call.
+      return next.startCall(call, requestHeaders);
+    }
+
+    public String[] accumulatedValues() {
+      return this.gotValues.toArray(new String[0]);
+    }
+
+    public void assertIntegrity() {
+      this.unaryResults.forEach(
+          (String method, CopyOnWriteArrayList<XGoogSpannerRequestId> values) -> {
+            XGoogSpannerRequestId.assertMonotonicityOfIds(method, values);
+          });
+      this.streamingResults.forEach(
+          (String method, CopyOnWriteArrayList<XGoogSpannerRequestId> values) -> {
+            XGoogSpannerRequestId.assertMonotonicityOfIds(method, values);
+          });
+    }
+
+    public static class methodAndRequestId {
+      String method;
+      String requestId;
+
+      public methodAndRequestId(String method, String requestId) {
+        this.method = method;
+        this.requestId = requestId;
+      }
+
+      public String toString() {
+        return "{" + this.method + ":" + this.requestId + "}";
+      }
+    }
+
+    public methodAndRequestId[] accumulatedUnaryValues() {
+      List<methodAndRequestId> accumulated = new ArrayList();
+      this.unaryResults.forEach(
+          (String method, CopyOnWriteArrayList<XGoogSpannerRequestId> values) -> {
+            for (int i = 0; i < values.size(); i++) {
+              accumulated.add(new methodAndRequestId(method, values.get(i).toString()));
+            }
+          });
+      return accumulated.toArray(new methodAndRequestId[0]);
+    }
+
+    public methodAndRequestId[] accumulatedStreamingValues() {
+      List<methodAndRequestId> accumulated = new ArrayList();
+      this.streamingResults.forEach(
+          (String method, CopyOnWriteArrayList<XGoogSpannerRequestId> values) -> {
+            for (int i = 0; i < values.size(); i++) {
+              accumulated.add(new methodAndRequestId(method, values.get(i).toString()));
+            }
+          });
+      return accumulated.toArray(new methodAndRequestId[0]);
+    }
+
+    public void printAccumulatedValues() {
+      methodAndRequestId[] unary = this.accumulatedUnaryValues();
+      System.out.println("accumulatedUnaryvalues");
+      for (int i = 0; i < unary.length; i++) {
+        System.out.println("\t" + unary[i].toString());
+      }
+      methodAndRequestId[] streaming = this.accumulatedStreamingValues();
+      System.out.println("accumulatedStreaminvalues");
+      for (int i = 0; i < streaming.length; i++) {
+        System.out.println("\t" + streaming[i].toString());
+      }
+    }
+
+    public void reset() {
+      this.gotValues.clear();
+      this.unaryResults.clear();
+      this.streamingResults.clear();
+    }
   }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/XGoogSpannerRequestIdTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/XGoogSpannerRequestIdTest.java
@@ -171,19 +171,6 @@ public class XGoogSpannerRequestIdTest {
       return accumulated.toArray(new methodAndRequestId[0]);
     }
 
-    public void printAccumulatedValues() {
-      methodAndRequestId[] unary = this.accumulatedUnaryValues();
-      System.out.println("accumulatedUnaryvalues");
-      for (int i = 0; i < unary.length; i++) {
-        System.out.println("\t" + unary[i].toString());
-      }
-      methodAndRequestId[] streaming = this.accumulatedStreamingValues();
-      System.out.println("accumulatedStreaminvalues");
-      for (int i = 0; i < streaming.length; i++) {
-        System.out.println("\t" + streaming[i].toString());
-      }
-    }
-
     public void reset() {
       this.gotValues.clear();
       this.unaryResults.clear();


### PR DESCRIPTION
This change plumbs x-goog-spanner-request-id into BatchCreateSessions and asserts that the header is present for that method.

Updates #3537