### PR TITLE
feat: TPC support

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsProvider.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsProvider.java
@@ -68,12 +68,16 @@ final class BuiltInMetricsProvider {
   private BuiltInMetricsProvider() {}
 
   OpenTelemetry getOrCreateOpenTelemetry(
-      String projectId, @Nullable Credentials credentials, @Nullable String monitoringHost) {
+      String projectId,
+      @Nullable Credentials credentials,
+      @Nullable String monitoringHost,
+      String universeDomain) {
     try {
       if (this.openTelemetry == null) {
         SdkMeterProviderBuilder sdkMeterProviderBuilder = SdkMeterProvider.builder();
         BuiltInMetricsView.registerBuiltinMetrics(
-            SpannerCloudMonitoringExporter.create(projectId, credentials, monitoringHost),
+            SpannerCloudMonitoringExporter.create(
+                projectId, credentials, monitoringHost, universeDomain),
             sdkMeterProviderBuilder);
         sdkMeterProviderBuilder.setResource(Resource.create(createResourceAttributes(projectId)));
         SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
@@ -95,10 +99,13 @@ final class BuiltInMetricsProvider {
       InstantiatingGrpcChannelProvider.Builder channelProviderBuilder,
       String projectId,
       @Nullable Credentials credentials,
-      @Nullable String monitoringHost) {
+      @Nullable String monitoringHost,
+      String universeDomain) {
     GrpcOpenTelemetry grpcOpenTelemetry =
         GrpcOpenTelemetry.newBuilder()
-            .sdk(this.getOrCreateOpenTelemetry(projectId, credentials, monitoringHost))
+            .sdk(
+                this.getOrCreateOpenTelemetry(
+                    projectId, credentials, monitoringHost, universeDomain))
             .enableMetrics(BuiltInMetricsConstant.GRPC_METRICS_TO_ENABLE)
             // Disable gRPCs default metrics as they are not needed for Spanner.
             .disableMetrics(BuiltInMetricsConstant.GRPC_METRICS_ENABLED_BY_DEFAULT)

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporter.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporter.java
@@ -88,7 +88,7 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
     if (monitoringHost != null) {
       settingsBuilder.setEndpoint(monitoringHost);
     }
-    if (Strings.isNullOrEmpty(universeDomain)) {
+    if (!Strings.isNullOrEmpty(universeDomain)) {
       settingsBuilder.setUniverseDomain(universeDomain);
     }
 
@@ -115,6 +115,11 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
     }
 
     return exportSpannerClientMetrics(collection);
+  }
+
+  @VisibleForTesting
+  MetricServiceClient getMetricServiceClient() {
+    return client;
   }
 
   /** Export client built in metrics */

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporter.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporter.java
@@ -27,6 +27,7 @@ import com.google.auth.Credentials;
 import com.google.cloud.monitoring.v3.MetricServiceClient;
 import com.google.cloud.monitoring.v3.MetricServiceSettings;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.monitoring.v3.CreateTimeSeriesRequest;
@@ -71,7 +72,10 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
   private final String spannerProjectId;
 
   static SpannerCloudMonitoringExporter create(
-      String projectId, @Nullable Credentials credentials, @Nullable String monitoringHost)
+      String projectId,
+      @Nullable Credentials credentials,
+      @Nullable String monitoringHost,
+      String universeDomain)
       throws IOException {
     MetricServiceSettings.Builder settingsBuilder = MetricServiceSettings.newBuilder();
     CredentialsProvider credentialsProvider;
@@ -83,6 +87,9 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
     settingsBuilder.setCredentialsProvider(credentialsProvider);
     if (monitoringHost != null) {
       settingsBuilder.setEndpoint(monitoringHost);
+    }
+    if (Strings.isNullOrEmpty(universeDomain)) {
+      settingsBuilder.setUniverseDomain(universeDomain);
     }
 
     Duration timeout = Duration.ofMinutes(1);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -887,7 +887,9 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     }
 
     @Deprecated
-    @ObsoleteApi("This will be removed in upcoming version without breaking change release. You should use universalDomain to configure the built-in metrics endpoint for a partner universe.")
+    @ObsoleteApi(
+        "This will be removed in an upcoming version without a major version bump. You should use"
+            + " universalDomain to configure the built-in metrics endpoint for a partner universe.")
     default String getMonitoringHost() {
       return null;
     }
@@ -1683,7 +1685,9 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
 
     /** Sets the monitoring host to be used for Built-in client side metrics */
     @Deprecated
-    @ObsoleteApi("This will be removed in upcoming version without breaking change release. You should use universalDomain to configure the built-in metrics endpoint for a partner universe.")
+    @ObsoleteApi(
+        "This will be removed in an upcoming version without a major version bump. You should use"
+            + " universalDomain to configure the built-in metrics endpoint for a partner universe.")
     public Builder setMonitoringHost(String monitoringHost) {
       this.monitoringHost = monitoringHost;
       return this;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -120,7 +120,8 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
   private static final String PG_ADAPTER_CLIENT_LIB_TOKEN = "pg-adapter";
 
   private static final String API_SHORT_NAME = "Spanner";
-  private static final String DEFAULT_HOST = "https://spanner.googleapis.com";
+  private static final String SPANNER_SERVICE_NAME = "spanner";
+  private static final String GOOGLE_DEFAULT_UNIVERSE = "googleapis.com";
   private static final String EXPERIMENTAL_HOST_PROJECT_ID = "default";
 
   private static final ImmutableSet<String> SCOPES =
@@ -780,9 +781,18 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     databaseRole = builder.databaseRole;
     sessionLabels = builder.sessionLabels;
     try {
-      spannerStubSettings = builder.spannerStubSettingsBuilder.build();
-      instanceAdminStubSettings = builder.instanceAdminStubSettingsBuilder.build();
-      databaseAdminStubSettings = builder.databaseAdminStubSettingsBuilder.build();
+      spannerStubSettings =
+          builder.spannerStubSettingsBuilder.setUniverseDomain(getResolvedUniverseDomain()).build();
+      instanceAdminStubSettings =
+          builder
+              .instanceAdminStubSettingsBuilder
+              .setUniverseDomain(getResolvedUniverseDomain())
+              .build();
+      databaseAdminStubSettings =
+          builder
+              .databaseAdminStubSettingsBuilder
+              .setUniverseDomain(getResolvedUniverseDomain())
+              .build();
     } catch (IOException e) {
       throw SpannerExceptionFactory.newSpannerException(e);
     }
@@ -822,6 +832,11 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     enableEndToEndTracing = builder.enableEndToEndTracing;
     monitoringHost = builder.monitoringHost;
     defaultTransactionOptions = builder.defaultTransactionOptions;
+  }
+
+  private String getResolvedUniverseDomain() {
+    String universeDomain = getUniverseDomain();
+    return Strings.isNullOrEmpty(universeDomain) ? GOOGLE_DEFAULT_UNIVERSE : universeDomain;
   }
 
   /**
@@ -871,6 +886,8 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
       return false;
     }
 
+    @Deprecated
+    @ObsoleteApi("This will be removed in upcoming version without breaking change release. You should use universalDomain to configure the built-in metrics endpoint for a partner universe.")
     default String getMonitoringHost() {
       return null;
     }
@@ -1665,6 +1682,8 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     }
 
     /** Sets the monitoring host to be used for Built-in client side metrics */
+    @Deprecated
+    @ObsoleteApi("This will be removed in upcoming version without breaking change release. You should use universalDomain to configure the built-in metrics endpoint for a partner universe.")
     public Builder setMonitoringHost(String monitoringHost) {
       this.monitoringHost = monitoringHost;
       return this;
@@ -2035,7 +2054,11 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
   public void enablegRPCMetrics(InstantiatingGrpcChannelProvider.Builder channelProviderBuilder) {
     if (SpannerOptions.environment.isEnableGRPCBuiltInMetrics()) {
       this.builtInMetricsProvider.enableGrpcMetrics(
-          channelProviderBuilder, this.getProjectId(), getCredentials(), this.monitoringHost);
+          channelProviderBuilder,
+          this.getProjectId(),
+          getCredentials(),
+          this.monitoringHost,
+          getUniverseDomain());
     }
   }
 
@@ -2081,7 +2104,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
   private ApiTracerFactory createMetricsApiTracerFactory() {
     OpenTelemetry openTelemetry =
         this.builtInMetricsProvider.getOrCreateOpenTelemetry(
-            this.getProjectId(), getCredentials(), this.monitoringHost);
+            this.getProjectId(), getCredentials(), this.monitoringHost, getUniverseDomain());
 
     return openTelemetry != null
         ? new BuiltInMetricsTracerFactory(
@@ -2181,7 +2204,11 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
 
   @Override
   protected String getDefaultHost() {
-    return DEFAULT_HOST;
+    String universeDomain = getUniverseDomain();
+    if (Strings.isNullOrEmpty(universeDomain)) {
+      universeDomain = GOOGLE_DEFAULT_UNIVERSE;
+    }
+    return String.format("https://%s.%s", SPANNER_SERVICE_NAME, universeDomain);
   }
 
   private static class SpannerDefaults implements ServiceDefaults<Spanner, SpannerOptions> {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -781,17 +781,18 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     databaseRole = builder.databaseRole;
     sessionLabels = builder.sessionLabels;
     try {
+      String resolvedUniversalDomain = getResolvedUniverseDomain();
       spannerStubSettings =
-          builder.spannerStubSettingsBuilder.setUniverseDomain(getResolvedUniverseDomain()).build();
+          builder.spannerStubSettingsBuilder.setUniverseDomain(resolvedUniversalDomain).build();
       instanceAdminStubSettings =
           builder
               .instanceAdminStubSettingsBuilder
-              .setUniverseDomain(getResolvedUniverseDomain())
+              .setUniverseDomain(resolvedUniversalDomain)
               .build();
       databaseAdminStubSettings =
           builder
               .databaseAdminStubSettingsBuilder
-              .setUniverseDomain(getResolvedUniverseDomain())
+              .setUniverseDomain(resolvedUniversalDomain)
               .build();
     } catch (IOException e) {
       throw SpannerExceptionFactory.newSpannerException(e);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
@@ -77,6 +77,7 @@ import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.connection.StatementExecutor.StatementExecutorType;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.base.Suppliers;
@@ -970,7 +971,7 @@ public class ConnectionOptions {
       return null;
     }
     try {
-      URL url = new URL(host);
+      URL url = new URL(MoreObjects.firstNonNull(host, DEFAULT_HOST));
       ExternalChannelProvider provider =
           ExternalChannelProvider.class.cast(Class.forName(channelProvider).newInstance());
       return provider.getChannelProvider(url.getHost(), url.getPort());

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
@@ -49,6 +49,7 @@ import static com.google.cloud.spanner.connection.ConnectionProperties.ROUTE_TO_
 import static com.google.cloud.spanner.connection.ConnectionProperties.TRACING_PREFIX;
 import static com.google.cloud.spanner.connection.ConnectionProperties.TRACK_CONNECTION_LEAKS;
 import static com.google.cloud.spanner.connection.ConnectionProperties.TRACK_SESSION_LEAKS;
+import static com.google.cloud.spanner.connection.ConnectionProperties.UNIVERSE_DOMAIN;
 import static com.google.cloud.spanner.connection.ConnectionProperties.USER_AGENT;
 import static com.google.cloud.spanner.connection.ConnectionProperties.USE_AUTO_SAVEPOINTS_FOR_EMULATOR;
 import static com.google.cloud.spanner.connection.ConnectionProperties.USE_PLAIN_TEXT;
@@ -769,7 +770,7 @@ public class ConnectionOptions {
       boolean autoConfigEmulator,
       boolean usePlainText,
       Map<String, String> environment) {
-    String host;
+    String host = null;
     if (Objects.equals(endpoint, DEFAULT_ENDPOINT) && matcher.group(Builder.HOST_GROUP) == null) {
       if (autoConfigEmulator) {
         if (Strings.isNullOrEmpty(environment.get(SPANNER_EMULATOR_HOST_ENV_VAR))) {
@@ -777,8 +778,6 @@ public class ConnectionOptions {
         } else {
           return PLAIN_TEXT_PROTOCOL + "//" + environment.get(SPANNER_EMULATOR_HOST_ENV_VAR);
         }
-      } else {
-        return DEFAULT_HOST;
       }
     } else if (!Objects.equals(endpoint, DEFAULT_ENDPOINT)) {
       // Add '//' at the start of the endpoint to conform to the standard URL specification.
@@ -791,6 +790,9 @@ public class ConnectionOptions {
           && !host.matches(".*:\\d+$")) {
         host = String.format("%s:15000", host);
       }
+    }
+    if (host == null) {
+      return null;
     }
     if (usePlainText) {
       return PLAIN_TEXT_PROTOCOL + host;
@@ -1084,6 +1086,10 @@ public class ConnectionOptions {
 
   Boolean isEnableDirectAccess() {
     return getInitialConnectionPropertyValue(ENABLE_DIRECT_ACCESS);
+  }
+
+  String getUniverseDomain() {
+    return getInitialConnectionPropertyValue(UNIVERSE_DOMAIN);
   }
 
   String getClientCertificate() {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java
@@ -200,6 +200,14 @@ public class ConnectionProperties {
           BOOLEANS,
           BooleanConverter.INSTANCE,
           Context.STARTUP);
+  static final ConnectionProperty<String> UNIVERSE_DOMAIN =
+      create(
+          "universeDomain",
+          "Configure the connection to try to connect to Spanner using "
+              + "a different partner Google Universe than GDU (googleapis.com).",
+          "googleapis.com",
+          StringValueConverter.INSTANCE,
+          Context.STARTUP);
   static final ConnectionProperty<Boolean> USE_AUTO_SAVEPOINTS_FOR_EMULATOR =
       create(
           "useAutoSavepointsForEmulator",

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
@@ -165,6 +165,7 @@ public class SpannerPool {
     private final String clientCertificateKey;
     private final boolean isExperimentalHost;
     private final Boolean enableDirectAccess;
+    private final String universeDomain;
 
     @VisibleForTesting
     static SpannerPoolKey of(ConnectionOptions options) {
@@ -200,6 +201,7 @@ public class SpannerPool {
       this.clientCertificateKey = options.getClientCertificateKey();
       this.isExperimentalHost = options.isExperimentalHost();
       this.enableDirectAccess = options.isEnableDirectAccess();
+      this.universeDomain = options.getUniverseDomain();
     }
 
     @Override
@@ -226,7 +228,8 @@ public class SpannerPool {
           && Objects.equals(this.clientCertificate, other.clientCertificate)
           && Objects.equals(this.clientCertificateKey, other.clientCertificateKey)
           && Objects.equals(this.isExperimentalHost, other.isExperimentalHost)
-          && Objects.equals(this.enableDirectAccess, other.enableDirectAccess);
+          && Objects.equals(this.enableDirectAccess, other.enableDirectAccess)
+          && Objects.equals(this.universeDomain, other.universeDomain);
     }
 
     @Override
@@ -249,7 +252,8 @@ public class SpannerPool {
           this.clientCertificate,
           this.clientCertificateKey,
           this.isExperimentalHost,
-          this.enableDirectAccess);
+          this.enableDirectAccess,
+          this.universeDomain);
     }
   }
 
@@ -418,6 +422,9 @@ public class SpannerPool {
     }
     if (key.enableDirectAccess != null) {
       builder.setEnableDirectAccess(key.enableDirectAccess);
+    }
+    if (key.universeDomain != null) {
+      builder.setUniverseDomain(key.universeDomain);
     }
     if (options.getConfigurator() != null) {
       options.getConfigurator().configure(builder);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterTest.java
@@ -30,6 +30,7 @@ import static com.google.cloud.spanner.BuiltInMetricsConstant.OPERATION_COUNT_NA
 import static com.google.cloud.spanner.BuiltInMetricsConstant.OPERATION_LATENCIES_NAME;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.PROJECT_ID_KEY;
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -39,6 +40,7 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.monitoring.v3.MetricServiceClient;
+import com.google.cloud.monitoring.v3.MetricServiceSettings;
 import com.google.cloud.monitoring.v3.stub.MetricServiceStub;
 import com.google.common.collect.ImmutableList;
 import com.google.monitoring.v3.CreateTimeSeriesRequest;
@@ -457,6 +459,25 @@ public class SpannerCloudMonitoringExporterTest {
         SpannerCloudMonitoringExporter.create(projectId, null, null, null);
     assertThat(actualExporter.getAggregationTemporality(InstrumentType.COUNTER))
         .isEqualTo(AggregationTemporality.CUMULATIVE);
+  }
+
+  @Test
+  public void testUniverseDomain() throws IOException {
+    SpannerCloudMonitoringExporter actualExporter =
+        SpannerCloudMonitoringExporter.create(projectId, null, null, "abc.goog");
+    MetricServiceSettings metricServiceSettings =
+        actualExporter.getMetricServiceClient().getSettings();
+
+    assertEquals("abc.goog", metricServiceSettings.getUniverseDomain());
+    assertEquals("monitoring.abc.goog:443", metricServiceSettings.getEndpoint());
+
+    actualExporter =
+        SpannerCloudMonitoringExporter.create(
+            projectId, null, "monitoringa.abc.goog:443", "abc.goog");
+    metricServiceSettings = actualExporter.getMetricServiceClient().getSettings();
+
+    assertEquals("abc.goog", metricServiceSettings.getUniverseDomain());
+    assertEquals("monitoringa.abc.goog:443", metricServiceSettings.getEndpoint());
   }
 
   private static class FakeMetricServiceClient extends MetricServiceClient {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterTest.java
@@ -454,7 +454,7 @@ public class SpannerCloudMonitoringExporterTest {
   @Test
   public void getAggregationTemporality() throws IOException {
     SpannerCloudMonitoringExporter actualExporter =
-        SpannerCloudMonitoringExporter.create(projectId, null, null);
+        SpannerCloudMonitoringExporter.create(projectId, null, null, null);
     assertThat(actualExporter.getAggregationTemporality(InstrumentType.COUNTER))
         .isEqualTo(AggregationTemporality.CUMULATIVE);
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
@@ -761,11 +761,11 @@ public class SpannerOptionsTest {
     String metricsEndpoint = "test-endpoint:443";
     assertNull(SpannerOptions.newBuilder().setProjectId("p").build().getMonitoringHost());
     assertThat(
-            SpannerOptions.newBuilder()
-                .setProjectId("p")
-                .setMonitoringHost(metricsEndpoint)
-                .build()
-                .getMonitoringHost())
+        SpannerOptions.newBuilder()
+            .setProjectId("p")
+            .setMonitoringHost(metricsEndpoint)
+            .build()
+            .getMonitoringHost())
         .isEqualTo(metricsEndpoint);
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
@@ -761,11 +761,11 @@ public class SpannerOptionsTest {
     String metricsEndpoint = "test-endpoint:443";
     assertNull(SpannerOptions.newBuilder().setProjectId("p").build().getMonitoringHost());
     assertThat(
-        SpannerOptions.newBuilder()
-            .setProjectId("p")
-            .setMonitoringHost(metricsEndpoint)
-            .build()
-            .getMonitoringHost())
+            SpannerOptions.newBuilder()
+                .setProjectId("p")
+                .setMonitoringHost(metricsEndpoint)
+                .build()
+                .getMonitoringHost())
         .isEqualTo(metricsEndpoint);
   }
 


### PR DESCRIPTION
**Description:**

This PR adds the support for configuring Partner Universe(TPU) in Java Spanner Client Library.

* Decides the monitoring host based on universeDomain set in SpannerOptions
* Decides the default host in SpannerOptions based on universeDomain
* Provides support for universeDomain in ConnectionProperties(JDBC)
* Removes the existing `setMonitoringHost` method which is no longer needed. TPC is not live yet so this functionality was not used.

