### PR TITLE
chore: skip the internal retry if last_statement is set

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -818,7 +818,11 @@ abstract class AbstractReadContext
               @Nullable ByteString resumeToken,
               AsyncResultSet.StreamMessageListener streamListener) {
             GrpcStreamIterator stream =
-                new GrpcStreamIterator(statement, prefetchChunks, cancelQueryWhenClientIsClosed);
+                new GrpcStreamIterator(
+                    statement,
+                    request.getLastStatement(),
+                    prefetchChunks,
+                    cancelQueryWhenClientIsClosed);
             if (streamListener != null) {
               stream.registerListener(streamListener);
             }
@@ -935,7 +939,8 @@ abstract class AbstractReadContext
   public void onTransactionMetadata(Transaction transaction, boolean shouldIncludeId) {}
 
   @Override
-  public SpannerException onError(SpannerException e, boolean withBeginTransaction) {
+  public SpannerException onError(
+      SpannerException e, boolean withBeginTransaction, boolean lastStatement) {
     this.session.onError(e);
     return e;
   }
@@ -1009,6 +1014,8 @@ abstract class AbstractReadContext
     }
     final int prefetchChunks =
         readOptions.hasPrefetchChunks() ? readOptions.prefetchChunks() : defaultPrefetchChunks;
+    final boolean lastStatement =
+        readOptions.hasLastStatement() ? readOptions.isLastStatement() : false;
     ResumableStreamIterator stream =
         new ResumableStreamIterator(
             MAX_BUFFERED_CHUNKS,
@@ -1025,7 +1032,8 @@ abstract class AbstractReadContext
               @Nullable ByteString resumeToken,
               AsyncResultSet.StreamMessageListener streamListener) {
             GrpcStreamIterator stream =
-                new GrpcStreamIterator(prefetchChunks, cancelQueryWhenClientIsClosed);
+                new GrpcStreamIterator(
+                    lastStatement, prefetchChunks, cancelQueryWhenClientIsClosed);
             if (streamListener != null) {
               stream.registerListener(streamListener);
             }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractResultSet.java
@@ -56,7 +56,8 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
         throws SpannerException;
 
     /** Called when the read finishes with an error. Returns the error that should be thrown. */
-    SpannerException onError(SpannerException e, boolean withBeginTransaction);
+    SpannerException onError(
+        SpannerException e, boolean withBeginTransaction, boolean lastStatement);
 
     /** Called when the read finishes normally. */
     void onDone(boolean withBeginTransaction);
@@ -152,6 +153,8 @@ abstract class AbstractResultSet<R> extends AbstractStructReader implements Resu
     void close(@Nullable String message);
 
     boolean isWithBeginTransaction();
+
+    boolean isLastStatement();
 
     /**
      * @param streamMessageListener A class object which implements StreamMessageListener

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/GrpcResultSet.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/GrpcResultSet.java
@@ -109,7 +109,8 @@ class GrpcResultSet extends AbstractResultSet<List<Object>>
     } catch (Throwable t) {
       throw yieldError(
           SpannerExceptionFactory.asSpannerException(t),
-          iterator.isWithBeginTransaction() && currRow == null);
+          iterator.isWithBeginTransaction() && currRow == null,
+          iterator.isLastStatement());
     }
   }
 
@@ -149,8 +150,9 @@ class GrpcResultSet extends AbstractResultSet<List<Object>>
     return currRow.getType();
   }
 
-  private SpannerException yieldError(SpannerException e, boolean beginTransaction) {
-    SpannerException toThrow = listener.onError(e, beginTransaction);
+  private SpannerException yieldError(
+      SpannerException e, boolean beginTransaction, boolean lastStatement) {
+    SpannerException toThrow = listener.onError(e, beginTransaction, lastStatement);
     close();
     throw toThrow;
   }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/GrpcStreamIterator.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/GrpcStreamIterator.java
@@ -49,20 +49,26 @@ class GrpcStreamIterator extends AbstractIterator<PartialResultSet>
 
   private SpannerRpc.StreamingCall call;
   private volatile boolean withBeginTransaction;
+  private final boolean lastStatement;
   private TimeUnit streamWaitTimeoutUnit;
   private long streamWaitTimeoutValue;
   private SpannerException error;
   private boolean done;
 
   @VisibleForTesting
-  GrpcStreamIterator(int prefetchChunks, boolean cancelQueryWhenClientIsClosed) {
-    this(null, prefetchChunks, cancelQueryWhenClientIsClosed);
+  GrpcStreamIterator(
+      boolean lastStatement, int prefetchChunks, boolean cancelQueryWhenClientIsClosed) {
+    this(null, lastStatement, prefetchChunks, cancelQueryWhenClientIsClosed);
   }
 
   @VisibleForTesting
   GrpcStreamIterator(
-      Statement statement, int prefetchChunks, boolean cancelQueryWhenClientIsClosed) {
+      Statement statement,
+      boolean lastStatement,
+      int prefetchChunks,
+      boolean cancelQueryWhenClientIsClosed) {
     this.statement = statement;
+    this.lastStatement = lastStatement;
     this.prefetchChunks = prefetchChunks;
     this.consumer = new ConsumerImpl(cancelQueryWhenClientIsClosed);
     // One extra to allow for END_OF_STREAM message.
@@ -116,6 +122,11 @@ class GrpcStreamIterator extends AbstractIterator<PartialResultSet>
   @Override
   public boolean isWithBeginTransaction() {
     return withBeginTransaction;
+  }
+
+  @Override
+  public boolean isLastStatement() {
+    return lastStatement;
   }
 
   @Override

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/GrpcValueIterator.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/GrpcValueIterator.java
@@ -183,6 +183,10 @@ class GrpcValueIterator extends AbstractIterator<com.google.protobuf.Value> {
     return stream.isWithBeginTransaction();
   }
 
+  boolean isLastStatement() {
+    return stream.isLastStatement();
+  }
+
   /**
    * @param a is a mutable list and b will be concatenated into a.
    */

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ResumableStreamIterator.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/ResumableStreamIterator.java
@@ -243,6 +243,11 @@ abstract class ResumableStreamIterator extends AbstractIterator<PartialResultSet
   }
 
   @Override
+  public boolean isLastStatement() {
+    return stream != null && stream.isLastStatement();
+  }
+
+  @Override
   @InternalApi
   public boolean initiateStreaming(AsyncResultSet.StreamMessageListener streamMessageListener) {
     this.streamMessageListener = streamMessageListener;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GrpcResultSetTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/GrpcResultSetTest.java
@@ -75,7 +75,8 @@ public class GrpcResultSetTest {
         throws SpannerException {}
 
     @Override
-    public SpannerException onError(SpannerException e, boolean withBeginTransaction) {
+    public SpannerException onError(
+        SpannerException e, boolean withBeginTransaction, boolean lastStatement) {
       return e;
     }
 
@@ -88,7 +89,9 @@ public class GrpcResultSetTest {
 
   @Before
   public void setUp() {
-    stream = new GrpcStreamIterator(10, /* cancelQueryWhenClientIsClosed= */ false);
+    stream =
+        new GrpcStreamIterator(
+            /* lastStatement= */ false, 10, /* cancelQueryWhenClientIsClosed= */ false);
     stream.setCall(
         new SpannerRpc.StreamingCall() {
           @Override

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadFormatTestRunner.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ReadFormatTestRunner.java
@@ -51,7 +51,8 @@ public class ReadFormatTestRunner extends ParentRunner<JSONObject> {
         throws SpannerException {}
 
     @Override
-    public SpannerException onError(SpannerException e, boolean withBeginTransaction) {
+    public SpannerException onError(
+        SpannerException e, boolean withBeginTransaction, boolean lastStatement) {
       return e;
     }
 
@@ -118,7 +119,9 @@ public class ReadFormatTestRunner extends ParentRunner<JSONObject> {
     }
 
     private void run() throws Exception {
-      stream = new GrpcStreamIterator(10, /* cancelQueryWhenClientIsClosed= */ false);
+      stream =
+          new GrpcStreamIterator(
+              /* lastStatement= */ false, 10, /* cancelQueryWhenClientIsClosed= */ false);
       stream.setCall(
           new SpannerRpc.StreamingCall() {
             @Override

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ResultSetsHelper.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ResultSetsHelper.java
@@ -48,6 +48,11 @@ public class ResultSetsHelper {
           }
 
           @Override
+          public boolean isLastStatement() {
+            return false;
+          }
+
+          @Override
           public boolean hasNext() {
             return first || iterator.hasNext();
           }
@@ -77,7 +82,8 @@ public class ResultSetsHelper {
               throws SpannerException {}
 
           @Override
-          public SpannerException onError(SpannerException e, boolean withBeginTransaction) {
+          public SpannerException onError(
+              SpannerException e, boolean withBeginTransaction, boolean isLastStatement) {
             return e;
           }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ResumableStreamIteratorTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ResumableStreamIteratorTest.java
@@ -140,6 +140,11 @@ public class ResumableStreamIteratorTest {
     public boolean isWithBeginTransaction() {
       return false;
     }
+
+    @Override
+    public boolean isLastStatement() {
+      return false;
+    }
   }
 
   Starter starter = Mockito.mock(Starter.class);


### PR DESCRIPTION
If the first statement in a transaction carries an InlineBeginTransaction option, the transaction will be retried if the statement fails, as the RPC did not return a transaction ID. This retry can be skipped if the statement also carried the last_statement flag, as no more statements are allowed after that statement.
