### PR TITLE
feat: support option for setting client_id while creating Spanner DatabaseClient

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Spanner.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Spanner.java
@@ -125,6 +125,29 @@ public interface Spanner extends Service<SpannerOptions>, AutoCloseable {
    */
   DatabaseClient getDatabaseClient(DatabaseId db);
 
+
+  /**
+   * Returns a {@code DatabaseClient} for the given database and given client id. It uses a pool of sessions to talk to
+   * the database.
+   * <!--SNIPPET get_db_client-->
+   *
+   * <pre>{@code
+   * SpannerOptions options = SpannerOptions.newBuilder().build();
+   * Spanner spanner = options.getService();
+   * final String project = "test-project";
+   * final String instance = "test-instance";
+   * final String database = "example-db";
+   * final String client_id = "client_id"
+   * DatabaseId db =
+   *     DatabaseId.of(project, instance, database);
+   *
+   * DatabaseClient dbClient = spanner.getDatabaseClient(db, client_id);
+   * }</pre>
+   *
+   * <!--SNIPPET get_db_client-->
+   */
+  DatabaseClient getDatabaseClient(DatabaseId db, String clientId);
+
   /**
    * Returns a {@code BatchClient} to do batch operations on Cloud Spanner databases. Batch client
    * is useful when one wants to read/query a large amount of data from Cloud Spanner across

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Spanner.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Spanner.java
@@ -125,10 +125,9 @@ public interface Spanner extends Service<SpannerOptions>, AutoCloseable {
    */
   DatabaseClient getDatabaseClient(DatabaseId db);
 
-
   /**
-   * Returns a {@code DatabaseClient} for the given database and given client id. It uses a pool of sessions to talk to
-   * the database.
+   * Returns a {@code DatabaseClient} for the given database and given client id. It uses a pool of
+   * sessions to talk to the database.
    * <!--SNIPPET get_db_client-->
    *
    * <pre>{@code

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
@@ -254,9 +254,12 @@ class SpannerImpl extends BaseService<SpannerOptions> implements Spanner {
 
   @Override
   public DatabaseClient getDatabaseClient(DatabaseId db) {
+    return getDatabaseClient(db, null);
+  }
+
+  public DatabaseClient getDatabaseClient(DatabaseId db, String clientId) {
     synchronized (this) {
       checkClosed();
-      String clientId = null;
       if (dbClients.containsKey(db) && !dbClients.get(db).isValid()) {
         // Close the invalidated client and remove it.
         dbClients.get(db).closeAsync(new ClosedException());

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
@@ -108,7 +108,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
@@ -254,8 +253,7 @@ class ConnectionImpl implements Connection {
     }
   }
 
-  private StatementTimeout statementTimeout =
-      new StatementTimeout();
+  private StatementTimeout statementTimeout = new StatementTimeout();
   private boolean closed = false;
 
   private final Spanner spanner;
@@ -330,14 +328,15 @@ class ConnectionImpl implements Connection {
     final DatabaseId databaseId = options.getDatabaseId();
     try {
       Optional<String> clientIdOpt = extractClientIdOptional(options);
-      if(clientIdOpt.isPresent()) {
+      if (clientIdOpt.isPresent()) {
         tempDbClient = spanner.getDatabaseClient(databaseId, clientIdOpt.get());
       }
-    } catch(Exception e) {
-      System.err.println("WARNING: Failed during DatabaseClient initialization (possibly getting specific ID), falling back to default. Error: "
-          + e.getMessage());
+    } catch (Exception e) {
+      System.err.println(
+          "WARNING: Failed during DatabaseClient initialization (possibly getting specific ID), falling back to default. Error: "
+              + e.getMessage());
     }
-    if(tempDbClient == null) {
+    if (tempDbClient == null) {
       tempDbClient = spanner.getDatabaseClient(databaseId);
     }
     this.dbClient = tempDbClient;
@@ -566,8 +565,7 @@ class ConnectionImpl implements Connection {
     return closed;
   }
 
-  private <T> T getConnectionPropertyValue(
-      ConnectionProperty<T> property) {
+  private <T> T getConnectionPropertyValue(ConnectionProperty<T> property) {
     return this.connectionState.getValue(property).getValue();
   }
 
@@ -587,9 +585,8 @@ class ConnectionImpl implements Connection {
   /**
    * Sets a connection property value only for the duration of the current transaction. The effects
    * of this will be undone once the transaction ends, regardless whether the transaction is
-   * committed or rolled back. 'Local' properties are supported for both {@link
-   * Type#TRANSACTIONAL} and {@link
-   * Type#NON_TRANSACTIONAL} connection states.
+   * committed or rolled back. 'Local' properties are supported for both {@link Type#TRANSACTIONAL}
+   * and {@link Type#NON_TRANSACTIONAL} connection states.
    *
    * <p>NOTE: This feature is not yet exposed in the public API.
    */

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionImpl.java
@@ -340,6 +340,9 @@ class ConnectionImpl implements Connection {
         if (clientIdString != null && !clientIdString.isEmpty()) {
           tempDbClient = spanner.getDatabaseClient(options.getDatabaseId(), clientIdString);
         }
+        else {
+          tempDbClient = spanner.getDatabaseClient(options.getDatabaseId());
+        }
       } else {
         tempDbClient = spanner.getDatabaseClient(options.getDatabaseId());
       }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
@@ -46,6 +46,7 @@ import static com.google.cloud.spanner.connection.ConnectionProperties.RETRY_ABO
 import static com.google.cloud.spanner.connection.ConnectionProperties.RETURN_COMMIT_STATS;
 import static com.google.cloud.spanner.connection.ConnectionProperties.ROUTE_TO_LEADER;
 import static com.google.cloud.spanner.connection.ConnectionProperties.TRACING_PREFIX;
+import static com.google.cloud.spanner.connection.ConnectionProperties.CLIENT_ID;
 import static com.google.cloud.spanner.connection.ConnectionProperties.TRACK_CONNECTION_LEAKS;
 import static com.google.cloud.spanner.connection.ConnectionProperties.TRACK_SESSION_LEAKS;
 import static com.google.cloud.spanner.connection.ConnectionProperties.USER_AGENT;
@@ -539,6 +540,11 @@ public class ConnectionOptions {
       return this;
     }
 
+    public Builder setClientId(String clientId) {
+      setConnectionPropertyValue(CLIENT_ID, clientId);
+      return this;
+    }
+
     /** @return the {@link ConnectionOptions} */
     public ConnectionOptions build() {
       Preconditions.checkState(this.uri != null, "Connection URI is required");
@@ -603,7 +609,6 @@ public class ConnectionOptions {
 
     // Create the initial connection state from the parsed properties in the connection URL.
     this.initialConnectionState = new ConnectionState(connectionPropertyValues);
-
     // Check that at most one of credentials location, encoded credentials, credentials provider and
     // OUAuth token has been specified in the connection URI.
     Preconditions.checkArgument(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
@@ -21,6 +21,7 @@ import static com.google.cloud.spanner.connection.ConnectionProperties.AUTO_CONF
 import static com.google.cloud.spanner.connection.ConnectionProperties.AUTO_PARTITION_MODE;
 import static com.google.cloud.spanner.connection.ConnectionProperties.CHANNEL_PROVIDER;
 import static com.google.cloud.spanner.connection.ConnectionProperties.CLIENT_CERTIFICATE;
+import static com.google.cloud.spanner.connection.ConnectionProperties.CLIENT_ID;
 import static com.google.cloud.spanner.connection.ConnectionProperties.CLIENT_KEY;
 import static com.google.cloud.spanner.connection.ConnectionProperties.CREDENTIALS_PROVIDER;
 import static com.google.cloud.spanner.connection.ConnectionProperties.CREDENTIALS_URL;
@@ -46,7 +47,6 @@ import static com.google.cloud.spanner.connection.ConnectionProperties.RETRY_ABO
 import static com.google.cloud.spanner.connection.ConnectionProperties.RETURN_COMMIT_STATS;
 import static com.google.cloud.spanner.connection.ConnectionProperties.ROUTE_TO_LEADER;
 import static com.google.cloud.spanner.connection.ConnectionProperties.TRACING_PREFIX;
-import static com.google.cloud.spanner.connection.ConnectionProperties.CLIENT_ID;
 import static com.google.cloud.spanner.connection.ConnectionProperties.TRACK_CONNECTION_LEAKS;
 import static com.google.cloud.spanner.connection.ConnectionProperties.TRACK_SESSION_LEAKS;
 import static com.google.cloud.spanner.connection.ConnectionProperties.USER_AGENT;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java
@@ -135,6 +135,14 @@ public class ConnectionProperties {
 
   private static final Boolean[] BOOLEANS = new Boolean[] {Boolean.TRUE, Boolean.FALSE};
 
+  static final ConnectionProperty<String> CLIENT_ID =
+      create(
+          "client_id",
+          "Client Id to use for this connection. Can only be set at the start up time",
+          null,
+          StringValueConverter.INSTANCE,
+          Context.STARTUP);
+
   static final ConnectionProperty<ConnectionState.Type> CONNECTION_STATE_TYPE =
       create(
           "connection_state_type",

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerImplTest.java
@@ -358,6 +358,40 @@ public class SpannerImplTest {
     assertNotNull(instanceAdminClient);
   }
 
+  @Test
+  public void testGetDatabaseClient_when_clientId_is_not_null() {
+    String dbName =
+        String.format("projects/p1/instances/i1/databases/%s", UUID.randomUUID().toString());
+    DatabaseId db = DatabaseId.of(dbName);
+
+    Mockito.when(spannerOptions.getTransportOptions())
+        .thenReturn(GrpcTransportOptions.newBuilder().build());
+    Mockito.when(spannerOptions.getSessionPoolOptions())
+        .thenReturn(SessionPoolOptions.newBuilder().setMinSessions(0).build());
+    Mockito.when(spannerOptions.getDatabaseRole()).thenReturn("role");
+
+    DatabaseClientImpl databaseClient = (DatabaseClientImpl) impl.getDatabaseClient(db, "clientId-1");
+    assertThat(databaseClient.clientId).isEqualTo("clientId-1");
+
+    // Get same db client again.
+    DatabaseClientImpl databaseClient1 = (DatabaseClientImpl) impl.getDatabaseClient(db, "clientId-1");
+    assertThat(databaseClient1.clientId).isEqualTo(databaseClient.clientId);
+
+    // Get a db client for a different database.
+    String dbName2 =
+        String.format("projects/p1/instances/i1/databases/%s", UUID.randomUUID().toString());
+    DatabaseId db2 = DatabaseId.of(dbName2);
+    DatabaseClientImpl databaseClient2 = (DatabaseClientImpl) impl.getDatabaseClient(db2, "clientId-1");
+    assertThat(databaseClient2.clientId).isEqualTo("clientId-1");
+
+    // Getting a new database client for an invalidated database should use the same client id.
+    databaseClient.pool.setResourceNotFoundException(
+        new DatabaseNotFoundException(DoNotConstructDirectly.ALLOWED, "not found", null, null));
+    DatabaseClientImpl revalidated = (DatabaseClientImpl) impl.getDatabaseClient(db, "clientId-1");
+    assertThat(revalidated).isNotSameInstanceAs(databaseClient);
+    assertThat(revalidated.clientId).isEqualTo(databaseClient.clientId);
+  }
+
   private void closeSpannerAndIncludeStacktrace(Spanner spanner) {
     spanner.close();
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerImplTest.java
@@ -370,18 +370,21 @@ public class SpannerImplTest {
         .thenReturn(SessionPoolOptions.newBuilder().setMinSessions(0).build());
     Mockito.when(spannerOptions.getDatabaseRole()).thenReturn("role");
 
-    DatabaseClientImpl databaseClient = (DatabaseClientImpl) impl.getDatabaseClient(db, "clientId-1");
+    DatabaseClientImpl databaseClient =
+        (DatabaseClientImpl) impl.getDatabaseClient(db, "clientId-1");
     assertThat(databaseClient.clientId).isEqualTo("clientId-1");
 
     // Get same db client again.
-    DatabaseClientImpl databaseClient1 = (DatabaseClientImpl) impl.getDatabaseClient(db, "clientId-1");
+    DatabaseClientImpl databaseClient1 =
+        (DatabaseClientImpl) impl.getDatabaseClient(db, "clientId-1");
     assertThat(databaseClient1.clientId).isEqualTo(databaseClient.clientId);
 
     // Get a db client for a different database.
     String dbName2 =
         String.format("projects/p1/instances/i1/databases/%s", UUID.randomUUID().toString());
     DatabaseId db2 = DatabaseId.of(dbName2);
-    DatabaseClientImpl databaseClient2 = (DatabaseClientImpl) impl.getDatabaseClient(db2, "clientId-1");
+    DatabaseClientImpl databaseClient2 =
+        (DatabaseClientImpl) impl.getDatabaseClient(db2, "clientId-1");
     assertThat(databaseClient2.clientId).isEqualTo("clientId-1");
 
     // Getting a new database client for an invalidated database should use the same client id.


### PR DESCRIPTION
Fixes #1856.

**Summary:**

This PR adds support for specifying an optional `clientId` when creating a Spanner `DatabaseClient`. This allows client applications (including JDBC connections using the `;client_id=` property) to identify themselves to the Spanner service, primarily for enhanced monitoring and logging capabilities.

**Implementation:**

* Added the `getDatabaseClient(DatabaseId db, String clientId)` overload to the `Spanner` interface.
* Modified connection setup logic to parse and utilize the `clientId` when obtaining the `DatabaseClient`.

**Testing:**

* All unit tests pass (`mvn test`).