### PR TITLE
chore: util method for creating statement with params

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Statement.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Statement.java
@@ -144,6 +144,11 @@ public final class Statement implements Serializable {
     return new Statement(sql, ImmutableMap.of(), /*queryOptions=*/ null);
   }
 
+  /** Creates a {@link Statement} with the given SQL text and parameters. */
+  public static Statement of(String sql, ImmutableMap<String, Value> parameters) {
+    return new Statement(sql, parameters, /*queryOptions=*/ null);
+  }
+
   /** Creates a new statement builder with the SQL text {@code sql}. */
   public static Builder newBuilder(String sql) {
     return new Builder(sql);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/StatementTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/StatementTest.java
@@ -18,6 +18,8 @@ package com.google.cloud.spanner;
 
 import static com.google.common.testing.SerializableTester.reserializeAndAssert;
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
@@ -39,6 +41,17 @@ public class StatementTest {
     assertThat(stmt.getSql()).isEqualTo(sql);
     assertThat(stmt.getParameters()).isEmpty();
     assertThat(stmt.toString()).isEqualTo(sql);
+    reserializeAndAssert(stmt);
+  }
+
+  @Test
+  public void basicWithParameters() {
+    String sql = "SELECT @name";
+    Statement stmt = Statement.of(sql, ImmutableMap.of("name", Value.string("hello")));
+    assertEquals(sql, stmt.getSql());
+    assertFalse(stmt.getParameters().isEmpty());
+    assertEquals(Value.string("hello"), stmt.getParameters().get("name"));
+    assertEquals(sql + " {name: hello}", stmt.toString());
     reserializeAndAssert(stmt);
   }
 


### PR DESCRIPTION
Currently, statements with parameters can only be created through a Statement.Builder. This has the disadvantage that Statement.Builder uses a StringBuilder internally, which means that each time Statement.newBuilder() is called, a new StringBuilder with the initial SQL statement is created. Later, when the statement is built, the contents of the StringBuilder are copied into a new string. This is efficient for statements that are built with multiple SQL fragements that are appended together. It is however inefficient for statements that are created with a fixed SQL string.

This change therefore adds an additional util method to directly create a Statement from a string and an immutable map of parameters. Calling this method directly does not invoke any internal copy methods, and is more efficient for clients that have both the SQL string and the parameters readily available. This method will be used by PGAdapter, that does have this information available directly.
