### PR TITLE
fix: drop max message size

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -344,8 +344,6 @@ public class GapicSpannerRpc implements SpannerRpc {
           InstantiatingGrpcChannelProvider.newBuilder()
               .setChannelConfigurator(options.getChannelConfigurator())
               .setEndpoint(options.getEndpoint())
-              .setMaxInboundMessageSize(MAX_MESSAGE_SIZE)
-              .setMaxInboundMetadataSize(MAX_METADATA_SIZE)
               .setPoolSize(options.getNumChannels())
 
               // Set a keepalive time of 120 seconds to help long running


### PR DESCRIPTION
Drop the client-side hardcoded max message size to prevent errors if the server sends larger than expected messages.
