### PR TITLE
fix: adjust the initial polling delay for ddl operations

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -1168,9 +1168,6 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
       databaseAdminStubSettingsBuilder
           .createDatabaseOperationSettings()
           .setPollingAlgorithm(shortInitialPollingDelayAlgorithm);
-      databaseAdminStubSettingsBuilder
-          .updateDatabaseDdlOperationSettings()
-          .setPollingAlgorithm(shortInitialPollingDelayAlgorithm);
 
       // The polling setting with a long initial delay as we expect
       // the operation to take a bit long time to return.
@@ -1185,6 +1182,22 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
       databaseAdminStubSettingsBuilder
           .restoreDatabaseOperationSettings()
           .setPollingAlgorithm(longInitialPollingDelayAlgorithm);
+
+      // updateDatabaseDdl requires a separate setting because
+      // it has no existing overrides on RPC timeouts for LRO polling.
+      databaseAdminStubSettingsBuilder
+          .updateDatabaseDdlOperationSettings()
+          .setPollingAlgorithm(
+              OperationTimedPollAlgorithm.create(
+                  RetrySettings.newBuilder()
+                      .setInitialRetryDelayDuration(Duration.ofMillis(1000L))
+                      .setRetryDelayMultiplier(1.5)
+                      .setMaxRetryDelayDuration(Duration.ofMillis(45000L))
+                      .setInitialRpcTimeoutDuration(Duration.ZERO)
+                      .setRpcTimeoutMultiplier(1.0)
+                      .setMaxRpcTimeoutDuration(Duration.ZERO)
+                      .setTotalTimeoutDuration(Duration.ofHours(48L))
+                      .build()));
     }
 
     Builder(SpannerOptions options) {


### PR DESCRIPTION
We found that `updateDatabaseDdl` can take 20-30 secs to return due to the high initial poll delay. After adjusting the initial retry delay, the ddl latency has been improved to 2-3 secs. Therefore, we make the changes to improve the DDL latency for `CreateDatabase` and `UpdateDatabaseDdl` which are important for initial experience and are expected to be faster. 

Changes in this PR: 

* Change `UpdateDatabaseDdl`'s `InitialRetryDelayDuration` from 20s to 1s. 
* Change `CreateDatabase`'s `InitialRetryDelayDuration` from 20s to 1s. 
* Change `UpdateDatabaseDdl`'s `TotalTimeoutDuration` from 24h to 48h. 