### PR TITLE
chore: enable experimentalHost support for pgAdapter

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
@@ -163,6 +163,7 @@ public class SpannerPool {
     private final boolean enableEndToEndTracing;
     private final String clientCertificate;
     private final String clientCertificateKey;
+    private final boolean isExperimentalHost;
 
     @VisibleForTesting
     static SpannerPoolKey of(ConnectionOptions options) {
@@ -196,6 +197,7 @@ public class SpannerPool {
       this.enableEndToEndTracing = options.isEndToEndTracingEnabled();
       this.clientCertificate = options.getClientCertificate();
       this.clientCertificateKey = options.getClientCertificateKey();
+      this.isExperimentalHost = options.isExperimentalHost();
     }
 
     @Override
@@ -220,7 +222,8 @@ public class SpannerPool {
           && Objects.equals(this.enableApiTracing, other.enableApiTracing)
           && Objects.equals(this.enableEndToEndTracing, other.enableEndToEndTracing)
           && Objects.equals(this.clientCertificate, other.clientCertificate)
-          && Objects.equals(this.clientCertificateKey, other.clientCertificateKey);
+          && Objects.equals(this.clientCertificateKey, other.clientCertificateKey)
+          && Objects.equals(this.isExperimentalHost, other.isExperimentalHost);
     }
 
     @Override
@@ -241,7 +244,8 @@ public class SpannerPool {
           this.enableApiTracing,
           this.enableEndToEndTracing,
           this.clientCertificate,
-          this.clientCertificateKey);
+          this.clientCertificateKey,
+          this.isExperimentalHost);
     }
   }
 
@@ -404,6 +408,9 @@ public class SpannerPool {
     }
     if (key.clientCertificate != null && key.clientCertificateKey != null) {
       builder.useClientCert(key.clientCertificate, key.clientCertificateKey);
+    }
+    if (key.isExperimentalHost) {
+      builder.setExperimentalHost(key.host);
     }
     if (options.getConfigurator() != null) {
       options.getConfigurator().configure(builder);


### PR DESCRIPTION
Ensure multiplexed sessions are used when client is connecting to an experimental host using PGAdapter - by passing additional parameter -r "isExperimentalHost=true"