### PR TITLE
fix: remove trailing semicolons in DDL

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DdlClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DdlClient.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * Convenience class for executing Data Definition Language statements on transactions that support
@@ -137,7 +138,21 @@ class DdlClient {
       dbBuilder.setProtoDescriptors(protoDescriptors);
     }
     Database db = dbBuilder.build();
-    return dbAdminClient.updateDatabaseDdl(db, statements, null);
+    return dbAdminClient.updateDatabaseDdl(
+        db,
+        statements.stream().map(DdlClient::stripTrailingSemicolon).collect(Collectors.toList()),
+        null);
+  }
+
+  static String stripTrailingSemicolon(String input) {
+    if (!input.contains(";")) {
+      return input;
+    }
+    String trimmed = input.trim();
+    if (trimmed.endsWith(";")) {
+      return trimmed.substring(0, trimmed.length() - 1);
+    }
+    return input;
   }
 
   /** Returns true if the statement is a `CREATE DATABASE ...` statement. */


### PR DESCRIPTION
The Connection API should automatically remove any trailing semicolons in DDL statements. Spanner accepts trailing semicolons in queries and DML statements, but not in DDL statements. Previously, the Connection API would remove all comments and trailing semicolons from DDL statements. Comments are now supported in DDL statements, and are therefore no longer removed by the Conneciton API, but that change also unintentionally kept any trailing semicolons in the SQL string that is sent to Spanner.

Fixes https://github.com/cloudspannerecosystem/liquibase-spanner/issues/481
