### PR TITLE
chore: demo of error when deleting an empty set of keys

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITReadTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITReadTest.java
@@ -37,7 +37,6 @@ import com.google.cloud.spanner.KeyRange;
 import com.google.cloud.spanner.KeySet;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Options;
-import com.google.cloud.spanner.Options.TransactionOption;
 import com.google.cloud.spanner.ParallelIntegrationTest;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerException;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITReadTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITReadTest.java
@@ -37,6 +37,7 @@ import com.google.cloud.spanner.KeyRange;
 import com.google.cloud.spanner.KeySet;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Options;
+import com.google.cloud.spanner.Options.TransactionOption;
 import com.google.cloud.spanner.ParallelIntegrationTest;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerException;
@@ -45,6 +46,7 @@ import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.connection.ConnectionOptions;
 import com.google.cloud.spanner.testing.RemoteSpannerHelper;
+import com.google.common.collect.ImmutableList;
 import com.google.spanner.v1.DirectedReadOptions;
 import com.google.spanner.v1.DirectedReadOptions.IncludeReplicas;
 import com.google.spanner.v1.DirectedReadOptions.ReplicaSelection;
@@ -538,5 +540,13 @@ public class ITReadTest {
 
   private void checkRangeWithLimit(Source source, long limit, KeyRange range, int... expectedRows) {
     checkReadRange(source, KeySet.range(range), limit, expectedRows);
+  }
+
+  @Test
+  public void testWriteEmptyMutationsDemultiplexed() {
+    KeySet keySet = KeySet.newBuilder().build();
+    Mutation emptyMutation = Mutation.delete("TestTable", keySet);
+
+    postgreSQLClient.write(ImmutableList.of(emptyMutation));
   }
 }


### PR DESCRIPTION
This PR demonstrates how to reproduce the following error when issuing a `write()` with a `Mutation` with an empty keyset:

```java
    KeySet keySet = KeySet.newBuilder().build();
    Mutation emptyMutation = Mutation.delete("TestTable", keySet);
```

```
com.google.cloud.spanner.SpannerException: INVALID_ARGUMENT: io.grpc.StatusRuntimeException: INVALID_ARGUMENT: Failed to initialize transaction due to invalid mutation key.

	at com.google.cloud.spanner.SpannerExceptionFactory.newSpannerExceptionPreformatted(SpannerExceptionFactory.java:396)
	at com.google.cloud.spanner.SpannerExceptionFactory.newSpannerException(SpannerExceptionFactory.java:223)
	at com.google.cloud.spanner.SpannerExceptionFactory.newSpannerException(SpannerExceptionFactory.java:135)
	at com.google.cloud.spanner.TransactionRunnerImpl$TransactionContextImpl.commit(TransactionRunnerImpl.java:373)
	at com.google.cloud.spanner.TransactionRunnerImpl.lambda$runInternal$0(TransactionRunnerImpl.java:1336)
	at com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:102)
	at com.google.cloud.RetryHelper.run(RetryHelper.java:76)
	at com.google.cloud.RetryHelper.runWithRetries(RetryHelper.java:50)
	at com.google.cloud.spanner.SpannerRetryHelper.runTxWithRetriesOnAborted(SpannerRetryHelper.java:91)
	at com.google.cloud.spanner.SpannerRetryHelper.runTxWithRetriesOnAborted(SpannerRetryHelper.java:70)
	at com.google.cloud.spanner.TransactionRunnerImpl.runInternal(TransactionRunnerImpl.java:1352)
	at com.google.cloud.spanner.TransactionRunnerImpl.run(TransactionRunnerImpl.java:1252)
	at com.google.cloud.spanner.MultiplexedSessionTransactionRunner.run(MultiplexedSessionDatabaseClient.java:98)
	at com.google.cloud.spanner.SessionImpl.writeWithOptions(SessionImpl.java:250)
	at com.google.cloud.spanner.MultiplexedSessionDatabaseClient.writeWithOptions(MultiplexedSessionDatabaseClient.java:674)
	at com.google.cloud.spanner.DatabaseClientImpl.writeWithOptions(DatabaseClientImpl.java:209)
	at com.google.cloud.spanner.DatabaseClientImpl.write(DatabaseClientImpl.java:199)
	at com.google.cloud.spanner.it.ITReadTest.testWriteEmptyMutations(ITReadTest.java:548)
	Caused by: com.google.cloud.spanner.SpannerException: INVALID_ARGUMENT: io.grpc.StatusRuntimeException: INVALID_ARGUMENT: Failed to initialize transaction due to invalid mutation key.
	
```