### PR TITLE
feat: enable ALTS hard bound token in DirectPath

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -368,6 +368,10 @@ public class GapicSpannerRpc implements SpannerRpc {
       boolean isAttemptDirectPathXds = isEnableDirectPathXdsEnv();
       if (isAttemptDirectPathXds) {
         defaultChannelProviderBuilder.setAttemptDirectPath(true);
+        // This will let the credentials try to fetch a hard-bound access token if the runtime
+        // environment supports it.
+        defaultChannelProviderBuilder.setAllowHardBoundTokenTypes(
+            Collections.singletonList(InstantiatingGrpcChannelProvider.HardBoundTokenTypes.ALTS));
         defaultChannelProviderBuilder.setAttemptDirectPathXds();
       }
 


### PR DESCRIPTION
Same as #3645 that was reverted earlier. The Cloud Spanner backend is now able to process the bound token if sent.