### PR TITLE
fix: findColumn was case-sensitive

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Type.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Type.java
@@ -472,9 +472,9 @@ public final class Type implements Serializable {
       Map<String, Integer> tmp = new TreeMap<>();
       for (int i = 0; i < getStructFields().size(); ++i) {
         Type.StructField field = getStructFields().get(i);
-        if (tmp.put(field.getName(), i) != null) {
+        if (tmp.put(field.getName().toLowerCase(), i) != null) {
           // Column name appears more than once: mark as ambiguous.
-          tmp.put(field.getName(), AMBIGUOUS_FIELD);
+          tmp.put(field.getName().toLowerCase(), AMBIGUOUS_FIELD);
         }
       }
       // Benign race: Java's final field semantics mean that if we see a non-null "fieldsByName",
@@ -485,7 +485,10 @@ public final class Type implements Serializable {
       fieldsByName = ImmutableMap.copyOf(tmp);
     }
 
-    Integer index = fieldsByName.get(fieldName);
+    if (fieldName == null) {
+      throw new IllegalArgumentException("Field name cannot be null");
+    }
+    Integer index = fieldsByName.get(fieldName.toLowerCase());
     if (index == null) {
       throw new IllegalArgumentException("Field not found: " + fieldName);
     }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TypeTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TypeTest.java
@@ -522,7 +522,7 @@ public class TypeTest {
     assertThat(t.getStructFields().get(2).getType()).isEqualTo(Type.pgNumeric());
     assertThat(t.toString()).isEqualTo("STRUCT<f1 INT64, f2 STRING, f3 NUMERIC<PG_NUMERIC>>");
     assertThat(t.getFieldIndex("f1")).isEqualTo(0);
-    assertThat(t.getFieldIndex("f2")).isEqualTo(1);
+    assertThat(t.getFieldIndex("F2")).isEqualTo(1);
     assertThat(t.getFieldIndex("f3")).isEqualTo(2);
 
     assertProtoEquals(


### PR DESCRIPTION
**Description:**

Currently we store all the columns in a Treemap in a case-sensitive way. In Hibernate, we can query columns using case-insensitive way. 

To fix this, we will be storing all the fields in a Lowercase format. To retrieve it, we will convert the requested column name to lowercase before actually looking in the map.