### PR TITLE
chore: remove redundant graal-sdk dependency

### DIFF
--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -355,13 +355,6 @@
       <artifactId>grpc-rls</artifactId>
       <scope>runtime</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.graalvm.sdk</groupId>
-      <artifactId>graal-sdk</artifactId>
-      <version>${graal-sdk.version}</version>
-      <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>org.graalvm.sdk</groupId>
       <artifactId>nativeimage</artifactId>


### PR DESCRIPTION
We only make use of org.graalvm.nativeimage for native image configs and the use of graal-sdk is deprecated: https://github.com/oracle/graal/blob/fefc2a03a1e46ce60ce4b03f223d83640fbef0f4/sdk/CHANGELOG.md#version-2310