### PR TITLE
feat: enable AFE and gRPC metrics for DP

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -923,8 +923,16 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
 
     @Override
     public boolean isEnableGRPCBuiltInMetrics() {
-      return "false"
-          .equalsIgnoreCase(System.getenv(SPANNER_DISABLE_DIRECT_ACCESS_GRPC_BUILTIN_METRICS));
+      // Enable gRPC built-in metrics if:
+      // 1. The env var SPANNER_DISABLE_DIRECT_ACCESS_GRPC_BUILTIN_METRICS is explicitly set to
+      // "false", OR
+      // 2. DirectPath is enabled AND the env var is not set to "true"
+      // This allows metrics to be enabled by default when DirectPath is on, unless explicitly
+      // disabled via env.
+      String grpcDisableEnv = System.getenv("SPANNER_DISABLE_DIRECT_ACCESS_GRPC_BUILTIN_METRICS");
+      boolean isDirectPathEnabled = GapicSpannerRpc.isEnableDirectPathXdsEnv();
+      return ("false".equalsIgnoreCase(grpcDisableEnv))
+          || (isDirectPathEnabled && !"true".equalsIgnoreCase(grpcDisableEnv));
     }
 
     @Override
@@ -1994,8 +2002,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
   }
 
   public void enablegRPCMetrics(InstantiatingGrpcChannelProvider.Builder channelProviderBuilder) {
-    if (GapicSpannerRpc.isEnableDirectPathXdsEnv()
-        || SpannerOptions.environment.isEnableGRPCBuiltInMetrics()) {
+    if (SpannerOptions.environment.isEnableGRPCBuiltInMetrics()) {
       this.builtInMetricsProvider.enableGrpcMetrics(
           channelProviderBuilder, this.getProjectId(), getCredentials(), this.monitoringHost);
     }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -1994,7 +1994,8 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
   }
 
   public void enablegRPCMetrics(InstantiatingGrpcChannelProvider.Builder channelProviderBuilder) {
-    if (SpannerOptions.environment.isEnableGRPCBuiltInMetrics()) {
+    if (GapicSpannerRpc.isEnableDirectPathXdsEnv()
+        || SpannerOptions.environment.isEnableGRPCBuiltInMetrics()) {
       this.builtInMetricsProvider.enableGrpcMetrics(
           channelProviderBuilder, this.getProjectId(), getCredentials(), this.monitoringHost);
     }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -367,8 +367,7 @@ public class GapicSpannerRpc implements SpannerRpc {
                       .withEncoding(compressorName))
               .setHeaderProvider(headerProviderWithUserAgent)
               .setAllowNonDefaultServiceAccount(true);
-      String directPathXdsEnv = System.getenv("GOOGLE_SPANNER_ENABLE_DIRECT_ACCESS");
-      boolean isAttemptDirectPathXds = Boolean.parseBoolean(directPathXdsEnv);
+      boolean isAttemptDirectPathXds = isEnableDirectPathXdsEnv();
       if (isAttemptDirectPathXds) {
         defaultChannelProviderBuilder.setAttemptDirectPath(true);
         defaultChannelProviderBuilder.setAttemptDirectPathXds();
@@ -678,7 +677,12 @@ public class GapicSpannerRpc implements SpannerRpc {
   }
 
   public static boolean isEnableAFEServerTiming() {
-    return "false".equalsIgnoreCase(System.getenv("SPANNER_DISABLE_AFE_SERVER_TIMING"));
+    return isEnableDirectPathXdsEnv()
+        || "false".equalsIgnoreCase(System.getenv("SPANNER_DISABLE_AFE_SERVER_TIMING"));
+  }
+
+  public static boolean isEnableDirectPathXdsEnv() {
+    return Boolean.parseBoolean(System.getenv("GOOGLE_SPANNER_ENABLE_DIRECT_ACCESS"));
   }
 
   private static final RetrySettings ADMIN_REQUESTS_LIMIT_EXCEEDED_RETRY_SETTINGS =

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -677,8 +677,15 @@ public class GapicSpannerRpc implements SpannerRpc {
   }
 
   public static boolean isEnableAFEServerTiming() {
-    return isEnableDirectPathXdsEnv()
-        || "false".equalsIgnoreCase(System.getenv("SPANNER_DISABLE_AFE_SERVER_TIMING"));
+    // Enable AFE metrics and add AFE header if:
+    // 1. The env var SPANNER_DISABLE_AFE_SERVER_TIMING is explicitly set to "false", OR
+    // 2. DirectPath is enabled AND the env var is not set to "true"
+    // This allows metrics to be enabled by default when DirectPath is on, unless explicitly
+    // disabled via env.
+    String afeDisableEnv = System.getenv("SPANNER_DISABLE_AFE_SERVER_TIMING");
+    boolean isDirectPathEnabled = isEnableDirectPathXdsEnv();
+    return ("false".equalsIgnoreCase(afeDisableEnv))
+        || (isDirectPathEnabled && !"true".equalsIgnoreCase(afeDisableEnv));
   }
 
   public static boolean isEnableDirectPathXdsEnv() {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
@@ -269,11 +269,6 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
       assertNotNull(attemptCountMetricData);
       assertThat(getAggregatedValue(attemptCountMetricData, expectedAttributes)).isEqualTo(1);
 
-      MetricData gfeLatencyMetricData =
-          getMetricData(metricReader, BuiltInMetricsConstant.GFE_LATENCIES_NAME);
-      double gfeLatencyValue = getAggregatedValue(gfeLatencyMetricData, expectedAttributes);
-      assertEquals(fakeServerTiming.get(), gfeLatencyValue, 0);
-
       assertFalse(
           checkIfMetricExists(metricReader, BuiltInMetricsConstant.GFE_CONNECTIVITY_ERROR_NAME));
       assertFalse(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
@@ -34,6 +34,7 @@ import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
 import com.google.cloud.spanner.connection.RandomResultSetGenerator;
+import com.google.cloud.spanner.spi.v1.GapicSpannerRpc;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
@@ -190,16 +191,23 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
     assertNotNull(attemptCountMetricData);
     assertThat(getAggregatedValue(attemptCountMetricData, expectedAttributes)).isEqualTo(1);
 
-    MetricData gfeLatencyMetricData =
-        getMetricData(metricReader, BuiltInMetricsConstant.GFE_LATENCIES_NAME);
-    double gfeLatencyValue = getAggregatedValue(gfeLatencyMetricData, expectedAttributes);
-    assertEquals(fakeServerTiming.get(), gfeLatencyValue, 0);
-
-    assertFalse(
+   assertFalse(
         checkIfMetricExists(metricReader, BuiltInMetricsConstant.GFE_CONNECTIVITY_ERROR_NAME));
-    assertFalse(checkIfMetricExists(metricReader, BuiltInMetricsConstant.AFE_LATENCIES_NAME));
     assertFalse(
         checkIfMetricExists(metricReader, BuiltInMetricsConstant.AFE_CONNECTIVITY_ERROR_NAME));
+    if (GapicSpannerRpc.isEnableDirectPathXdsEnv()) {
+      // AFE metrics are enabled for DirectPath.
+      MetricData afeLatencyMetricData =
+          getMetricData(metricReader, BuiltInMetricsConstant.AFE_LATENCIES_NAME);
+      double afeLatencyValue = getAggregatedValue(afeLatencyMetricData, expectedAttributes);
+      assertEquals(fakeAFEServerTiming.get(), afeLatencyValue, 0);
+    } else {
+      MetricData gfeLatencyMetricData =
+          getMetricData(metricReader, BuiltInMetricsConstant.GFE_LATENCIES_NAME);
+      double gfeLatencyValue = getAggregatedValue(gfeLatencyMetricData, expectedAttributes);
+      assertEquals(fakeServerTiming.get(), gfeLatencyValue, 0);
+      assertFalse(checkIfMetricExists(metricReader, BuiltInMetricsConstant.AFE_LATENCIES_NAME));
+    }
   }
 
   private boolean isJava8() {
@@ -261,20 +269,19 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
       assertNotNull(attemptCountMetricData);
       assertThat(getAggregatedValue(attemptCountMetricData, expectedAttributes)).isEqualTo(1);
 
-      MetricData gfeLatencyMetricData =
-          getMetricData(metricReader, BuiltInMetricsConstant.GFE_LATENCIES_NAME);
-      double gfeLatencyValue = getAggregatedValue(gfeLatencyMetricData, expectedAttributes);
-      assertEquals(fakeServerTiming.get(), gfeLatencyValue, 0);
-
       assertFalse(
           checkIfMetricExists(metricReader, BuiltInMetricsConstant.GFE_CONNECTIVITY_ERROR_NAME));
-
+      assertFalse(
+          checkIfMetricExists(metricReader, BuiltInMetricsConstant.AFE_CONNECTIVITY_ERROR_NAME));
       MetricData afeLatencyMetricData =
           getMetricData(metricReader, BuiltInMetricsConstant.AFE_LATENCIES_NAME);
       double afeLatencyValue = getAggregatedValue(afeLatencyMetricData, expectedAttributes);
       assertEquals(fakeAFEServerTiming.get(), afeLatencyValue, 0);
-      assertFalse(
-          checkIfMetricExists(metricReader, BuiltInMetricsConstant.AFE_CONNECTIVITY_ERROR_NAME));
+
+      MetricData gfeLatencyMetricData =
+          getMetricData(metricReader, BuiltInMetricsConstant.GFE_LATENCIES_NAME);
+      double gfeLatencyValue = getAggregatedValue(gfeLatencyMetricData, expectedAttributes);
+      assertEquals(fakeServerTiming.get(), gfeLatencyValue, 0);
     } finally {
       writeableEnvironmentVariables.remove("GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS");
     }
@@ -445,13 +452,20 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
             .put(BuiltInMetricsConstant.METHOD_KEY, "Spanner.ExecuteSql")
             .build();
 
-    MetricData gfeConnectivityMetricData =
-        getMetricData(metricReader, BuiltInMetricsConstant.GFE_CONNECTIVITY_ERROR_NAME);
-    assertThat(getAggregatedValue(gfeConnectivityMetricData, expectedAttributes)).isEqualTo(1);
     assertFalse(checkIfMetricExists(metricReader, BuiltInMetricsConstant.AFE_LATENCIES_NAME));
     assertFalse(checkIfMetricExists(metricReader, BuiltInMetricsConstant.GFE_LATENCIES_NAME));
-    assertFalse(
-        checkIfMetricExists(metricReader, BuiltInMetricsConstant.AFE_CONNECTIVITY_ERROR_NAME));
+    if (GapicSpannerRpc.isEnableDirectPathXdsEnv()) {
+      MetricData afeConnectivityMetricData =
+          getMetricData(metricReader, BuiltInMetricsConstant.AFE_CONNECTIVITY_ERROR_NAME);
+      assertThat(getAggregatedValue(afeConnectivityMetricData, expectedAttributes)).isEqualTo(1);
+    } else {
+      MetricData gfeConnectivityMetricData =
+          getMetricData(metricReader, BuiltInMetricsConstant.GFE_CONNECTIVITY_ERROR_NAME);
+      assertThat(getAggregatedValue(gfeConnectivityMetricData, expectedAttributes)).isEqualTo(1);
+      assertFalse(
+          checkIfMetricExists(metricReader, BuiltInMetricsConstant.AFE_CONNECTIVITY_ERROR_NAME));
+    }
+
     spannerNoHeader.close();
     serverNoHeader.shutdown();
     serverNoHeader.awaitTermination();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
@@ -191,7 +191,7 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
     assertNotNull(attemptCountMetricData);
     assertThat(getAggregatedValue(attemptCountMetricData, expectedAttributes)).isEqualTo(1);
 
-   assertFalse(
+    assertFalse(
         checkIfMetricExists(metricReader, BuiltInMetricsConstant.GFE_CONNECTIVITY_ERROR_NAME));
     assertFalse(
         checkIfMetricExists(metricReader, BuiltInMetricsConstant.AFE_CONNECTIVITY_ERROR_NAME));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
@@ -200,12 +200,12 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
       MetricData afeLatencyMetricData =
           getMetricData(metricReader, BuiltInMetricsConstant.AFE_LATENCIES_NAME);
       double afeLatencyValue = getAggregatedValue(afeLatencyMetricData, expectedAttributes);
-      assertEquals(fakeAFEServerTiming.get(), afeLatencyValue, 0);
+      assertEquals(fakeAFEServerTiming.get(), afeLatencyValue, 1e-6);
     } else {
       MetricData gfeLatencyMetricData =
           getMetricData(metricReader, BuiltInMetricsConstant.GFE_LATENCIES_NAME);
       double gfeLatencyValue = getAggregatedValue(gfeLatencyMetricData, expectedAttributes);
-      assertEquals(fakeServerTiming.get(), gfeLatencyValue, 0);
+      assertEquals(fakeServerTiming.get(), gfeLatencyValue, 1e-6);
       assertFalse(checkIfMetricExists(metricReader, BuiltInMetricsConstant.AFE_LATENCIES_NAME));
     }
   }
@@ -276,12 +276,12 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
       MetricData afeLatencyMetricData =
           getMetricData(metricReader, BuiltInMetricsConstant.AFE_LATENCIES_NAME);
       double afeLatencyValue = getAggregatedValue(afeLatencyMetricData, expectedAttributes);
-      assertEquals(fakeAFEServerTiming.get(), afeLatencyValue, 0);
+      assertEquals(fakeAFEServerTiming.get(), afeLatencyValue, 1e-6);
 
       MetricData gfeLatencyMetricData =
           getMetricData(metricReader, BuiltInMetricsConstant.GFE_LATENCIES_NAME);
       double gfeLatencyValue = getAggregatedValue(gfeLatencyMetricData, expectedAttributes);
-      assertEquals(fakeServerTiming.get(), gfeLatencyValue, 0);
+      assertEquals(fakeServerTiming.get(), gfeLatencyValue, 1e-6);
     } finally {
       writeableEnvironmentVariables.remove("GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS");
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
@@ -269,6 +269,11 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
       assertNotNull(attemptCountMetricData);
       assertThat(getAggregatedValue(attemptCountMetricData, expectedAttributes)).isEqualTo(1);
 
+      MetricData gfeLatencyMetricData =
+          getMetricData(metricReader, BuiltInMetricsConstant.GFE_LATENCIES_NAME);
+      double gfeLatencyValue = getAggregatedValue(gfeLatencyMetricData, expectedAttributes);
+      assertEquals(fakeServerTiming.get(), gfeLatencyValue, 0);
+
       assertFalse(
           checkIfMetricExists(metricReader, BuiltInMetricsConstant.GFE_CONNECTIVITY_ERROR_NAME));
       assertFalse(


### PR DESCRIPTION
Enable gRPC/AFE built-in metrics if:
1. The env var SPANNER_DISABLE_DIRECT_ACCESS_GRPC_BUILTIN_METRICS / SPANNER_DISABLE_AFE_SERVER_TIMING is explicitly set to "false", OR
2. DirectPath is enabled AND the env var is not set to "true". This allows metrics to be enabled by default when DirectPath is on, unless explicitly disabled via env.
   
This PR also skips GFE metrics when DirectPath is used.
