### PR TITLE
fix: change server timing duration attribute to float as per w3c

### DIFF
--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -349,6 +349,20 @@
     <method>com.google.cloud.spanner.spi.v1.SpannerRpc$StreamingCall executeQuery(com.google.spanner.v1.ExecuteSqlRequest, com.google.cloud.spanner.spi.v1.SpannerRpc$ResultStreamConsumer, java.util.Map)</method>
     <to>com.google.cloud.spanner.spi.v1.SpannerRpc$StreamingCall executeQuery(com.google.spanner.v1.ExecuteSqlRequest, java.util.Map, boolean)</to>
   </difference>
+  <!-- (CompositeTracer is an internal API) -->
+  <difference>
+    <differenceType>7005</differenceType>
+    <className>com/google/cloud/spanner/CompositeTracer$CompositeTracer</className>
+    <method>void recordGFELatency(java.lang.Long)</method>
+    <to>void recordGFELatency(java.lang.Float)</to>
+  </difference>
+  <!-- (CompositeTracer is an internal API) -->
+  <difference>
+    <differenceType>7005</differenceType>
+    <className>com/google/cloud/spanner/CompositeTracer$CompositeTracer</className>
+    <method>void recordAFELatency(java.lang.Long)</method>
+    <to>void recordAFELatency(java.lang.Float)</to>
+  </difference>
   <difference>
     <differenceType>7006</differenceType>
     <className>com/google/cloud/spanner/spi/v1/GapicSpannerRpc</className>

--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -349,20 +349,6 @@
     <method>com.google.cloud.spanner.spi.v1.SpannerRpc$StreamingCall executeQuery(com.google.spanner.v1.ExecuteSqlRequest, com.google.cloud.spanner.spi.v1.SpannerRpc$ResultStreamConsumer, java.util.Map)</method>
     <to>com.google.cloud.spanner.spi.v1.SpannerRpc$StreamingCall executeQuery(com.google.spanner.v1.ExecuteSqlRequest, java.util.Map, boolean)</to>
   </difference>
-  <!-- (CompositeTracer is an internal API) -->
-  <difference>
-    <differenceType>7005</differenceType>
-    <className>com/google/cloud/spanner/CompositeTracer$CompositeTracer</className>
-    <method>void recordGFELatency(java.lang.Long)</method>
-    <to>void recordGFELatency(java.lang.Float)</to>
-  </difference>
-  <!-- (CompositeTracer is an internal API) -->
-  <difference>
-    <differenceType>7005</differenceType>
-    <className>com/google/cloud/spanner/CompositeTracer$CompositeTracer</className>
-    <method>void recordAFELatency(java.lang.Long)</method>
-    <to>void recordAFELatency(java.lang.Float)</to>
-  </difference>
   <difference>
     <differenceType>7006</differenceType>
     <className>com/google/cloud/spanner/spi/v1/GapicSpannerRpc</className>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsRecorder.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsRecorder.java
