### PR TITLE
chore: skip ITQueueTest in cloud-devel

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITQueueTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITQueueTest.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.spanner.it;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assume.assumeTrue;
@@ -66,14 +65,6 @@ public class ITQueueTest {
 
   private static DatabaseClient client;
 
-  private static boolean isUsingCloudDevel() {
-    String jobType = System.getenv("JOB_TYPE");
-
-    // Assumes that the jobType contains the string "cloud-devel" to signal that
-    // the environment is cloud-devel.
-    return !isNullOrEmpty(jobType) && jobType.contains("cloud-devel");
-  }
-
   private Struct readRow(String queue, Key key, String... columns) {
     return client.singleUse(TimestampBound.strong()).readRow(queue, key, Arrays.asList(columns));
   }
@@ -81,7 +72,7 @@ public class ITQueueTest {
   @BeforeClass
   public static void setUpTestSuite() {
     // TODO: remove once the feature is fully enabled in prod
-    assumeTrue("Queue is currently only supported in cloud-devel", isUsingCloudDevel());
+    assumeTrue("Queue tests are temporarily disabled", false);
     Database googleStandardSQLDatabase =
         env.getTestHelper().createTestDatabase(GOOGLE_STANDARD_SQL_SCHEMA);
     googleStandardSQLClient = env.getTestHelper().getDatabaseClient(googleStandardSQLDatabase);


### PR DESCRIPTION
This PR temporarily skips the `ITQueueTest` in the `cloud-devel` environment because the Cloud Spanner Queues feature is not supported and throws `UNIMPLEMENTED` errors.

Test failure log: https://fusion2.corp.google.com/invocations/d878e622-09d6-4f00-89a6-52c4fd58e422

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-spanner/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes test failure ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
