### PR TITLE
fix: Fix transaction tag issue with blind-write

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionImpl.java
@@ -32,6 +32,7 @@ import com.google.cloud.spanner.Options.UpdateOption;
 import com.google.cloud.spanner.SessionClient.SessionOption;
 import com.google.cloud.spanner.TransactionRunnerImpl.TransactionContextImpl;
 import com.google.cloud.spanner.spi.v1.SpannerRpc;
+import com.google.common.base.Strings;
 import com.google.common.base.Ticker;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -510,6 +511,10 @@ class SessionImpl implements Session {
                             transactionOptions, previousTransactionId)));
     if (sessionReference.getIsMultiplexed() && mutation != null) {
       requestBuilder.setMutationKey(mutation);
+    }
+    if (sessionReference.getIsMultiplexed() && !Strings.isNullOrEmpty(transactionOptions.tag())) {
+      requestBuilder.setRequestOptions(
+          RequestOptions.newBuilder().setTransactionTag(transactionOptions.tag()).build());
     }
     final BeginTransactionRequest request = requestBuilder.build();
     final ApiFuture<Transaction> requestFuture;


### PR DESCRIPTION
**Description:**

Currently with the multiplexed session, SpanFE doesn't honor transaction tag for blind-write cases. Ideally this needs to be fixed in SpanFE which takes a long time. As a temporary workaround suggested by SpanFE, we are passing transaction tag in begin request to unblock beam release.

**More details:** b/461229444