### PR TITLE
sort requestids before checking monotonicity

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/XGoogSpannerRequestId.java
@@ -199,4 +199,10 @@ public class XGoogSpannerRequestId {
     return XGoogSpannerRequestId.of(
         replacementClientId, this.nthChannelId, this.nthRequest, this.attempt);
   }
+
+  @VisibleForTesting
+  XGoogSpannerRequestId withAttempt(long replacementAttempt) {
+    return XGoogSpannerRequestId.of(
+        this.nthClientId, this.nthChannelId, this.nthRequest, replacementAttempt);
+  }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DatabaseClientImplTest.java
@@ -1417,8 +1417,7 @@ public class DatabaseClientImplTest {
 
     List<CommitRequest> commitRequests = mockSpanner.getRequestsOfType(CommitRequest.class);
     assertEquals(2, commitRequests.size());
-    // TODO(@odeke-em): Enable in later PR.
-    // xGoogReqIdInterceptor.assertIntegrity();
+    xGoogReqIdInterceptor.assertIntegrity();
   }
 
   @Test
@@ -2910,34 +2909,34 @@ public class DatabaseClientImplTest {
 
       DatabaseClientImpl dbImpl = ((DatabaseClientImpl) client);
       int channelId = 0;
-      try (Session session = dbImpl.getSession()) {
-        channelId = ((PooledSessionFuture) session).getChannel();
+      try (PooledSessionFuture session = dbImpl.getSession()) {
+        channelId = session.getChannel();
       }
       int dbId = dbImpl.dbId;
       long NON_DETERMINISTIC = XGoogSpannerRequestIdTest.NON_DETERMINISTIC;
       XGoogSpannerRequestIdTest.MethodAndRequestId[] wantStreamingValues = {
         XGoogSpannerRequestIdTest.ofMethodAndRequestId(
             "google.spanner.v1.Spanner/ExecuteStreamingSql",
-            new XGoogSpannerRequestId(NON_DETERMINISTIC, channelId, 6, 1)),
+            new XGoogSpannerRequestId(
+                NON_DETERMINISTIC, NON_DETERMINISTIC, NON_DETERMINISTIC, NON_DETERMINISTIC)),
       };
-      if (false) { // TODO(@odeke-em): enable in next PRs.
-        xGoogReqIdInterceptor.checkExpectedStreamingXGoogRequestIds(wantStreamingValues);
-      }
+      xGoogReqIdInterceptor.checkExpectedStreamingXGoogRequestIds(wantStreamingValues);
 
       XGoogSpannerRequestIdTest.MethodAndRequestId[] wantUnaryValues = {
         XGoogSpannerRequestIdTest.ofMethodAndRequestId(
             "google.spanner.v1.Spanner/BeginTransaction",
-            new XGoogSpannerRequestId(NON_DETERMINISTIC, channelId, 7, 1)),
+            new XGoogSpannerRequestId(
+                NON_DETERMINISTIC, NON_DETERMINISTIC, NON_DETERMINISTIC, NON_DETERMINISTIC)),
         XGoogSpannerRequestIdTest.ofMethodAndRequestId(
             "google.spanner.v1.Spanner/CreateSession",
-            new XGoogSpannerRequestId(NON_DETERMINISTIC, 0, 1, 1)),
+            new XGoogSpannerRequestId(
+                NON_DETERMINISTIC, NON_DETERMINISTIC, NON_DETERMINISTIC, NON_DETERMINISTIC)),
         XGoogSpannerRequestIdTest.ofMethodAndRequestId(
             "google.spanner.v1.Spanner/ExecuteSql",
-            new XGoogSpannerRequestId(NON_DETERMINISTIC, channelId, 8, 1)),
+            new XGoogSpannerRequestId(
+                NON_DETERMINISTIC, NON_DETERMINISTIC, NON_DETERMINISTIC, NON_DETERMINISTIC)),
       };
-      if (false) { // TODO(@odeke-em): enable in next PRs.
-        xGoogReqIdInterceptor.checkExpectedUnaryXGoogRequestIdsAsSuffixes(wantUnaryValues);
-      }
+      xGoogReqIdInterceptor.checkExpectedUnaryXGoogRequestIdsAsSuffixes(wantUnaryValues);
     }
   }
 
