### PR TITLE
fix: Remove URL encoding in project name

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceAdminClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceAdminClientImpl.java
@@ -53,7 +53,7 @@ class InstanceAdminClientImpl implements InstanceAdminClient {
   }
 
   private static final PathTemplate PROJECT_NAME_TEMPLATE =
-      PathTemplate.create("projects/{project}");
+      PathTemplate.createWithoutUrlEncoding("projects/{project}");
   private final DatabaseAdminClient dbClient;
   private final String projectId;
   private final SpannerRpc rpc;


### PR DESCRIPTION
**Description:**

Path template is encoding the generated project name by default. It is converting `:` into `%3A` which is causing issues in the Spanner. Spanner checks if project name is valid by checking the characters. 