### PR TITLE
feat: include RequestID in requests and errors

### DIFF
--- a/google-cloud-spanner/clirr-ignored-differences.xml
+++ b/google-cloud-spanner/clirr-ignored-differences.xml
@@ -1087,9 +1087,56 @@
     <differenceType>7002</differenceType>
     <className>com/google/cloud/spanner/CompositeTracer</className>
     <method>void recordGFELatency(java.lang.Float)</method>
-  </difference><difference>
-  <differenceType>7002</differenceType>
-  <className>com/google/cloud/spanner/CompositeTracer</className>
-  <method>void recordGfeHeaderMissingCount(java.lang.Long)</method>
-</difference>
+  </difference>
+  <difference>
+    <differenceType>7002</differenceType>
+    <className>com/google/cloud/spanner/CompositeTracer</className>
+    <method>void recordGfeHeaderMissingCount(java.lang.Long)</method>
+  </difference>
+
+  <difference>
+    <differenceType>7002</differenceType>
+    <className>com/google/cloud/spanner/SpannerException</className>
+    <method>void setRequestId(com.google.cloud.spanner.XGoogSpannerRequestId)</method>
+  </difference>
+  <difference>
+    <differenceType>7002</differenceType>
+    <className>com/google/cloud/spanner/SpannerExceptionFactory</className>
+    <method>com.google.cloud.spanner.SpannerBatchUpdateException newSpannerBatchUpdateException(com.google.cloud.spanner.ErrorCode, java.lang.String, long[], com.google.cloud.spanner.XGoogSpannerRequestId)</method>
+  </difference>
+  <difference>
+    <differenceType>7002</differenceType>
+    <className>com/google/cloud/spanner/SpannerExceptionFactory</className>
+    <method>com.google.cloud.spanner.SpannerException newSpannerException(com.google.cloud.spanner.ErrorCode, java.lang.String, java.lang.Throwable, com.google.cloud.spanner.XGoogSpannerRequestId)</method>
+  </difference>
+  <difference>
+    <differenceType>7002</differenceType>
+    <className>com/google/cloud/spanner/SpannerExceptionFactory</className>
+    <method>com.google.cloud.spanner.SpannerException newSpannerException(com.google.cloud.spanner.ErrorCode, java.lang.String, com.google.cloud.spanner.XGoogSpannerRequestId)</method>
+  </difference>
+  <difference>
+    <differenceType>7002</differenceType>
+    <className>com/google/cloud/spanner/SpannerExceptionFactory</className>
+    <method>com.google.cloud.spanner.SpannerException newSpannerException(java.lang.Throwable, com.google.cloud.spanner.XGoogSpannerRequestId)</method>
+  </difference>
+  <difference>
+    <differenceType>7002</differenceType>
+    <className>com/google/cloud/spanner/SpannerExceptionFactory</className>
+    <method>com.google.cloud.spanner.SpannerException newSpannerException(io.grpc.Context, java.lang.Throwable, com.google.cloud.spanner.XGoogSpannerRequestId)</method>
+  </difference>
+  <difference>
+    <differenceType>7002</differenceType>
+    <className>com/google/cloud/spanner/SpannerExceptionFactory</className>
+    <method>com.google.cloud.spanner.SpannerException propagateInterrupt(java.lang.InterruptedException, com.google.cloud.spanner.XGoogSpannerRequestId)</method>
+  </difference>
+  <difference>
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/spanner/XGoogSpannerRequestId</className>
+    <field>REQUEST_HEADER_KEY</field>
+  </difference>
+  <difference>
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/spanner/XGoogSpannerRequestId</className>
+    <field>REQUEST_ID</field>
+  </difference>
 </differences>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbortedException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbortedException.java
