### PR TITLE
fix: potential NullPointerException in Value#hashCode

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Value.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Value.java
@@ -1716,7 +1716,10 @@ public abstract class Value implements Serializable {
        * while calculating valueHash of Float32 type. Note that this is not applicable for composite
        * types containing FLOAT32.
        */
-      if (type.getCode() == Type.Code.FLOAT32 && !isNull && Float.isNaN(getFloat32())) {
+      if (type != null
+          && type.getCode() == Type.Code.FLOAT32
+          && !isNull
+          && Float.isNaN(getFloat32())) {
         typeToHash = Type.float64();
       }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueTest.java
@@ -94,6 +94,8 @@ public class ValueTest {
     assertNull(v.getType());
     assertFalse(v.isNull());
     assertSame(proto, v.toProto());
+    assertNotEquals(0, v.hashCode());
+    assertEquals(v, Value.untyped(proto));
 
     assertEquals(
         v, Value.untyped(com.google.protobuf.Value.newBuilder().setStringValue("test").build()));


### PR DESCRIPTION
The `Value#hashCode()` method threw a NullPointerException for untyped values.
