### PR TITLE
ci: disable split points IT

### DIFF
--- a/samples/snippets/src/test/java/com/example/spanner/DatabaseAddSplitPointsIT.java
+++ b/samples/snippets/src/test/java/com/example/spanner/DatabaseAddSplitPointsIT.java
@@ -46,7 +46,8 @@ public class DatabaseAddSplitPointsIT extends SampleTestBase {
         .get();
   }
 
-  @Test
+  // TODO: Enable the test once the issue with split points is resolved
+  // @Test
   public void testAddSplits() throws Exception {
     final String out =
         SampleRunner.runSample(


### PR DESCRIPTION
**Description:**

Currently there's an open issue where on database deletion split points quota should be reclaimed. Currently it's not happening. There's a limitation of 50 split points can be added in an instance. 

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-spanner/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