@@ -38,7 +38,7 @@ public class AbortedException extends SpannerException {
   /** Private constructor. Use {@link SpannerExceptionFactory} to create instances. */
   AbortedException(
       DoNotConstructDirectly token, @Nullable String message, @Nullable Throwable cause) {
-    this(token, message, cause, null, null);
+    this(token, message, cause, null);
   }
 
   /** Private constructor. Use {@link SpannerExceptionFactory} to create instances. */
@@ -46,9 +46,8 @@ public class AbortedException extends SpannerException {
       DoNotConstructDirectly token,
       @Nullable String message,
       @Nullable Throwable cause,
-      @Nullable ApiException apiException,
-      @Nullable XGoogSpannerRequestId reqId) {
-    super(token, ErrorCode.ABORTED, IS_RETRYABLE, message, cause, apiException, reqId);
+      @Nullable ApiException apiException) {
+    super(token, ErrorCode.ABORTED, IS_RETRYABLE, message, cause, apiException);
     if (cause instanceof AbortedException) {
       this.transactionID = ((AbortedException) cause).getTransactionID();
     }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AbstractReadContext.java
@@ -457,30 +457,22 @@ abstract class AbstractReadContext
     }
 
     private void initTransactionInternal(BeginTransactionRequest request) {
-      XGoogSpannerRequestId reqId =
-          session.getRequestIdCreator().nextRequestId(session.getChannel(), 1);
       try {
         Transaction transaction =
-            rpc.beginTransaction(
-                request, reqId.withOptions(getTransactionChannelHint()), isRouteToLeader());
+            rpc.beginTransaction(request, getTransactionChannelHint(), isRouteToLeader());
         if (!transaction.hasReadTimestamp()) {
           throw SpannerExceptionFactory.newSpannerException(
-              ErrorCode.INTERNAL,
-              "Missing expected transaction.read_timestamp metadata field",
-              reqId);
+              ErrorCode.INTERNAL, "Missing expected transaction.read_timestamp metadata field");
         }
         if (transaction.getId().isEmpty()) {
           throw SpannerExceptionFactory.newSpannerException(
-              ErrorCode.INTERNAL, "Missing expected transaction.id metadata field", reqId);
+              ErrorCode.INTERNAL, "Missing expected transaction.id metadata field");
         }
         try {
           timestamp = Timestamp.fromProto(transaction.getReadTimestamp());
         } catch (IllegalArgumentException e) {
           throw SpannerExceptionFactory.newSpannerException(
-              ErrorCode.INTERNAL,
-              "Bad value in transaction.read_timestamp metadata field",
-              e,
-              reqId);
+              ErrorCode.INTERNAL, "Bad value in transaction.read_timestamp metadata field", e);
         }
         transactionId = transaction.getId();
         span.addAnnotation(
@@ -816,7 +808,8 @@ abstract class AbstractReadContext
           @Override
           CloseableIterator<PartialResultSet> startStream(
               @Nullable ByteString resumeToken,
-              AsyncResultSet.StreamMessageListener streamListener) {
+              AsyncResultSet.StreamMessageListener streamListener,
+              XGoogSpannerRequestId requestId) {
             GrpcStreamIterator stream =
                 new GrpcStreamIterator(
                     statement,
@@ -839,12 +832,12 @@ abstract class AbstractReadContext
             if (selector != null) {
               request.setTransaction(selector);
             }
-            this.ensureNonNullXGoogRequestId();
             SpannerRpc.StreamingCall call =
                 rpc.executeQuery(
                     request.build(),
                     stream.consumer(),
-                    this.xGoogRequestId.withOptions(getTransactionChannelHint()),
+                    getTransactionChannelHint(),
+                    requestId,
                     isRouteToLeader());
             session.markUsed(clock.instant());
             stream.setCall(call, request.getTransaction().hasBegin());
@@ -860,7 +853,7 @@ abstract class AbstractReadContext
         stream, this, options.hasDecodeMode() ? options.decodeMode() : defaultDecodeMode);
   }
 
-  Map<SpannerRpc.Option, ?> getChannelHintOptions(
+  static Map<SpannerRpc.Option, ?> getChannelHintOptions(
       Map<SpannerRpc.Option, ?> channelHintForSession, Long channelHintForTransaction) {
     if (channelHintForSession != null) {
       return channelHintForSession;
@@ -1030,7 +1023,8 @@ abstract class AbstractReadContext
           @Override
           CloseableIterator<PartialResultSet> startStream(
               @Nullable ByteString resumeToken,
-              AsyncResultSet.StreamMessageListener streamListener) {
+              AsyncResultSet.StreamMessageListener streamListener,
+              XGoogSpannerRequestId requestId) {
             GrpcStreamIterator stream =
                 new GrpcStreamIterator(
                     lastStatement, prefetchChunks, cancelQueryWhenClientIsClosed);
@@ -1048,13 +1042,12 @@ abstract class AbstractReadContext
               builder.setTransaction(selector);
             }
             builder.setRequestOptions(buildRequestOptions(readOptions));
-            this.incrementXGoogRequestIdAttempt();
-            this.xGoogRequestId.setChannelId(session.getChannel());
             SpannerRpc.StreamingCall call =
                 rpc.read(
                     builder.build(),
                     stream.consumer(),
-                    this.xGoogRequestId.withOptions(getTransactionChannelHint()),
+                    getTransactionChannelHint(),
+                    requestId,
                     isRouteToLeader());
             session.markUsed(clock.instant());
             stream.setCall(call, /* withBeginTransaction= */ builder.getTransaction().hasBegin());

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AdminRequestsPerMinuteExceededException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AdminRequestsPerMinuteExceededException.java
@@ -32,7 +32,7 @@ public class AdminRequestsPerMinuteExceededException extends SpannerException {
   /** Private constructor. Use {@link SpannerExceptionFactory} to create instances. */
   AdminRequestsPerMinuteExceededException(
       DoNotConstructDirectly token, @Nullable String message, @Nullable Throwable cause) {
-    this(token, message, cause, null, null);
+    this(token, message, cause, null);
   }
 
   /** Private constructor. Use {@link SpannerExceptionFactory} to create instances. */
@@ -40,8 +40,7 @@ public class AdminRequestsPerMinuteExceededException extends SpannerException {
       DoNotConstructDirectly token,
       @Nullable String message,
       @Nullable Throwable cause,
-      @Nullable ApiException apiException,
-      @Nullable XGoogSpannerRequestId reqId) {
-    super(token, ErrorCode.RESOURCE_EXHAUSTED, true, message, cause, apiException, reqId);
+      @Nullable ApiException apiException) {
+    super(token, ErrorCode.RESOURCE_EXHAUSTED, true, message, cause, apiException);
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchClientImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BatchClientImpl.java
@@ -250,11 +250,9 @@ public class BatchClientImpl implements BatchClient {
       }
       builder.setPartitionOptions(pbuilder.build());
 
-      XGoogSpannerRequestId reqId =
-          session.getRequestIdCreator().nextRequestId(session.getChannel(), 1);
       final PartitionReadRequest request = builder.build();
       try {
-        PartitionResponse response = rpc.partitionRead(request, reqId.withOptions(options));
+        PartitionResponse response = rpc.partitionRead(request, options);
         ImmutableList.Builder<Partition> partitions = ImmutableList.builder();
         for (com.google.spanner.v1.Partition p : response.getPartitionsList()) {
           Partition partition =
@@ -274,7 +272,6 @@ public class BatchClientImpl implements BatchClient {
           return partitionReadUsingIndex(
               partitionOptions, table, index, keys, columns, true, option);
         }
-        e.setRequestId(reqId);
         throw e;
       }
     }
@@ -316,11 +313,9 @@ public class BatchClientImpl implements BatchClient {
       }
       builder.setPartitionOptions(pbuilder.build());
 
-      XGoogSpannerRequestId reqId =
-          session.getRequestIdCreator().nextRequestId(session.getChannel(), 1);
       final PartitionQueryRequest request = builder.build();
       try {
-        PartitionResponse response = rpc.partitionQuery(request, reqId.withOptions(options));
+        PartitionResponse response = rpc.partitionQuery(request, options);
         ImmutableList.Builder<Partition> partitions = ImmutableList.builder();
         for (com.google.spanner.v1.Partition p : response.getPartitionsList()) {
           Partition partition =
@@ -333,7 +328,6 @@ public class BatchClientImpl implements BatchClient {
         if (!isFallback && maybeMarkUnimplementedForPartitionedOps(e)) {
           return partitionQuery(partitionOptions, statement, true, option);
         }
-        e.setRequestId(reqId);
         throw e;
       }
     }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsConstant.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsConstant.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.spanner;
 
-import static com.google.cloud.spanner.XGoogSpannerRequestId.REQUEST_ID;
+import static com.google.cloud.spanner.XGoogSpannerRequestId.REQUEST_ID_HEADER_NAME;
 
 import com.google.api.core.InternalApi;
 import com.google.api.gax.tracing.OpenTelemetryMetricsRecorder;
@@ -98,10 +98,12 @@ public class BuiltInMetricsConstant {
       AttributeKey.stringKey("directpath_enabled");
   public static final AttributeKey<String> DIRECT_PATH_USED_KEY =
       AttributeKey.stringKey("directpath_used");
-  public static final AttributeKey<String> REQUEST_ID_KEY = AttributeKey.stringKey(REQUEST_ID);
+  public static final AttributeKey<String> REQUEST_ID_KEY =
+      AttributeKey.stringKey(REQUEST_ID_HEADER_NAME);
   public static final AttributeKey<String> GRPC_XDS_RESOURCE_TYPE_KEY =
       AttributeKey.stringKey("grpc.xds.resource_type");
-  public static Set<String> ALLOWED_EXEMPLARS_ATTRIBUTES = new HashSet<>(Arrays.asList(REQUEST_ID));
+  public static Set<String> ALLOWED_EXEMPLARS_ATTRIBUTES =
+      new HashSet<>(Arrays.asList(REQUEST_ID_HEADER_NAME));
 
   // IP address prefixes allocated for DirectPath backends.
   public static final String DP_IPV6_PREFIX = "2001:4860:8040";

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseNotFoundException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DatabaseNotFoundException.java
@@ -35,7 +35,7 @@ public class DatabaseNotFoundException extends ResourceNotFoundException {
       @Nullable String message,
       ResourceInfo resourceInfo,
       @Nullable Throwable cause) {
-    this(token, message, resourceInfo, cause, null, null);
+    this(token, message, resourceInfo, cause, null);
   }
 
   /** Private constructor. Use {@link SpannerExceptionFactory} to create instances. */
@@ -44,8 +44,7 @@ public class DatabaseNotFoundException extends ResourceNotFoundException {
       @Nullable String message,
       ResourceInfo resourceInfo,
       @Nullable Throwable cause,
-      @Nullable ApiException apiException,
-      @Nullable XGoogSpannerRequestId reqId) {
-    super(token, message, resourceInfo, cause, apiException, reqId);
+      @Nullable ApiException apiException) {
+    super(token, message, resourceInfo, cause, apiException);
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceNotFoundException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/InstanceNotFoundException.java
@@ -35,7 +35,7 @@ public class InstanceNotFoundException extends ResourceNotFoundException {
       @Nullable String message,
       ResourceInfo resourceInfo,
       @Nullable Throwable cause) {
-    this(token, message, resourceInfo, cause, null, null);
+    this(token, message, resourceInfo, cause, null);
   }
 
   /** Private constructor. Use {@link SpannerExceptionFactory} to create instances. */
@@ -44,8 +44,7 @@ public class InstanceNotFoundException extends ResourceNotFoundException {
       @Nullable String message,
       ResourceInfo resourceInfo,
       @Nullable Throwable cause,
-      @Nullable ApiException apiException,
-      @Nullable XGoogSpannerRequestId reqId) {
-    super(token, message, resourceInfo, cause, apiException, reqId);
+      @Nullable ApiException apiException) {
+    super(token, message, resourceInfo, cause, apiException);
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MissingDefaultSequenceKindException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MissingDefaultSequenceKindException.java
@@ -38,9 +38,8 @@ public class MissingDefaultSequenceKindException extends SpannerException {
       ErrorCode errorCode,
       String message,
       Throwable cause,
-      @Nullable ApiException apiException,
-      @Nullable XGoogSpannerRequestId reqId) {
-    super(token, errorCode, /* retryable= */ false, message, cause, apiException, reqId);
+      @Nullable ApiException apiException) {
+    super(token, errorCode, /* retryable= */ false, message, cause, apiException);
   }
 
   static boolean isMissingDefaultSequenceKindException(Throwable cause) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MultiplexedSessionDatabaseClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MultiplexedSessionDatabaseClient.java
@@ -745,7 +745,7 @@ final class MultiplexedSessionDatabaseClient extends AbstractMultiplexedSessionD
 
   @Override
   public long executePartitionedUpdate(Statement stmt, UpdateOption... options) {
-    return createMultiplexedSessionTransaction(/* singleUse= */ true)
+    return createMultiplexedSessionTransaction(/* singleUse= */ false)
         .executePartitionedUpdate(stmt, options);
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionNotFoundException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SessionNotFoundException.java
@@ -35,7 +35,7 @@ public class SessionNotFoundException extends ResourceNotFoundException {
       @Nullable String message,
       ResourceInfo resourceInfo,
       @Nullable Throwable cause) {
-    this(token, message, resourceInfo, cause, null, null);
+    this(token, message, resourceInfo, cause, null);
   }
 
   /** Private constructor. Use {@link SpannerExceptionFactory} to create instances. */
@@ -44,8 +44,7 @@ public class SessionNotFoundException extends ResourceNotFoundException {
       @Nullable String message,
       ResourceInfo resourceInfo,
       @Nullable Throwable cause,
-      @Nullable ApiException apiException,
-      @Nullable XGoogSpannerRequestId reqId) {
-    super(token, message, resourceInfo, cause, apiException, reqId);
+      @Nullable ApiException apiException) {
+    super(token, message, resourceInfo, cause, apiException);
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerApiFutures.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerApiFutures.java
@@ -35,10 +35,9 @@ public class SpannerApiFutures {
       }
       throw SpannerExceptionFactory.asSpannerException(e.getCause());
     } catch (InterruptedException e) {
-      throw SpannerExceptionFactory.propagateInterrupt(e, null /*TODO: requestId*/);
+      throw SpannerExceptionFactory.propagateInterrupt(e);
     } catch (CancellationException e) {
-      throw SpannerExceptionFactory.newSpannerExceptionForCancellation(
-          null, e, null /*TODO: requestId*/);
+      throw SpannerExceptionFactory.newSpannerExceptionForCancellation(null, e);
     }
   }
 }

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerBatchUpdateException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerBatchUpdateException.java
@@ -25,9 +25,8 @@ public class SpannerBatchUpdateException extends SpannerException {
       ErrorCode code,
       String message,
       long[] counts,
-      Throwable cause,
-      XGoogSpannerRequestId reqId) {
-    super(token, code, false, message, cause, null, reqId);
+      Throwable cause) {
+    super(token, code, false, message, cause, null);
     updateCounts = counts;
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
@@ -459,6 +459,14 @@ class SpannerImpl extends BaseService<SpannerOptions> implements Spanner {
     }
   }
 
+  void resetRequestIdCounters() {
+    gapicRpc.getRequestIdCreator().reset();
+  }
+
+  long getRequestIdClientId() {
+    return gapicRpc.getRequestIdCreator().getClientId();
+  }
+
   /** Helper class for gRPC calls that can return paginated results. */
   abstract static class PageFetcher<S, T> implements NextPageFetcher<S> {
     private String nextPageToken;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerRetryHelper.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerRetryHelper.java
@@ -116,8 +116,7 @@ class SpannerRetryHelper {
     public boolean shouldRetry(Throwable prevThrowable, T prevResponse)
         throws CancellationException {
       if (Context.current().isCancelled()) {
-        throw SpannerExceptionFactory.newSpannerExceptionForCancellation(
-            Context.current(), null, null);
+        throw SpannerExceptionFactory.newSpannerExceptionForCancellation(Context.current(), null);
       }
       return prevThrowable instanceof AbortedException
           || prevThrowable instanceof com.google.api.gax.rpc.AbortedException;

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionMutationLimitExceededException.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionMutationLimitExceededException.java
@@ -37,9 +37,8 @@ public class TransactionMutationLimitExceededException extends SpannerException 
       ErrorCode errorCode,
       String message,
       Throwable cause,
-      @Nullable ApiException apiException,
-      @Nullable XGoogSpannerRequestId reqId) {
-    super(token, errorCode, /* retryable= */ false, message, cause, apiException, reqId);
+      @Nullable ApiException apiException) {
+    super(token, errorCode, /* retryable= */ false, message, cause, apiException);
   }
 
   static boolean isTransactionMutationLimitException(ErrorCode code, String message) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -449,8 +449,6 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
 
       @Override
       public void run() {
-        XGoogSpannerRequestId reqId =
-            session.getRequestIdCreator().nextRequestId(session.getChannel(), 1);
         try {
           prev.get();
           if (transactionId == null && transactionIdFuture == null) {
@@ -493,8 +491,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
           final ApiFuture<com.google.spanner.v1.CommitResponse> commitFuture;
           final ISpan opSpan = tracer.spanBuilderWithExplicitParent(SpannerImpl.COMMIT, span);
           try (IScope ignore = tracer.withSpan(opSpan)) {
-            commitFuture =
-                rpc.commitAsync(commitRequest, reqId.withOptions(getTransactionChannelHint()));
+            commitFuture = rpc.commitAsync(commitRequest, getTransactionChannelHint());
           }
           session.markUsed(clock.instant());
           commitFuture.addListener(
@@ -505,7 +502,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
                     // future, but we add a result here as well as a safety precaution.
                     res.setException(
                         SpannerExceptionFactory.newSpannerException(
-                            ErrorCode.INTERNAL, "commitFuture is not done", reqId));
+                            ErrorCode.INTERNAL, "commitFuture is not done"));
                     return;
                   }
                   com.google.spanner.v1.CommitResponse proto = commitFuture.get();
@@ -535,9 +532,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
                   }
                   if (!proto.hasCommitTimestamp()) {
                     throw newSpannerException(
-                        ErrorCode.INTERNAL,
-                        "Missing commitTimestamp:\n" + session.getName(),
-                        reqId);
+                        ErrorCode.INTERNAL, "Missing commitTimestamp:\n" + session.getName());
                   }
                   span.addAnnotation("Commit Done");
                   opSpan.end();
@@ -577,8 +572,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
           res.setException(SpannerExceptionFactory.propagateTimeout(e));
         } catch (Throwable e) {
           res.setException(
-              SpannerExceptionFactory.newSpannerException(
-                  e.getCause() == null ? e : e.getCause(), reqId));
+              SpannerExceptionFactory.newSpannerException(e.getCause() == null ? e : e.getCause()));
         }
       }
     }
@@ -697,8 +691,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
           }
           throw se;
         } catch (InterruptedException e) {
-          throw SpannerExceptionFactory.newSpannerExceptionForCancellation(
-              null, e, null /*TODO: requestId*/);
+          throw SpannerExceptionFactory.newSpannerExceptionForCancellation(null, e);
         }
       }
       // There is already a transactionId available. Include that id as the transaction to use.
@@ -938,12 +931,9 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
       final ExecuteSqlRequest.Builder builder =
           getExecuteSqlRequestBuilder(
               statement, queryMode, options, /* withTransactionSelector= */ true);
-      XGoogSpannerRequestId reqId =
-          session.getRequestIdCreator().nextRequestId(session.getChannel(), 1);
       try {
         com.google.spanner.v1.ResultSet resultSet =
-            rpc.executeQuery(
-                builder.build(), reqId.withOptions(getTransactionChannelHint()), isRouteToLeader());
+            rpc.executeQuery(builder.build(), getTransactionChannelHint(), isRouteToLeader());
         session.markUsed(clock.instant());
         if (resultSet.getMetadata().hasTransaction()) {
           onTransactionMetadata(
@@ -1076,11 +1066,9 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
         }
         final ExecuteBatchDmlRequest.Builder builder =
             getExecuteBatchDmlRequestBuilder(statements, options);
-        XGoogSpannerRequestId reqId =
-            session.getRequestIdCreator().nextRequestId(session.getChannel(), 1);
         try {
           com.google.spanner.v1.ExecuteBatchDmlResponse response =
-              rpc.executeBatchDml(builder.build(), reqId.withOptions(getTransactionChannelHint()));
+              rpc.executeBatchDml(builder.build(), getTransactionChannelHint());
           session.markUsed(clock.instant());
           long[] results = new long[response.getResultSetsCount()];
           for (int i = 0; i < response.getResultSetsCount(); ++i) {
@@ -1104,8 +1092,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
             throw newSpannerBatchUpdateException(
                 ErrorCode.fromRpcStatus(response.getStatus()),
                 response.getStatus().getMessage(),
-                results,
-                reqId);
+                results);
           }
           return results;
         } catch (Throwable e) {
@@ -1140,15 +1127,11 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
         final ExecuteBatchDmlRequest.Builder builder =
             getExecuteBatchDmlRequestBuilder(statements, options);
         ApiFuture<com.google.spanner.v1.ExecuteBatchDmlResponse> response;
-        XGoogSpannerRequestId reqId =
-            session.getRequestIdCreator().nextRequestId(session.getChannel(), 1);
         try {
           // Register the update as an async operation that must finish before the transaction may
           // commit.
           increaseAsyncOperations();
-          response =
-              rpc.executeBatchDmlAsync(
-                  builder.build(), reqId.withOptions(getTransactionChannelHint()));
+          response = rpc.executeBatchDmlAsync(builder.build(), getTransactionChannelHint());
           session.markUsed(clock.instant());
         } catch (Throwable t) {
           decreaseAsyncOperations();
@@ -1178,8 +1161,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
                     throw newSpannerBatchUpdateException(
                         ErrorCode.fromRpcStatus(batchDmlResponse.getStatus()),
                         batchDmlResponse.getStatus().getMessage(),
-                        results,
-                        reqId);
+                        results);
                   }
                   return results;
                 },
@@ -1233,7 +1215,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
   private final SessionImpl session;
   private final Options options;
   private ISpan span;
-  private TraceWrapper tracer;
+  private final TraceWrapper tracer;
   private TransactionContextImpl txn;
   private volatile boolean isValid = true;
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DdlBatch.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/DdlBatch.java
@@ -266,7 +266,7 @@ class DdlBatch extends AbstractBaseUnitOfWork {
               } catch (SpannerException e) {
                 long[] updateCounts = extractUpdateCounts(operationReference.get());
                 throw SpannerExceptionFactory.newSpannerBatchUpdateException(
-                    e.getErrorCode(), e.getMessage(), updateCounts, null /* TODO: requestId */);
+                    e.getErrorCode(), e.getMessage(), updateCounts);
               }
             } catch (Throwable t) {
               span.setStatus(StatusCode.ERROR);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/HeaderInterceptor.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/HeaderInterceptor.java
@@ -188,7 +188,7 @@ class HeaderInterceptor implements ClientInterceptor {
       if (afeLatency != null) {
         span.setAttribute("afe_latency", afeLatency.toString());
       }
-      span.setAttribute(XGoogSpannerRequestId.REQUEST_ID, requestId);
+      span.setAttribute(XGoogSpannerRequestId.REQUEST_ID_HEADER_NAME, requestId);
     }
   }
 
@@ -260,7 +260,7 @@ class HeaderInterceptor implements ClientInterceptor {
   }
 
   private String extractRequestId(Metadata headers) throws ExecutionException {
-    return headers.get(XGoogSpannerRequestId.REQUEST_HEADER_KEY);
+    return headers.get(XGoogSpannerRequestId.REQUEST_ID_HEADER_KEY);
   }
 
   private TagContext getTagContext(String key, String method, DatabaseName databaseName)

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/RequestIdCreatorImpl.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/RequestIdCreatorImpl.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.spi.v1;
+
+import com.google.cloud.spanner.XGoogSpannerRequestId;
+import com.google.cloud.spanner.XGoogSpannerRequestId.RequestIdCreator;
+import java.util.concurrent.atomic.AtomicLong;
+
+class RequestIdCreatorImpl implements RequestIdCreator {
+  private static final AtomicLong NEXT_CLIENT_ID = new AtomicLong();
+
+  private final long clientId = NEXT_CLIENT_ID.incrementAndGet();
+  private final AtomicLong requestId = new AtomicLong();
+
+  @Override
+  public long getClientId() {
+    return this.clientId;
+  }
+
+  @Override
+  public XGoogSpannerRequestId nextRequestId(long channelId) {
+    return XGoogSpannerRequestId.of(clientId, channelId, requestId.incrementAndGet(), 0);
+  }
+
+  @Override
+  public void reset() {
+    requestId.set(0);
+  }
+}

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/RequestIdInterceptor.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/RequestIdInterceptor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.spi.v1;
+
+import static com.google.cloud.spanner.XGoogSpannerRequestId.REQUEST_ID_CALL_OPTIONS_KEY;
+import static com.google.cloud.spanner.XGoogSpannerRequestId.REQUEST_ID_HEADER_KEY;
+
+import com.google.cloud.spanner.XGoogSpannerRequestId;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall;
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
+import io.grpc.MethodDescriptor;
+import java.util.concurrent.atomic.AtomicLong;
+
+class RequestIdInterceptor implements ClientInterceptor {
+  static final CallOptions.Key<AtomicLong> ATTEMPT_KEY = CallOptions.Key.create("Attempt");
+  private static final String RESPONSE_ENCODING_KEY_NAME = "x-response-encoding";
+  private static final Key<String> RESPONSE_ENCODING_KEY =
+      Key.of(RESPONSE_ENCODING_KEY_NAME, Metadata.ASCII_STRING_MARSHALLER);
+
+  RequestIdInterceptor() {}
+
+  @Override
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+      MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+    return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+        next.newCall(method, callOptions)) {
+      @Override
+      public void start(Listener<RespT> responseListener, Metadata headers) {
+        XGoogSpannerRequestId requestId = callOptions.getOption(REQUEST_ID_CALL_OPTIONS_KEY);
+        if (requestId != null) {
+          requestId.incrementAttempt();
+          headers.put(REQUEST_ID_HEADER_KEY, requestId.getHeaderValue());
+        }
+        super.start(responseListener, headers);
+      }
+    };
+  }
+}

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerInterceptorProvider.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerInterceptorProvider.java
@@ -64,6 +64,7 @@ public class SpannerInterceptorProvider implements GrpcInterceptorProvider {
     defaultInterceptorList.add(
         new LoggingInterceptor(Logger.getLogger(GapicSpannerRpc.class.getName()), Level.FINER));
     defaultInterceptorList.add(new HeaderInterceptor(new SpannerRpcMetrics(openTelemetry)));
+    defaultInterceptorList.add(new RequestIdInterceptor());
     return new SpannerInterceptorProvider(ImmutableList.copyOf(defaultInterceptorList));
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerRpc.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerRpc.java
@@ -27,6 +27,8 @@ import com.google.cloud.ServiceRpc;
 import com.google.cloud.spanner.BackupId;
 import com.google.cloud.spanner.Restore;
 import com.google.cloud.spanner.SpannerException;
+import com.google.cloud.spanner.XGoogSpannerRequestId;
+import com.google.cloud.spanner.XGoogSpannerRequestId.RequestIdCreator;
 import com.google.cloud.spanner.admin.database.v1.stub.DatabaseAdminStub;
 import com.google.cloud.spanner.admin.database.v1.stub.DatabaseAdminStubSettings;
 import com.google.cloud.spanner.admin.instance.v1.stub.InstanceAdminStub;
@@ -78,8 +80,7 @@ import javax.annotation.Nullable;
 public interface SpannerRpc extends ServiceRpc {
   /** Options passed in {@link SpannerRpc} methods to control how an RPC is issued. */
   enum Option {
-    CHANNEL_HINT("Channel Hint"),
-    REQUEST_ID("Request Id");
+    CHANNEL_HINT("Channel Hint");
 
     private final String value;
 
@@ -187,6 +188,10 @@ public interface SpannerRpc extends ServiceRpc {
      * @param message a message to use in the final status of any underlying RPC
      */
     void cancel(@Nullable String message);
+  }
+
+  default RequestIdCreator getRequestIdCreator() {
+    throw new UnsupportedOperationException("Not implemented");
   }
 
   // Instance admin APIs.
@@ -389,6 +394,7 @@ public interface SpannerRpc extends ServiceRpc {
       ReadRequest request,
       ResultStreamConsumer consumer,
       @Nullable Map<Option, ?> options,
+      XGoogSpannerRequestId requestId,
       boolean routeToLeader);
 
   /** Returns the retry settings for streaming query operations. */
@@ -428,7 +434,10 @@ public interface SpannerRpc extends ServiceRpc {
   RetrySettings getPartitionedDmlRetrySettings();
 
   ServerStream<PartialResultSet> executeStreamingPartitionedDml(
-      ExecuteSqlRequest request, @Nullable Map<Option, ?> options, Duration timeout);
+      ExecuteSqlRequest request,
+      @Nullable Map<Option, ?> options,
+      XGoogSpannerRequestId requestId,
+      Duration timeout);
 
   ServerStream<BatchWriteResponse> batchWriteAtLeastOnce(
       BatchWriteRequest request, @Nullable Map<Option, ?> options);
@@ -445,6 +454,7 @@ public interface SpannerRpc extends ServiceRpc {
       ExecuteSqlRequest request,
       ResultStreamConsumer consumer,
       @Nullable Map<Option, ?> options,
+      XGoogSpannerRequestId requestId,
       boolean routeToLeader);
 
   ExecuteBatchDmlResponse executeBatchDml(ExecuteBatchDmlRequest build, Map<Option, ?> options);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BaseSessionPoolTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BaseSessionPoolTest.java
@@ -27,6 +27,7 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.cloud.grpc.GrpcTransportOptions.ExecutorFactory;
 import com.google.cloud.spanner.Options.TransactionOption;
+import com.google.cloud.spanner.XGoogSpannerRequestId.NoopRequestIdCreator;
 import com.google.cloud.spanner.spi.v1.SpannerRpc.Option;
 import com.google.protobuf.Empty;
 import com.google.protobuf.Timestamp;
@@ -72,6 +73,7 @@ abstract class BaseSessionPoolTest {
     final SessionImpl session = mock(SessionImpl.class);
     Map options = new HashMap<>();
     options.put(Option.CHANNEL_HINT, channelHint.getAndIncrement());
+    when(session.getRequestIdCreator()).thenReturn(NoopRequestIdCreator.INSTANCE);
     when(session.getOptions()).thenReturn(options);
     when(session.getName())
         .thenReturn(

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RequestIdMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RequestIdMockServerTest.java
@@ -1,0 +1,727 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+import static com.google.cloud.spanner.DisableDefaultMtlsProvider.disableDefaultMtlsProvider;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import com.google.cloud.NoCredentials;
+import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
+import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.cloud.spanner.connection.RandomResultSetGenerator;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.Value;
+import com.google.rpc.RetryInfo;
+import com.google.spanner.v1.BeginTransactionRequest;
+import com.google.spanner.v1.CommitRequest;
+import com.google.spanner.v1.CreateSessionRequest;
+import com.google.spanner.v1.ExecuteSqlRequest;
+import com.google.spanner.v1.ReadRequest;
+import com.google.spanner.v1.ResultSetMetadata;
+import com.google.spanner.v1.ResultSetStats;
+import com.google.spanner.v1.StructType;
+import com.google.spanner.v1.StructType.Field;
+import com.google.spanner.v1.Type;
+import com.google.spanner.v1.TypeCode;
+import io.grpc.Context;
+import io.grpc.Contexts;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.Server;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
+import io.grpc.protobuf.ProtoUtils;
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.threeten.bp.Duration;
+
+@SuppressWarnings({"StatementWithEmptyBody", "resource"})
+@RunWith(JUnit4.class)
+public class RequestIdMockServerTest {
+  private static MockSpannerServiceImpl mockSpanner;
+  private static Server server;
+  private static Spanner spanner;
+
+  private static final Statement SELECT1 = Statement.of("SELECT 1");
+  private static final com.google.spanner.v1.ResultSet SELECT1_RESULT_SET =
+      com.google.spanner.v1.ResultSet.newBuilder()
+          .setMetadata(
+              ResultSetMetadata.newBuilder()
+                  .setRowType(
+                      StructType.newBuilder()
+                          .addFields(
+                              Field.newBuilder()
+                                  .setName("c")
+                                  .setType(Type.newBuilder().setCode(TypeCode.INT64).build())
+                                  .build())
+                          .build())
+                  .build())
+          .addRows(
+              ListValue.newBuilder()
+                  .addValues(Value.newBuilder().setStringValue("1").build())
+                  .build())
+          .build();
+  private static final Statement DML = Statement.of("insert into test_table (id) values (1)");
+
+  private static final ConcurrentLinkedQueue<XGoogSpannerRequestId> requestIds =
+      new ConcurrentLinkedQueue<>();
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    assumeTrue(System.getenv("GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS") == null);
+    assumeTrue(System.getenv("GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW") == null);
+
+    disableDefaultMtlsProvider();
+    mockSpanner = new MockSpannerServiceImpl();
+    mockSpanner.setAbortProbability(0.0D); // We don't want any unpredictable aborted transactions.
+
+    InetSocketAddress address = new InetSocketAddress("localhost", 0);
+    server =
+        NettyServerBuilder.forAddress(address)
+            .addService(mockSpanner)
+            .intercept(
+                new ServerInterceptor() {
+                  @Override
+                  public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+                      ServerCall<ReqT, RespT> call,
+                      Metadata headers,
+                      ServerCallHandler<ReqT, RespT> next) {
+                    try {
+                      String requestId = headers.get(XGoogSpannerRequestId.REQUEST_ID_HEADER_KEY);
+                      if (requestId != null) {
+                        requestIds.add(XGoogSpannerRequestId.of(requestId));
+                      } else {
+                        requestIds.add(XGoogSpannerRequestId.of(0, 0, 0, 0));
+                      }
+                    } catch (Throwable t) {
+                      // Ignore and continue
+                    }
+                    return Contexts.interceptCall(Context.current(), call, headers, next);
+                  }
+                })
+            .build()
+            .start();
+    spanner = createSpanner();
+
+    setupResults();
+  }
+
+  private static Spanner createSpanner() {
+    return SpannerOptions.newBuilder()
+        .setProjectId("test-project")
+        .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
+        .setHost("http://localhost:" + server.getPort())
+        .setCredentials(NoCredentials.getInstance())
+        .setSessionPoolOption(
+            SessionPoolOptions.newBuilder()
+                .setFailOnSessionLeak()
+                .setMinSessions(0)
+                .setSkipVerifyingBeginTransactionForMuxRW(true)
+                .setWaitForMinSessions(Duration.ofSeconds(5))
+                .build())
+        .build()
+        .getService();
+  }
+
+  private static void setupResults() {
+    mockSpanner.putStatementResult(StatementResult.query(SELECT1, SELECT1_RESULT_SET));
+    mockSpanner.putStatementResult(StatementResult.update(DML, 1L));
+  }
+
+  static Metadata createMinimalRetryInfo() {
+    Metadata trailers = new Metadata();
+    RetryInfo retryInfo =
+        RetryInfo.newBuilder()
+            .setRetryDelay(
+                com.google.protobuf.Duration.newBuilder()
+                    .setNanos((int) TimeUnit.MILLISECONDS.toNanos(1L))
+                    .setSeconds(0L))
+            .build();
+    trailers.put(ProtoUtils.keyForProto(RetryInfo.getDefaultInstance()), retryInfo);
+    return trailers;
+  }
+
+  @AfterClass
+  public static void teardown() throws InterruptedException {
+    if (spanner != null) {
+      spanner.close();
+    }
+    if (server != null) {
+      server.shutdown();
+      server.awaitTermination();
+    }
+  }
+
+  @Before
+  public void prepareTest() {
+    // Call getClient() to make sure the multiplexed session has been created.
+    // Then clear all requests that were received as part of that so we don't need to include
+    // that in the test verifications.
+    getClient();
+    mockSpanner.reset();
+    requestIds.clear();
+    ((SpannerImpl) spanner).resetRequestIdCounters();
+  }
+
+  private DatabaseClient getClient() {
+    return spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+  }
+
+  private long getClientId() {
+    return ((SpannerImpl) spanner).getRequestIdClientId();
+  }
+
+  @Test
+  public void testSingleUseQuery() {
+    try (ResultSet resultSet = getClient().singleUse().executeQuery(SELECT1)) {
+      while (resultSet.next()) {}
+    }
+
+    assertEquals(ImmutableList.of(ExecuteSqlRequest.class), mockSpanner.getRequestTypes());
+    List<XGoogSpannerRequestId> actual = ImmutableList.copyOf(requestIds);
+    verifyRequestIds(ImmutableList.of(XGoogSpannerRequestId.of(getClientId(), -1, 1, 1)), actual);
+  }
+
+  @Test
+  public void testQueryError() {
+    Statement query = Statement.of("select * from invalid_table");
+    mockSpanner.putStatementResult(
+        StatementResult.exception(
+            query, Status.NOT_FOUND.withDescription("Table not found").asRuntimeException()));
+
+    XGoogSpannerRequestId requestIdFromException;
+    try (ResultSet resultSet = getClient().singleUse().executeQuery(query)) {
+      SpannerException exception = assertThrows(SpannerException.class, resultSet::next);
+      assertEquals(ErrorCode.NOT_FOUND, exception.getErrorCode());
+      assertNotNull(exception.getRequestId());
+      assertNotEquals("Request ID should not be empty", "", exception.getRequestId());
+      requestIdFromException = XGoogSpannerRequestId.of(exception.getRequestId());
+    }
+
+    assertEquals(ImmutableList.of(ExecuteSqlRequest.class), mockSpanner.getRequestTypes());
+    List<XGoogSpannerRequestId> actual = ImmutableList.copyOf(requestIds);
+    verifyRequestIds(ImmutableList.of(XGoogSpannerRequestId.of(getClientId(), -1, 1, 1)), actual);
+    assertEquals(actual.get(0), requestIdFromException);
+  }
+
+  @Test
+  public void testMultiUseReadOnlyTransaction() {
+    try (ReadOnlyTransaction transaction = getClient().readOnlyTransaction()) {
+      for (int i = 0; i < 2; i++) {
+        try (ResultSet resultSet = transaction.executeQuery(SELECT1)) {
+          while (resultSet.next()) {}
+        }
+      }
+    }
+
+    assertEquals(
+        ImmutableList.of(
+            BeginTransactionRequest.class, ExecuteSqlRequest.class, ExecuteSqlRequest.class),
+        mockSpanner.getRequestTypes());
+    List<XGoogSpannerRequestId> actual = ImmutableList.copyOf(requestIds);
+    verifyRequestIds(
+        ImmutableList.of(
+            XGoogSpannerRequestId.of(getClientId(), -1, 1, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, 2, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, 3, 1)),
+        actual);
+    verifySameChannelId(actual);
+  }
+
+  @Test
+  public void testDml() {
+    getClient().readWriteTransaction().run(transaction -> transaction.executeUpdate(DML));
+
+    assertEquals(
+        ImmutableList.of(ExecuteSqlRequest.class, CommitRequest.class),
+        mockSpanner.getRequestTypes());
+    List<XGoogSpannerRequestId> actual = ImmutableList.copyOf(requestIds);
+    verifyRequestIds(
+        ImmutableList.of(
+            XGoogSpannerRequestId.of(getClientId(), -1, 1, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, 2, 1)),
+        actual);
+    verifySameChannelId(actual);
+  }
+
+  @Test
+  public void testDmlError() {
+    Statement invalidDml = Statement.of("insert into invalid_table (id) values (1)");
+    mockSpanner.putStatementResult(
+        StatementResult.exception(
+            invalidDml, Status.NOT_FOUND.withDescription("Table not found").asRuntimeException()));
+
+    SpannerException exception =
+        assertThrows(
+            SpannerException.class,
+            () ->
+                getClient()
+                    .readWriteTransaction()
+                    .run(transaction -> transaction.executeUpdate(invalidDml)));
+    assertEquals(ErrorCode.NOT_FOUND, exception.getErrorCode());
+    assertNotNull(exception.getRequestId());
+    assertNotEquals("Request ID should not be empty", "", exception.getRequestId());
+    XGoogSpannerRequestId requestIdFromException =
+        XGoogSpannerRequestId.of(exception.getRequestId());
+
+    assertEquals(ImmutableList.of(ExecuteSqlRequest.class), mockSpanner.getRequestTypes());
+    List<XGoogSpannerRequestId> actual = ImmutableList.copyOf(requestIds);
+    verifyRequestIds(ImmutableList.of(XGoogSpannerRequestId.of(getClientId(), -1, 1, 1)), actual);
+    assertEquals(actual.get(0), requestIdFromException);
+  }
+
+  @Test
+  public void testAbortedTransaction() {
+    mockSpanner.setCommitExecutionTime(
+        SimulatedExecutionTime.ofException(
+            Status.ABORTED.asRuntimeException(createMinimalRetryInfo())));
+    getClient()
+        .readWriteTransaction()
+        .run(
+            transaction -> {
+              try (ResultSet resultSet = transaction.executeQuery(SELECT1)) {
+                while (resultSet.next()) {}
+              }
+              return transaction.executeUpdate(DML);
+            });
+
+    assertEquals(
+        ImmutableList.of(
+            ExecuteSqlRequest.class,
+            ExecuteSqlRequest.class,
+            CommitRequest.class,
+            ExecuteSqlRequest.class,
+            ExecuteSqlRequest.class,
+            CommitRequest.class),
+        mockSpanner.getRequestTypes());
+    List<XGoogSpannerRequestId> actual = ImmutableList.copyOf(requestIds);
+    int requestId = 0;
+    verifyRequestIds(
+        ImmutableList.of(
+            XGoogSpannerRequestId.of(getClientId(), -1, ++requestId, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, ++requestId, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, ++requestId, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, ++requestId, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, ++requestId, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, ++requestId, 1)),
+        actual);
+    verifySameChannelId(actual.subList(0, 3));
+    verifySameChannelId(actual.subList(3, 6));
+  }
+
+  @Test
+  public void testMix() {
+    getClient()
+        .readWriteTransaction()
+        .run(
+            transaction -> {
+              try (ResultSet resultSet = transaction.executeQuery(SELECT1)) {
+                while (resultSet.next()) {}
+              }
+              return transaction.executeUpdate(DML);
+            });
+    try (ReadOnlyTransaction transaction = getClient().readOnlyTransaction()) {
+      for (int i = 0; i < 2; i++) {
+        try (ResultSet resultSet = transaction.executeQuery(SELECT1)) {
+          while (resultSet.next()) {}
+        }
+      }
+    }
+    try (ResultSet resultSet = getClient().singleUse().executeQuery(SELECT1)) {
+      while (resultSet.next()) {}
+    }
+    mockSpanner.putStatementResult(
+        StatementResult.query(
+            Statement.of("SELECT my_column FROM my_table WHERE 1=1"), SELECT1_RESULT_SET));
+    try (ResultSet resultSet =
+        getClient().singleUse().read("my_table", KeySet.all(), ImmutableList.of("my_column"))) {
+      while (resultSet.next()) {}
+    }
+
+    assertEquals(
+        ImmutableList.of(
+            ExecuteSqlRequest.class,
+            ExecuteSqlRequest.class,
+            CommitRequest.class,
+            BeginTransactionRequest.class,
+            ExecuteSqlRequest.class,
+            ExecuteSqlRequest.class,
+            ExecuteSqlRequest.class,
+            ReadRequest.class),
+        mockSpanner.getRequestTypes());
+    List<XGoogSpannerRequestId> actual = ImmutableList.copyOf(requestIds);
+    int requestId = 0;
+    verifyRequestIds(
+        ImmutableList.of(
+            XGoogSpannerRequestId.of(getClientId(), -1, ++requestId, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, ++requestId, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, ++requestId, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, ++requestId, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, ++requestId, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, ++requestId, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, ++requestId, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, ++requestId, 1)),
+        actual);
+    verifySameChannelId(actual.subList(0, 3));
+    verifySameChannelId(actual.subList(3, 6));
+  }
+
+  @Test
+  public void testUnaryUnavailable() {
+    mockSpanner.setExecuteSqlExecutionTime(
+        SimulatedExecutionTime.ofException(
+            Status.UNAVAILABLE.asRuntimeException(createMinimalRetryInfo())));
+
+    getClient().readWriteTransaction().run(transaction -> transaction.executeUpdate(DML));
+
+    assertEquals(
+        ImmutableList.of(ExecuteSqlRequest.class, ExecuteSqlRequest.class, CommitRequest.class),
+        mockSpanner.getRequestTypes());
+    List<XGoogSpannerRequestId> actual = ImmutableList.copyOf(requestIds);
+    verifyRequestIds(
+        ImmutableList.of(
+            XGoogSpannerRequestId.of(getClientId(), -1, 1, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, 1, 2),
+            XGoogSpannerRequestId.of(getClientId(), -1, 2, 1)),
+        actual);
+    verifySameChannelId(actual);
+  }
+
+  @Test
+  public void testStreamingQueryUnavailable() {
+    mockSpanner.setExecuteStreamingSqlExecutionTime(
+        SimulatedExecutionTime.ofException(
+            Status.UNAVAILABLE.asRuntimeException(createMinimalRetryInfo())));
+
+    try (ResultSet resultSet = getClient().singleUse().executeQuery(SELECT1)) {
+      while (resultSet.next()) {}
+    }
+
+    assertEquals(
+        ImmutableList.of(ExecuteSqlRequest.class, ExecuteSqlRequest.class),
+        mockSpanner.getRequestTypes());
+    List<XGoogSpannerRequestId> actual = ImmutableList.copyOf(requestIds);
+    verifyRequestIds(
+        ImmutableList.of(
+            XGoogSpannerRequestId.of(getClientId(), -1, 1, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, 1, 2)),
+        actual);
+  }
+
+  @Test
+  public void testStreamingQueryUnavailableHalfway() {
+    int numRows = 5;
+    Statement statement = Statement.of("select * from random");
+    mockSpanner.putStatementResult(
+        StatementResult.query(statement, new RandomResultSetGenerator(numRows).generate()));
+    mockSpanner.setExecuteStreamingSqlExecutionTime(
+        SimulatedExecutionTime.ofStreamException(
+            Status.UNAVAILABLE.asRuntimeException(createMinimalRetryInfo()), 2));
+
+    try (ResultSet resultSet = getClient().singleUse().executeQuery(statement)) {
+      while (resultSet.next()) {}
+    }
+
+    assertEquals(
+        ImmutableList.of(ExecuteSqlRequest.class, ExecuteSqlRequest.class),
+        mockSpanner.getRequestTypes());
+    List<XGoogSpannerRequestId> actual = ImmutableList.copyOf(requestIds);
+    verifyRequestIds(
+        ImmutableList.of(
+            XGoogSpannerRequestId.of(getClientId(), -1, 1, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, 1, 2)),
+        actual);
+    List<ExecuteSqlRequest> requests = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class);
+    assertEquals(ByteString.empty(), requests.get(0).getResumeToken());
+    assertNotEquals(ByteString.empty(), requests.get(1).getResumeToken());
+  }
+
+  @Test
+  public void testStreamingReadUnavailable() {
+    mockSpanner.setStreamingReadExecutionTime(
+        SimulatedExecutionTime.ofException(
+            Status.UNAVAILABLE.asRuntimeException(createMinimalRetryInfo())));
+
+    mockSpanner.putStatementResult(
+        StatementResult.query(
+            Statement.of("SELECT my_column FROM my_table WHERE 1=1"), SELECT1_RESULT_SET));
+    try (ResultSet resultSet =
+        getClient().singleUse().read("my_table", KeySet.all(), ImmutableList.of("my_column"))) {
+      while (resultSet.next()) {}
+    }
+
+    assertEquals(
+        ImmutableList.of(ReadRequest.class, ReadRequest.class), mockSpanner.getRequestTypes());
+    List<XGoogSpannerRequestId> actual = ImmutableList.copyOf(requestIds);
+    verifyRequestIds(
+        ImmutableList.of(
+            XGoogSpannerRequestId.of(getClientId(), -1, 1, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, 1, 2)),
+        actual);
+  }
+
+  @Test
+  public void testStreamingReadUnavailableHalfway() {
+    int numRows = 5;
+    Statement statement = Statement.of("SELECT my_column FROM my_table WHERE 1=1");
+    mockSpanner.putStatementResult(
+        StatementResult.query(statement, new RandomResultSetGenerator(numRows).generate()));
+    mockSpanner.setStreamingReadExecutionTime(
+        SimulatedExecutionTime.ofStreamException(
+            Status.UNAVAILABLE.asRuntimeException(createMinimalRetryInfo()), 2));
+
+    try (ResultSet resultSet =
+        getClient().singleUse().read("my_table", KeySet.all(), ImmutableList.of("my_column"))) {
+      while (resultSet.next()) {}
+    }
+
+    assertEquals(
+        ImmutableList.of(ReadRequest.class, ReadRequest.class), mockSpanner.getRequestTypes());
+    List<XGoogSpannerRequestId> actual = ImmutableList.copyOf(requestIds);
+    verifyRequestIds(
+        ImmutableList.of(
+            XGoogSpannerRequestId.of(getClientId(), -1, 1, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, 1, 2)),
+        actual);
+    List<ReadRequest> requests = mockSpanner.getRequestsOfType(ReadRequest.class);
+    assertEquals(ByteString.empty(), requests.get(0).getResumeToken());
+    assertNotEquals(ByteString.empty(), requests.get(1).getResumeToken());
+  }
+
+  @Test
+  public void testPartitionedDml() {
+    getClient().executePartitionedUpdate(DML);
+
+    assertEquals(
+        ImmutableList.of(BeginTransactionRequest.class, ExecuteSqlRequest.class),
+        mockSpanner.getRequestTypes());
+    List<XGoogSpannerRequestId> actual = ImmutableList.copyOf(requestIds);
+    verifyRequestIds(
+        ImmutableList.of(
+            XGoogSpannerRequestId.of(getClientId(), -1, 1, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, 2, 1)),
+        actual);
+    verifySameChannelId(actual);
+  }
+
+  @Test
+  public void testPartitionedDmlError() {
+    Statement invalidDml = Statement.of("update invalid_table set col=true where col=false");
+    mockSpanner.putStatementResult(
+        StatementResult.exception(
+            invalidDml, Status.NOT_FOUND.withDescription("Table not found").asRuntimeException()));
+
+    SpannerException exception =
+        assertThrows(
+            SpannerException.class, () -> getClient().executePartitionedUpdate(invalidDml));
+    assertEquals(ErrorCode.NOT_FOUND, exception.getErrorCode());
+    assertNotNull(exception.getRequestId());
+    assertNotEquals("", exception.getRequestId());
+
+    assertEquals(
+        ImmutableList.of(BeginTransactionRequest.class, ExecuteSqlRequest.class),
+        mockSpanner.getRequestTypes());
+    List<XGoogSpannerRequestId> actual = ImmutableList.copyOf(requestIds);
+    verifyRequestIds(
+        ImmutableList.of(
+            XGoogSpannerRequestId.of(getClientId(), -1, 1, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, 2, 1)),
+        actual);
+    verifySameChannelId(actual);
+    assertEquals(XGoogSpannerRequestId.of(exception.getRequestId()), actual.get(1));
+  }
+
+  @Test
+  public void testPartitionedDmlAborted() {
+    mockSpanner.setExecuteStreamingSqlExecutionTime(
+        SimulatedExecutionTime.ofException(
+            Status.ABORTED.asRuntimeException(createMinimalRetryInfo())));
+
+    getClient().executePartitionedUpdate(DML);
+
+    assertEquals(
+        ImmutableList.of(
+            BeginTransactionRequest.class,
+            ExecuteSqlRequest.class,
+            BeginTransactionRequest.class,
+            ExecuteSqlRequest.class),
+        mockSpanner.getRequestTypes());
+    List<XGoogSpannerRequestId> actual = ImmutableList.copyOf(requestIds);
+    verifyRequestIds(
+        ImmutableList.of(
+            XGoogSpannerRequestId.of(getClientId(), -1, 1, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, 2, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, 3, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, 4, 1)),
+        actual);
+    verifySameChannelId(actual);
+  }
+
+  @Test
+  public void testPartitionedDmlUnavailable() {
+    mockSpanner.setExecuteStreamingSqlExecutionTime(
+        SimulatedExecutionTime.ofException(
+            Status.UNAVAILABLE.asRuntimeException(createMinimalRetryInfo())));
+
+    getClient().executePartitionedUpdate(DML);
+
+    assertEquals(
+        ImmutableList.of(
+            BeginTransactionRequest.class,
+            ExecuteSqlRequest.class,
+            BeginTransactionRequest.class,
+            ExecuteSqlRequest.class),
+        mockSpanner.getRequestTypes());
+    List<XGoogSpannerRequestId> actual = ImmutableList.copyOf(requestIds);
+    verifyRequestIds(
+        ImmutableList.of(
+            XGoogSpannerRequestId.of(getClientId(), -1, 1, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, 2, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, 3, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, 4, 1)),
+        actual);
+    verifySameChannelId(actual);
+  }
+
+  @Test
+  public void testPartitionedDmlUnavailableWithResumeToken() {
+    Statement update = Statement.of("UPDATE my_table SET active=true where 1=1");
+    mockSpanner.putStatementResult(
+        StatementResult.query(
+            update,
+            com.google.spanner.v1.ResultSet.newBuilder()
+                .setMetadata(
+                    ResultSetMetadata.newBuilder()
+                        .setRowType(StructType.newBuilder().build())
+                        .build())
+                .addRows(ListValue.newBuilder().build())
+                .addRows(ListValue.newBuilder().build())
+                .addRows(ListValue.newBuilder().build())
+                .setStats(ResultSetStats.newBuilder().setRowCountLowerBound(100L).build())
+                .build()));
+    mockSpanner.setExecuteStreamingSqlExecutionTime(
+        SimulatedExecutionTime.ofStreamException(
+            Status.UNAVAILABLE.asRuntimeException(createMinimalRetryInfo()), 2L));
+
+    getClient().executePartitionedUpdate(update);
+
+    assertEquals(
+        ImmutableList.of(
+            BeginTransactionRequest.class, ExecuteSqlRequest.class, ExecuteSqlRequest.class),
+        mockSpanner.getRequestTypes());
+    List<XGoogSpannerRequestId> actual = ImmutableList.copyOf(requestIds);
+    verifyRequestIds(
+        ImmutableList.of(
+            XGoogSpannerRequestId.of(getClientId(), -1, 1, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, 2, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, 2, 2)),
+        actual);
+    verifySameChannelId(actual);
+  }
+
+  @Test
+  public void testOtherClientId() {
+    // Execute a query with the default client from this test class.
+    try (ResultSet resultSet = getClient().singleUse().executeQuery(SELECT1)) {
+      while (resultSet.next()) {}
+    }
+    // Create a new client and use that to execute a query. This should use a different client ID.
+    long otherClientId;
+    try (Spanner spanner = createSpanner()) {
+      otherClientId = ((SpannerImpl) spanner).getRequestIdClientId();
+      DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+      try (ResultSet resultSet = client.singleUse().executeQuery(SELECT1)) {
+        while (resultSet.next()) {}
+      }
+    }
+    // Execute another query with the default client. This should use the original client ID.
+    try (ResultSet resultSet = getClient().singleUse().executeQuery(SELECT1)) {
+      while (resultSet.next()) {}
+    }
+    assertEquals(
+        ImmutableList.of(
+            ExecuteSqlRequest.class,
+            CreateSessionRequest.class,
+            ExecuteSqlRequest.class,
+            ExecuteSqlRequest.class),
+        mockSpanner.getRequestTypes());
+    List<XGoogSpannerRequestId> actual = ImmutableList.copyOf(requestIds);
+    verifyRequestIds(
+        ImmutableList.of(
+            XGoogSpannerRequestId.of(getClientId(), -1, 1, 1),
+            // The CreateSession RPC from the initialization of the second client is included in
+            // the requests that we see. This request does not include a channel hint, hence the
+            // zero value for the channel number in the request ID.
+            XGoogSpannerRequestId.of(otherClientId, 0, 1, 1),
+            XGoogSpannerRequestId.of(otherClientId, -1, 2, 1),
+            XGoogSpannerRequestId.of(getClientId(), -1, 2, 1)),
+        actual);
+  }
+
+  private void verifyRequestIds(
+      List<XGoogSpannerRequestId> expectedIds, List<XGoogSpannerRequestId> actualIds) {
+    assertEquals(message(expectedIds, actualIds), expectedIds.size(), actualIds.size());
+    int i = 0;
+    for (XGoogSpannerRequestId actual : actualIds) {
+      XGoogSpannerRequestId expected = expectedIds.get(i);
+      if (expected.getNthChannelId() > -1) {
+        assertEquals(expected, actual);
+      } else {
+        assertTrue(message(expectedIds, actualIds), equalsIgnoringChannelId(expected, actual));
+        assertTrue(message(expectedIds, actualIds), actual.hasChannelId());
+      }
+      i++;
+    }
+  }
+
+  private void verifySameChannelId(List<XGoogSpannerRequestId> requestIds) {
+    for (int i = 0; i < requestIds.size() - 1; i++) {
+      XGoogSpannerRequestId requestId = requestIds.get(i);
+      assertTrue(requestId.hasChannelId());
+      assertEquals(requestId.getNthChannelId(), requestIds.get(i + 1).getNthChannelId());
+    }
+  }
+
+  private boolean equalsIgnoringChannelId(
+      XGoogSpannerRequestId expected, XGoogSpannerRequestId actual) {
+    return expected.getNthClientId() == actual.getNthClientId()
+        && expected.getNthRequest() == actual.getNthRequest()
+        && expected.getAttempt() == actual.getAttempt();
+  }
+
+  private String message(List<XGoogSpannerRequestId> expected, List<XGoogSpannerRequestId> actual) {
+    return String.format("\n Got: %s\nWant: %s", actual, expected);
+  }
+}

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ResumableStreamIteratorTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ResumableStreamIteratorTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.api.client.util.BackOff;
 import com.google.cloud.spanner.ErrorHandler.DefaultErrorHandler;
+import com.google.cloud.spanner.XGoogSpannerRequestId.NoopRequestIdCreator;
 import com.google.cloud.spanner.v1.stub.SpannerStubSettings;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
@@ -168,11 +169,12 @@ public class ResumableStreamIteratorTest {
             DefaultErrorHandler.INSTANCE,
             SpannerStubSettings.newBuilder().executeStreamingSqlSettings().getRetrySettings(),
             SpannerStubSettings.newBuilder().executeStreamingSqlSettings().getRetryableCodes(),
-            new XGoogSpannerRequestId.NoopRequestIdCreator()) {
+            NoopRequestIdCreator.INSTANCE) {
           @Override
           AbstractResultSet.CloseableIterator<PartialResultSet> startStream(
               @Nullable ByteString resumeToken,
-              AsyncResultSet.StreamMessageListener streamMessageListener) {
+              AsyncResultSet.StreamMessageListener streamMessageListener,
+              XGoogSpannerRequestId requestId) {
             return starter.startStream(resumeToken, null);
           }
         };

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionClientTests.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SessionClientTests.java
@@ -18,7 +18,7 @@ package com.google.cloud.spanner;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
@@ -163,7 +163,6 @@ public class SessionClientTests {
       assertEquals(
           deleteOptionsCaptor.getValue().get(SpannerRpc.Option.CHANNEL_HINT),
           options.getValue().get(SpannerRpc.Option.CHANNEL_HINT));
-      assertTrue(deleteOptionsCaptor.getValue().containsKey(SpannerRpc.Option.REQUEST_ID));
     }
   }
 
@@ -207,9 +206,7 @@ public class SessionClientTests {
       client.createMultiplexedSession(consumer);
     }
     // for multiplexed session there is no channel hint pass in the RPC options
-    assertNotNull(options.getValue());
-    assertEquals(options.getValue().get(Option.CHANNEL_HINT), null);
-    assertNotNull(options.getValue().get(Option.REQUEST_ID));
+    assertNull(options.getValue());
     assertEquals(1, returnedSessionCount.get());
   }
 
