### PR TITLE
fix: add env var to allow disabling directpath bound token

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -368,10 +368,12 @@ public class GapicSpannerRpc implements SpannerRpc {
       boolean isEnableDirectAccess = options.isEnableDirectAccess();
       if (isEnableDirectAccess) {
         defaultChannelProviderBuilder.setAttemptDirectPath(true);
-        // This will let the credentials try to fetch a hard-bound access token if the runtime
-        // environment supports it.
-        defaultChannelProviderBuilder.setAllowHardBoundTokenTypes(
-            Collections.singletonList(InstantiatingGrpcChannelProvider.HardBoundTokenTypes.ALTS));
+        if (isEnableDirectPathBoundToken()) {
+          // This will let the credentials try to fetch a hard-bound access token if the runtime
+          // environment supports it.
+          defaultChannelProviderBuilder.setAllowHardBoundTokenTypes(
+              Collections.singletonList(InstantiatingGrpcChannelProvider.HardBoundTokenTypes.ALTS));
+        }
         defaultChannelProviderBuilder.setAttemptDirectPathXds();
       }
 
@@ -685,6 +687,10 @@ public class GapicSpannerRpc implements SpannerRpc {
 
   public static boolean isEnableDirectPathXdsEnv() {
     return Boolean.parseBoolean(System.getenv("GOOGLE_SPANNER_ENABLE_DIRECT_ACCESS"));
+  }
+
+  public static boolean isEnableDirectPathBoundToken() {
+    return !Boolean.parseBoolean(System.getenv("GOOGLE_SPANNER_DISABLE_DIRECT_ACCESS_BOUND_TOKEN"));
   }
 
   private static final RetrySettings ADMIN_REQUESTS_LIMIT_EXCEEDED_RETRY_SETTINGS =


### PR DESCRIPTION
Inspired by https://github.com/googleapis/java-bigtable/pull/2695

The token issuing side is still behind so hopefully it's not too late to add this knob out of extra caution. Users will be able to use it to turn off this flow if anything goes wrong.