### PR TITLE
chore: make StatementExecutorType public

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
@@ -556,7 +556,11 @@ public class ConnectionOptions {
       return this;
     }
 
-    Builder setStatementExecutorType(StatementExecutorType statementExecutorType) {
+    /**
+     * Sets the executor type to use for connections. See {@link StatementExecutorType} for more
+     * information on what the different options mean.
+     */
+    public Builder setStatementExecutorType(StatementExecutorType statementExecutorType) {
       this.statementExecutorType = statementExecutorType;
       return this;
     }
@@ -920,7 +924,11 @@ public class ConnectionOptions {
     return getInitialConnectionPropertyValue(CREDENTIALS_PROVIDER);
   }
 
-  StatementExecutorType getStatementExecutorType() {
+  /**
+   * Returns the executor type that is used by connections that are created from this {@link
+   * ConnectionOptions} instance.
+   */
+  public StatementExecutorType getStatementExecutorType() {
     return this.statementExecutorType;
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/StatementExecutor.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/StatementExecutor.java
@@ -172,9 +172,23 @@ class StatementExecutor {
    */
   private final List<StatementExecutionInterceptor> interceptors;
 
-  enum StatementExecutorType {
+  /** The executor type that is used for statements that are executed on a connection. */
+  public enum StatementExecutorType {
+    /**
+     * Use a platform thread per connection. This allows async execution of statements, but costs
+     * more resources than the other options.
+     */
     PLATFORM_THREAD,
+    /**
+     * Use a virtual thread per connection. This allows async execution of statements. Virtual
+     * threads are only supported on Java 21 and higher.
+     */
     VIRTUAL_THREAD,
+    /**
+     * Use the calling thread for execution. This does not support async execution of statements.
+     * This option is used by drivers that do not support async execution, such as JDBC and
+     * PGAdapter.
+     */
     DIRECT_EXECUTOR,
   }
 


### PR DESCRIPTION
Make the getter/setter for StatementExecutorType public, so these can be set by the JDBC driver and PGAdapter.
