### PR TITLE
chore(x-goog-spanner-request-id): enable tests for more RPCs

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java
@@ -1101,7 +1101,7 @@ public final class Options implements Serializable {
       if (this.reqId == null || other.reqId == null) {
         return this.reqId == null && other.reqId == null;
       }
-      return this.reqId.equals(other.reqId);
+      return Objects.equals(this.reqId, other.reqId);
     }
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerException.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spanner;
 
+import com.google.api.core.InternalApi;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.ErrorDetails;
 import com.google.cloud.grpc.BaseGrpcServiceException;
@@ -198,7 +199,8 @@ public class SpannerException extends BaseGrpcServiceException {
     return null;
   }
 
-  /** Sets the requestId. This method is meant to be used internally and not by customers. */
+  /** Sets the requestId. */
+  @InternalApi
   public void setRequestId(XGoogSpannerRequestId reqId) {
     this.requestId = reqId;
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -228,20 +228,22 @@ public class DatabaseClientImplTest {
     Set<String> checkMethods =
         new HashSet(
             Arrays.asList(
-                "google.spanner.v1.Spanner/BatchCreateSessions"
-                // As functionality is added, uncomment each method.
-                // "google.spanner.v1.Spanner/BatchWrite",
-                // "google.spanner.v1.Spanner/BeginTransaction",
-                // "google.spanner.v1.Spanner/CreateSession",
-                // "google.spanner.v1.Spanner/DeleteSession",
-                // "google.spanner.v1.Spanner/ExecuteBatchDml",
-                // "google.spanner.v1.Spanner/ExecuteSql",
-                // "google.spanner.v1.Spanner/ExecuteStreamingSql",
-                // "google.spanner.v1.Spanner/StreamingRead",
-                // "google.spanner.v1.Spanner/PartitionQuery",
-                // "google.spanner.v1.Spanner/PartitionRead",
-                // "google.spanner.v1.Spanner/Commit",
-                ));
+                "google.spanner.v1.Spanner/BatchCreateSessions",
+                "google.spanner.v1.Spanner/BatchWrite",
+                "google.spanner.v1.Spanner/BeginTransaction",
+                "google.spanner.v1.Spanner/Commit",
+                "google.spanner.v1.Spanner/CreateSession",
+                "google.spanner.v1.Spanner/DeleteSession",
+                "google.spanner.v1.Spanner/ExecuteBatchDml",
+                "google.spanner.v1.Spanner/ExecuteSql",
+                "google.spanner.v1.Spanner/ExecuteStreamingSql",
+                "google.spanner.v1.Spanner/GetSession",
+                "google.spanner.v1.Spanner/ListSessions",
+                "google.spanner.v1.Spanner/PartitionQuery",
+                "google.spanner.v1.Spanner/PartitionRead",
+                "google.spanner.v1.Spanner/Read",
+                "google.spanner.v1.Spanner/Rollback",
+                "google.spanner.v1.Spanner/StreamingRead"));
     xGoogReqIdInterceptor = new XGoogSpannerRequestIdTest.ServerHeaderEnforcer(checkMethods);
     executor = Executors.newSingleThreadExecutor();
     String uniqueName = InProcessServerBuilder.generateName();

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/PartitionedDmlTransactionTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/PartitionedDmlTransactionTest.java
@@ -96,6 +96,8 @@ public class PartitionedDmlTransactionTest {
   public void setup() {
     MockitoAnnotations.initMocks(this);
     when(session.getName()).thenReturn(sessionId);
+    when(session.getRequestIdCreator())
+        .thenReturn(new XGoogSpannerRequestId.NoopRequestIdCreator());
     when(session.getOptions()).thenReturn(Collections.EMPTY_MAP);
     when(session.getRequestIdCreator())
         .thenReturn(new XGoogSpannerRequestId.NoopRequestIdCreator());


### PR DESCRIPTION
Enable asserting that all the Spanner Method RPCs have
x-goog-spanner-request-id.

Updates #3537