### PR TITLE
chore: Migrate executor tests to use ServiceAccountCredentials.fromStream()

### DIFF
--- a/google-cloud-spanner-executor/src/main/java/com/google/cloud/executor/spanner/CloudClientExecutor.java
+++ b/google-cloud-spanner-executor/src/main/java/com/google/cloud/executor/spanner/CloudClientExecutor.java
@@ -27,6 +27,7 @@ import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnavailableException;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.NoCredentials;
@@ -888,7 +889,7 @@ public class CloudClientExecutor extends CloudExecutor {
       credentials = NoCredentials.getInstance();
     } else {
       credentials =
-          GoogleCredentials.fromStream(
+          ServiceAccountCredentials.fromStream(
               new ByteArrayInputStream(
                   FileUtils.readFileToByteArray(new File(WorkerProxy.serviceKeyFile))),
               HTTP_TRANSPORT_FACTORY);

--- a/google-cloud-spanner-executor/src/main/java/com/google/cloud/executor/spanner/WorkerProxy.java
+++ b/google-cloud-spanner-executor/src/main/java/com/google/cloud/executor/spanner/WorkerProxy.java
@@ -19,7 +19,7 @@ package com.google.cloud.executor.spanner;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.auth.Credentials;
 import com.google.auth.http.HttpTransportFactory;
-import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.opentelemetry.trace.TraceConfiguration;
 import com.google.cloud.opentelemetry.trace.TraceExporter;
 import com.google.cloud.spanner.ErrorCode;
@@ -87,7 +87,7 @@ public class WorkerProxy {
     // Read credentials from the serviceKeyFile.
     HttpTransportFactory HTTP_TRANSPORT_FACTORY = NetHttpTransport::new;
     Credentials credentials =
-        GoogleCredentials.fromStream(
+        ServiceAccountCredentials.fromStream(
             new ByteArrayInputStream(FileUtils.readFileToByteArray(new File(serviceKeyFile))),
             HTTP_TRANSPORT_FACTORY);
 


### PR DESCRIPTION
See b/437991832 for more information.

Executor tests use a SA Key and can be created from `ServiceAccountCredentials.fromStream()`