@@ -241,9 +238,7 @@ public class SessionClientTests {
       client.createMultiplexedSession(consumer);
     }
     // for multiplexed session there is no channel hint pass in the RPC options
-    assertNotNull(options.getValue());
-    assertEquals(options.getValue().get(Option.CHANNEL_HINT), null);
-    assertNotNull(options.getValue().get(Option.REQUEST_ID));
+    assertNull(options.getValue());
   }
 
   @SuppressWarnings("unchecked")

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterTest.java
@@ -371,7 +371,7 @@ public class SpannerCloudMonitoringExporterTest {
     DoubleExemplarData exemplar =
         ImmutableDoubleExemplarData.create(
             Attributes.builder()
-                .put(XGoogSpannerRequestId.REQUEST_ID, "test")
+                .put(XGoogSpannerRequestId.REQUEST_ID_HEADER_NAME, "test")
                 .put("lang", "java")
                 .build(),
             recordTimeEpoch,
@@ -448,8 +448,10 @@ public class SpannerCloudMonitoringExporterTest {
     // Assert only 1 attachment is there with 1 label for request_id.
     assertThat(filterAttributes.size()).isEqualTo(1);
     assertThat(filterAttributes.get(0).getLabelCount()).isEqualTo(1);
-    assertThat(filterAttributes.get(0).containsLabel(XGoogSpannerRequestId.REQUEST_ID)).isTrue();
-    assertThat(filterAttributes.get(0).getLabelOrThrow(XGoogSpannerRequestId.REQUEST_ID))
+    assertThat(filterAttributes.get(0).containsLabel(XGoogSpannerRequestId.REQUEST_ID_HEADER_NAME))
+        .isTrue();
+    assertThat(
+            filterAttributes.get(0).getLabelOrThrow(XGoogSpannerRequestId.REQUEST_ID_HEADER_NAME))
         .isEqualTo("test");
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerExceptionFactoryTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerExceptionFactoryTest.java
@@ -251,17 +251,4 @@ public class SpannerExceptionFactoryTest {
 
     return trailers;
   }
-
-  @Test
-  public void withRequestId() {
-    XGoogSpannerRequestId reqIdIn = XGoogSpannerRequestId.of(1, 2, 3, 4);
-    Status status = Status.fromCodeValue(Status.Code.ABORTED.value());
-    Exception exc = new StatusRuntimeException(status);
-    SpannerException spannerExceptionWithReqId =
-        SpannerExceptionFactory.newSpannerException(exc, reqIdIn);
-    assertThat(spannerExceptionWithReqId.getRequestId()).isEqualTo(reqIdIn.toString());
-    SpannerException spannerExceptionWithoutReqId =
-        SpannerExceptionFactory.newSpannerException(exc);
-    assertThat(spannerExceptionWithoutReqId.getRequestId()).isEqualTo("");
-  }
 }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionContextImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionContextImplTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.api.core.ApiFutures;
 import com.google.cloud.spanner.TransactionRunnerImpl.TransactionContextImpl;
+import com.google.cloud.spanner.XGoogSpannerRequestId.NoopRequestIdCreator;
 import com.google.cloud.spanner.spi.v1.SpannerRpc;
 import com.google.cloud.spanner.v1.stub.SpannerStubSettings;
 import com.google.protobuf.ByteString;
@@ -66,9 +67,9 @@ public class TransactionContextImplTest {
                 com.google.spanner.v1.CommitResponse.newBuilder()
                     .setCommitTimestamp(Timestamp.newBuilder().setSeconds(99L).setNanos(10).build())
                     .build()));
+    when(rpc.getRequestIdCreator()).thenReturn(NoopRequestIdCreator.INSTANCE);
     when(session.getName()).thenReturn("test");
-    when(session.getRequestIdCreator())
-        .thenReturn(new XGoogSpannerRequestId.NoopRequestIdCreator());
+    when(session.getRequestIdCreator()).thenReturn(NoopRequestIdCreator.INSTANCE);
     doNothing().when(span).setStatus(any(Throwable.class));
     doNothing().when(span).end();
     doNothing().when(span).addAnnotation("Starting Commit");
@@ -212,8 +213,7 @@ public class TransactionContextImplTest {
   private void batchDml(int status) {
     SessionImpl session = mock(SessionImpl.class);
     when(session.getName()).thenReturn("test");
-    when(session.getRequestIdCreator())
-        .thenReturn(new XGoogSpannerRequestId.NoopRequestIdCreator());
+    when(session.getRequestIdCreator()).thenReturn(NoopRequestIdCreator.INSTANCE);
     SpannerRpc rpc = mock(SpannerRpc.class);
     ExecuteBatchDmlResponse response =
         ExecuteBatchDmlResponse.newBuilder()

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionManagerImplTest.java
@@ -241,7 +241,7 @@ public class TransactionManagerImplTest {
             Mockito.anyString(),
             Mockito.anyString(),
             Mockito.anyMap(),
-            Mockito.anyMap(),
+            Mockito.eq(null),
             Mockito.eq(true)))
         .thenAnswer(
             invocation ->
@@ -324,7 +324,7 @@ public class TransactionManagerImplTest {
             Mockito.anyString(),
             Mockito.anyString(),
             Mockito.anyMap(),
-            Mockito.anyMap(),
+            Mockito.eq(null),
             Mockito.eq(true)))
         .thenAnswer(
             invocation ->

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
@@ -36,6 +36,7 @@ import com.google.cloud.grpc.GrpcTransportOptions.ExecutorFactory;
 import com.google.cloud.spanner.ErrorHandler.DefaultErrorHandler;
 import com.google.cloud.spanner.SessionClient.SessionId;
 import com.google.cloud.spanner.TransactionRunnerImpl.TransactionContextImpl;
+import com.google.cloud.spanner.XGoogSpannerRequestId.NoopRequestIdCreator;
 import com.google.cloud.spanner.spi.v1.SpannerRpc;
 import com.google.cloud.spanner.v1.stub.SpannerStubSettings;
 import com.google.common.base.Preconditions;
@@ -121,8 +122,8 @@ public class TransactionRunnerImplTest {
     when(session.getErrorHandler()).thenReturn(DefaultErrorHandler.INSTANCE);
     when(session.newTransaction(eq(Options.fromTransactionOptions()), any())).thenReturn(txn);
     when(session.getTracer()).thenReturn(tracer);
-    when(session.getRequestIdCreator())
-        .thenReturn(new XGoogSpannerRequestId.NoopRequestIdCreator());
+    when(session.getRequestIdCreator()).thenReturn(NoopRequestIdCreator.INSTANCE);
+    when(rpc.getRequestIdCreator()).thenReturn(NoopRequestIdCreator.INSTANCE);
     when(rpc.executeQuery(Mockito.any(ExecuteSqlRequest.class), Mockito.anyMap(), eq(true)))
         .thenAnswer(
             invocation -> {
@@ -195,7 +196,7 @@ public class TransactionRunnerImplTest {
             Mockito.anyString(),
             Mockito.anyString(),
             Mockito.anyMap(),
-            Mockito.anyMap(),
+            Mockito.eq(null),
             Mockito.eq(true)))
         .thenAnswer(
             invocation ->
@@ -336,7 +337,6 @@ public class TransactionRunnerImplTest {
             spanner,
             new SessionReference(
                 "projects/p/instances/i/databases/d/sessions/s", Collections.EMPTY_MAP)) {};
-    session.setRequestIdCreator(new XGoogSpannerRequestId.NoopRequestIdCreator());
     session.setCurrentSpan(new OpenTelemetrySpan(mock(io.opentelemetry.api.trace.Span.class)));
     TransactionRunnerImpl runner = new TransactionRunnerImpl(session);
     runner.setSpan(span);

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/RunTransactionMockServerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/RunTransactionMockServerTest.java
@@ -151,7 +151,7 @@ public class RunTransactionMockServerTest extends AbstractMockServerTest {
                         return null;
                       }));
       assertEquals(ErrorCode.INVALID_ARGUMENT, exception.getErrorCode());
-      assertTrue(exception.getMessage(), exception.getMessage().endsWith("invalid statement"));
+      assertTrue(exception.getMessage(), exception.getMessage().contains("invalid statement"));
     }
     assertEquals(2, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
     assertEquals(0, mockSpanner.countRequestsOfType(CommitRequest.class));


### PR DESCRIPTION
- Send a RequestID to Spanner for each request
- Make sure that the attempt number of the RequestID is increased if the RPC is retried.
- Include the RequestID in every error that is thrown due to an error that is returned by Spanner.

This change removes most of the manual handling of RequestIDs, and instead lets the `SpannerRpc` implementation and a couple of interceptors handle RequestIDs.