### PR TITLE
chore: Update to ServiceAccountCredentials.fromStream for WorkerProxy.serviceKeyFile

### DIFF
--- a/google-cloud-spanner-executor/src/main/java/com/google/cloud/executor/spanner/CloudClientExecutor.java
+++ b/google-cloud-spanner-executor/src/main/java/com/google/cloud/executor/spanner/CloudClientExecutor.java
@@ -26,7 +26,6 @@ import com.google.api.gax.rpc.DeadlineExceededException;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnavailableException;
 import com.google.auth.Credentials;
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
@@ -807,7 +806,7 @@ public class CloudClientExecutor extends CloudExecutor {
       credentials = NoCredentials.getInstance();
     } else {
       credentials =
-          GoogleCredentials.fromStream(
+          ServiceAccountCredentials.fromStream(
               new ByteArrayInputStream(
                   FileUtils.readFileToByteArray(new File(WorkerProxy.serviceKeyFile))),
               HTTP_TRANSPORT_FACTORY);


### PR DESCRIPTION
Remove the last occurence in CloudClientExecutor.java regarding `GoogleCredential.fromStream()`. The executor system tests always use a SA key. 