### PR TITLE
fix: preserve channel configurator for grpc-gcp and add opt-out for gcp OTel metrics

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -227,6 +227,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
   private final boolean autoThrottleAdministrativeRequests;
   private final RetrySettings retryAdministrativeRequestsSettings;
   private final boolean trackTransactionStarter;
+  private final boolean enableGrpcGcpOtelMetrics;
   private final BuiltInMetricsProvider builtInMetricsProvider = BuiltInMetricsProvider.INSTANCE;
 
   /**
@@ -895,6 +896,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     autoThrottleAdministrativeRequests = builder.autoThrottleAdministrativeRequests;
     retryAdministrativeRequestsSettings = builder.retryAdministrativeRequestsSettings;
     trackTransactionStarter = builder.trackTransactionStarter;
+    enableGrpcGcpOtelMetrics = builder.enableGrpcGcpOtelMetrics;
     defaultQueryOptions = builder.defaultQueryOptions;
     envQueryOptions = builder.getEnvironmentQueryOptions();
     if (envQueryOptions.equals(QueryOptions.getDefaultInstance())) {
@@ -975,6 +977,10 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
       return false;
     }
 
+    default boolean isEnableGrpcGcpOtelMetrics() {
+      return true;
+    }
+
     default boolean isEnableEndToEndTracing() {
       return false;
     }
@@ -1013,6 +1019,8 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     private static final String SPANNER_DISABLE_BUILTIN_METRICS = "SPANNER_DISABLE_BUILTIN_METRICS";
     private static final String SPANNER_DISABLE_DIRECT_ACCESS_GRPC_BUILTIN_METRICS =
         "SPANNER_DISABLE_DIRECT_ACCESS_GRPC_BUILTIN_METRICS";
+    private static final String SPANNER_DISABLE_GRPC_GCP_OTEL_METRICS =
+        "SPANNER_DISABLE_GRPC_GCP_OTEL_METRICS";
     private static final String SPANNER_MONITORING_HOST = "SPANNER_MONITORING_HOST";
 
     private SpannerEnvironmentImpl() {}
@@ -1056,6 +1064,11 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
       // disabled via env.
       return !Boolean.parseBoolean(
           System.getenv(SPANNER_DISABLE_DIRECT_ACCESS_GRPC_BUILTIN_METRICS));
+    }
+
+    @Override
+    public boolean isEnableGrpcGcpOtelMetrics() {
+      return !Boolean.parseBoolean(System.getenv(SPANNER_DISABLE_GRPC_GCP_OTEL_METRICS));
     }
 
     @Override
@@ -1128,6 +1141,8 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     private boolean autoThrottleAdministrativeRequests = false;
     private boolean trackTransactionStarter = false;
     private Map<DatabaseId, QueryOptions> defaultQueryOptions = new HashMap<>();
+    private boolean enableGrpcGcpOtelMetrics =
+        SpannerOptions.environment.isEnableGrpcGcpOtelMetrics();
     private CallCredentialsProvider callCredentialsProvider;
     private CloseableExecutorProvider asyncExecutorProvider;
     private String compressorName;
@@ -1231,6 +1246,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
       this.autoThrottleAdministrativeRequests = options.autoThrottleAdministrativeRequests;
       this.retryAdministrativeRequestsSettings = options.retryAdministrativeRequestsSettings;
       this.trackTransactionStarter = options.trackTransactionStarter;
+      this.enableGrpcGcpOtelMetrics = options.enableGrpcGcpOtelMetrics;
       this.defaultQueryOptions = options.defaultQueryOptions;
       this.callCredentialsProvider = options.callCredentialsProvider;
       this.asyncExecutorProvider = options.asyncExecutorProvider;
@@ -1751,6 +1767,17 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     }
 
     /**
+     * Sets whether to enable or disable grpc-gcp OpenTelemetry metrics injection. When disabled,
+     * Spanner will not automatically inject an OpenTelemetry {@link
+     * io.opentelemetry.api.metrics.Meter} into grpc-gcp. If a Meter or MetricRegistry is explicitly
+     * provided via {@link GcpManagedChannelOptions}, those settings will still be honored.
+     */
+    public Builder setGrpcGcpOtelMetricsEnabled(boolean enableGrpcGcpOtelMetrics) {
+      this.enableGrpcGcpOtelMetrics = enableGrpcGcpOtelMetrics;
+      return this;
+    }
+
+    /**
      * Sets the channel pool options for dynamic channel pooling. Use this to configure the dynamic
      * channel pool behavior when {@link #enableDynamicChannelPool()} is enabled.
      *
@@ -2209,6 +2236,10 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
 
   public boolean isGrpcGcpExtensionEnabled() {
     return grpcGcpExtensionEnabled;
+  }
+
+  public boolean isGrpcGcpOtelMetricsEnabled() {
+    return enableGrpcGcpOtelMetrics;
   }
 
   public GcpManagedChannelOptions getGrpcGcpOptions() {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpcTest.java
@@ -27,9 +27,11 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
+import com.google.api.core.ApiFunction;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.grpc.GrpcCallContext;
 import com.google.api.gax.grpc.GrpcTransportChannel;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.ApiClientHeaderProvider;
 import com.google.api.gax.rpc.HeaderProvider;
@@ -38,6 +40,8 @@ import com.google.auth.Credentials;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.cloud.ServiceOptions;
+import com.google.cloud.grpc.GcpManagedChannelOptions;
+import com.google.cloud.grpc.GcpManagedChannelOptions.GcpMetricsOptions;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.Dialect;
@@ -80,6 +84,7 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 import io.grpc.auth.MoreCallCredentials;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import io.grpc.protobuf.lite.ProtoLiteUtils;
 import io.opentelemetry.api.OpenTelemetry;
@@ -961,6 +966,55 @@ public class GapicSpannerRpcTest {
         writeableEnvironmentVariables.put(envVar, originalValue);
       }
     }
+  }
+
+  @Test
+  public void testGrpcGcpExtensionPreservesChannelConfigurator() throws Exception {
+    InstantiatingGrpcChannelProvider.Builder channelProviderBuilder =
+        InstantiatingGrpcChannelProvider.newBuilder();
+    AtomicBoolean baseConfiguratorCalled = new AtomicBoolean(false);
+    channelProviderBuilder.setChannelConfigurator(
+        builder -> {
+          baseConfiguratorCalled.set(true);
+          return builder;
+        });
+
+    SpannerOptions options =
+        SpannerOptions.newBuilder().setProjectId("[PROJECT]").enableGrpcGcpExtension().build();
+
+    java.lang.reflect.Method method =
+        GapicSpannerRpc.class.getDeclaredMethod(
+            "maybeEnableGrpcGcpExtension",
+            InstantiatingGrpcChannelProvider.Builder.class,
+            SpannerOptions.class);
+    method.setAccessible(true);
+    method.invoke(null, channelProviderBuilder, options);
+
+    ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder> chainedConfigurator =
+        channelProviderBuilder.getChannelConfigurator();
+    chainedConfigurator.apply(NettyChannelBuilder.forAddress("localhost", 1));
+
+    assertTrue(baseConfiguratorCalled.get());
+  }
+
+  @Test
+  public void testGrpcGcpOtelMetricsDisabledSkipsMeterInjection() throws Exception {
+    SpannerOptions options =
+        SpannerOptions.newBuilder()
+            .setProjectId("[PROJECT]")
+            .setGrpcGcpOtelMetricsEnabled(false)
+            .build();
+
+    java.lang.reflect.Method method =
+        GapicSpannerRpc.class.getDeclaredMethod(
+            "grpcGcpOptionsWithMetricsAndDcp", SpannerOptions.class);
+    method.setAccessible(true);
+    GcpManagedChannelOptions grpcGcpOptions =
+        (GcpManagedChannelOptions) method.invoke(null, options);
+    GcpMetricsOptions metricsOptions = grpcGcpOptions.getMetricsOptions();
+
+    assertNotNull(metricsOptions);
+    assertNull(metricsOptions.getOpenTelemetryMeter());
   }
 
   private static final class RecordingTransportChannelProvider implements TransportChannelProvider {


### PR DESCRIPTION
 - Preserve the existing channel configurator when enabling grpc‑gcp so gRPC metrics instrumentation is not dropped.
  - Add a toggle to disable grpc‑gcp OpenTelemetry meter injection via SpannerOptions and
    SPANNER_DISABLE_GRPC_GCP_OTEL_METRICS.
  - Add unit tests covering configurator preservation and the new opt‑out behavior.
