### PR TITLE
ci: update instance for directpath tests

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -160,7 +160,7 @@ integration-cloud-devel-directpath-enabled)
       -Denforcer.skip=true \
       -Dmaven.main.skip=true \
       -Dspanner.gce.config.server_url=https://staging-wrenchworks.sandbox.googleapis.com \
-      -Dspanner.testenv.instance=projects/span-cloud-testing/instances/spanner-java-client-directpath \
+      -Dspanner.testenv.instance=projects/span-cloud-testing/instances/cloud-spanner-java-directpath \
       -Dspanner.gce.config.project_id=span-cloud-testing \
       -fae \
       verify


### PR DESCRIPTION
**Description:**

Spanner instance spanner-java-client-directpath is stuck in a DELETING state where Spanner team is trying to figure out how to clean up. Changing the instance to run the tests.