### PR TITLE
chore: add routing hints and cache updates for begin/commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>libraries-bom</artifactId>
-      <version>26.76.0</version>
+      <version>26.78.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>
@@ -41,7 +41,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-spanner</artifactId>
-  <version>6.110.0</version>
+  <version>6.112.0</version>
 </dependency>
 
 ```

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/ChannelFinder.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/ChannelFinder.java
@@ -94,40 +94,36 @@ public final class ChannelFinder {
   }
 
   public ChannelEndpoint findServer(BeginTransactionRequest.Builder reqBuilder) {
-    if (!reqBuilder.hasMutationKey()
-        || !recipeCache.computeKeys(
-            reqBuilder.getMutationKey(), reqBuilder.getRoutingHintBuilder())) {
+    if (!reqBuilder.hasMutationKey()) {
       return null;
     }
-    return fillRoutingHint(
+    return routeMutation(
+        reqBuilder.getMutationKey(),
         preferLeader(reqBuilder.getOptions()),
-        KeyRangeCache.RangeMode.COVERING_SPLIT,
-        DirectedReadOptions.getDefaultInstance(),
         reqBuilder.getRoutingHintBuilder());
   }
 
-  public void fillRoutingHint(CommitRequest.Builder reqBuilder) {
+  public ChannelEndpoint fillRoutingHint(CommitRequest.Builder reqBuilder) {
     if (reqBuilder.getMutationsCount() == 0) {
-      return;
+      return null;
     }
     Mutation mutation = reqBuilder.getMutations(0);
-    if (!recipeCache.computeKeys(mutation, reqBuilder.getRoutingHintBuilder())) {
-      return;
-    }
-    fillRoutingHint(
-        /* preferLeader= */ true,
-        KeyRangeCache.RangeMode.COVERING_SPLIT,
-        DirectedReadOptions.getDefaultInstance(),
-        reqBuilder.getRoutingHintBuilder());
+    return routeMutation(mutation, /* preferLeader= */ true, reqBuilder.getRoutingHintBuilder());
   }
 
-  private ChannelEndpoint fillRoutingHint(
-      TransactionSelector transactionSelector,
-      DirectedReadOptions directedReadOptions,
-      KeyRangeCache.RangeMode rangeMode,
-      RoutingHint.Builder hintBuilder) {
+  private ChannelEndpoint routeMutation(
+      Mutation mutation, boolean preferLeader, RoutingHint.Builder hintBuilder) {
+    recipeCache.applySchemaGeneration(hintBuilder);
+    TargetRange target = recipeCache.mutationToTargetRange(mutation);
+    if (target == null) {
+      return null;
+    }
+    recipeCache.applyTargetRange(hintBuilder, target);
     return fillRoutingHint(
-        preferLeader(transactionSelector), rangeMode, directedReadOptions, hintBuilder);
+        preferLeader,
+        KeyRangeCache.RangeMode.COVERING_SPLIT,
+        DirectedReadOptions.getDefaultInstance(),
+        hintBuilder);
   }
 
   private ChannelEndpoint fillRoutingHint(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/ChannelFinder.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/ChannelFinder.java
@@ -19,8 +19,10 @@ package com.google.cloud.spanner.spi.v1;
 import com.google.api.core.InternalApi;
 import com.google.spanner.v1.BeginTransactionRequest;
 import com.google.spanner.v1.CacheUpdate;
+import com.google.spanner.v1.CommitRequest;
 import com.google.spanner.v1.DirectedReadOptions;
 import com.google.spanner.v1.ExecuteSqlRequest;
+import com.google.spanner.v1.Mutation;
 import com.google.spanner.v1.ReadRequest;
 import com.google.spanner.v1.RoutingHint;
 import com.google.spanner.v1.TransactionOptions;
@@ -92,23 +94,31 @@ public final class ChannelFinder {
   }
 
   public ChannelEndpoint findServer(BeginTransactionRequest.Builder reqBuilder) {
-    if (!reqBuilder.hasMutationKey()) {
+    if (!reqBuilder.hasMutationKey()
+        || !recipeCache.computeKeys(
+            reqBuilder.getMutationKey(), reqBuilder.getRoutingHintBuilder())) {
       return null;
-    }
-    TargetRange target = recipeCache.mutationToTargetRange(reqBuilder.getMutationKey());
-    if (target == null) {
-      return null;
-    }
-    RoutingHint.Builder hintBuilder = RoutingHint.newBuilder();
-    hintBuilder.setKey(target.start);
-    if (!target.limit.isEmpty()) {
-      hintBuilder.setLimitKey(target.limit);
     }
     return fillRoutingHint(
         preferLeader(reqBuilder.getOptions()),
         KeyRangeCache.RangeMode.COVERING_SPLIT,
         DirectedReadOptions.getDefaultInstance(),
-        hintBuilder);
+        reqBuilder.getRoutingHintBuilder());
+  }
+
+  public void fillRoutingHint(CommitRequest.Builder reqBuilder) {
+    if (reqBuilder.getMutationsCount() == 0) {
+      return;
+    }
+    Mutation mutation = reqBuilder.getMutations(0);
+    if (!recipeCache.computeKeys(mutation, reqBuilder.getRoutingHintBuilder())) {
+      return;
+    }
+    fillRoutingHint(
+        /* preferLeader= */ true,
+        KeyRangeCache.RangeMode.COVERING_SPLIT,
+        DirectedReadOptions.getDefaultInstance(),
+        reqBuilder.getRoutingHintBuilder());
   }
 
   private ChannelEndpoint fillRoutingHint(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/ChannelFinder.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/ChannelFinder.java
@@ -27,7 +27,10 @@ import com.google.spanner.v1.ReadRequest;
 import com.google.spanner.v1.RoutingHint;
 import com.google.spanner.v1.TransactionOptions;
 import com.google.spanner.v1.TransactionSelector;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -104,11 +107,35 @@ public final class ChannelFinder {
   }
 
   public ChannelEndpoint fillRoutingHint(CommitRequest.Builder reqBuilder) {
-    if (reqBuilder.getMutationsCount() == 0) {
+    Mutation mutation = selectMutationForRouting(reqBuilder.getMutationsList());
+    if (mutation == null) {
       return null;
     }
-    Mutation mutation = reqBuilder.getMutations(0);
     return routeMutation(mutation, /* preferLeader= */ true, reqBuilder.getRoutingHintBuilder());
+  }
+
+  private static Mutation selectMutationForRouting(List<Mutation> mutations) {
+    if (mutations.isEmpty()) {
+      return null;
+    }
+    List<Mutation> mutationsExcludingInsert = new ArrayList<>();
+    Mutation largestInsertMutation = null;
+    for (Mutation mutation : mutations) {
+      if (!mutation.hasInsert()) {
+        mutationsExcludingInsert.add(mutation);
+        continue;
+      }
+      if (largestInsertMutation == null
+          || mutation.getInsert().getValuesCount()
+              > largestInsertMutation.getInsert().getValuesCount()) {
+        largestInsertMutation = mutation;
+      }
+    }
+    if (!mutationsExcludingInsert.isEmpty()) {
+      return mutationsExcludingInsert.get(
+          ThreadLocalRandom.current().nextInt(mutationsExcludingInsert.size()));
+    }
+    return largestInsertMutation;
   }
 
   private ChannelEndpoint routeMutation(

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/KeyAwareChannel.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/KeyAwareChannel.java
@@ -383,7 +383,11 @@ final class KeyAwareChannel extends ManagedChannel {
             request = reqBuilder.build();
           }
           if (!request.getTransactionId().isEmpty()) {
-            endpoint = parentChannel.affinityEndpoint(request.getTransactionId());
+            ChannelEndpoint affinityEndpoint =
+                parentChannel.affinityEndpoint(request.getTransactionId());
+            if (affinityEndpoint != null) {
+              endpoint = affinityEndpoint;
+            }
             transactionIdToClear = request.getTransactionId();
           }
           if (reqBuilder != null) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/KeyAwareChannel.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/KeyAwareChannel.java
@@ -23,6 +23,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.protobuf.ByteString;
 import com.google.spanner.v1.BeginTransactionRequest;
 import com.google.spanner.v1.CommitRequest;
+import com.google.spanner.v1.CommitResponse;
 import com.google.spanner.v1.ExecuteSqlRequest;
 import com.google.spanner.v1.PartialResultSet;
 import com.google.spanner.v1.ReadRequest;
@@ -47,9 +48,10 @@ import javax.annotation.Nullable;
 /**
  * ManagedChannel that routes eligible requests using location-aware routing hints.
  *
- * <p>Routing hints are applied to streaming read/query and unary ExecuteSql. Commit/Rollback use
- * transaction affinity when available. BeginTransaction is routed only when a mutation key is
- * provided.
+ * <p>Routing hints are applied to streaming read/query and unary ExecuteSql. Mutation-based
+ * BeginTransaction and Commit requests also carry routing hints when recipes are available.
+ * Commit/Rollback use transaction affinity when available. BeginTransaction is routed only when a
+ * mutation key is provided.
  */
 @InternalApi
 final class KeyAwareChannel extends ManagedChannel {
@@ -355,8 +357,10 @@ final class KeyAwareChannel extends ManagedChannel {
           BeginTransactionRequest.Builder reqBuilder =
               ((BeginTransactionRequest) message).toBuilder();
           String databaseId = parentChannel.extractDatabaseIdFromSession(reqBuilder.getSession());
-          if (databaseId != null && reqBuilder.hasMutationKey()) {
+          if (databaseId != null) {
             finder = parentChannel.getOrCreateChannelFinder(databaseId);
+          }
+          if (finder != null && reqBuilder.hasMutationKey()) {
             endpoint = finder.findServer(reqBuilder);
           }
           if (reqBuilder.hasOptions() && reqBuilder.getOptions().hasReadOnly()) {
@@ -367,11 +371,19 @@ final class KeyAwareChannel extends ManagedChannel {
           }
           message = (RequestT) reqBuilder.build();
         } else if (message instanceof CommitRequest) {
-          CommitRequest request = (CommitRequest) message;
-          if (!request.getTransactionId().isEmpty()) {
-            endpoint = parentChannel.affinityEndpoint(request.getTransactionId());
-            transactionIdToClear = request.getTransactionId();
+          CommitRequest.Builder reqBuilder = ((CommitRequest) message).toBuilder();
+          String databaseId = parentChannel.extractDatabaseIdFromSession(reqBuilder.getSession());
+          if (databaseId != null) {
+            finder = parentChannel.getOrCreateChannelFinder(databaseId);
           }
+          if (finder != null) {
+            finder.fillRoutingHint(reqBuilder);
+          }
+          if (!reqBuilder.getTransactionId().isEmpty()) {
+            endpoint = parentChannel.affinityEndpoint(reqBuilder.getTransactionId());
+            transactionIdToClear = reqBuilder.getTransactionId();
+          }
+          message = (RequestT) reqBuilder.build();
         } else if (message instanceof RollbackRequest) {
           RollbackRequest request = (RollbackRequest) message;
           if (!request.getTransactionId().isEmpty()) {
@@ -610,7 +622,15 @@ final class KeyAwareChannel extends ManagedChannel {
         transactionId = transactionIdFromMetadata(response);
       } else if (message instanceof Transaction) {
         Transaction response = (Transaction) message;
+        if (response.hasCacheUpdate() && call.channelFinder != null) {
+          call.channelFinder.update(response.getCacheUpdate());
+        }
         transactionId = transactionIdFromTransaction(response);
+      } else if (message instanceof CommitResponse) {
+        CommitResponse response = (CommitResponse) message;
+        if (response.hasCacheUpdate() && call.channelFinder != null) {
+          call.channelFinder.update(response.getCacheUpdate());
+        }
       }
       if (transactionId != null) {
         if (call.isReadOnlyBegin) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/KeyAwareChannel.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/KeyAwareChannel.java
@@ -371,19 +371,24 @@ final class KeyAwareChannel extends ManagedChannel {
           }
           message = (RequestT) reqBuilder.build();
         } else if (message instanceof CommitRequest) {
-          CommitRequest.Builder reqBuilder = ((CommitRequest) message).toBuilder();
-          String databaseId = parentChannel.extractDatabaseIdFromSession(reqBuilder.getSession());
+          CommitRequest request = (CommitRequest) message;
+          String databaseId = parentChannel.extractDatabaseIdFromSession(request.getSession());
           if (databaseId != null) {
             finder = parentChannel.getOrCreateChannelFinder(databaseId);
           }
-          if (finder != null) {
-            finder.fillRoutingHint(reqBuilder);
+          CommitRequest.Builder reqBuilder = null;
+          if (finder != null && request.getMutationsCount() > 0) {
+            reqBuilder = request.toBuilder();
+            endpoint = finder.fillRoutingHint(reqBuilder);
+            request = reqBuilder.build();
           }
-          if (!reqBuilder.getTransactionId().isEmpty()) {
-            endpoint = parentChannel.affinityEndpoint(reqBuilder.getTransactionId());
-            transactionIdToClear = reqBuilder.getTransactionId();
+          if (!request.getTransactionId().isEmpty()) {
+            endpoint = parentChannel.affinityEndpoint(request.getTransactionId());
+            transactionIdToClear = request.getTransactionId();
           }
-          message = (RequestT) reqBuilder.build();
+          if (reqBuilder != null) {
+            message = (RequestT) request;
+          }
         } else if (message instanceof RollbackRequest) {
           RollbackRequest request = (RollbackRequest) message;
           if (!request.getTransactionId().isEmpty()) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/KeyRecipeCache.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/KeyRecipeCache.java
@@ -158,9 +158,7 @@ public final class KeyRecipeCache {
     long reqFp = fingerprint(reqBuilder.buildPartial());
 
     RoutingHint.Builder hintBuilder = reqBuilder.getRoutingHintBuilder();
-    if (!schemaGeneration.isEmpty()) {
-      hintBuilder.setSchemaGeneration(schemaGeneration);
-    }
+    applySchemaGeneration(hintBuilder);
 
     PreparedRead preparedRead = getIfPresent(preparedReads, reqFp);
     if (preparedRead == null) {
@@ -186,10 +184,7 @@ public final class KeyRecipeCache {
 
     try {
       TargetRange target = recipe.keySetToTargetRange(reqBuilder.getKeySet());
-      hintBuilder.setKey(target.start);
-      if (!target.limit.isEmpty()) {
-        hintBuilder.setLimitKey(target.limit);
-      }
+      applyTargetRange(hintBuilder, target);
     } catch (IllegalArgumentException e) {
       logger.fine("Failed key encoding: " + e.getMessage());
     }
@@ -199,9 +194,7 @@ public final class KeyRecipeCache {
     long reqFp = fingerprint(reqBuilder.buildPartial());
 
     RoutingHint.Builder hintBuilder = reqBuilder.getRoutingHintBuilder();
-    if (!schemaGeneration.isEmpty()) {
-      hintBuilder.setSchemaGeneration(schemaGeneration);
-    }
+    applySchemaGeneration(hintBuilder);
 
     PreparedQuery preparedQuery = getIfPresent(preparedQueries, reqFp);
     if (preparedQuery == null) {
@@ -221,30 +214,23 @@ public final class KeyRecipeCache {
 
     try {
       TargetRange target = recipe.queryParamsToTargetRange(reqBuilder.getParams());
-      hintBuilder.setKey(target.start);
-      if (!target.limit.isEmpty()) {
-        hintBuilder.setLimitKey(target.limit);
-      }
+      applyTargetRange(hintBuilder, target);
     } catch (IllegalArgumentException e) {
       logger.fine("Failed query param encoding: " + e.getMessage());
     }
   }
 
-  boolean computeKeys(Mutation mutation, RoutingHint.Builder hintBuilder) {
+  void applySchemaGeneration(RoutingHint.Builder hintBuilder) {
     if (!schemaGeneration.isEmpty()) {
       hintBuilder.setSchemaGeneration(schemaGeneration);
     }
+  }
 
-    TargetRange target = mutationToTargetRange(mutation);
-    if (target == null) {
-      return false;
-    }
-
+  void applyTargetRange(RoutingHint.Builder hintBuilder, TargetRange target) {
     hintBuilder.setKey(target.start);
     if (!target.limit.isEmpty()) {
       hintBuilder.setLimitKey(target.limit);
     }
-    return true;
   }
 
   public TargetRange mutationToTargetRange(Mutation mutation) {

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/KeyRecipeCache.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/KeyRecipeCache.java
@@ -230,6 +230,23 @@ public final class KeyRecipeCache {
     }
   }
 
+  boolean computeKeys(Mutation mutation, RoutingHint.Builder hintBuilder) {
+    if (!schemaGeneration.isEmpty()) {
+      hintBuilder.setSchemaGeneration(schemaGeneration);
+    }
+
+    TargetRange target = mutationToTargetRange(mutation);
+    if (target == null) {
+      return false;
+    }
+
+    hintBuilder.setKey(target.start);
+    if (!target.limit.isEmpty()) {
+      hintBuilder.setLimitKey(target.limit);
+    }
+    return true;
+  }
+
   public TargetRange mutationToTargetRange(Mutation mutation) {
     if (mutation == null) {
       return null;

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/KeyAwareChannelTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/KeyAwareChannelTest.java
@@ -405,6 +405,105 @@ public class KeyAwareChannelTest {
   }
 
   @Test
+  public void singleUseCommitUsesSameMutationSelectionHeuristicAsBeginTransaction()
+      throws Exception {
+    TestHarness harness = createHarness();
+    seedCache(harness, createMutationRecipeCacheUpdate());
+
+    Mutation deleteMutation = createDeleteMutation("b");
+
+    ClientCall<BeginTransactionRequest, Transaction> beginCall =
+        harness.channel.newCall(SpannerGrpc.getBeginTransactionMethod(), CallOptions.DEFAULT);
+    beginCall.start(new CapturingListener<Transaction>(), new Metadata());
+    beginCall.sendMessage(
+        BeginTransactionRequest.newBuilder()
+            .setSession(SESSION)
+            .setMutationKey(deleteMutation)
+            .build());
+
+    @SuppressWarnings("unchecked")
+    RecordingClientCall<BeginTransactionRequest, Transaction> beginDelegate =
+        (RecordingClientCall<BeginTransactionRequest, Transaction>)
+            harness.defaultManagedChannel.latestCall();
+
+    assertNotNull(beginDelegate.lastMessage);
+    RoutingHint expectedRoutingHint = beginDelegate.lastMessage.getRoutingHint();
+
+    ClientCall<CommitRequest, CommitResponse> commitCall =
+        harness.channel.newCall(SpannerGrpc.getCommitMethod(), CallOptions.DEFAULT);
+    commitCall.start(new CapturingListener<CommitResponse>(), new Metadata());
+    commitCall.sendMessage(
+        CommitRequest.newBuilder()
+            .setSession(SESSION)
+            .setSingleUseTransaction(
+                TransactionOptions.newBuilder()
+                    .setReadWrite(TransactionOptions.ReadWrite.getDefaultInstance()))
+            .addMutations(createInsertMutation("a"))
+            .addMutations(deleteMutation)
+            .build());
+
+    @SuppressWarnings("unchecked")
+    RecordingClientCall<CommitRequest, CommitResponse> commitDelegate =
+        (RecordingClientCall<CommitRequest, CommitResponse>)
+            harness.defaultManagedChannel.latestCall();
+
+    assertNotNull(commitDelegate.lastMessage);
+    assertEquals(expectedRoutingHint, commitDelegate.lastMessage.getRoutingHint());
+  }
+
+  @Test
+  public void commitWithTransactionIdRoutesUsingRoutingHintWhenAffinityMissing() throws Exception {
+    TestHarness harness = createHarness();
+    ByteString transactionId = ByteString.copyFromUtf8("tx-without-affinity");
+    seedCache(harness, createMutationRecipeCacheUpdate());
+
+    ClientCall<CommitRequest, CommitResponse> firstCommitCall =
+        harness.channel.newCall(SpannerGrpc.getCommitMethod(), CallOptions.DEFAULT);
+    firstCommitCall.start(new CapturingListener<CommitResponse>(), new Metadata());
+    firstCommitCall.sendMessage(
+        CommitRequest.newBuilder()
+            .setSession(SESSION)
+            .setTransactionId(transactionId)
+            .addMutations(createInsertMutation("b"))
+            .build());
+
+    @SuppressWarnings("unchecked")
+    RecordingClientCall<CommitRequest, CommitResponse> firstCommitDelegate =
+        (RecordingClientCall<CommitRequest, CommitResponse>)
+            harness.defaultManagedChannel.latestCall();
+
+    assertNotNull(firstCommitDelegate.lastMessage);
+    RoutingHint routingHint = firstCommitDelegate.lastMessage.getRoutingHint();
+    assertFalse(routingHint.getKey().isEmpty());
+
+    seedCache(harness, createRangeCacheUpdateForHint(routingHint));
+
+    ClientCall<CommitRequest, CommitResponse> secondCommitCall =
+        harness.channel.newCall(SpannerGrpc.getCommitMethod(), CallOptions.DEFAULT);
+    secondCommitCall.start(new CapturingListener<CommitResponse>(), new Metadata());
+    secondCommitCall.sendMessage(
+        CommitRequest.newBuilder()
+            .setSession(SESSION)
+            .setTransactionId(transactionId)
+            .addMutations(createInsertMutation("b"))
+            .build());
+
+    assertThat(harness.endpointCache.callCountForAddress(DEFAULT_ADDRESS)).isEqualTo(3);
+    assertThat(harness.endpointCache.callCountForAddress("server-a:1234")).isEqualTo(1);
+
+    @SuppressWarnings("unchecked")
+    RecordingClientCall<CommitRequest, CommitResponse> commitDelegate =
+        (RecordingClientCall<CommitRequest, CommitResponse>)
+            harness.endpointCache.latestCallForAddress("server-a:1234");
+
+    assertNotNull(commitDelegate.lastMessage);
+    assertEquals(7L, commitDelegate.lastMessage.getRoutingHint().getDatabaseId());
+    assertEquals(
+        "1", commitDelegate.lastMessage.getRoutingHint().getSchemaGeneration().toStringUtf8());
+    assertFalse(commitDelegate.lastMessage.getRoutingHint().getKey().isEmpty());
+  }
+
+  @Test
   public void commitResponseCacheUpdateEnablesSubsequentBeginRoutingHint() throws Exception {
     TestHarness harness = createHarness();
     ByteString transactionId = ByteString.copyFromUtf8("tx-before-commit-cache-update");
@@ -893,6 +992,21 @@ public class KeyAwareChannelTest {
                 .addValues(
                     ListValue.newBuilder()
                         .addValues(Value.newBuilder().setStringValue(keyValue).build())
+                        .build()))
+        .build();
+  }
+
+  private static Mutation createDeleteMutation(String keyValue) {
+    return Mutation.newBuilder()
+        .setDelete(
+            Mutation.Delete.newBuilder()
+                .setTable("T")
+                .setKeySet(
+                    com.google.spanner.v1.KeySet.newBuilder()
+                        .addKeys(
+                            ListValue.newBuilder()
+                                .addValues(Value.newBuilder().setStringValue(keyValue).build())
+                                .build())
                         .build()))
         .build();
   }

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/KeyAwareChannelTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/KeyAwareChannelTest.java
@@ -22,15 +22,20 @@ import static org.junit.Assert.assertThrows;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.TextFormat;
+import com.google.protobuf.Value;
 import com.google.spanner.v1.BeginTransactionRequest;
 import com.google.spanner.v1.CacheUpdate;
 import com.google.spanner.v1.CommitRequest;
 import com.google.spanner.v1.CommitResponse;
 import com.google.spanner.v1.ExecuteSqlRequest;
 import com.google.spanner.v1.Group;
+import com.google.spanner.v1.Mutation;
 import com.google.spanner.v1.PartialResultSet;
 import com.google.spanner.v1.Range;
 import com.google.spanner.v1.ReadRequest;
+import com.google.spanner.v1.RecipeList;
 import com.google.spanner.v1.ResultSet;
 import com.google.spanner.v1.ResultSetMetadata;
 import com.google.spanner.v1.RollbackRequest;
@@ -272,6 +277,124 @@ public class KeyAwareChannelTest {
 
     assertThat(harness.endpointCache.callCountForAddress(DEFAULT_ADDRESS)).isEqualTo(1);
     assertThat(harness.endpointCache.callCountForAddress("routed:1234")).isEqualTo(1);
+  }
+
+  @Test
+  public void beginTransactionWithMutationKeyAddsRoutingHint() throws Exception {
+    TestHarness harness = createHarness();
+    seedCache(harness, createMutationRoutingCacheUpdate());
+
+    Mutation mutation = createInsertMutation("b");
+    ClientCall<BeginTransactionRequest, Transaction> beginCall =
+        harness.channel.newCall(SpannerGrpc.getBeginTransactionMethod(), CallOptions.DEFAULT);
+    beginCall.start(new CapturingListener<Transaction>(), new Metadata());
+    beginCall.sendMessage(
+        BeginTransactionRequest.newBuilder().setSession(SESSION).setMutationKey(mutation).build());
+
+    @SuppressWarnings("unchecked")
+    RecordingClientCall<BeginTransactionRequest, Transaction> beginDelegate =
+        (RecordingClientCall<BeginTransactionRequest, Transaction>)
+            harness.defaultManagedChannel.latestCall();
+
+    assertThat(beginDelegate.lastMessage).isNotNull();
+    assertThat(beginDelegate.lastMessage.getRoutingHint().getDatabaseId()).isEqualTo(7L);
+    assertThat(beginDelegate.lastMessage.getRoutingHint().getSchemaGeneration().toStringUtf8())
+        .isEqualTo("1");
+    assertThat(beginDelegate.lastMessage.getRoutingHint().getKey().isEmpty()).isFalse();
+  }
+
+  @Test
+  public void transactionCacheUpdateEnablesCommitRoutingHint() throws Exception {
+    TestHarness harness = createHarness();
+    ByteString transactionId = ByteString.copyFromUtf8("tx-with-cache-update");
+
+    ClientCall<BeginTransactionRequest, Transaction> beginCall =
+        harness.channel.newCall(SpannerGrpc.getBeginTransactionMethod(), CallOptions.DEFAULT);
+    beginCall.start(new CapturingListener<Transaction>(), new Metadata());
+    beginCall.sendMessage(BeginTransactionRequest.newBuilder().setSession(SESSION).build());
+
+    @SuppressWarnings("unchecked")
+    RecordingClientCall<BeginTransactionRequest, Transaction> beginDelegate =
+        (RecordingClientCall<BeginTransactionRequest, Transaction>)
+            harness.defaultManagedChannel.latestCall();
+    beginDelegate.emitOnMessage(
+        Transaction.newBuilder()
+            .setId(transactionId)
+            .setCacheUpdate(createMutationRoutingCacheUpdate())
+            .build());
+    beginDelegate.emitOnClose(Status.OK, new Metadata());
+
+    ClientCall<CommitRequest, CommitResponse> commitCall =
+        harness.channel.newCall(SpannerGrpc.getCommitMethod(), CallOptions.DEFAULT);
+    commitCall.start(new CapturingListener<CommitResponse>(), new Metadata());
+    commitCall.sendMessage(
+        CommitRequest.newBuilder()
+            .setSession(SESSION)
+            .setTransactionId(transactionId)
+            .addMutations(createInsertMutation("b"))
+            .build());
+
+    @SuppressWarnings("unchecked")
+    RecordingClientCall<CommitRequest, CommitResponse> commitDelegate =
+        (RecordingClientCall<CommitRequest, CommitResponse>)
+            harness.defaultManagedChannel.latestCall();
+
+    assertThat(commitDelegate.lastMessage).isNotNull();
+    assertThat(commitDelegate.lastMessage.getRoutingHint().getDatabaseId()).isEqualTo(7L);
+    assertThat(commitDelegate.lastMessage.getRoutingHint().getSchemaGeneration().toStringUtf8())
+        .isEqualTo("1");
+    assertThat(commitDelegate.lastMessage.getRoutingHint().getKey().isEmpty()).isFalse();
+  }
+
+  @Test
+  public void commitResponseCacheUpdateEnablesSubsequentBeginRoutingHint() throws Exception {
+    TestHarness harness = createHarness();
+    ByteString transactionId = ByteString.copyFromUtf8("tx-before-commit-cache-update");
+
+    ClientCall<BeginTransactionRequest, Transaction> beginCall =
+        harness.channel.newCall(SpannerGrpc.getBeginTransactionMethod(), CallOptions.DEFAULT);
+    beginCall.start(new CapturingListener<Transaction>(), new Metadata());
+    beginCall.sendMessage(BeginTransactionRequest.newBuilder().setSession(SESSION).build());
+
+    @SuppressWarnings("unchecked")
+    RecordingClientCall<BeginTransactionRequest, Transaction> beginDelegate =
+        (RecordingClientCall<BeginTransactionRequest, Transaction>)
+            harness.defaultManagedChannel.latestCall();
+    beginDelegate.emitOnMessage(Transaction.newBuilder().setId(transactionId).build());
+    beginDelegate.emitOnClose(Status.OK, new Metadata());
+
+    ClientCall<CommitRequest, CommitResponse> commitCall =
+        harness.channel.newCall(SpannerGrpc.getCommitMethod(), CallOptions.DEFAULT);
+    commitCall.start(new CapturingListener<CommitResponse>(), new Metadata());
+    commitCall.sendMessage(
+        CommitRequest.newBuilder().setSession(SESSION).setTransactionId(transactionId).build());
+
+    @SuppressWarnings("unchecked")
+    RecordingClientCall<CommitRequest, CommitResponse> commitDelegate =
+        (RecordingClientCall<CommitRequest, CommitResponse>)
+            harness.defaultManagedChannel.latestCall();
+    commitDelegate.emitOnMessage(
+        CommitResponse.newBuilder().setCacheUpdate(createMutationRoutingCacheUpdate()).build());
+    commitDelegate.emitOnClose(Status.OK, new Metadata());
+
+    Mutation mutation = createInsertMutation("b");
+    ClientCall<BeginTransactionRequest, Transaction> secondBeginCall =
+        harness.channel.newCall(SpannerGrpc.getBeginTransactionMethod(), CallOptions.DEFAULT);
+    secondBeginCall.start(new CapturingListener<Transaction>(), new Metadata());
+    secondBeginCall.sendMessage(
+        BeginTransactionRequest.newBuilder().setSession(SESSION).setMutationKey(mutation).build());
+
+    @SuppressWarnings("unchecked")
+    RecordingClientCall<BeginTransactionRequest, Transaction> routedBeginDelegate =
+        (RecordingClientCall<BeginTransactionRequest, Transaction>)
+            harness.defaultManagedChannel.latestCall();
+
+    assertThat(routedBeginDelegate.lastMessage).isNotNull();
+    assertThat(routedBeginDelegate.lastMessage.getRoutingHint().getDatabaseId()).isEqualTo(7L);
+    assertThat(
+            routedBeginDelegate.lastMessage.getRoutingHint().getSchemaGeneration().toStringUtf8())
+        .isEqualTo("1");
+    assertThat(routedBeginDelegate.lastMessage.getRoutingHint().getKey().isEmpty()).isFalse();
   }
 
   @Test
@@ -635,6 +758,43 @@ public class KeyAwareChannelTest {
         .build();
   }
 
+  private static CacheUpdate createMutationRoutingCacheUpdate() throws TextFormat.ParseException {
+    RecipeList keyRecipes =
+        parseRecipeList(
+            "schema_generation: \"1\"\n"
+                + "recipe {\n"
+                + "  table_name: \"T\"\n"
+                + "  part { tag: 1 }\n"
+                + "  part {\n"
+                + "    order: ASCENDING\n"
+                + "    null_order: NULLS_FIRST\n"
+                + "    type { code: STRING }\n"
+                + "    identifier: \"k\"\n"
+                + "  }\n"
+                + "}\n");
+    return CacheUpdate.newBuilder()
+        .setDatabaseId(7L)
+        .setKeyRecipes(keyRecipes)
+        .addRange(
+            Range.newBuilder()
+                .setStartKey(bytes("a"))
+                .setLimitKey(bytes("m"))
+                .setGroupUid(1L)
+                .setSplitId(1L)
+                .setGeneration(bytes("1")))
+        .addGroup(
+            Group.newBuilder()
+                .setGroupUid(1L)
+                .setGeneration(bytes("1"))
+                .addTablets(
+                    Tablet.newBuilder()
+                        .setTabletUid(1L)
+                        .setServerAddress("server-a:1234")
+                        .setIncarnation(bytes("1"))
+                        .setDistance(0)))
+        .build();
+  }
+
   private static void seedCache(TestHarness harness, CacheUpdate cacheUpdate) {
     ClientCall<ExecuteSqlRequest, ResultSet> seedCall =
         harness.channel.newCall(SpannerGrpc.getExecuteSqlMethod(), CallOptions.DEFAULT);
@@ -650,6 +810,25 @@ public class KeyAwareChannelTest {
         (RecordingClientCall<ExecuteSqlRequest, ResultSet>)
             harness.defaultManagedChannel.latestCall();
     seedDelegate.emitOnMessage(ResultSet.newBuilder().setCacheUpdate(cacheUpdate).build());
+  }
+
+  private static Mutation createInsertMutation(String keyValue) {
+    return Mutation.newBuilder()
+        .setInsert(
+            Mutation.Write.newBuilder()
+                .setTable("T")
+                .addColumns("k")
+                .addValues(
+                    ListValue.newBuilder()
+                        .addValues(Value.newBuilder().setStringValue(keyValue).build())
+                        .build()))
+        .build();
+  }
+
+  private static RecipeList parseRecipeList(String text) throws TextFormat.ParseException {
+    RecipeList.Builder builder = RecipeList.newBuilder();
+    TextFormat.merge(text, builder);
+    return builder.build();
   }
 
   private static TestHarness createHarness() throws IOException {
@@ -841,6 +1020,7 @@ public class KeyAwareChannelTest {
   private static final class RecordingClientCall<RequestT, ResponseT>
       extends ClientCall<RequestT, ResponseT> {
     @Nullable private ClientCall.Listener<ResponseT> listener;
+    @Nullable private RequestT lastMessage;
     private boolean cancelCalled;
     @Nullable private String cancelMessage;
     @Nullable private Throwable cancelCause;
@@ -864,7 +1044,9 @@ public class KeyAwareChannelTest {
     public void halfClose() {}
 
     @Override
-    public void sendMessage(RequestT message) {}
+    public void sendMessage(RequestT message) {
+      this.lastMessage = message;
+    }
 
     void emitOnMessage(ResponseT response) {
       if (listener != null) {

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/KeyAwareChannelTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/KeyAwareChannelTest.java
@@ -17,6 +17,9 @@
 package com.google.cloud.spanner.spi.v1;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
@@ -296,11 +299,11 @@ public class KeyAwareChannelTest {
         (RecordingClientCall<BeginTransactionRequest, Transaction>)
             harness.defaultManagedChannel.latestCall();
 
-    assertThat(beginDelegate.lastMessage).isNotNull();
-    assertThat(beginDelegate.lastMessage.getRoutingHint().getDatabaseId()).isEqualTo(7L);
-    assertThat(beginDelegate.lastMessage.getRoutingHint().getSchemaGeneration().toStringUtf8())
-        .isEqualTo("1");
-    assertThat(beginDelegate.lastMessage.getRoutingHint().getKey().isEmpty()).isFalse();
+    assertNotNull(beginDelegate.lastMessage);
+    assertEquals(7L, beginDelegate.lastMessage.getRoutingHint().getDatabaseId());
+    assertEquals(
+        "1", beginDelegate.lastMessage.getRoutingHint().getSchemaGeneration().toStringUtf8());
+    assertFalse(beginDelegate.lastMessage.getRoutingHint().getKey().isEmpty());
   }
 
   @Test
@@ -339,11 +342,66 @@ public class KeyAwareChannelTest {
         (RecordingClientCall<CommitRequest, CommitResponse>)
             harness.defaultManagedChannel.latestCall();
 
-    assertThat(commitDelegate.lastMessage).isNotNull();
-    assertThat(commitDelegate.lastMessage.getRoutingHint().getDatabaseId()).isEqualTo(7L);
-    assertThat(commitDelegate.lastMessage.getRoutingHint().getSchemaGeneration().toStringUtf8())
-        .isEqualTo("1");
-    assertThat(commitDelegate.lastMessage.getRoutingHint().getKey().isEmpty()).isFalse();
+    assertNotNull(commitDelegate.lastMessage);
+    assertEquals(7L, commitDelegate.lastMessage.getRoutingHint().getDatabaseId());
+    assertEquals(
+        "1", commitDelegate.lastMessage.getRoutingHint().getSchemaGeneration().toStringUtf8());
+    assertFalse(commitDelegate.lastMessage.getRoutingHint().getKey().isEmpty());
+  }
+
+  @Test
+  public void singleUseCommitWithMutationsRoutesUsingRoutingHint() throws Exception {
+    TestHarness harness = createHarness();
+    seedCache(harness, createMutationRecipeCacheUpdate());
+
+    ClientCall<CommitRequest, CommitResponse> firstCommitCall =
+        harness.channel.newCall(SpannerGrpc.getCommitMethod(), CallOptions.DEFAULT);
+    firstCommitCall.start(new CapturingListener<CommitResponse>(), new Metadata());
+    firstCommitCall.sendMessage(
+        CommitRequest.newBuilder()
+            .setSession(SESSION)
+            .setSingleUseTransaction(
+                TransactionOptions.newBuilder()
+                    .setReadWrite(TransactionOptions.ReadWrite.getDefaultInstance()))
+            .addMutations(createInsertMutation("b"))
+            .build());
+
+    @SuppressWarnings("unchecked")
+    RecordingClientCall<CommitRequest, CommitResponse> firstCommitDelegate =
+        (RecordingClientCall<CommitRequest, CommitResponse>)
+            harness.defaultManagedChannel.latestCall();
+
+    assertNotNull(firstCommitDelegate.lastMessage);
+    RoutingHint routingHint = firstCommitDelegate.lastMessage.getRoutingHint();
+    assertFalse(routingHint.getKey().isEmpty());
+
+    seedCache(harness, createRangeCacheUpdateForHint(routingHint));
+
+    ClientCall<CommitRequest, CommitResponse> secondCommitCall =
+        harness.channel.newCall(SpannerGrpc.getCommitMethod(), CallOptions.DEFAULT);
+    secondCommitCall.start(new CapturingListener<CommitResponse>(), new Metadata());
+    secondCommitCall.sendMessage(
+        CommitRequest.newBuilder()
+            .setSession(SESSION)
+            .setSingleUseTransaction(
+                TransactionOptions.newBuilder()
+                    .setReadWrite(TransactionOptions.ReadWrite.getDefaultInstance()))
+            .addMutations(createInsertMutation("b"))
+            .build());
+
+    assertThat(harness.endpointCache.callCountForAddress(DEFAULT_ADDRESS)).isEqualTo(3);
+    assertThat(harness.endpointCache.callCountForAddress("server-a:1234")).isEqualTo(1);
+
+    @SuppressWarnings("unchecked")
+    RecordingClientCall<CommitRequest, CommitResponse> commitDelegate =
+        (RecordingClientCall<CommitRequest, CommitResponse>)
+            harness.endpointCache.latestCallForAddress("server-a:1234");
+
+    assertNotNull(commitDelegate.lastMessage);
+    assertEquals(7L, commitDelegate.lastMessage.getRoutingHint().getDatabaseId());
+    assertEquals(
+        "1", commitDelegate.lastMessage.getRoutingHint().getSchemaGeneration().toStringUtf8());
+    assertFalse(commitDelegate.lastMessage.getRoutingHint().getKey().isEmpty());
   }
 
   @Test
@@ -389,12 +447,11 @@ public class KeyAwareChannelTest {
         (RecordingClientCall<BeginTransactionRequest, Transaction>)
             harness.defaultManagedChannel.latestCall();
 
-    assertThat(routedBeginDelegate.lastMessage).isNotNull();
-    assertThat(routedBeginDelegate.lastMessage.getRoutingHint().getDatabaseId()).isEqualTo(7L);
-    assertThat(
-            routedBeginDelegate.lastMessage.getRoutingHint().getSchemaGeneration().toStringUtf8())
-        .isEqualTo("1");
-    assertThat(routedBeginDelegate.lastMessage.getRoutingHint().getKey().isEmpty()).isFalse();
+    assertNotNull(routedBeginDelegate.lastMessage);
+    assertEquals(7L, routedBeginDelegate.lastMessage.getRoutingHint().getDatabaseId());
+    assertEquals(
+        "1", routedBeginDelegate.lastMessage.getRoutingHint().getSchemaGeneration().toStringUtf8());
+    assertFalse(routedBeginDelegate.lastMessage.getRoutingHint().getKey().isEmpty());
   }
 
   @Test
@@ -759,6 +816,13 @@ public class KeyAwareChannelTest {
   }
 
   private static CacheUpdate createMutationRoutingCacheUpdate() throws TextFormat.ParseException {
+    return createMutationRecipeCacheUpdate().toBuilder()
+        .mergeFrom(
+            createRangeCacheUpdateForHint(RoutingHint.newBuilder().setKey(bytes("a")).build()))
+        .build();
+  }
+
+  private static CacheUpdate createMutationRecipeCacheUpdate() throws TextFormat.ParseException {
     RecipeList keyRecipes =
         parseRecipeList(
             "schema_generation: \"1\"\n"
@@ -772,13 +836,21 @@ public class KeyAwareChannelTest {
                 + "    identifier: \"k\"\n"
                 + "  }\n"
                 + "}\n");
+    return CacheUpdate.newBuilder().setDatabaseId(7L).setKeyRecipes(keyRecipes).build();
+  }
+
+  private static CacheUpdate createRangeCacheUpdateForHint(RoutingHint hint) {
+    ByteString key = hint.getKey();
+    ByteString limitKey =
+        hint.getLimitKey().isEmpty()
+            ? key.concat(ByteString.copyFrom(new byte[] {0}))
+            : hint.getLimitKey();
     return CacheUpdate.newBuilder()
         .setDatabaseId(7L)
-        .setKeyRecipes(keyRecipes)
         .addRange(
             Range.newBuilder()
-                .setStartKey(bytes("a"))
-                .setLimitKey(bytes("m"))
+                .setStartKey(key)
+                .setLimitKey(limitKey)
                 .setGroupUid(1L)
                 .setSplitId(1L)
                 .setGeneration(bytes("1")))


### PR DESCRIPTION
  ## Summary

  This change extends key-aware routing to include mutation-based `BeginTransaction` and `Commit` request payloads, and teaches the response path to consume `CacheUpdate` from `Transaction` and `CommitResponse`.

  ## What changed

  - Populate `RoutingHint` on `BeginTransaction` when a `mutationKey` is present
  - Populate `RoutingHint` on `Commit` from the first mutation in the request
  - Keep existing transaction-affinity routing for `Commit`/`Rollback`
  - Apply `CacheUpdate` from:
    - `Transaction`
    - `CommitResponse`
  - Add focused `KeyAwareChannel` tests for the new request/response behavior
