### PR TITLE
chore: additional cleanup of graal nativeimage dependency

### DIFF
--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -390,7 +390,6 @@
     <dependency>
       <groupId>org.graalvm.sdk</groupId>
       <artifactId>nativeimage</artifactId>
-      <version>${graal-sdk-nativeimage.version}</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
Realized that sdk-platform-java-config is already handling the dependencyManagement of the graal-sdk dependency through java-shared-config so we don't actually need to explicitly specify the maven property here. Let's rely on that instead to make the versions consistent across all repos:  https://github.com/googleapis/java-shared-config/blob/9749349a1b427a38b6241ff55621e5fe982a0a60/native-image-shared-config/pom.xml#L69-L82
