### PR TITLE
chore: route multi-use read-only txn reads via location-aware cache

### DIFF
--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/ChannelFinder.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/ChannelFinder.java
@@ -66,12 +66,7 @@ public final class ChannelFinder {
   }
 
   public ChannelEndpoint findServer(ReadRequest.Builder reqBuilder) {
-    recipeCache.computeKeys(reqBuilder);
-    return fillRoutingHint(
-        reqBuilder.getTransaction(),
-        reqBuilder.getDirectedReadOptions(),
-        KeyRangeCache.RangeMode.COVERING_SPLIT,
-        reqBuilder.getRoutingHintBuilder());
+    return findServer(reqBuilder, preferLeader(reqBuilder.getTransaction()));
   }
 
   public ChannelEndpoint findServer(ReadRequest.Builder reqBuilder, boolean preferLeader) {
@@ -84,12 +79,7 @@ public final class ChannelFinder {
   }
 
   public ChannelEndpoint findServer(ExecuteSqlRequest.Builder reqBuilder) {
-    recipeCache.computeKeys(reqBuilder);
-    return fillRoutingHint(
-        reqBuilder.getTransaction(),
-        reqBuilder.getDirectedReadOptions(),
-        KeyRangeCache.RangeMode.PICK_RANDOM,
-        reqBuilder.getRoutingHintBuilder());
+    return findServer(reqBuilder, preferLeader(reqBuilder.getTransaction()));
   }
 
   public ChannelEndpoint findServer(ExecuteSqlRequest.Builder reqBuilder, boolean preferLeader) {


### PR DESCRIPTION
  - Added support for multi-use read-only transaction routing so reads/queries are sent to the cached routed server (based
    on routing hints/key ranges) instead of being pinned by transaction affinity/default endpoint.
  - Introduced read-only transaction tracking in KeyAwareChannel to:
      - identify read-only txn IDs from BeginTransaction responses
      - preserve strong/stale leader preference for subsequent requests
      - bypass affinity lookup/recording for those txn IDs
  - Extended ChannelFinder with overloads that allow explicit preferLeader routing for ReadRequest and ExecuteSqlRequest.
  - Ensured cleanup removes both affinity and read-only tracking state when transaction is closed.
  - Added unit tests in KeyAwareChannelTest for:
      - independent per-request routing within the same read-only txn
      - no affinity recording for read-only txns
      - cleanup path coverage.