### PR TITLE
chore: remove explicit grpc-gcp version pinning

### DIFF
--- a/google-cloud-spanner-executor/pom.xml
+++ b/google-cloud-spanner-executor/pom.xml
@@ -62,7 +62,6 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>grpc-gcp</artifactId>
-      <version>${grpc.gcp.version}</version>
     </dependency>
     <dependency>
       <groupId>io.opentelemetry.semconv</groupId>

--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -166,7 +166,6 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>grpc-gcp</artifactId>
-      <version>${grpc.gcp.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,6 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <github.global.server>github</github.global.server>
     <site.installationModule>google-cloud-spanner-parent</site.installationModule>
-    <grpc.gcp.version>1.9.0</grpc.gcp.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
 ## Summary
  - Remove explicit `grpc-gcp` version pinning (1.9.0) from pom files
  - The version is already managed by `sdk-platform-java-config`, making the local pinning redundant