@@ -3023,35 +3022,35 @@ public class DatabaseClientImplTest {
 
       DatabaseClientImpl dbImpl = ((DatabaseClientImpl) client);
       int channelId = 0;
-      try (Session session = dbImpl.getSession()) {
-        channelId = ((PooledSessionFuture) session).getChannel();
+      try (PooledSessionFuture session = dbImpl.getSession()) {
+        channelId = session.getChannel();
       }
       int dbId = dbImpl.dbId;
       long NON_DETERMINISTIC = XGoogSpannerRequestIdTest.NON_DETERMINISTIC;
       XGoogSpannerRequestIdTest.MethodAndRequestId[] wantStreamingValues = {
         XGoogSpannerRequestIdTest.ofMethodAndRequestId(
             "google.spanner.v1.Spanner/ExecuteStreamingSql",
-            new XGoogSpannerRequestId(NON_DETERMINISTIC, channelId, 6, 1)),
+            new XGoogSpannerRequestId(
+                NON_DETERMINISTIC, NON_DETERMINISTIC, NON_DETERMINISTIC, NON_DETERMINISTIC)),
       };
 
-      if (false) { // TODO(@odeke-em): enable in next PRs.
-        xGoogReqIdInterceptor.checkExpectedStreamingXGoogRequestIds(wantStreamingValues);
-      }
+      xGoogReqIdInterceptor.checkExpectedStreamingXGoogRequestIds(wantStreamingValues);
 
       XGoogSpannerRequestIdTest.MethodAndRequestId[] wantUnaryValues = {
         XGoogSpannerRequestIdTest.ofMethodAndRequestId(
             "google.spanner.v1.Spanner/BeginTransaction",
-            new XGoogSpannerRequestId(NON_DETERMINISTIC, channelId, 7, 1)),
+            new XGoogSpannerRequestId(
+                NON_DETERMINISTIC, NON_DETERMINISTIC, NON_DETERMINISTIC, NON_DETERMINISTIC)),
         XGoogSpannerRequestIdTest.ofMethodAndRequestId(
             "google.spanner.v1.Spanner/CreateSession",
-            new XGoogSpannerRequestId(NON_DETERMINISTIC, 0, 1, 1)),
+            new XGoogSpannerRequestId(
+                NON_DETERMINISTIC, NON_DETERMINISTIC, NON_DETERMINISTIC, NON_DETERMINISTIC)),
         XGoogSpannerRequestIdTest.ofMethodAndRequestId(
             "google.spanner.v1.Spanner/ExecuteSql",
-            new XGoogSpannerRequestId(NON_DETERMINISTIC, channelId, 8, 1)),
+            new XGoogSpannerRequestId(
+                NON_DETERMINISTIC, NON_DETERMINISTIC, NON_DETERMINISTIC, NON_DETERMINISTIC)),
       };
-      if (false) { // TODO(@odeke-em): enable in next PRs.
-        xGoogReqIdInterceptor.checkExpectedUnaryXGoogRequestIdsAsSuffixes(wantUnaryValues);
-      }
+      xGoogReqIdInterceptor.checkExpectedUnaryXGoogRequestIdsAsSuffixes(wantUnaryValues);
     }
   }
 
@@ -5304,8 +5303,7 @@ public class DatabaseClientImplTest {
       assertEquals(1L, resultSet.getLong(0));
       assertFalse(resultSet.next());
     } finally {
-      // TODO(@odeke-em): Enable in later PR.
-      // xGoogReqIdInterceptor.assertIntegrity();
+      xGoogReqIdInterceptor.assertIntegrity();
     }
   }
 
@@ -5394,9 +5392,7 @@ public class DatabaseClientImplTest {
             "google.spanner.v1.Spanner/CreateSession",
             new XGoogSpannerRequestId(NON_DETERMINISTIC, 0, 1, 1)),
       };
-      if (false) { // TODO(@odeke-em): enable in next PRs.
-        xGoogReqIdInterceptor.checkExpectedUnaryXGoogRequestIdsAsSuffixes(wantUnaryValues);
-      }
+      xGoogReqIdInterceptor.checkExpectedUnaryXGoogRequestIdsAsSuffixes(wantUnaryValues);
     }
   }
 


### PR DESCRIPTION
This change enables some tests that had been disabled for later.

Updates: googleapis/google-cloud-java#12250 

