### PR TITLE
chore: add release-please config for protobuf-4.x

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -54,3 +54,8 @@ branches:
     bumpMinorPreMajor: true
     handleGHRelease: true
     branch: 6.95.x
+  - releaseType: java-yoshi
+    bumpMinorPreMajor: true
+    handleGHRelease: true
+    branch: protobuf-4.x-rc
+    manifest: true


### PR DESCRIPTION
[go/cloud-java:protobuf-4.x-upgrade](http://goto.google.com/cloud-java:protobuf-4.x-upgrade)

Config in https://github.com/googleapis/java-spanner/blob/protobuf-4.x-rc/release-please-config.json