### PR TITLE
chore: replace old spanner teams with spanner-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,5 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# The @googleapis/spanner-client-libraries-java is the default owner for changes in this repo
-*                       @googleapis/cloud-sdk-java-team @googleapis/spanner-client-libraries-java
+# The @googleapis/spanner-team is the default owner for changes in this repo
+*                       @googleapis/cloud-sdk-java-team @googleapis/spanner-team


### PR DESCRIPTION
This PR replaces old Spanner and platform teams with the new spanner-team and cloud-sdk-platform-team. b/478003109