### PR TITLE
fix: backslash at end of string literal was misinterpreted

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractStatementParser.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractStatementParser.java
@@ -1033,8 +1033,9 @@ public abstract class AbstractStatementParser {
       } else if (supportsBackslashEscape()
           && currentChar == BACKSLASH
           && length > currentIndex + 1
-          && sql.charAt(currentIndex + 1) == startQuote) {
-        // This is an escaped quote (e.g. 'foo\'bar').
+          && (sql.charAt(currentIndex + 1) == startQuote
+              || sql.charAt(currentIndex + 1) == BACKSLASH)) {
+        // This is an escaped quote (e.g. 'foo\'bar') or an escaped backslash (e.g. 'test\\').
         // Note that in raw strings, the \ officially does not start an escape sequence, but the
         // result is still the same, as in a raw string 'both characters are preserved'.
         appendIfNotNull(result, currentChar);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SpannerStatementParserTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SpannerStatementParserTest.java
@@ -54,6 +54,7 @@ public class SpannerStatementParserTest {
     assertEquals("'foo\"bar\"'", skip("'foo\"bar\"'  ", 0));
     assertEquals("\"foo'bar'\"", skip("\"foo'bar'\"  ", 0));
     assertEquals("`foo'bar'`", skip("`foo'bar'`  ", 0));
+    assertEquals("'test\\\\'", skip("'test\\\\'", 0));
 
     assertEquals("'''foo'bar'''", skip("'''foo'bar'''  ", 0));
     assertEquals("'''foo\\'bar'''", skip("'''foo\\'bar'''  ", 0));

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementParserTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/StatementParserTest.java
@@ -1268,6 +1268,10 @@ public class StatementParserTest {
         "@p1'''?it\\'?s \n ?it\\'?s'''@p2",
         parser.convertPositionalParametersToNamedParameters('?', "?'''?it\\'?s \n ?it\\'?s'''?")
             .sqlWithNamedParameters);
+    assertEquals(
+        "@p1'?test?\\\\'@p2",
+        parser.convertPositionalParametersToNamedParameters('?', "?'?test?\\\\'?")
+            .sqlWithNamedParameters);
 
     assertUnclosedLiteral(parser, "?'?it\\'?s \n ?it\\'?s'?");
     assertUnclosedLiteral(parser, "?'?it\\'?s \n ?it\\'?s?");


### PR DESCRIPTION
SQL strings that contained a string literal with a backslash as the last character were misinterpreted by the statement parser as containing unclosed string literals.

Fixes https://github.com/googleapis/java-spanner-jdbc/issues/2303
