### PR TITLE
chore: prevent start and stop to run in parallel

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MultiplexedSessionDatabaseClient.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MultiplexedSessionDatabaseClient.java
@@ -562,7 +562,7 @@ final class MultiplexedSessionDatabaseClient extends AbstractMultiplexedSessionD
       this.clock = clock;
     }
 
-    void start() {
+    private synchronized void start() {
       // Schedule the maintainer to run once every ten minutes (by default).
       long loopFrequencyMillis =
           MultiplexedSessionDatabaseClient.this
@@ -577,7 +577,7 @@ final class MultiplexedSessionDatabaseClient extends AbstractMultiplexedSessionD
               this::maintain, loopFrequencyMillis, loopFrequencyMillis, TimeUnit.MILLISECONDS);
     }
 
-    void stop() {
+    private synchronized void stop() {
       if (this.scheduledFuture != null) {
         this.scheduledFuture.cancel(false);
       }


### PR DESCRIPTION
Synchronize the start() and stop() methods of the session maintainer to prevent them from running at the same time. That could cause a data race on the scheduled future that the start() method sets, and the stop() method reads.
