### PR TITLE
fix: automatically set default_sequence_kind for CREATE SEQUENCE

### DIFF
--- a/.github/workflows/update_generation_config.yaml
+++ b/.github/workflows/update_generation_config.yaml
@@ -26,7 +26,7 @@ jobs:
       # the branch into which the pull request is merged
       base_branch: main
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         token: ${{ secrets.CLOUD_JAVA_BOT_TOKEN }}

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MissingDefaultSequenceKindException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MissingDefaultSequenceKindException.java
@@ -28,7 +28,9 @@ public class MissingDefaultSequenceKindException extends SpannerException {
   private static final long serialVersionUID = 1L;
 
   private static final Pattern PATTERN =
-      Pattern.compile(".*Please specify the sequence kind explicitly or set the database option `default_sequence_kind`\\.");
+      Pattern.compile(
+          ".*Please specify the sequence kind explicitly or set the database option"
+              + " `default_sequence_kind`\\.");
 
   /** Private constructor. Use {@link SpannerExceptionFactory} to create instances. */
   MissingDefaultSequenceKindException(


### PR DESCRIPTION
Relax the pattern that is used to match errors that should lead to setting a default sequence kind and then retrying the DDL statement. The current pattern would only match errors that were returned for `IDENTITY` or `serial` columns, and not for `CREATE SEQUENCE` statements.