### PR TITLE
fix: getCommitResponse() should return error if tx rolled back

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncTransactionManager.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncTransactionManager.java
@@ -203,7 +203,12 @@ public interface AsyncTransactionManager extends AutoCloseable {
   /** Returns the state of the transaction. */
   TransactionState getState();
 
-  /** Returns the {@link CommitResponse} of this transaction. */
+  /**
+   * Returns an {@link ApiFuture} with the eventual {@link CommitResponse} of this transaction. This
+   * method can be called before the transaction has been committed. The {@link ApiFuture} will be
+   * done when the transaction is committed or rolled back. If the commit fails or the transaction
+   * is rolled back, the result of this {@link ApiFuture} will be an exception.
+   */
   ApiFuture<CommitResponse> getCommitResponse();
 
   /**

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncTransactionManagerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncTransactionManagerImpl.java
@@ -191,6 +191,11 @@ final class AsyncTransactionManagerImpl
     Preconditions.checkState(
         txnState == TransactionState.STARTED,
         "rollback can only be called if the transaction is in progress");
+    if (!commitResponse.isDone()) {
+      commitResponse.setException(
+          SpannerExceptionFactory.newSpannerException(
+              ErrorCode.FAILED_PRECONDITION, "The transaction has been rolled back"));
+    }
     try {
       return ApiFutures.transformAsync(
           txn.rollbackAsync(),

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncTransactionManagerTest.java
@@ -25,6 +25,7 @@ import static com.google.cloud.spanner.MockSpannerTestUtil.UPDATE_STATEMENT;
 import static com.google.cloud.spanner.SpannerApiFutures.get;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -198,6 +199,39 @@ public class AsyncTransactionManagerTest extends AbstractAsyncTransactionTest {
           return false;
         },
         0L);
+  }
+
+  @Test
+  public void testAsyncTransactionManager_commitResponseReturnsErrorAfterRollback()
+      throws Exception {
+    try (AsyncTransactionManager manager = client().transactionManagerAsync()) {
+      TransactionContextFuture transactionContextFuture = manager.beginAsync();
+      ApiFuture<CommitResponse> commitResponse = manager.getCommitResponse();
+      while (true) {
+        try {
+          AsyncTransactionStep<Void, ?> next =
+              transactionContextFuture.then(
+                  (transactionContext, ignored) ->
+                      transactionContext.bufferAsync(
+                          Collections.singleton(Mutation.delete("FOO", Key.of("foo")))),
+                  executor);
+          assertFalse(commitResponse.isDone());
+          manager.rollbackAsync().get();
+          assertTrue(commitResponse.isDone());
+          ExecutionException executionException =
+              assertThrows(ExecutionException.class, commitResponse::get);
+          assertEquals(SpannerException.class, executionException.getCause().getClass());
+          SpannerException spannerException = (SpannerException) executionException.getCause();
+          assertEquals(ErrorCode.FAILED_PRECONDITION, spannerException.getErrorCode());
+          assertEquals(
+              "FAILED_PRECONDITION: The transaction has been rolled back",
+              spannerException.getMessage());
+          break;
+        } catch (AbortedException e) {
+          transactionContextFuture = manager.resetForRetryAsync();
+        }
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
The ApiFuture that is returned by the AsyncTransactionManager#getCommitResponse() method should finish with an error if the transaction is rolled back.
