### PR TITLE
fix: Refine connectivity metric for RPCs that receive no response and sent to Transport layer 

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerGrpcStreamTracer.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerGrpcStreamTracer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spanner;
+
+import io.grpc.ClientStreamTracer;
+import io.grpc.Metadata;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/** Captures the event when a request is sent from the gRPC client. */
+public class SpannerGrpcStreamTracer extends ClientStreamTracer {
+
+  private final AtomicBoolean outBoundMessageSent = new AtomicBoolean(false);
+
+  public SpannerGrpcStreamTracer() {}
+
+  public boolean isOutBoundMessageSent() {
+    return outBoundMessageSent.get();
+  }
+
+  /** An outbound message has been serialized and sent to the transport. */
+  @Override
+  public void outboundMessageSent(int seqNo, long optionalWireSize, long optionalUncompressedSize) {
+    outBoundMessageSent.set(true);
+  }
+
+  public static class Factory extends ClientStreamTracer.Factory {
+
+    SpannerGrpcStreamTracer spannerGrpcStreamTracer;
+
+    public Factory(SpannerGrpcStreamTracer spannerGrpcStreamTracer) {
+      this.spannerGrpcStreamTracer = spannerGrpcStreamTracer;
+    }
+
+    @Override
+    public ClientStreamTracer newClientStreamTracer(
+        ClientStreamTracer.StreamInfo info, Metadata headers) {
+      return spannerGrpcStreamTracer;
+    }
+  }
+}

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
@@ -347,6 +347,10 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
     // Attempt count should have a failed metric point for CreateSession.
     assertEquals(
         1, getAggregatedValue(attemptCountMetricData, expectedAttributesCreateSessionFailed), 0);
+
+    // Connectivity count will not increase as client did not attempt to send the request
+    assertFalse(
+        checkIfMetricExists(metricReader, BuiltInMetricsConstant.GFE_CONNECTIVITY_ERROR_NAME));
   }
 
   @Test
@@ -390,6 +394,8 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
 
     assertFalse(checkIfMetricExists(metricReader, BuiltInMetricsConstant.AFE_LATENCIES_NAME));
     assertFalse(checkIfMetricExists(metricReader, BuiltInMetricsConstant.GFE_LATENCIES_NAME));
+    assertTrue(
+        checkIfMetricExists(metricReader, BuiltInMetricsConstant.GFE_CONNECTIVITY_ERROR_NAME));
     // Metric is disabled currently
     assertFalse(
         checkIfMetricExists(metricReader, BuiltInMetricsConstant.AFE_CONNECTIVITY_ERROR_NAME));


### PR DESCRIPTION
This PR enhances the connectivity error metrics in the Java Spanner client library to provide a more accurate and comprehensive tracking of network-related issues.

Description:
The current connectivity error metric is only incremented in the rare event that a response header is received from the server but lacks GFE/AFE server timing latency. This limitation means that more common and critical connectivity problems are not captured, such as:

1. Network issues that prevent requests from being sent to the server.
2. Requests that are sent but for which no response is ever received or cancelled from Client.

To address this gap, this change updates the logic to also capture RPCs that have been passed to the gRPC transport layer but for which no response is received. This will result in a more accurate and reliable connectivity error metric.

**Note** Client-side timeouts that occur before an RPC is sent to the transport layer are explicitly excluded from this metric.