@@ -97,8 +97,8 @@ class BuiltInMetricsRecorder extends OpenTelemetryMetricsRecorder {
    * @param attributes Map of the attributes to store
    */
   void recordServerTimingHeaderMetrics(
-      Long gfeLatency,
-      Long afeLatency,
+      Float gfeLatency,
+      Float afeLatency,
       Long gfeHeaderMissingCount,
       Long afeHeaderMissingCount,
       Map<String, String> attributes) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsTracer.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsTracer.java
@@ -37,8 +37,8 @@ class BuiltInMetricsTracer extends MetricsTracer implements ApiTracer {
   private final BuiltInMetricsRecorder builtInOpenTelemetryMetricsRecorder;
   // These are RPC specific attributes and pertain to a specific API Trace
   private final Map<String, String> attributes = new HashMap<>();
-  private Long gfeLatency = null;
-  private Long afeLatency = null;
+  private Float gfeLatency = null;
+  private Float afeLatency = null;
   private long gfeHeaderMissingCount = 0;
   private long afeHeaderMissingCount = 0;
 
@@ -119,11 +119,11 @@ class BuiltInMetricsTracer extends MetricsTracer implements ApiTracer {
         gfeLatency, afeLatency, gfeHeaderMissingCount, afeHeaderMissingCount, attributes);
   }
 
-  void recordGFELatency(Long gfeLatency) {
+  void recordGFELatency(Float gfeLatency) {
     this.gfeLatency = gfeLatency;
   }
 
-  void recordAFELatency(Long afeLatency) {
+  void recordAFELatency(Float afeLatency) {
     this.afeLatency = afeLatency;
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/CompositeTracer.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/CompositeTracer.java
@@ -191,7 +191,6 @@ public class CompositeTracer extends BaseApiTracer {
     }
   }
 
-  @Deprecated
   public void recordGFELatency(Long gfeLatency) {
     for (ApiTracer child : children) {
       if (child instanceof BuiltInMetricsTracer) {
@@ -208,7 +207,6 @@ public class CompositeTracer extends BaseApiTracer {
     }
   }
 
-  @Deprecated
   public void recordAFELatency(Long afeLatency) {
     for (ApiTracer child : children) {
       if (child instanceof BuiltInMetricsTracer) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/CompositeTracer.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/CompositeTracer.java
@@ -191,7 +191,7 @@ public class CompositeTracer extends BaseApiTracer {
     }
   }
 
-  public void recordGFELatency(Long gfeLatency) {
+  public void recordGFELatency(Float gfeLatency) {
     for (ApiTracer child : children) {
       if (child instanceof BuiltInMetricsTracer) {
         ((BuiltInMetricsTracer) child).recordGFELatency(gfeLatency);
@@ -207,7 +207,7 @@ public class CompositeTracer extends BaseApiTracer {
     }
   }
 
-  public void recordAFELatency(Long afeLatency) {
+  public void recordAFELatency(Float afeLatency) {
     for (ApiTracer child : children) {
       if (child instanceof BuiltInMetricsTracer) {
         ((BuiltInMetricsTracer) child).recordAFELatency(afeLatency);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/CompositeTracer.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/CompositeTracer.java
@@ -191,10 +191,11 @@ public class CompositeTracer extends BaseApiTracer {
     }
   }
 
-  public void recordGFELatency(Float gfeLatency) {
+  @Deprecated
+  public void recordGFELatency(Long gfeLatency) {
     for (ApiTracer child : children) {
       if (child instanceof BuiltInMetricsTracer) {
-        ((BuiltInMetricsTracer) child).recordGFELatency(gfeLatency);
+        ((BuiltInMetricsTracer) child).recordGFELatency(Float.valueOf(gfeLatency));
       }
     }
   }
@@ -207,10 +208,11 @@ public class CompositeTracer extends BaseApiTracer {
     }
   }
 
-  public void recordAFELatency(Float afeLatency) {
+  @Deprecated
+  public void recordAFELatency(Long afeLatency) {
     for (ApiTracer child : children) {
       if (child instanceof BuiltInMetricsTracer) {
-        ((BuiltInMetricsTracer) child).recordAFELatency(afeLatency);
+        ((BuiltInMetricsTracer) child).recordAFELatency(Float.valueOf(afeLatency));
       }
     }
   }
@@ -219,6 +221,22 @@ public class CompositeTracer extends BaseApiTracer {
     for (ApiTracer child : children) {
       if (child instanceof BuiltInMetricsTracer) {
         ((BuiltInMetricsTracer) child).recordAfeHeaderMissingCount(value);
+      }
+    }
+  }
+
+  public void recordGFELatency(Float gfeLatency) {
+    for (ApiTracer child : children) {
+      if (child instanceof BuiltInMetricsTracer) {
+        ((BuiltInMetricsTracer) child).recordGFELatency(gfeLatency);
+      }
+    }
+  }
+
+  public void recordAFELatency(Float afeLatency) {
+    for (ApiTracer child : children) {
+      if (child instanceof BuiltInMetricsTracer) {
+        ((BuiltInMetricsTracer) child).recordAFELatency(afeLatency);
       }
     }
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/HeaderInterceptor.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/HeaderInterceptor.java
@@ -76,7 +76,7 @@ class HeaderInterceptor implements ClientInterceptor {
   private static final Metadata.Key<String> GOOGLE_CLOUD_RESOURCE_PREFIX_KEY =
       Metadata.Key.of("google-cloud-resource-prefix", Metadata.ASCII_STRING_MARSHALLER);
   private static final Pattern SERVER_TIMING_PATTERN =
-      Pattern.compile("(?<metricName>[a-zA-Z0-9_-]+);\\s*dur=(?<duration>\\d+)");
+      Pattern.compile("(?<metricName>[a-zA-Z0-9_-]+);\\s*dur=(?<duration>\\d+(\\.\\d+)?)");
   private static final Pattern GOOGLE_CLOUD_RESOURCE_PREFIX_PATTERN =
       Pattern.compile(
           ".*projects/(?<project>\\p{ASCII}[^/]*)(/instances/(?<instance>\\p{ASCII}[^/]*))?(/databases/(?<database>\\p{ASCII}[^/]*))?");
@@ -162,15 +162,15 @@ class HeaderInterceptor implements ClientInterceptor {
       // would fail to parse it correctly. To make the parsing more robust, the logic has been
       // updated to handle multiple metrics gracefully.
 
-      Map<String, Long> serverTimingMetrics = parseServerTimingHeader(serverTiming);
+      Map<String, Float> serverTimingMetrics = parseServerTimingHeader(serverTiming);
       if (serverTimingMetrics.containsKey(GFE_TIMING_HEADER)) {
-        long gfeLatency = serverTimingMetrics.get(GFE_TIMING_HEADER);
+        float gfeLatency = serverTimingMetrics.get(GFE_TIMING_HEADER);
 
-        measureMap.put(SPANNER_GFE_LATENCY, gfeLatency);
+        measureMap.put(SPANNER_GFE_LATENCY, (long) gfeLatency);
         measureMap.put(SPANNER_GFE_HEADER_MISSING_COUNT, 0L);
         measureMap.record(tagContext);
 
-        spannerRpcMetrics.recordGfeLatency(gfeLatency, attributes);
+        spannerRpcMetrics.recordGfeLatency((long) gfeLatency, attributes);
         spannerRpcMetrics.recordGfeHeaderMissingCount(0L, attributes);
         if (compositeTracer != null) {
           compositeTracer.recordGFELatency(gfeLatency);
@@ -189,7 +189,7 @@ class HeaderInterceptor implements ClientInterceptor {
       // Record AFE metrics
       if (compositeTracer != null && GapicSpannerRpc.isEnableAFEServerTiming()) {
         if (serverTimingMetrics.containsKey(AFE_TIMING_HEADER)) {
-          long afeLatency = serverTimingMetrics.get(AFE_TIMING_HEADER);
+          float afeLatency = serverTimingMetrics.get(AFE_TIMING_HEADER);
           compositeTracer.recordAFELatency(afeLatency);
         } else {
           compositeTracer.recordAfeHeaderMissingCount(1L);
@@ -200,8 +200,8 @@ class HeaderInterceptor implements ClientInterceptor {
     }
   }
 
-  private Map<String, Long> parseServerTimingHeader(String serverTiming) {
-    Map<String, Long> serverTimingMetrics = new HashMap<>();
+  private Map<String, Float> parseServerTimingHeader(String serverTiming) {
+    Map<String, Float> serverTimingMetrics = new HashMap<>();
     if (serverTiming != null) {
       Matcher matcher = SERVER_TIMING_PATTERN.matcher(serverTiming);
       while (matcher.find()) {
@@ -209,7 +209,7 @@ class HeaderInterceptor implements ClientInterceptor {
         String durationStr = matcher.group("duration");
 
         if (metricName != null && durationStr != null) {
-          serverTimingMetrics.put(metricName, Long.valueOf(durationStr));
+          serverTimingMetrics.put(metricName, Float.valueOf(durationStr));
         }
       }
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractNettyMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractNettyMockServerTest.java
@@ -31,7 +31,7 @@ import java.net.InetSocketAddress;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -44,11 +44,10 @@ abstract class AbstractNettyMockServerTest {
   protected static InetSocketAddress address;
   static ExecutorService executor;
   protected static LocalChannelProvider channelProvider;
-  protected static AtomicInteger fakeServerTiming =
-      new AtomicInteger(new Random().nextInt(1000) + 1);
-
-  protected static AtomicInteger fakeAFEServerTiming =
-      new AtomicInteger(new Random().nextInt(500) + 1);
+  protected static final AtomicReference<Float> fakeServerTiming =
+      new AtomicReference<>((float) (new Random().nextDouble() * 1000) + 1);
+  protected static final AtomicReference<Float> fakeAFEServerTiming =
+      new AtomicReference<>((float) new Random().nextInt(500) + 1);
 
   protected Spanner spanner;
 
@@ -76,7 +75,7 @@ abstract class AbstractNettyMockServerTest {
                             headers.put(
                                 Metadata.Key.of("server-timing", Metadata.ASCII_STRING_MARSHALLER),
                                 String.format(
-                                    "afe; dur=%d, gfet4t7; dur=%d",
+                                    "afe; dur=%f, gfet4t7; dur=%f",
                                     fakeAFEServerTiming.get(), fakeServerTiming.get()));
                             super.sendHeaders(headers);
                           }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
@@ -84,7 +84,7 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
       Attributes.builder().put(BuiltInMetricsConstant.DIRECT_PATH_USED_KEY, "false").build();
   ;
 
-  private static final long MIN_LATENCY = 0;
+  private static final double MIN_LATENCY = 0;
 
   private DatabaseClient client;
 
@@ -159,7 +159,7 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
       assertFalse(resultSet.next());
     }
 
-    long elapsed = stopwatch.elapsed(TimeUnit.MILLISECONDS);
+    double elapsed = stopwatch.elapsed(TimeUnit.MILLISECONDS);
     Attributes expectedAttributes =
         expectedCommonBaseAttributes.toBuilder()
             .putAll(expectedCommonRequestAttributes)
@@ -170,13 +170,14 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
     MetricData operationLatencyMetricData =
         getMetricData(metricReader, BuiltInMetricsConstant.OPERATION_LATENCIES_NAME);
     assertNotNull(operationLatencyMetricData);
-    long operationLatencyValue = getAggregatedValue(operationLatencyMetricData, expectedAttributes);
+    double operationLatencyValue =
+        getAggregatedValue(operationLatencyMetricData, expectedAttributes);
     assertThat(operationLatencyValue).isIn(Range.closed(MIN_LATENCY, elapsed));
 
     MetricData attemptLatencyMetricData =
         getMetricData(metricReader, BuiltInMetricsConstant.ATTEMPT_LATENCIES_NAME);
     assertNotNull(attemptLatencyMetricData);
-    long attemptLatencyValue = getAggregatedValue(attemptLatencyMetricData, expectedAttributes);
+    double attemptLatencyValue = getAggregatedValue(attemptLatencyMetricData, expectedAttributes);
     assertThat(attemptLatencyValue).isIn(Range.closed(MIN_LATENCY, elapsed));
 
     MetricData operationCountMetricData =
@@ -191,7 +192,7 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
 
     MetricData gfeLatencyMetricData =
         getMetricData(metricReader, BuiltInMetricsConstant.GFE_LATENCIES_NAME);
-    long gfeLatencyValue = getAggregatedValue(gfeLatencyMetricData, expectedAttributes);
+    double gfeLatencyValue = getAggregatedValue(gfeLatencyMetricData, expectedAttributes);
     assertEquals(fakeServerTiming.get(), gfeLatencyValue, 0);
 
     assertFalse(
@@ -229,7 +230,7 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
         assertFalse(resultSet.next());
       }
 
-      long elapsed = stopwatch.elapsed(TimeUnit.MILLISECONDS);
+      double elapsed = stopwatch.elapsed(TimeUnit.MILLISECONDS);
       Attributes expectedAttributes =
           expectedCommonBaseAttributes.toBuilder()
               .putAll(expectedCommonRequestAttributes)
@@ -240,14 +241,14 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
       MetricData operationLatencyMetricData =
           getMetricData(metricReader, BuiltInMetricsConstant.OPERATION_LATENCIES_NAME);
       assertNotNull(operationLatencyMetricData);
-      long operationLatencyValue =
+      double operationLatencyValue =
           getAggregatedValue(operationLatencyMetricData, expectedAttributes);
       assertThat(operationLatencyValue).isIn(Range.closed(MIN_LATENCY, elapsed));
 
       MetricData attemptLatencyMetricData =
           getMetricData(metricReader, BuiltInMetricsConstant.ATTEMPT_LATENCIES_NAME);
       assertNotNull(attemptLatencyMetricData);
-      long attemptLatencyValue = getAggregatedValue(attemptLatencyMetricData, expectedAttributes);
+      double attemptLatencyValue = getAggregatedValue(attemptLatencyMetricData, expectedAttributes);
       assertThat(attemptLatencyValue).isIn(Range.closed(MIN_LATENCY, elapsed));
 
       MetricData operationCountMetricData =
@@ -262,7 +263,7 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
 
       MetricData gfeLatencyMetricData =
           getMetricData(metricReader, BuiltInMetricsConstant.GFE_LATENCIES_NAME);
-      long gfeLatencyValue = getAggregatedValue(gfeLatencyMetricData, expectedAttributes);
+      double gfeLatencyValue = getAggregatedValue(gfeLatencyMetricData, expectedAttributes);
       assertEquals(fakeServerTiming.get(), gfeLatencyValue, 0);
 
       assertFalse(
@@ -270,7 +271,7 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
 
       MetricData afeLatencyMetricData =
           getMetricData(metricReader, BuiltInMetricsConstant.AFE_LATENCIES_NAME);
-      long afeLatencyValue = getAggregatedValue(afeLatencyMetricData, expectedAttributes);
+      double afeLatencyValue = getAggregatedValue(afeLatencyMetricData, expectedAttributes);
       assertEquals(fakeAFEServerTiming.get(), afeLatencyValue, 0);
       assertFalse(
           checkIfMetricExists(metricReader, BuiltInMetricsConstant.AFE_CONNECTIVITY_ERROR_NAME));
@@ -402,7 +403,7 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
 
     // Attempt count should have a failed metric point for CreateSession.
     assertEquals(
-        1, getAggregatedValue(attemptCountMetricData, expectedAttributesCreateSessionFailed));
+        1, getAggregatedValue(attemptCountMetricData, expectedAttributesCreateSessionFailed), 0);
   }
 
   @Test
@@ -509,14 +510,14 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
     return false;
   }
 
-  private long getAggregatedValue(MetricData metricData, Attributes attributes) {
+  private float getAggregatedValue(MetricData metricData, Attributes attributes) {
     switch (metricData.getType()) {
       case HISTOGRAM:
         return metricData.getHistogramData().getPoints().stream()
             .filter(pd -> pd.getAttributes().equals(attributes))
-            .map(data -> (long) data.getSum() / data.getCount())
+            .map(data -> (float) data.getSum() / data.getCount())
             .findFirst()
-            .orElse(0L);
+            .orElse(0F);
       case LONG_SUM:
         return metricData.getLongSumData().getPoints().stream()
             .filter(pd -> pd.getAttributes().equals(attributes))


### PR DESCRIPTION
Currently the Java implementation only parses the [integer part](https://github.com/googleapis/java-spanner/blob/32b2373d62cac3047d9686c56af278c706d7c488/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/HeaderInterceptor.java#L79).

According to the w3c standard, this should be a float (https://www.w3.org/TR/server-timing/#duration-attribute).