### PR TITLE
chore: Add gcp resource name span attribute

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TraceWrapper.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TraceWrapper.java
@@ -57,6 +57,7 @@ class TraceWrapper {
       AttributeKey.stringKey("gcp.client.repo");
   private static final AttributeKey<String> GCP_RESOURCE_NAME_KEY =
       AttributeKey.stringKey("gcp.resource.name");
+  private static final String GCP_RESOURCE_NAME_PREFIX = "//spanner.googleapis.com/";
   private static final AttributeKey<String> THREAD_NAME_KEY = AttributeKey.stringKey("thread.name");
 
   private final Tracer openCensusTracer;
@@ -221,7 +222,7 @@ class TraceWrapper {
     AttributesBuilder builder = Attributes.builder();
     builder.put(DB_NAME_KEY, db.getDatabase());
     builder.put(INSTANCE_NAME_KEY, db.getInstanceId().getInstance());
-    builder.put(GCP_RESOURCE_NAME_KEY, "//spanner.googleapis.com/" + db.getName());
+    builder.put(GCP_RESOURCE_NAME_KEY, GCP_RESOURCE_NAME_PREFIX + db.getName());
     return builder.build();
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetrySpanTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetrySpanTest.java
@@ -914,7 +914,9 @@ public class OpenTelemetrySpanTest {
         GaxProperties.getLibraryVersion(TraceWrapper.class));
     assertEquals(
         span.getAttributes().get(AttributeKey.stringKey("gcp.resource.name")),
-        String.format("//spanner.googleapis.com/projects/%s/instances/%s/databases/%s", TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+        String.format(
+            "//spanner.googleapis.com/projects/%s/instances/%s/databases/%s",
+            TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
   }
 
   private static void verifyTableAttributes(SpanData span) {


### PR DESCRIPTION
Adding a new span attribute called gcp.resource.name which contains an identifier to a particular spanner instance and database in the following format:

//spanner.googleapis.com/projects/{project}/instances/{instance_id}/databases/{database_id}
Example:

//spanner.googleapis.com/projects/my_project/instances/my_instance/databases/my_database

