### PR TITLE
chore: Update GceTestEnvConfig to use ServiceAccountCredential.fromStream()

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GceTestEnvConfig.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GceTestEnvConfig.java
@@ -21,7 +21,7 @@ import static com.google.cloud.spanner.testing.ExperimentalHostHelper.setExperim
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
-import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.spanner.spi.v1.SpannerInterceptorProvider;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -80,7 +80,8 @@ public class GceTestEnvConfig implements TestEnvConfig {
     }
     if (!credentialsFile.isEmpty()) {
       try {
-        builder.setCredentials(GoogleCredentials.fromStream(new FileInputStream(credentialsFile)));
+        builder.setCredentials(
+            ServiceAccountCredentials.fromStream(new FileInputStream(credentialsFile)));
       } catch (IOException e) {
         throw new RuntimeException(e);
       }


### PR DESCRIPTION
See b/437991832 for more information.

Local invocation of this test would be using a ServiceAccountCredential